### PR TITLE
Seasonal: Nerf Han Chinese Side, Flavor Changes

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -361,7 +361,7 @@ exports.Formats = [
 		team: 'randomSeasonalMulan',
 		ruleset: ['HP Percentage Mod', 'Sleep Clause Mod', 'Cancel Mod'],
 		onBegin: function () {
-			this.add('message', "General Shang! The Huns are marching towards the Imperial City! Train your recruits quickly and make your stand!");
+			this.add('message', "General Li Shang! The Huns are marching towards the Imperial City! Train your recruits quickly and make your stand!");
 			this.seasonal.songCount = 0;
 			this.seasonal.song = [
 				"Let's get down to business, to defeat the Huns!", "Did they send me daughters, when I asked for sons?",
@@ -385,16 +385,14 @@ exports.Formats = [
 				move.accuracy = 100;
 				move.target = "self";
 				move.onTryHit = function (target, source, move) {
+					this.attrLastMove('[still]');
+					this.add('-anim', source, "Bulk Up", source);
 					if (this.seasonal.songCount < this.seasonal.song.length) {
 						this.add('-message', '"' + this.seasonal.song[this.seasonal.songCount] + '"');
 						if (this.seasonal.verses[this.seasonal.songCount]) {
 							this.add('-message', "Because of the difficult training, the new recruits are more experienced!");
 							if (this.seasonal.songCount === 27) {
 								this.add('-message', "The recruits are now fully trained!");
-							}
-							if (source.name !== 'Li Shang' && source.name !== 'Mushu') {
-								var boosts = (this.seasonal.morale % 2 ? {def: 1, spd: 1} : {atk: 1, spa: 1});
-								this.boost(boosts, source, source, move);
 							}
 							this.seasonal.morale++;
 						}
@@ -404,20 +402,26 @@ exports.Formats = [
 					}
 					return null;
 				};
-			} else if (move.id === 'octazooka') {
+			} else if (move.id === 'searingshot') {
 				move.name = "Fire Rocket";
 				move.category = 'Physical';
-				move.basePower = 180;
+				move.basePower = 160;
 				move.type = '???';
-				move.accuracy = 90;
+				move.accuracy = 80;
+				move.willCrit = false;
 				delete move.secondaries;
+				delete move.flags.bullet;
 				move.ignoreOffense = true; // Fireworks not affected by boosts from morale
 				move.onTry = function (source, target) {
+					this.attrLastMove('[still]');
 					// If the soldier is inexperienced, the rocket can explode in their face. 50% chance at 0 morale, 33% at 1, 17% at 2, 0% afterwards.
 					if (source.name !== 'Li Shang' && (this.random(6) > (this.seasonal.morale + 2))) {
+						this.add('-anim', source, "Eruption", source);
 						this.add('-message', "But " + source.name + "'s inexperience caused the rocket to backfire!");
 						this.damage(Math.ceil(source.maxhp / 8), source, source, "the explosion", true);
 						return null;
+					} else {
+						this.add('-anim', source, "Eruption", target);
 					}
 				};
 			} else if (move.id === 'sacredfire') {
@@ -429,7 +433,7 @@ exports.Formats = [
 			this.seasonal.morale = this.seasonal.morale || 0;
 			if (pokemon.name in {'Mulan': 1, 'Yao': 1, 'Ling': 1, 'Chien-Po': 1}) {
 				var offense = Math.ceil(this.seasonal.morale / 2) - 1;
-				var defense = Math.floor(this.seasonal.morale / 2);
+				var defense = Math.floor(this.seasonal.morale / 2) - 1;
 				this.boost({atk: offense, spa: offense, def: defense, spd: defense}, pokemon, pokemon, this.getMove('sing'));
 			}
 

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2752,6 +2752,9 @@ exports.BattleScripts = {
 				pokemon = chinese[i];
 				template = this.getTemplate(pokemon);
 
+				// Li Shang shouldn't be an NFE Pokemon.
+				if (names[pokemonLeft] === "Li Shang" && template.evos.length) continue;
+
 				// We don't want too many Fighting or Flying weaknesses, since those moves will be common
 				// Hard limit it to two, since after factoring in Chien-Po we might have a lot of common weakness
 				var mainWeakness = {};
@@ -2774,8 +2777,10 @@ exports.BattleScripts = {
 				set.species = toId(set.name);
 				set.name = names[pokemonLeft];
 				set.gender = (set.name === "Mulan" ? 'F' : 'M');
-				set.moves[4] = 'sing';
-				set.moves[5] = 'octazooka';
+				set.moves[4] = 'searingshot';
+				if (set.name === "Li Shang") {
+					set.moves[5] = 'sing';
+				}
 				team.push(set);
 				pokemonLeft++;
 			}
@@ -2788,20 +2793,19 @@ exports.BattleScripts = {
 			set.species = toId(set.name);
 			set.name = "Chien-Po";
 			set.gender = 'M';
-			set.moves[4] = 'sing';
-			set.moves[5] = 'octazooka';
+			set.moves[4] = 'searingshot';
 			team.push(set);
 
 			// Add Eddie Murphy-- I mean, Mushu, to the team as a Dragonair.
 			template = this.getTemplate('dragonair');
-			template.randomBattleMoves = ['dragondance', 'outrage', 'aquatail', 'waterfall', 'fusionbolt', 'extremespeed', 'dracometeor', 'dragonascent'];
+			template.randomBattleMoves = ['dragondance', 'aquatail', 'waterfall', 'wildcharge', 'extremespeed', 'dracometeor', 'dragonascent'];
 			set = this.randomSet(template, 5);
 			set.species = toId(set.name);
 			set.name = "Mushu";
 			set.gender = 'M';
 			set.ability = "Turboblaze";
-			set.moves[4] = 'sing';
-			set.moves[5] = 'sacredfire';
+			set.moves[4] = 'sacredfire';
+			set.moves[5] = 'dragonrush';
 			team.push(set);
 		} else {
 			var huns = [


### PR DESCRIPTION
Mechanics Changes:
- Fire Rocket does less damage, cannot crit.
- Fire Rocket is no longer a bullet move (for Chesnaught)
- Only Li Shang can Train Recruits.
- Recruits start with lowered defenses as well.
- Edit Mushu's movepool.

Flavor Changes:
- Train Recruits now uses Bulk Up's animation.
- Fire Rocket now uses Eruption's animation. Backfires cause the animation
  to strike the user instead!
- Use Searing Shot as Fire Rocket instead of Octazooka.