### PR TITLE
Fix /me and /announce in PM messaging

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -130,8 +130,9 @@ var commands = exports.commands = {
 			switch (targetCmd) {
 			case 'me':
 			case 'announce':
+				break;
 			case 'invite':
-				var targetRoomid = toId(target.substr(8));
+				var targetRoomid = toId(target.substr(targetCmdIndex + 1));
 				if (targetRoomid === 'global') return false;
 
 				var targetRoom = Rooms.search(targetRoomid) || Simulator.battles[targetRoomid];


### PR DESCRIPTION
Morfent's changes to /invite accidentally broke /me and /announce since
they ran off the single break command that was there before. This fixes
that by giving them back a break command.

Also updated PM /invite to use targetCmdIndex in case other aliases to
/invite are created in the future; these will break with a hardcoded value
in that substring command.