### PR TITLE
Leftovers heal after switching in in Gen2

### DIFF
--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -875,7 +875,6 @@ exports.BattleScripts = {
 			this.debug('instafaint: ' + this.faintQueue.map('target').map('name'));
 			this.faintMessages(true);
 			target.faint();
-			this.queue = [];
 		} else {
 			damage = this.runEvent('AfterDamage', target, source, effect, damage);
 		}

--- a/test/simulator/items/leftovers.js
+++ b/test/simulator/items/leftovers.js
@@ -1,0 +1,27 @@
+var assert = require('assert');
+var battle;
+
+describe('Leftovers - GSC', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should heal after switch', function () {
+		battle = BattleEngine.Battle.construct('battle-leftovers-gsc', 'gen2customgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Blissey', item: 'leftovers', moves: ['healbell']},
+			{species: 'Magikarp', level: 1, moves: ['splash']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Miltank", moves: ['seismictoss']}
+		]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, 614);
+
+		battle.choose('p1', 'switch 2');
+		battle.commitDecisions();
+
+		battle.choose('p1', 'switch 2');
+		assert.strictEqual(battle.p1.active[0].hp, 656);
+	});
+});


### PR DESCRIPTION
(the description was here, but was incorrect, in any case, residuals occur after faint switch in Gen2)