### PR TITLE
Random Battle Updates

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -563,7 +563,7 @@ exports.BattleFormatsData = {
 		tier: "NFE"
 	},
 	poliwrath: {
-		randomBattleMoves: ["raindance","hydropump","focusblast","icebeam","rest","sleeptalk","scald","circlethrow"],
+		randomBattleMoves: ["hydropump","focusblast","icebeam","rest","sleeptalk","scald","circlethrow"],
 		randomDoubleBattleMoves: ["substitute","helpinghand","icywind","encore","waterfall","protect","icepunch","poisonjab","earthquake","brickbreak"],
 		eventPokemon: [
 			{"generation":3,"level":42,"moves":["helpinghand","hydropump","raindance","brickbreak"]}
@@ -3602,11 +3602,11 @@ exports.BattleFormatsData = {
 		tier: "PU"
 	},
 	finneon: {
-		randomBattleMoves: ["surf","uturn","icebeam","hiddenpowerelectric","hiddenpowergrass","raindance"],
+		randomBattleMoves: ["surf","uturn","icebeam","hiddenpowerelectric","hiddenpowergrass"],
 		tier: "LC"
 	},
 	lumineon: {
-		randomBattleMoves: ["waterfall","scald","uturn","icebeam","toxic","raindance"],
+		randomBattleMoves: ["waterfall","scald","uturn","icebeam","toxic"],
 		randomDoubleBattleMoves: ["surf","uturn","icebeam","toxic","raindance","tailwind","protect"],
 		tier: "PU"
 	},
@@ -4140,7 +4140,7 @@ exports.BattleFormatsData = {
 		tier: "NFE"
 	},
 	seismitoad: {
-		randomBattleMoves: ["hydropump","scald","sludgewave","earthquake","knockoff","stealthrock","toxic","raindance"],
+		randomBattleMoves: ["hydropump","scald","sludgewave","earthquake","knockoff","stealthrock","toxic"],
 		randomDoubleBattleMoves: ["hydropump","muddywater","sludgebomb","earthquake","hiddenpowerelectric","icywind","protect"],
 		tier: "NU"
 	},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1638,10 +1638,14 @@ exports.BattleScripts = {
 		} else if (ability === 'Unburden') {
 			item = 'Red Card';
 			// Give Unburden mons a Normal Gem if they have a Normal-type attacking move (except Explosion or Rapid Spin)
+			// Alternatively, give them White Herb if they have a move that lowers their stats
 			for (var m in moves) {
 				var move = this.getMove(moves[m]);
 				if (move.type === 'Normal' && (move.basePower || move.basePowerCallback) && move.id !== 'explosion' && move.id !== 'rapidspin') {
 					item = 'Normal Gem';
+					break;
+				} else if (move.id in {superpower:1, leafstorm:1, overheat:1, dracometeor:1}) {
+					item = 'White Herb';
 					break;
 				}
 			}
@@ -1671,7 +1675,7 @@ exports.BattleScripts = {
 			item = 'Air Balloon';
 		} else if ((hasMove['eruption'] || hasMove['waterspout']) && !counter['Status']) {
 			item = 'Choice Scarf';
-		} else if ((hasMove['flail'] || hasMove['reversal']) && !hasMove['endure'] && ability !== 'Sturdy') {
+		} else if ((hasMove['flail'] || hasMove['reversal'] || hasMove['endeavor']) && !hasMove['endure'] && ability !== 'Sturdy') {
 			item = 'Focus Sash';
 		} else if (hasMove['substitute'] || hasMove['detect'] || hasMove['protect'] || hasMove['roar'] || hasMove['whirlwind'] || hasMove['sleeptalk'] || ability === 'Moody') {
 			item = 'Leftovers';
@@ -2755,9 +2759,11 @@ exports.BattleScripts = {
 			item = 'Flying Gem';
 		} else if (ability === 'Unburden') {
 			item = 'Red Card';
-			// Give Unburden mons a Normal Gem if they have Fake Out
+			// Give Unburden mons a Normal Gem if they have Fake Out, or White Herb if they have a move that lowers stats
 			if (hasMove['fakeout']) {
 				item = 'Normal Gem';
+			} else if (hasMove['leafstorm'] || hasMove['dracometeor'] || hasMove['overheat'] || hasMove['superpower']) {
+				item = 'White Herb';
 			}
 
 		// medium priority


### PR DESCRIPTION
- Lumineon and Poliwrath have Storm Drain and Water Absorb respectively,
  which is always chosen over Swift Swim, so Rain Dance is unneccessary.
- Give Pokemon with Endeavor a Focus Sash.
- Give Unburden mons with stat-lowering moves a White Herb (specifically
  targets Unburden Sceptile)