### PR TITLE
Item usage refactor

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -1989,7 +1989,6 @@ var Battle = (function() {
 					SubDamage: 1,
 					Heal: 1,
 					TakeItem: 1,
-					UseItem: 1,
 					SetStatus: 1,
 					CriticalHit: 1,
 					ModifyPokemon: 1,

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -279,8 +279,10 @@ exports.BattleAbilities = {
 	"cheekpouch": {
 		desc: "Restores HP when this Pokemon consumes a berry.",
 		shortDesc: "Restores HP when this Pokemon consumes a berry.",
-		onEatItem: function(item, pokemon) {
-			this.heal(pokemon.maxhp/4);
+		onUseItem: function(item, pokemon) {
+			if (item.isBerry) {
+				this.heal(pokemon.maxhp/4, pokemon);
+			}
 		},
 		id: "cheekpouch",
 		name: "Cheek Pouch",
@@ -3025,7 +3027,9 @@ exports.BattleAbilities = {
 		onStart: function(pokemon) {
 			this.add('-ability',pokemon,'Unnerve',pokemon.side.foe);
 		},
-		onFoeEatItem: false,
+		onFoeTryUseItem: function(item, pokemon) {
+			if (item.isBerry) return false;
+		},
 		id: "unnerve",
 		name: "Unnerve",
 		rating: 1,

--- a/data/items.js
+++ b/data/items.js
@@ -99,10 +99,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/2) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(pokemon.maxhp/8);
 			if (pokemon.getNature().minus === 'spd') {
 				pokemon.addVolatile('confusion');
@@ -182,10 +182,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4|| (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.boost({spd:1});
 		},
 		num: 205,
@@ -214,10 +214,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.status === 'frz') {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			if (pokemon.status === 'frz') {
 				pokemon.cureStatus();
 			}
@@ -260,13 +260,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Steel' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 199,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Steel-type attack. Single use."
@@ -560,13 +560,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Rock' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 195,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Rock-type attack. Single use."
@@ -582,10 +582,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.status === 'par') {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			if (pokemon.status === 'par') {
 				pokemon.cureStatus();
 			}
@@ -613,10 +613,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.status === 'slp') {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			if (pokemon.status === 'slp') {
 				pokemon.cureStatus();
 			}
@@ -636,13 +636,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Normal' && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 200,
 		gen: 4,
 		desc: "Halves damage taken from a Normal-type attack. Single use."
@@ -744,13 +744,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Fighting' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 189,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Fighting-type attack. Single use."
@@ -777,13 +777,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Flying' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 192,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Flying-type attack. Single use."
@@ -799,13 +799,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Dark' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 198,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Dark-type attack. Single use."
@@ -846,7 +846,7 @@ exports.BattleItems = {
 		},
 		onModifyPriority: function(priority, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4 || (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				if (pokemon.eatItem()) {
+				if (pokemon.useItem()) {
 					this.add('-activate', pokemon, 'Custap Berry');
 					pokemon.removeVolatile('custapberry');
 					return priority + 0.1;
@@ -1169,12 +1169,12 @@ exports.BattleItems = {
 		effect: {
 			duration: 1,
 			onUpdate: function(target) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					target.removeVolatile('enigmaberry');
 				}
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(pokemon.maxhp/4);
 		},
 		num: 208,
@@ -1258,10 +1258,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/2) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(pokemon.maxhp/8);
 			if (pokemon.getNature().minus === 'atk') {
 				pokemon.addVolatile('confusion');
@@ -1441,10 +1441,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4 || (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.boost({def:1});
 		},
 		num: 202,
@@ -1631,13 +1631,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Dragon' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 197,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Dragon-type attack. Single use."
@@ -1749,10 +1749,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/2) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(pokemon.maxhp/8);
 			if (pokemon.getNature().minus === 'def') {
 				pokemon.addVolatile('confusion');
@@ -1875,12 +1875,12 @@ exports.BattleItems = {
 		},
 		onAfterMoveSecondary: function(target, source, move) {
 			if (source && source !== target && move && move.category === 'Physical') {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.damage(source.maxhp/8, source, target);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 211,
 		gen: 4,
 		desc: "If holder is hit by a physical move, attacker loses 1/8 of its max HP. Single use."
@@ -1896,13 +1896,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Ghost' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 196,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Ghost-type attack. Single use."
@@ -1918,13 +1918,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Poison' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 190,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Poison-type attack. Single use."
@@ -1940,10 +1940,10 @@ exports.BattleItems = {
 		},
 		onAfterDamage: function(damage, target, source, move) {
 			if (move.category === 'Physical') {
-				target.eatItem();
+				target.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.boost({def: 1});
 		},
 		num: -6,
@@ -2028,10 +2028,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4 || (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			pokemon.addVolatile('focusenergy');
 		},
 		num: 206,
@@ -2114,10 +2114,10 @@ exports.BattleItems = {
 			if (move && move.pp === 0) {
 				pokemon.addVolatile('leppaberry');
 				pokemon.volatiles['leppaberry'].move = move;
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			var move;
 			if (pokemon.volatiles['leppaberry']) {
 				move = pokemon.volatiles['leppaberry'].move;
@@ -2158,10 +2158,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4 || (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.boost({atk:1});
 		},
 		num: 201,
@@ -2279,10 +2279,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.status || pokemon.volatiles['confusion']) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			pokemon.cureStatus();
 			pokemon.removeVolatile('confusion');
 		},
@@ -2381,10 +2381,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/2) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(pokemon.maxhp/8);
 			if (pokemon.getNature().minus === 'spe') {
 				pokemon.addVolatile('confusion');
@@ -2441,10 +2441,10 @@ exports.BattleItems = {
 		},
 		onAfterDamage: function(damage, target, source, move) {
 			if (move.category === 'Special') {
-				target.eatItem();
+				target.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.boost({spd: 1});
 		},
 		num: -6,
@@ -2646,10 +2646,10 @@ exports.BattleItems = {
 		},
 		onResidual: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4 || (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			pokemon.addVolatile('micleberry');
 		},
 		effect: {
@@ -2831,13 +2831,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Fire' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 184,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Fire-type attack. Single use."
@@ -2881,10 +2881,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/2) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(10);
 		},
 		num: 155,
@@ -2923,13 +2923,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Water' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 185,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Water-type attack. Single use."
@@ -2945,13 +2945,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Psychic' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 193,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Psychic-type attack. Single use."
@@ -2967,10 +2967,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.status === 'psn' || pokemon.status === 'tox') {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			if (pokemon.status === 'psn' || pokemon.status === 'tox') {
 				pokemon.cureStatus();
 			}
@@ -2990,10 +2990,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.volatiles['confusion']) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			pokemon.removeVolatile('confusion');
 		},
 		num: 156,
@@ -3011,10 +3011,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4 || (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.boost({spa:1});
 		},
 		num: 204,
@@ -3268,10 +3268,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.status === 'brn') {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			if (pokemon.status === 'brn') {
 				pokemon.cureStatus();
 			}
@@ -3371,13 +3371,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Grass' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 187,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Grass-type attack. Single use."
@@ -3488,13 +3488,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Fairy' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: -6,
 		gen: 6,
 		desc: "Halves damage taken from a super effective Fairy-type attack. Single use."
@@ -3510,12 +3510,12 @@ exports.BattleItems = {
 		},
 		onAfterMoveSecondary: function(target, source, move) {
 			if (source && source !== target && move && move.category === 'Special') {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.damage(source.maxhp/8, source, target);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 212,
 		gen: 4,
 		desc: "If holder is hit by a special move, attacker loses 1/8 of its max HP. Single use."
@@ -3550,10 +3550,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4 || (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.boost({spe:1});
 		},
 		num: 203,
@@ -3676,13 +3676,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Ground' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 191,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Ground-type attack. Single use."
@@ -3732,10 +3732,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/2) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(pokemon.maxhp/4);
 		},
 		num: 158,
@@ -3924,10 +3924,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/4 || (pokemon.hp <= pokemon.maxhp/2 && pokemon.ability === 'gluttony')) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			var stats = [];
 			for (var i in pokemon.boosts) {
 				if (i !== 'accuracy' && i !== 'evasion' && pokemon.boosts[i] < 6) {
@@ -4045,13 +4045,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Bug' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 194,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Bug-type attack. Single use."
@@ -4183,13 +4183,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Electric' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 186,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Electric-type attack. Single use."
@@ -4337,10 +4337,10 @@ exports.BattleItems = {
 		},
 		onUpdate: function(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp/2) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(pokemon.maxhp/8);
 			if (pokemon.getNature().minus === 'spa') {
 				pokemon.addVolatile('confusion');
@@ -4378,13 +4378,13 @@ exports.BattleItems = {
 		},
 		onSourceModifyDamage: function(damage, source, target, move) {
 			if (move.type === 'Ice' && this.getEffectiveness(move, target) > 0 && !target.volatiles['substitute']) {
-				if (target.eatItem()) {
+				if (target.useItem()) {
 					this.debug('-50% reduction');
 					return this.chainModify(0.5);
 				}
 			}
 		},
-		onEat: function() { },
+		onUseItem: function() { },
 		num: 188,
 		gen: 4,
 		desc: "Halves damage taken from a super effective Ice-type attack. Single use."

--- a/data/moves.js
+++ b/data/moves.js
@@ -1369,8 +1369,7 @@ exports.BattleMovedex = {
 			var item = target.getItem();
 			if (source.hp && item.isBerry && target.takeItem(source)) {
 				this.add('-enditem', target, item.name, '[from] stealeat', '[move] Bug Bite', '[of] '+source);
-				this.singleEvent('Eat', item, null, source, null, null);
-				source.ateBerry = true;
+				source.useItemSuccess(item);
 			}
 		},
 		secondary: false,
@@ -4275,8 +4274,7 @@ exports.BattleMovedex = {
 				move.basePower = item.fling.basePower;
 				if (item.isBerry && item.id !== 'enigmaberry') {
 					move.onHit = function(foe) {
-						this.singleEvent('Eat', item, null, foe, null, null);
-						foe.ateBerry = true;
+						foe.useItemSuccess(item);
 					};
 				} else if (item.fling.effect) {
 					move.onHit = item.fling.effect;
@@ -9298,8 +9296,7 @@ exports.BattleMovedex = {
 			var item = target.getItem();
 			if (source.hp && item.isBerry && target.takeItem(source)) {
 				this.add('-enditem', target, item.name, '[from] stealeat', '[move] Pluck', '[of] '+source);
-				this.singleEvent('Eat', item, null, source, null, null);
-				source.ateBerry = true;
+				source.useItemSuccess(item);
 			}
 		},
 		secondary: false,

--- a/mods/gen2/items.js
+++ b/mods/gen2/items.js
@@ -11,9 +11,9 @@ exports.BattleItems = {
 		name: "Berry",
 		isBerry: true,
 		onUpdate: function(pokemon) {
-			if (pokemon.hp <= pokemon.maxhp/2) pokemon.eatItem();
+			if (pokemon.hp <= pokemon.maxhp/2) pokemon.useItem();
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(10);
 		},
 		num: -2,

--- a/mods/gen3/items.js
+++ b/mods/gen3/items.js
@@ -148,7 +148,7 @@ exports.BattleItems = {
 	},
 	"sitrusberry": {
 		inherit: true,
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			this.heal(30);
 		}
 	},

--- a/mods/gen4/items.js
+++ b/mods/gen4/items.js
@@ -38,10 +38,10 @@ exports.BattleItems = {
 			var decision = this.willMove(pokemon);
 			this.debug('custap decision: '+decision);
 			if (decision) {
-				pokemon.eatItem();
+				pokemon.useItem();
 			}
 		},
-		onEat: function(pokemon) {
+		onUseItem: function(item, pokemon) {
 			var decision = this.willMove(pokemon);
 			this.debug('custap eaten: '+decision);
 			if (decision) {


### PR DESCRIPTION
Deprecate the method pokemon.eatItem, as well as the events 'Eat' and 'EatItem', due to being fundamentally the same as pokemon.useItem, 'Use' and 'UseItem'.
Implement the method pokemon.useItemSuccess  to handle extraordinary item usage (Pluck, Bug Bite, Fling). It's also called by pokemon.useItem.
Implement the event 'TryUseItem' to deal with the failure of ordinary item usage (e.g. due to Unnerve).
This cleans the codebase a bit and fixes bugs with Cheek Pouch (its activating when the opponent has Unnerve, and its not activating when using Pluck, Bug Bite or Fling), and Symbiosis (not activating when an ally eats a berry).