### PR TITLE
Gen 3: fix Trace Intimidate bug

### DIFF
--- a/mods/gen3/abilities.js
+++ b/mods/gen3/abilities.js
@@ -139,11 +139,10 @@ exports.BattleAbilities = {
 			if (!target || target.fainted) return;
 			var ability = this.getAbility(target.ability);
 			var bannedAbilities = {forecast:1, multitype:1, trace:1};
-			var onStartAbilities = {drizzle:1, drought:1, intimidate:1};
 			if (bannedAbilities[target.ability]) {
 				return;
 			}
-			if (onStartAbilities[target.ability] || pokemon.setAbility(ability)) {
+			if (pokemon.setAbility(ability)) {
 				this.add('-ability', pokemon, ability, '[from] ability: Trace', '[of] ' + target);
 			}
 		}


### PR DESCRIPTION
onStartAbilities tries to fix a bug later fixed in 065e293, but only
serves to prevent said abilities from being traced while still sending
messages that one was traced on each update.