### PR TITLE
Random Doubles Battle: Fix Stone Edge Redundancy Check

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2262,10 +2262,7 @@ exports.BattleScripts = {
 					if (hasMove['thunderbolt']) rejected = true;
 					break;
 				case 'stoneedge':
-					if (hasMove['rockslide']) rejected = true;
-					break;
-				case 'stoneedge':
-					if (hasMove['headsmash']) rejected = true;
+					if (hasMove['rockslide'] || hasMove['headsmash'] || hasMove['rockslide']) rejected = true;
 					break;
 				case 'bonemerang': case 'earthpower':
 					if (hasMove['earthquake']) rejected = true;
@@ -2296,9 +2293,6 @@ exports.BattleScripts = {
 					break;
 				case 'hiddenpowerice':
 					if (hasMove['icywind']) rejected = true;
-					break;
-				case 'stone edge':
-					if (hasMove['rockblast']) rejected = true;
 					break;
 
 				// Status:


### PR DESCRIPTION
Stone Edge somehow was a case three times in the switch statement, meaning
only the first one would have been checked. This fix merges the three
checks into one.