### PR TITLE
Six Additions to Random Double Battle Movespools 

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1001,7 +1001,7 @@ exports.BattleFormatsData = {
 	},
 	kangaskhan: {
 		randomBattleMoves: ["return","suckerpunch","earthquake","poweruppunch","crunch","fakeout"],
-		randomDoubleBattleMoves: ["fakeout","return","suckerpunch","earthquake","doubleedge","poweruppunch","crunch","protect"],
+		randomDoubleBattleMoves: ["fakeout","return","suckerpunch","earthquake","doubleedge","poweruppunch","crunch","protect","icepunch"],
 		eventPokemon: [
 			{"generation":3,"level":5,"gender":"F","abilities":["earlybird"],"moves":["yawn","wish"]},
 			{"generation":3,"level":10,"gender":"F","abilities":["earlybird"],"moves":["cometpunch","leer","bite"]},
@@ -3621,7 +3621,7 @@ exports.BattleFormatsData = {
 	},
 	rotomwash: {
 		randomBattleMoves: ["hydropump","thunderbolt","voltswitch","substitute","painsplit","hiddenpowerice","willowisp","trick"],
-		randomDoubleBattleMoves: ["hydropump","thunderbolt","voltswitch","substitute","painsplit","hiddenpowerice","willowisp","trick","electroweb","protect","hiddenpowergrass"],
+		randomDoubleBattleMoves: ["hydropump","thunderbolt","voltswitch","substitute","painsplit","hiddenpowerice","willowisp","trick","electroweb","protect","hiddenpowergrass","lightscreen","reflect"],
 		eventPokemon: [
 			{"generation":5,"level":10,"nature":"Naughty","moves":["uproar","astonish","trick","thundershock"],"pokeball":"cherishball"},
 			{"generation":6,"level":10,"nature":"Quirky","moves":["shockwave","astonish","trick","thunderwave"],"pokeball":"cherishball"}
@@ -3690,7 +3690,7 @@ exports.BattleFormatsData = {
 	},
 	heatran: {
 		randomBattleMoves: ["substitute","fireblast","lavaplume","willowisp","stealthrock","earthpower","hiddenpowerice","protect","toxic","roar"],
-		randomDoubleBattleMoves: ["heatwave","substitute","earthpower","protect","eruption","willowisp"],
+		randomDoubleBattleMoves: ["heatwave","substitute","earthpower","protect","eruption","willowisp","ancientpower"],
 		eventPokemon: [
 			{"generation":4,"level":50,"nature":"Quiet","moves":["eruption","magmastorm","earthpower","ancientpower"]}
 		],
@@ -3907,7 +3907,7 @@ exports.BattleFormatsData = {
 	},
 	serperior: {
 		randomBattleMoves: ["leafstorm","hiddenpowerfire","substitute","leechseed","dragonpulse","gigadrain"],
-		randomDoubleBattleMoves: ["leafstorm","hiddenpowerfire","substitute","taunt","grassyterrain","gigadrain","protect"],
+		randomDoubleBattleMoves: ["leafstorm","hiddenpowerfire","substitute","taunt","grassyterrain","gigadrain","protect","dragonpulse"],
 		eventPokemon: [
 			{"generation":5,"level":100,"gender":"M","isHidden":false,"moves":["leafstorm","substitute","gigadrain","leechseed"],"pokeball":"cherishball"},
 			{"generation":6,"level":50,"gender":"M","isHidden":true,"moves":["leafstorm","holdback","wringout","gigadrain"],"pokeball":"cherishball"}
@@ -4877,7 +4877,7 @@ exports.BattleFormatsData = {
 	},
 	talonflame: {
 		randomBattleMoves: ["bravebird","flareblitz","roost","swordsdance","uturn","willowisp","tailwind"],
-		randomDoubleBattleMoves: ["bravebird","flareblitz","roost","swordsdance","uturn","willowisp","tailwind","taunt","protect"],
+		randomDoubleBattleMoves: ["bravebird","flareblitz","roost","swordsdance","uturn","willowisp","tailwind","taunt","protect","steelwing"],
 		tier: "OU"
 	},
 	scatterbug: {
@@ -4972,7 +4972,7 @@ exports.BattleFormatsData = {
 	},
 	aegislash: {
 		randomBattleMoves: ["kingsshield","swordsdance","shadowclaw","sacredsword","ironhead","shadowsneak","autotomize","hiddenpowerice","shadowball"],
-		randomDoubleBattleMoves: ["kingsshield","swordsdance","shadowclaw","sacredsword","ironhead","shadowsneak","wideguard","hiddenpowerice","shadowball"],
+		randomDoubleBattleMoves: ["kingsshield","swordsdance","shadowclaw","sacredsword","ironhead","shadowsneak","wideguard","hiddenpowerice","shadowball","flashcannon"],
 		eventPokemon: [
 			{"generation":6,"level":50,"gender":"F","nature":"Quiet","moves":["wideguard","kingsshield","shadowball","flashcannon"],"pokeball":"cherishball"}
 		],


### PR DESCRIPTION
I play doubles a lot, and these are moves I have seen rise a lot in usage which may be nice for random battles. If you disagree with any of these, please let me know I only want this to got well.

Reasoning behind:
Talonflame -- Steel Wing: Mega Diancie is rising in and it coutners most of the metagame. A talon flame with Steel Wing has risen in usage to counter all of the common fairy types. 
Aegislash -- Flash Cannon: This move is a staple on every special Aegislash set with Shadow Ball. 
Serperior -- Dragon Pulse: With Serperior finally gaining contrary, dragon pulse works well for neutral coverage once Serperior is boosted, as well as checking Latios and other dragons that may carry ice beam. 
Heatran -- Ancient Power: Ancient Power serves as a check to Volcarona, Talonflame, and Mega Charizard Y. because f the x4 weakness, it almost always OHKO an unsuspecting pokemon. 
RotomWash -- Screens: These moves some of the top people at ladder use on Rotom-Wash I've battled to cut attacks damage as support. I think they are rising in usage.
Kangashkan -- Ice Punch: I see this move all the time now. Like ancient power on heatran, it OHKO's the most used pokemon in all of doubles Landorus-T. It also OHKO flygon, garchomp, and other unsuspecting pokemon with a x4 weakness to ice. As well as checking many used pokemon, Ice punch also can deal heavy damage on any dragon type (i.e. Lati@s) and can hit Ghost types even if it isn't very powerful. 

If you want me to remove any of these, please let me know. If this isn't in the right location, I'm sorry... I'm fairly new to Github :[ 
I hope you like these for random doubles move pools :D