### PR TITLE
NEXT: Remove mention of Aegislash on NEXT banlist

### DIFF
--- a/mods/gennext/README.md
+++ b/mods/gennext/README.md
@@ -508,6 +508,6 @@ Specifically, differences from regular OU:
 
 - unbanned: Gengarite, Kangaskhanite, Lucarionite, Blaziken, Genesect, Mawilite, Salamencite
 
-- banned: Kyurem, Kyurem-Black, Aegislash
+- banned: Kyurem, Kyurem-Black
 
 - There is no Moody Clause or Evasion Clause


### PR DESCRIPTION
Aegislash is already banned from OU, so there is no need to mention its
banning as one of the "differences from OU".