### PR TITLE
NEXT: Shadow Tag bug fix

### DIFF
--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -588,18 +588,20 @@ exports.BattleAbilities = {
 			pokemon.addVolatile('shadowtag');
 		},
 		effect: {
+			duration: 2,
 			onFoeModifyPokemon: function (pokemon) {
 				if (pokemon.ability !== 'shadowtag') {
 					pokemon.tryTrap(true);
 				}
 			}
 		},
+		onBeforeMovePriority: 15,
 		onBeforeMove: function (pokemon) {
 			pokemon.removeVolatile('shadowtag');
 		},
 		onFoeMaybeTrapPokemon: function (pokemon, source) {
 			if (!source) source = this.effectData.target;
-			if (pokemon.ability !== 'shadowtag' && !source.lastMove) {
+			if (pokemon.ability !== 'shadowtag' && !source.volatiles.shadowtag) {
 				pokemon.maybeTrapped = true;
 			}
 		}


### PR DESCRIPTION
The NEXT Readme says that Shadow Tag only lasts one turn, and this is
solved by applying a volatile to the Pokemon with Shadow Tag and removing
it when it attacks for the first time after switching in.

However, if the Pokemon with Shadow Tag is flinched, frozen, put to sleep,
or paralyzed, the effect of Shadow Tag will continue to later turns!

This is solved by giving Shadow Tag's BeforeMove event a higher priority
so that it can remove the volatile before flinching.