### PR TITLE
(Minor) Add a [still] tag to Sky Drop's preparation turn

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -12573,6 +12573,7 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {contact: 1, charge: 1, protect: 1, mirror: 1, gravity: 1, distance: 1},
 		isContact: true,
+		isTwoTurnMove: true,
 		onTryHit: function (target, source, move) {
 			if (target.fainted) return false;
 			if (source.removeVolatile(move.id)) {


### PR DESCRIPTION
This will let me change Sky Drop's animation properly back to a flight-style animation when I introduce the next graphics patch.