### PR TITLE
Random Battle: Priority vs. Choice Scarf and speed boosting moves

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -987,7 +987,7 @@ exports.BattleScripts = {
 				Physical: 0, Special: 0, Status: 0, damage: 0,
 				technician: 0, skilllink: 0, contrary: 0, sheerforce: 0, ironfist: 0, adaptability: 0, hustle: 0,
 				blaze: 0, overgrow: 0, swarm: 0, torrent: 0, serenegrace: 0,
-				recoil: 0, inaccurate: 0,
+				recoil: 0, inaccurate: 0, priority: 0,
 				physicalsetup: 0, specialsetup: 0, mixedsetup: 0
 			};
 			setupType = '';
@@ -1043,6 +1043,8 @@ exports.BattleScripts = {
 				}
 				// Moves with low accuracy:
 				if (move.accuracy && move.accuracy !== true && move.accuracy < 90) counter['inaccurate']++;
+				// Moves with non-zero priority:
+				if (move.priority !== 0) counter['priority']++;
 
 				// Moves that change stats:
 				if (ContraryMove[moveid]) counter['contrary']++;
@@ -1301,6 +1303,11 @@ exports.BattleScripts = {
 					if (hasMove['thunderwave'] || hasMove['willowisp'] || hasMove['yawn'] || hasMove['spore'] || hasMove['sleeppowder'] || hasMove['stunspore'] || hasMove['hypnosis']) rejected = true;
 					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
 					break;
+				}
+
+				// Increased/decreased priority moves unneeded with moves that boost only speed
+				if (move.priority !== 0 && (hasMove['rockpolish'] || hasMove['agility'])) {
+					rejected = true;
 				}
 
 				if (move.category === 'Special' && setupType === 'Physical' && !SetupException[move.id]) {
@@ -1601,9 +1608,9 @@ exports.BattleScripts = {
 			// less priority than if you'd had both
 			item = 'Light Clay';
 		} else if (counter.Physical >= 4 && !hasMove['fakeout'] && !hasMove['suckerpunch'] && !hasMove['flamecharge'] && !hasMove['rapidspin']) {
-			item = template.baseStats.spe > 82 && template.baseStats.spe < 109 && Math.random() * 3 > 1 ? 'Choice Scarf' : 'Choice Band';
+			item = template.baseStats.spe > 82 && template.baseStats.spe < 109 && !counter['priority'] && Math.random() * 3 > 1 ? 'Choice Scarf' : 'Choice Band';
 		} else if (counter.Special >= 4) {
-			item = template.baseStats.spe > 82 && template.baseStats.spe < 109 && Math.random() * 3 > 1 ? 'Choice Scarf' : 'Choice Specs';
+			item = template.baseStats.spe > 82 && template.baseStats.spe < 109 && !counter['priority'] && Math.random() * 3 > 1 ? 'Choice Scarf' : 'Choice Specs';
 		} else if (this.getEffectiveness('Ground', template) >= 2 && !hasType['Poison'] && ability !== 'Levitate' && !hasMove['magnetrise']) {
 			item = 'Air Balloon';
 		} else if ((hasMove['eruption'] || hasMove['waterspout']) && !counter['Status']) {
@@ -2342,6 +2349,11 @@ exports.BattleScripts = {
 				case 'toxic':
 					if (hasMove['thunderwave'] || hasMove['willowisp'] || hasMove['scald'] || hasMove['yawn'] || hasMove['spore'] || hasMove['sleeppowder']) rejected = true;
 					break;
+				}
+
+				// Increased/decreased priority moves unneeded with moves that boost only speed
+				if (move.priority !== 0 && (hasMove['rockpolish'] || hasMove['agility'])) {
+					rejected = true;
 				}
 
 				if (move.category === 'Special' && setupType === 'Physical' && !SetupException[move.id]) {


### PR DESCRIPTION
I'm not sure if these particular set generation policies are a good idea.

Maybe instead, remove the priority move if the Pokemon has Rock Polish/Agility, and not the other way around?