### PR TITLE
Tweak Double Random Battles to include the same things as Random Battle

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1744,7 +1744,7 @@ exports.BattleScripts = {
 		var pokemon = [];
 		for (var i in this.data.FormatsData) {
 			var template = this.getTemplate(i);
-			if (this.data.FormatsData[i].randomBattleMoves && !this.data.FormatsData[i].isNonstandard && !template.evos.length && (template.forme.substr(0, 4) !== 'Mega') && template.forme !== 'Primal') {
+			if (this.data.FormatsData[i].randomBattleMoves && !this.data.FormatsData[i].isNonstandard && !(template.tier in {'LC':1, 'LC Uber':1, 'NFE':1}) && (template.forme.substr(0, 4) !== 'Mega') && template.forme !== 'Primal') {
 				keys.push(i);
 			}
 		}
@@ -1771,6 +1771,10 @@ exports.BattleScripts = {
 			if (keys[i].substr(0, 8) === 'basculin' && Math.random() * 2 > 1) continue;
 			// Genesect formes have 1/5 the normal rate each (so Genesect as a whole has a normal rate)
 			if (keys[i].substr(0, 8) === 'genesect' && Math.random() * 5 > 1) continue;
+			// Gourgeist formes have 1/4 the normal rate each (so Gourgeist as a whole has a normal rate)
+			if (keys[i].substr(0, 9) === 'gourgeist' && Math.random() * 4 > 1) continue;
+			// Pikachu formes have 1/6 the normal rate each (so Pikachu as a whole has a normal rate)
+			if (keys[i].substr(0, 7) === 'pikachu' && Math.random() * 6 > 1) continue;
 			// Not available on XY
 			if (template.species === 'Pichu-Spiky-eared') continue;
 


### PR DESCRIPTION
- Allow tiered NFE Pokemon
- Gourgeist formes have equal chance
- Pikachu formes have equal chance

Basically does the same as 23c830562a4754f18ee4eab4cd3068597d2f9c8e but for double battles.