### PR TITLE
NEXT: Move Changes, and README Update

### DIFF
--- a/mods/gennext/README.md
+++ b/mods/gennext/README.md
@@ -166,6 +166,8 @@ New mechanic: Signature Pokemon:
 
   - Eelektross: Spark
 
+  - Hitmontop: Triple Kick
+
   - Kingdra: BubbleBeam (30% -1 Spe)
 
   - Galvantula: Electroweb (60 base power, 100% accuracy)
@@ -360,6 +362,8 @@ Minor learnset changes:
   Lock-On, Acid Spray, Octazooka, Stockpile
 
 - Masquerain gets Surf
+
+- Pidgeot gets Focus Blast
 
 - Butterfree, Beautifly, Masquerain, and Mothim get Hurricane
 

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -1013,10 +1013,6 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: true
 	},
-	triplekick: {
-		inherit: true,
-		accuracy: true
-	},
 	watershuriken: {
 		inherit: true,
 		accuracy: true
@@ -1404,6 +1400,14 @@ exports.BattleMovedex = {
 			if (user.template.id === 'galvantula') return this.chainModify(1.5);
 		},
 		accuracy: 100
+	},
+	triplekick: {
+		inherit: true,
+		basePower: 10,
+		onBasePower: function (power, user) {
+			if (user.template.id === 'hitmontop') return this.chainModify(1.5);
+		},
+		accuracy: true
 	},
 	gigadrain: {
 		inherit: true,

--- a/mods/gennext/scripts.js
+++ b/mods/gennext/scripts.js
@@ -18,6 +18,9 @@ exports.BattleScripts = {
 		// Meloetta: Fiery Dance
 		this.modData('Learnsets', 'meloetta').learnset.fierydance = ['5L100'];
 
+		// Pidgeot: Focus Blast
+		this.modData('Learnsets', 'pidgeot').learnset.focusblast = ['5L100'];
+
 		// Galvantula: Zap Cannon
 		this.modData('Learnsets', 'galvantula').learnset.zapcannon = ['5L100'];
 


### PR DESCRIPTION
Triple Kick is now Hitmontop's Signature Move (1.5x damage), Pidgeot learns Focus Blast for it's synergy with it's Mega form, and README is updated to include these changes.