### PR TITLE
Keen Eye is Starly's Hidden Ability in Gen5

### DIFF
--- a/mods/gen5/pokedex.js
+++ b/mods/gen5/pokedex.js
@@ -243,7 +243,7 @@ exports.BattlePokedex = {
 	},
 	starly: {
 		inherit: true,
-		abilities: {0:"Keen Eye"}
+		abilities: {0:"Keen Eye",H:"Keen Eye"}
 	},
 	staraptor: {
 		inherit: true,

--- a/team-validator.js
+++ b/team-validator.js
@@ -380,7 +380,9 @@ Validator = (function () {
 					ability.name !== template.abilities['H']) {
 					problems.push(name + " can't have " + set.ability + ".");
 				}
-				if (ability.name === template.abilities['H']) {
+				if (ability.name === template.abilities['H'] &&
+					ability.name !== template.abilities['0'] &&
+					ability.name !== template.abilities['1']) {
 					isHidden = true;
 
 					if (template.unreleasedHidden && banlistTable['illegal']) {
@@ -557,7 +559,12 @@ Validator = (function () {
 		var level = set.level || 100;
 
 		var isHidden = false;
-		if (set.ability && tools.getAbility(set.ability).name === template.abilities['H']) isHidden = true;
+		if (set.ability) {
+			var ability = tools.getAbility(set.ability).name;
+			isHidden = ability === template.abilities['H'] &&
+				ability !== template.abilities['0'] &&
+				ability !== template.abilities['1'];
+		}
 		var incompatibleHidden = false;
 
 		var limit1 = true;


### PR DESCRIPTION
This needs to be specified, because otherwise team validator thinks that Starly cannot have hidden ability, when it can when breeding Staravia (can be both genders) from Windswept Sky.

This change allows using egg moves on Staraptor, such as Double-Edge in Gen5 metagames.