### PR TITLE
Fix Sky Drop's BeforeMovePriority

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -12603,7 +12603,7 @@ exports.BattleMovedex = {
 				if (defender !== this.effectData.source) return;
 				defender.trapped = true;
 			},
-			onFoeBeforeMovePriority: 11,
+			onFoeBeforeMovePriority: 12,
 			onFoeBeforeMove: function (attacker, defender, move) {
 				if (attacker === this.effectData.source) {
 					this.debug('Sky drop nullifying.');


### PR DESCRIPTION
Sky Drop needs to occur before Stance Change and just about every other
ability, move, status, or volatile effect. Since Stance Change was
recently upgraded to BeforeMovePriority of 11, Sky Drop needs to be moved
up to 12.