### PR TITLE
NEXT: Bone Club ignores immunities

### DIFF
--- a/mods/gennext/README.md
+++ b/mods/gennext/README.md
@@ -321,9 +321,9 @@ Minor move changes:
 - Sound-based moves are no longer affected by immunities (ghosts can hear
   things)
 
-- Bonemerang and Bone Rush no longer affected by immunities (you can throw
-  a bone to hit air), Bone Rush nerfed to 20 base power since it should never
-  be viable
+- Bonemerang, Bone Club and Bone Rush are no longer affected by immunities 
+  (you can throw a bone to hit birds), Bone Rush nerfed to 20 base power 
+  since it should never be viable
 
 - Wing Attack and Power Gem are now like Dual Chop: 40 base power, 2-hit
 

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -694,8 +694,8 @@ exports.BattleMovedex = {
 		affectedByImmunities: false
 	},
 	/******************************************************************
-	Bonemerang, Bone Rush moves:
-	- not affected by immunities
+	Bonemerang, Bone Rush, Bone Club moves:
+	- not affected by Ground immunities
 	- Bone Rush nerfed to 20 base power so it's not viable on Lucario
 
 	Justification:
@@ -711,6 +711,11 @@ exports.BattleMovedex = {
 		basePower: 20,
 		affectedByImmunities: false,
 		accuracy: true
+	},
+	boneclub: {
+		inherit: true,
+		affectedByImmunities: false,
+		accuracy: 90
 	},
 	/******************************************************************
 	Relic Song:
@@ -1691,10 +1696,6 @@ exports.BattleMovedex = {
 		accuracy: 90
 	},
 	takedown: {
-		inherit: true,
-		accuracy: 90
-	},
-	boneclub: {
 		inherit: true,
 		accuracy: 90
 	},


### PR DESCRIPTION
~~Uses the same logic as Thousand Arrows - if Marowak somehow gets
Normalize (via Skill Swap) it shouldn't be able to hit Ghosts with
Bonemarang.~~

Bone Club is the last, forgotten Bone attack, so we let it ignore immunities
like Bonemerang and Bone Rush do.

Updated the README to have these changes.