### PR TITLE
Fixes for item removal

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -336,6 +336,7 @@ var BattlePokemon = (function() {
 	BattlePokemon.prototype.illusion = null;
 	BattlePokemon.prototype.fainted = false;
 	BattlePokemon.prototype.lastItem = '';
+	BattlePokemon.prototype.lastItemTurnData = {};
 	BattlePokemon.prototype.status = '';
 	BattlePokemon.prototype.position = 0;
 
@@ -344,7 +345,6 @@ var BattlePokemon = (function() {
 
 	BattlePokemon.prototype.lastDamage = 0;
 	BattlePokemon.prototype.lastAttackedBy = null;
-	BattlePokemon.prototype.usedItemThisTurn = false;
 	BattlePokemon.prototype.newlySwitched = false;
 	BattlePokemon.prototype.beingCalledBack = false;
 	BattlePokemon.prototype.isActive = false;
@@ -927,9 +927,9 @@ var BattlePokemon = (function() {
 			this.battle.singleEvent('Eat', item, this.itemData, this, source, sourceEffect);
 
 			this.lastItem = this.item;
+			this.lastItemTurnData = {id: this.item, effect: 'eatItem'};
 			this.item = '';
 			this.itemData = {id: '', target: this};
-			this.usedItemThisTurn = true;
 			return true;
 		}
 		return false;
@@ -959,9 +959,9 @@ var BattlePokemon = (function() {
 			this.battle.singleEvent('Use', item, this.itemData, this, source, sourceEffect);
 
 			this.lastItem = this.item;
+			this.lastItemTurnData = {id: this.item, effect: 'useItem'};
 			this.item = '';
 			this.itemData = {id: '', target: this};
-			this.usedItemThisTurn = true;
 			return true;
 		}
 		return false;
@@ -988,7 +988,8 @@ var BattlePokemon = (function() {
 		if (item.id) {
 			this.battle.singleEvent('Start', item, this.itemData, this, source, effect);
 		}
-		if (this.lastItem) this.usedItemThisTurn = true;
+		this.lastItemTurnData = {};
+		if (this.lastItem) this.lastItemTurnData = {id: this.lastItem, effect: 'setItem'};
 		return true;
 	};
 	BattlePokemon.prototype.tossItem = function(source) {
@@ -1000,7 +1001,7 @@ var BattlePokemon = (function() {
 			this.lastItem = item.id;
 			this.item = '';
 			this.itemData = {id: '', target: this};
-			this.usedItemThisTurn = true;
+			this.lastItemTurnData = {id: item.id, effect: 'tossItem'};
 			return item;
 		}
 		return false;
@@ -2434,7 +2435,7 @@ var Battle = (function() {
 				var pokemon = this.sides[i].active[j];
 				if (!pokemon) continue;
 				pokemon.moveThisTurn = '';
-				pokemon.usedItemThisTurn = false;
+				pokemon.lastItemTurnData = {};
 				pokemon.newlySwitched = false;
 				if (pokemon.lastAttackedBy) {
 					pokemon.lastAttackedBy.thisTurn = false;

--- a/battle-engine.js
+++ b/battle-engine.js
@@ -991,6 +991,20 @@ var BattlePokemon = (function() {
 		if (this.lastItem) this.usedItemThisTurn = true;
 		return true;
 	};
+	BattlePokemon.prototype.tossItem = function(source) {
+		if (!this.hp || !this.isActive) return false;
+		if (!this.item) return false;
+		if (!source) source = this;
+		var item = this.getItem();
+		if (this.battle.runEvent('TossItem', this, source, null, item)) {
+			this.lastItem = item.id;
+			this.item = '';
+			this.itemData = {id: '', target: this};
+			this.usedItemThisTurn = true;
+			return item;
+		}
+		return false;
+	};
 	BattlePokemon.prototype.getItem = function() {
 		return this.battle.getItem(this.item);
 	};

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2994,6 +2994,9 @@ exports.BattleAbilities = {
 		onTakeItem: function(item, pokemon) {
 			pokemon.addVolatile('unburden');
 		},
+		onTossItem: function(item, pokemon) {
+			pokemon.addVolatile('unburden');
+		},
 		effect: {
 			onModifySpe: function(speMod, pokemon) {
 				if (pokemon.ability !== 'unburden') {

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1831,9 +1831,10 @@ exports.BattleAbilities = {
 		onResidual: function(pokemon) {
 			var foe = pokemon.side.foe.randomActive();
 			if (!foe) return;
-			if (!pokemon.item && foe.lastItem && foe.usedItemThisTurn && foe.lastItem !== 'airballoon' && foe.lastItem !== 'ejectbutton') {
+			if (!pokemon.item && foe.lastItemTurnData.id && (foe.lastItemTurnData.effect === 'tossItem' || foe.lastItem !== 'airballoon' && foe.lastItem !== 'ejectbutton')) {
 				pokemon.setItem(foe.lastItem);
 				foe.lastItem = '';
+				foe.lastItemTurnData = {};
 				var item = pokemon.getItem();
 				this.add('-item', pokemon, item, '[from] Pickup');
 				if (item.isBerry) pokemon.update();

--- a/data/items.js
+++ b/data/items.js
@@ -2376,7 +2376,9 @@ exports.BattleItems = {
 		id: "mail",
 		name: "Mail",
 		spritenum: 403,
-		onTakeItem: false,
+		onTakeItem: function(item, source) {
+			if (!source.volatiles['knockoff']) return false;
+		},
 		isUnreleased: true,
 		gen: 2,
 		desc: "This item cannot be given to or taken from a Pokemon, except by Knock Off."

--- a/data/moves.js
+++ b/data/moves.js
@@ -4238,7 +4238,7 @@ exports.BattleMovedex = {
 			var item = pokemon.getItem();
 			if (item.fling) {
 				pokemon.addVolatile('fling');
-				pokemon.setItem('');
+				pokemon.tossItem();
 			}
 		},
 		onTryHit: function(target, source, move) {
@@ -8653,7 +8653,7 @@ exports.BattleMovedex = {
 				pokemon.addVolatile('naturalgift');
 				pokemon.volatiles['naturalgift'].basePower = item.naturalGift.basePower;
 				pokemon.volatiles['naturalgift'].type = item.naturalGift.type;
-				pokemon.setItem('');
+				pokemon.tossItem();
 			}
 		},
 		onTryHit: function(target, source) {

--- a/data/moves.js
+++ b/data/moves.js
@@ -7045,12 +7045,9 @@ exports.BattleMovedex = {
 		},
 		onAfterHit: function(target, source) {
 			if (source.hp) {
-				var item = target.getItem();
-				if (item.id === 'mail') {
-					target.setItem('');
-				} else {
-					item = target.takeItem(source);
-				}
+				target.addVolatile('knockoff');
+				var item = target.takeItem(source);
+				target.removeVolatile('knockoff');
 				if (item) {
 					this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] '+source);
 				}


### PR DESCRIPTION
Neither Fling nor Natural Gift triggered Unburden.
Mails removed by Knock Off were recyclable and did not trigger Unburden either.
Flinged Air Balloons and Eject Buttons were unaffected by Pick Up.
Implemented function pokemon.tossItem, for removing items that would be affected by Recycle and Pick Up, while detecting the removal and triggering a TossItem event.
Replaced the boolean pokemon.usedItemThisTurn by the object pokemon.lastItemTurnData to track the way in which the item was removed.