### PR TITLE
Weather Refactor: Regular weathers don't activate w/ Primal Weather set

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -1633,6 +1633,19 @@ Battle = (function () {
 		if (source === undefined && this.event && this.event.target) source = this.event.target;
 
 		if (this.weather === status.id && this.gen > 2) return false;
+		if (status.id) {
+			var result = this.runEvent('SetWeather', source, source, status);
+			if (!result) {
+				if (result === false) {
+					if (sourceEffect && sourceEffect.weather) {
+						this.add('-fail', source, sourceEffect, '[from]: ' + this.weather);
+					} else if (sourceEffect && sourceEffect.effectType === 'Ability') {
+						this.add('-ability', source, sourceEffect, '[from] ' + this.weather, '[fail]');
+					}
+				}
+				return null;
+			}
+		}
 		if (this.weather && !status.id) {
 			var oldstatus = this.getWeather();
 			this.singleEvent('End', oldstatus, this.weatherData, this);

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -600,10 +600,6 @@ exports.BattleAbilities = {
 		desc: "When this Pokemon enters the battlefield, the weather becomes Rain Dance (for 5 turns normally, or 8 turns while holding Damp Rock).",
 		shortDesc: "On switch-in, the weather becomes Rain Dance.",
 		onStart: function (source) {
-			if (this.isWeather(['desolateland', 'primordialsea', 'deltastream'])) {
-				this.add('-ability', source, 'Drizzle', '[from] ' + this.effectiveWeather(), '[fail]');
-				return null;
-			}
 			this.setWeather('raindance');
 		},
 		id: "drizzle",
@@ -615,10 +611,6 @@ exports.BattleAbilities = {
 		desc: "When this Pokemon enters the battlefield, the weather becomes Sunny Day (for 5 turns normally, or 8 turns while holding Heat Rock).",
 		shortDesc: "On switch-in, the weather becomes Sunny Day.",
 		onStart: function (source) {
-			if (this.isWeather(['desolateland', 'primordialsea', 'deltastream'])) {
-				this.add('-ability', source, 'Drought', '[from] ' + this.effectiveWeather(), '[fail]');
-				return null;
-			}
 			this.setWeather('sunnyday');
 		},
 		id: "drought",
@@ -2267,10 +2259,6 @@ exports.BattleAbilities = {
 		desc: "When this Pokemon enters the battlefield, the weather becomes Sandstorm (for 5 turns normally, or 8 turns while holding Smooth Rock).",
 		shortDesc: "On switch-in, the weather becomes Sandstorm.",
 		onStart: function (source) {
-			if (this.isWeather(['desolateland', 'primordialsea', 'deltastream'])) {
-				this.add('-ability', source, 'Sand Stream', '[from] ' + this.effectiveWeather(), '[fail]');
-				return null;
-			}
 			this.setWeather('sandstorm');
 		},
 		id: "sandstream",
@@ -2525,10 +2513,6 @@ exports.BattleAbilities = {
 		desc: "When this Pokemon enters the battlefield, the weather becomes Hail (for 5 turns normally, or 8 turns while holding Icy Rock).",
 		shortDesc: "On switch-in, the weather becomes Hail.",
 		onStart: function (source) {
-			if (this.isWeather(['desolateland', 'primordialsea', 'deltastream'])) {
-				this.add('-ability', source, 'Snow Warning', '[from] ' + this.effectiveWeather(), '[fail]');
-				return null;
-			}
 			this.setWeather('hail');
 		},
 		id: "snowwarning",

--- a/data/moves.js
+++ b/data/moves.js
@@ -5779,12 +5779,6 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {},
 		weather: 'hail',
-		onTry: function (target, source) {
-			if (this.isWeather(['desolateland', 'primordialsea', 'deltastream'])) {
-				this.add('-fail', source, 'move: Hail', '[from]: ' + this.effectiveWeather());
-				return null;
-			}
-		},
 		secondary: false,
 		target: "all",
 		type: "Ice"
@@ -10883,12 +10877,6 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {},
 		weather: 'RainDance',
-		onTry: function (target, source) {
-			if (this.isWeather(['desolateland', 'primordialsea', 'deltastream'])) {
-				this.add('-fail', source, 'move: Rain Dance', '[from]: ' + this.effectiveWeather());
-				return null;
-			}
-		},
 		secondary: false,
 		target: "all",
 		type: "Water"
@@ -11862,12 +11850,6 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {},
 		weather: 'Sandstorm',
-		onTry: function (target, source) {
-			if (this.isWeather(['desolateland', 'primordialsea', 'deltastream'])) {
-				this.add('-fail', source, 'move: Sandstorm', '[from]: ' + this.effectiveWeather());
-				return null;
-			}
-		},
 		secondary: false,
 		target: "all",
 		type: "Rock"
@@ -13890,12 +13872,6 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {},
 		weather: 'sunnyday',
-		onTry: function (target, source) {
-			if (this.isWeather(['desolateland', 'primordialsea', 'deltastream'])) {
-				this.add('-fail', source, 'move: Sunny Day', '[from]: ' + this.effectiveWeather());
-				return null;
-			}
-		},
 		secondary: false,
 		target: "all",
 		type: "Fire"

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -434,6 +434,9 @@ exports.BattleStatuses = {
 				return this.chainModify(1.5);
 			}
 		},
+		onSetWeather: function (target, source, weather) {
+			if (!(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
+		},
 		onStart: function () {
 			this.add('-weather', 'PrimordialSea');
 		},
@@ -500,6 +503,9 @@ exports.BattleStatuses = {
 				this.debug('Sunny Day fire boost');
 				return this.chainModify(1.5);
 			}
+		},
+		onSetWeather: function (target, source, weather) {
+			if (!(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
 		},
 		onStart: function () {
 			this.add('-weather', 'DesolateLand');
@@ -590,6 +596,9 @@ exports.BattleStatuses = {
 				this.add('-activate', '', 'deltastream');
 				return 0;
 			}
+		},
+		onSetWeather: function (target, source, weather) {
+			if (!(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
 		},
 		onStart: function () {
 			this.add('-weather', 'DeltaStream');


### PR DESCRIPTION
Moved all checks for primal weather into setWeather() instead of
hard-coding the check into every effect attempting to change the weather.

Also to prevent hardcoding, the check now runs on the event system, and
the primal weathers themselves deny regular weathers from being set.