### PR TITLE
Fix Anger Point's Interaction with Mold Breaker

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -120,8 +120,9 @@ exports.BattleAbilities = {
 	"angerpoint": {
 		desc: "If this Pokemon, and not its Substitute, is struck by a Critical Hit, its Attack is boosted to six stages.",
 		shortDesc: "If this Pokemon is hit by a critical hit, its Attack is boosted by 12.",
-		onCriticalHit: function (target) {
-			if (!target.volatiles['substitute']) {
+		onAfterDamage: function (damage, target, source, move) {
+			if (!target.hp) return;
+			if (move && move.effectType === 'Move' && move.crit) {
 				target.setBoost({atk: 6});
 				this.add('-setboost', target, 'atk', 12, '[from] ability: Anger Point');
 			}

--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -3,9 +3,12 @@ exports.BattleAbilities = {
 		inherit: true,
 		desc: "If this Pokemon, or its Substitute, is struck by a Critical Hit, its Attack is boosted to six stages.",
 		shortDesc: "If this Pokemon is hit by a critical hit, its Attack is boosted by 12.",
-		onCriticalHit: function (target) {
-			target.setBoost({atk: 6});
-			this.add('-setboost', target, 'atk', 12, '[from] ability: Anger Point');
+		onAfterSubDamage: function (damage, target, source, move) {
+			if (!target.hp) return;
+			if (move && move.effectType === 'Move' && move.crit) {
+				target.setBoost({atk: 6});
+				this.add('-setboost', target, 'atk', 12, '[from] ability: Anger Point');
+			}
 		}
 	},
 	"leafguard": {


### PR DESCRIPTION
Moved Anger Point's check for critical from onCritical to onAfterDamage.
This not only allows it to avoid being suppressed by Mold Breaker, it
also results in the Anger Point message being displayed in the correct
order with respect to the other messages.