### PR TITLE
Making Gen 3 Wish work properly

### DIFF
--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -702,42 +702,6 @@ exports.BattleMovedex = {
 			}
 		}
 	},
-	"wish2": {
-		num: -273,
-		accuracy: true,
-		basePower: 0,
-		category: "Status",
-		desc: "This is a move that is here to satisfy the wish2 side condition. It has no use otherwise.",
-		shortDesc: "No competitive use.",
-		id: "wish2",
-		name: "Wish2",
-		pp: 0,
-		priority: 0,
-		isSnatchable: true,
-		sideCondition: 'Wish2',
-		effect: {
-			onResidualOrder: 2,
-			onSwitchInPriority: -1,
-			onSwitchIn: function(target) {
-				if (target && !target.fainted && target.hp > 0) {
-					if (!source2) {
-						var source = this.effectData.source;
-					} else {
-						var source = source2;
-						delete source2;
-					}
-					var damage = target.heal(target.maxhp / 2, target, target);
-					if (damage) this.add('-heal',target,target.getHealth,'[from] move: Wish', '[wisher] ' + source.name);
-					target.side.removeSideCondition('Wish2');
-				} else {
-					return;
-				}
-			}
-		},
-		secondary: false,
-		target: "self",
-		type: "Normal"
-	},
 	wrap: {
 		inherit: true,
 		accuracy: 85

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -694,9 +694,49 @@ exports.BattleMovedex = {
 					var source = this.effectData.source;
 					var damage = this.heal(target.maxhp / 2, target, target);
 					if (damage) this.add('-heal', target, target.getHealth, '[from] move: Wish', '[wisher] ' + source.name);
+				} else if (!target || target.fainted || target.hp <= 0) {
+					var source = this.effectData.source;
+					global.source2 = source;
+					target.side.addSideCondition('Wish2');
 				}
 			}
 		}
+	},
+	"wish2": {
+		num: -273,
+		accuracy: true,
+		basePower: 0,
+		category: "Status",
+		desc: "This is a move that is here to satisfy the wish2 side condition. It has no use otherwise.",
+		shortDesc: "No competitive use.",
+		id: "wish2",
+		name: "Wish2",
+		pp: 0,
+		priority: 0,
+		isSnatchable: true,
+		sideCondition: 'Wish2',
+		effect: {
+			onResidualOrder: 2,
+			onSwitchInPriority: -1,
+			onSwitchIn: function(target) {
+				if (target && !target.fainted && target.hp > 0) {
+					if (!source2) {
+						var source = this.effectData.source;
+					} else {
+						var source = source2;
+						delete source2;
+					}
+					var damage = target.heal(target.maxhp / 2, target, target);
+					if (damage) this.add('-heal',target,target.getHealth,'[from] move: Wish', '[wisher] ' + source.name);
+					target.side.removeSideCondition('Wish2');
+				} else {
+					return;
+				}
+			}
+		},
+		secondary: false,
+		target: "self",
+		type: "Normal"
 	},
 	wrap: {
 		inherit: true,

--- a/mods/gen3/statuses.js
+++ b/mods/gen3/statuses.js
@@ -39,5 +39,25 @@ exports.BattleStatuses = {
 		// See http://upokecenter.dreamhosters.com/dex/?lang=en&move=182
 		inherit: true,
 		counterMax: 8
+	},
+	wish2: {
+		// this is a side condition
+		onResidualOrder: 2,
+		onSwitchInPriority: -1,
+		onSwitchIn: function(target) {
+			if (target && !target.fainted && target.hp > 0) {
+				if (!source2) {
+					var source = this.effectData.source;
+				} else {
+					var source = source2;
+					delete source2;
+				}
+				var damage = target.heal(target.maxhp / 2, target, target);
+				if (damage) this.add('-heal',target,target.getHealth,'[from] move: Wish', '[wisher] ' + source.name);
+				target.side.removeSideCondition('Wish2');
+			} else {
+				return;
+			}
+		}
 	}
 };


### PR DESCRIPTION
Wish will now heal the next Pokemon sent in if the initial target has fainted, after spikes damage as it should in gen 3.

As you can probably tell, the implementation is slightly unorthodox [I had to define a new move, wish2, for its side condition, as you cannot define 2 side conditions in moves, if I recall correctly], however this has been tested to work in the initially bugged scenario. If you were to attempt to access wish2 in a gen 3 custom game, it will show up as undefined [like any other move that isn't in the code], effectively making the move invisible except from the code itself. The global variable defined in wish's effect, source2, is immediately deleted after it is finished being used, clearing any unnecessary issues caused by said variable.