### PR TITLE
Prevent arbitrary JS in Pokemon names

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2307,11 +2307,11 @@ Battle = (function () {
 		if (typeof id !== 'string') id = id.id;
 		for (var i = 0; i < this.p1.pokemon.length; i++) {
 			var pokemon = this.p1.pokemon[i];
-			if (pokemon.id === id) return pokemon;
+			if (pokemon.id === id) return '' + pokemon;
 		}
 		for (var i = 0; i < this.p2.pokemon.length; i++) {
 			var pokemon = this.p2.pokemon[i];
-			if (pokemon.id === id) return pokemon;
+			if (pokemon.id === id) return '' + pokemon;
 		}
 		return null;
 	};


### PR DESCRIPTION
Currently, arbitrary javascript can be injected into battles theough
/eval and /evalbattle in the Pokemon name. The >s in their names will
still display, but they will no longer have the battle run their
injected code.