### PR TITLE
Make Resource monitor spam a room of its own instead of staff room

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,16 +121,16 @@ global.ResourceMonitor = {
 	 */
 	log: function (text) {
 		console.log(text);
-		if (Rooms.rooms.staff) {
-			Rooms.rooms.staff.add('||' + text);
-			Rooms.rooms.staff.update();
+		if (Rooms.rooms.resourcemonitor) {
+			Rooms.rooms.resourcemonitor.add('||' + text);
+			Rooms.rooms.resourcemonitor.update();
 		}
 	},
 	logHTML: function (text) {
 		console.log(text);
-		if (Rooms.rooms.staff) {
-			Rooms.rooms.staff.add('|html|' + text);
-			Rooms.rooms.staff.update();
+		if (Rooms.rooms.resourcemonitor) {
+			Rooms.rooms.resourcemonitor.add('|html|' + text);
+			Rooms.rooms.resourcemonitor.update();
 		}
 	},
 	countConnection: function (ip, name) {


### PR DESCRIPTION
Right now, ResourceMonitor spams staff room. This is usually useless, as most people in there can't do anything about it, and might get alarmed without a good reason. It usually only disrupts chat.
The room 'resourcemonitor' already exists.
If this is pulled in, we should add resourcemonitor to ajoin to technical upper staff on the configuration file or hardcode it in rooms.js