### PR TITLE
Remove Sleep Clause from Random Doubles/Triples

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -141,7 +141,7 @@ exports.Formats = [
 
 		gameType: 'doubles',
 		team: 'randomDoubles',
-		ruleset: ['PotD', 'Pokemon', 'Sleep Clause Mod', 'HP Percentage Mod']
+		ruleset: ['PotD', 'Pokemon', 'HP Percentage Mod']
 	},
 	{
 		name: "Smogon Doubles",
@@ -266,7 +266,7 @@ exports.Formats = [
 
 		gameType: 'triples',
 		team: 'randomDoubles',
-		ruleset: ['PotD', 'Pokemon', 'Sleep Clause Mod', 'HP Percentage Mod']
+		ruleset: ['PotD', 'Pokemon', 'HP Percentage Mod']
 	},
 	{
 		name: "Smogon Triples",


### PR DESCRIPTION
(why it's there, I don't know, it's not that any other doubles format has Sleep Clause Mod, and Dark Void cannot be generated for Random Doubles anyway)