### PR TITLE
Random Battle: Update Unfezant

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -4060,8 +4060,8 @@ exports.BattleFormatsData = {
 		tier: "NFE"
 	},
 	unfezant: {
-		randomBattleMoves: ["return","pluck","hypnosis","tailwind","uturn","roost"],
-		randomDoubleBattleMoves: ["pluck","uturn","return","protect","tailwind","taunt","wish"],
+		randomBattleMoves: ["return","pluck","hypnosis","tailwind","uturn","roost","nightslash"],
+		randomDoubleBattleMoves: ["pluck","uturn","return","protect","tailwind","taunt","roost","nightslash"],
 		tier: "PU"
 	},
 	blitzle: {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1541,6 +1541,8 @@ exports.BattleScripts = {
 			} else if (template.id === 'mawilemega') {
 				// Mega Mawile only needs Intimidate for a starting ability
 				ability = 'Intimidate';
+			} else if (template.id === 'unfezant') {
+				ability = 'Super Luck';
 			}
 		}
 
@@ -1609,6 +1611,8 @@ exports.BattleScripts = {
 			item = 'Stick';
 		} else if (template.species === 'Dedenne') {
 			item = 'Petaya Berry';
+		} else if (template.species === 'Unfezant' && counter['Physical'] >= 2) {
+			item = 'Scope Lens';
 		} else if (template.evos.length) {
 			item = 'Eviolite';
 		} else if (hasMove['reflect'] && hasMove['lightscreen']) {
@@ -2646,6 +2650,9 @@ exports.BattleScripts = {
 			if (abilities.indexOf('Intimidate') > -1 || template.id === 'mawilemega') {
 				ability = 'Intimidate';
 			}
+			if (template.id === 'unfezant') {
+				ability = 'Super Luck';
+			}
 		}
 
 		// Make EVs comply with the sets.
@@ -2733,6 +2740,8 @@ exports.BattleScripts = {
 			item = 'Black Sludge';
 		} else if (template.species === 'Dedenne') {
 			item = 'Petaya Berry';
+		} else if (template.species === 'Unfezant' && counter['Physical'] >= 2) {
+			item = 'Scope Lens';
 		} else if (template.evos.length) {
 			item = 'Eviolite';
 		} else if (hasMove['reflect'] && hasMove['lightscreen']) {


### PR DESCRIPTION
- Force Super Luck on Unfezant (it has a 33% chance of getting Big Pecks)
- Force Scope Lens on Unfezants with enough attacking moves
- Give Unfezant Night Slash
- Replace Wish with Roost in Doubles

Reasons for changes (not included in the commit message):
- Super Luck is Unfezant's only decent ability, and Scope Lens is found on nearly 50% of Unfezants.
- Night Slash has 100% crit, and is seen on 68% of Unfezants in PU.

Maybe I should just remove Roost entirely from the Doubles set