### PR TITLE
Fix Ability Activation Order for type changes

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -68,8 +68,9 @@ exports.BattleAbilities = {
 	"aerilate": {
 		desc: "Turns all of this Pokemon's Normal-typed attacks into Flying-type and deal 1.3x damage. Does not affect Hidden Power.",
 		shortDesc: "This Pokemon's Normal moves become Flying-type and do 1.3x damage.",
+		onModifyMovePriority: -1,
 		onModifyMove: function (move, pokemon) {
-			if (move.type === 'Normal' && move.id !== 'hiddenpower') {
+			if (move.type === 'Normal' && move.id !== 'naturalgift') {
 				move.type = 'Flying';
 				if (move.category !== 'Status') pokemon.addVolatile('aerilate');
 			}
@@ -1752,6 +1753,7 @@ exports.BattleAbilities = {
 	"normalize": {
 		desc: "Makes all of this Pokemon's attacks Normal-typed.",
 		shortDesc: "This Pokemon's moves all become Normal-typed.",
+		onModifyMovePriority: 1,
 		onModifyMove: function (move) {
 			if (move.id !== 'struggle') {
 				move.type = 'Normal';
@@ -1917,8 +1919,9 @@ exports.BattleAbilities = {
 	"pixilate": {
 		desc: "Turns all of this Pokemon's Normal-typed attacks into Fairy-type and deal 1.3x damage. Does not affect Hidden Power.",
 		shortDesc: "This Pokemon's Normal moves become Fairy-type and do 1.3x damage.",
+		onModifyMovePriority: -1,
 		onModifyMove: function (move, pokemon) {
-			if (move.type === 'Normal' && move.id !== 'hiddenpower') {
+			if (move.type === 'Normal' && move.id !== 'naturalgift') {
 				move.type = 'Fairy';
 				if (move.category !== 'Status') pokemon.addVolatile('pixilate');
 			}
@@ -2140,8 +2143,9 @@ exports.BattleAbilities = {
 	"refrigerate": {
 		desc: "Turns all of this Pokemon's Normal-typed attacks into Ice-typed and deal 1.3x damage. Does not affect Hidden Power.",
 		shortDesc: "This Pokemon's Normal moves become Ice-type and do 1.3x damage.",
+		onModifyMovePriority: -1,
 		onModifyMove: function (move, pokemon) {
-			if (move.type === 'Normal' && move.id !== 'hiddenpower') {
+			if (move.type === 'Normal' && move.id !== 'naturalgift') {
 				move.type = 'Ice';
 				if (move.category !== 'Status') pokemon.addVolatile('refrigerate');
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -3478,6 +3478,7 @@ exports.BattleMovedex = {
 			onStart: function (target) {
 				this.add('-singleturn', target, 'move: Electrify');
 			},
+			onModifyMovePriority: -2,
 			onModifyMove: function (move) {
 				this.debug('Electrify making move type electric');
 				move.type = 'Electric';
@@ -4526,7 +4527,7 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.effectData.item = pokemon.item;
 			},
-			onModifyMovePriority: -1,
+			onModifyMovePriority: -3,
 			onModifyMove: function (move) {
 				var item = this.getItem(this.effectData.item);
 				move.basePower = item.fling.basePower;
@@ -7297,6 +7298,7 @@ exports.BattleMovedex = {
 			onStart: function (target) {
 				this.add('-fieldactivate', 'move: Ion Deluge');
 			},
+			onModifyMovePriority: -2,
 			onModifyMove: function (move) {
 				if (move.type === 'Normal') {
 					move.type = 'Electric';

--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -63,6 +63,15 @@ exports.BattleAbilities = {
 		rating: 0,
 		num: 58
 	},
+	"normalize": {
+		inherit: true,
+		onModifyMovePriority: -1,
+		onModifyMove: function (move) {
+			if (move.id !== 'struggle') {
+				move.type = 'Normal';
+			}
+		}
+	},
 	"pickup": {
 		desc: "No in-battle effect.",
 		shortDesc: "No in-battle effect.",


### PR DESCRIPTION
~~Hidden Power is unaffected by Normalize.~~

~~Also a researcher should check if it's the case with Judgment and Techno Blast.~~

Fixed ability interactions with Hidden Power, Judgment, and other moves
that change their types.

Normalize > move's type change > -ate Ability > Ion Deluge/Electrify

For Gen 4, the order is: move's type change > Normalize