### PR TITLE
Fix logic error in private room check for /invite

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -135,12 +135,13 @@ var commands = exports.commands = {
 				var targetRoomid = toId(target.substr(8));
 				if (targetRoomid === 'global') return false;
 
-				var targetRoom = Rooms.search(targetRoomid) || Simulator.battles[targetRoomid];
-				if (!targetRoom) return connection.send('|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + "|/text The room '" + targetRoomid + "' does not exist.");
-				if (targetRoom.staffRoom && !targetUser.isStaff) return connection.send('|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + "|/text User '" + this.targetUsername + "' requires global auth to join room '" + targetRoom.id + "'.");
-				if (targetRoom.isPrivate && targetRoom.modjoin &&
-						Config.groupsranking.indexOf(targetRoom.auth[targetUser.userid] || ' ') < Config.groupsranking.indexOf(targetRoom.modjoin) || !targetUser.can('bypassall')) {
-					return connection.send('|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + "|/text The room '" + targetRoomid + "' does not exist.");
+				var targetRoom = Rooms.search(targetRoomid);
+				if (!targetRoom) return connection.send('|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + '|/text The room "' + targetRoomid + '" does not exist.');
+				if (targetRoom.staffRoom && !targetUser.isStaff) return connection.send('|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + '|/text User "' + this.targetUsername + '" requires global auth to join room "' + targetRoom.id + '".');
+				if (targetRoom.isPrivate && targetRoom.modjoin && targetRoom.auth) {
+					if (Config.groupsranking.indexOf(targetRoom.auth[targetUser.userid] || ' ') < Config.groupsranking.indexOf(targetRoom.modjoin) || !targetUser.can('bypassall')) {
+						return connection.send('|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + '|/text The room "' + targetRoomid + '" does not exist.');
+					}
 				}
 
 				target = '/invite ' + targetRoom.id;


### PR DESCRIPTION
Fix possible crash by checking that roomauth exists in a secret room
with modjoin on before checking if the target user has permission to
join. This also fixes a really, really stupid logic error in the last
commit that makes it impossible for anyone that can't bypassall to get
invited anywhere.