### PR TITLE
Update gulp-replace to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp": "~3.8.7",
     "gulp-jshint": "~1.8.4",
     "gulp-jscs": "~1.3.1",
-    "gulp-replace": "~0.4.0",
+    "gulp-replace": "~0.5.1",
     "jshint-stylish": "~0.1.5"
   }
 }


### PR DESCRIPTION
The old version of gulp-replace began to cause build errors due to one
of the dependencies (istextorbinary), which was fixed in this newest
release