### PR TITLE
Fix Unaware in Doubles and refactor stat ignoring abilities

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2950,9 +2950,11 @@ Battle = (function () {
 			ignoreNegativeOffensive = true;
 			ignorePositiveDefensive = true;
 		}
-
-		var ignoreOffensive = !!(move.ignoreOffensive || (ignoreNegativeOffensive && atkBoosts < 0));
-		var ignoreDefensive = !!(move.ignoreDefensive || (ignorePositiveDefensive && defBoosts > 0));
+		// Check for abilities to see if defenses or offenses are negated (Unaware, Mold Breaker, etc.)
+		var targetAbilityIgnoreOffensive = !target.ignore['Ability'] && target.getAbility().ignoreOffensive;
+		var pokemonAbilityIgnoreDefensive = !pokemon.ignore['Ability'] && pokemon.getAbility().ignoreDefensive;
+		var ignoreOffensive = !!(move.ignoreOffensive || targetAbilityIgnoreOffensive || (ignoreNegativeOffensive && atkBoosts < 0));
+		var ignoreDefensive = !!(move.ignoreDefensive || pokemonAbilityIgnoreDefensive || (ignorePositiveDefensive && defBoosts > 0));
 
 		if (ignoreOffensive) {
 			this.debug('Negating (sp)atk boost/penalty.');

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -3078,15 +3078,10 @@ exports.BattleAbilities = {
 		shortDesc: "This Pokemon ignores other Pokemon's stat changes when taking or doing damage.",
 		id: "unaware",
 		name: "Unaware",
-		onModifyMove: function (move, user, target) {
-			move.ignoreEvasion = true;
-			move.ignoreDefensive = true;
-		},
-		onSourceModifyMove: function (move, user, target) {
-			if (user.hasAbility(['moldbreaker', 'turboblaze', 'teravolt'])) return;
-			move.ignoreAccuracy = true;
-			move.ignoreOffensive = true;
-		},
+		ignoreEvasion: true,
+		ignoreDefensive: true,
+		ignoreAccuracy: true,
+		ignoreOffensive: true,
 		rating: 3,
 		num: 109
 	},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -225,14 +225,16 @@ exports.BattleScripts = {
 		// calculate true accuracy
 		var accuracy = move.accuracy;
 		if (accuracy !== true) {
-			if (!move.ignoreAccuracy) {
+			var targetAbilityIgnoreAccuracy = !target.ignore['Ability'] && target.getAbility().ignoreAccuracy;
+			if (!move.ignoreAccuracy && !targetAbilityIgnoreAccuracy) {
 				if (pokemon.boosts.accuracy > 0) {
 					accuracy *= boostTable[pokemon.boosts.accuracy];
 				} else {
 					accuracy /= boostTable[-pokemon.boosts.accuracy];
 				}
 			}
-			if (!move.ignoreEvasion) {
+			var pokemonAbilityIgnoreEvasion = !pokemon.ignore['Ability'] && pokemon.getAbility().ignoreEvasion;
+			if (!move.ignoreEvasion && !pokemonAbilityIgnoreEvasion) {
 				if (target.boosts.evasion > 0 && !move.ignorePositiveEvasion) {
 					accuracy /= boostTable[target.boosts.evasion];
 				} else if (target.boosts.evasion < 0) {


### PR DESCRIPTION
Unaware currently doesn't work because the ModifyMove event is fired on the move before each target is caculated in doubles and triples.
This means that the ModifyMove event should be fired for each target and the move not modified unless it fits the attacker-target.
It's easier and less expensive to use an ability property to check on attacker/target than to fire events.
This fixes Unaware in doubles/triples.