### PR TITLE
Fix Leech Seed on Allies

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -7712,7 +7712,7 @@ exports.BattleMovedex = {
 			},
 			onResidualOrder: 8,
 			onResidual: function (pokemon) {
-				var target = pokemon.side.foe.active[pokemon.volatiles['leechseed'].sourcePosition];
+				var target = this.effectData.source.side.active[pokemon.volatiles['leechseed'].sourcePosition];
 				if (!target || target.fainted || target.hp <= 0) {
 					this.debug('Nothing to leech into');
 					return;


### PR DESCRIPTION
When Leech Seed targets an ally in Double Battles, it should heal the
Pokemon at the ally's position, not an enemy.