### PR TITLE
Gen 1: Fix typo in formats-data.js

### DIFF
--- a/mods/gen1/formats-data.js
+++ b/mods/gen1/formats-data.js
@@ -445,7 +445,7 @@ exports.BattleFormatsData = {
 		tier: "UU"
 	},
 	voltorb: {
-		andomBattleMoves: ["thunder","thunderbolt","thunderwave","screech","flash","reflect"],
+		randomBattleMoves: ["thunder","thunderbolt","thunderwave","screech","flash","reflect"],
 		essentialMove: "explosion",
 		tier: "LC"
 	},


### PR DESCRIPTION
This fix makes Voltorb viable for selection for Gen 1 RandBats... for the one person that wanted it.