### PR TITLE
Support animation parameters for moves

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -384,6 +384,7 @@ exports.Formats = [
 				move.name = "Train Recruits";
 				move.accuracy = 100;
 				move.target = "self";
+				move.animAlias = 'Bulk Up';
 				move.onTryHit = function (target, source, move) {
 					if (this.seasonal.songCount < this.seasonal.song.length) {
 						this.add('-message', '"' + this.seasonal.song[this.seasonal.songCount] + '"');
@@ -410,6 +411,7 @@ exports.Formats = [
 				move.basePower = 180;
 				move.type = '???';
 				move.accuracy = 90;
+				move.animAlias = 'Eruption';
 				delete move.secondaries;
 				move.ignoreOffense = true; // Fireworks not affected by boosts from morale
 				move.onTry = function (source, target) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -82,6 +82,8 @@ exports.BattleScripts = {
 
 		if (move.isTwoTurnMove && !pokemon.volatiles[move.id]) {
 			attrs = '|[still]'; // suppress the default move animation
+		} else if (move.animAlias) {
+			attrs = '|[animalias]' + this.getMove(move.animAlias);
 		}
 
 		var movename = move.name;


### PR DESCRIPTION
Adds the [animalias] parameter, which allows a move to use a different
move's animation in the client. The intention is to use this with game
mods that have special moves that aren't coded into the server.