### PR TITLE
Add aliases for /weakness and /invite

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -133,6 +133,7 @@ var commands = exports.commands = {
 			case 'announce':
 				break;
 			case 'invite':
+			case 'inv':
 				var targetRoom = Rooms.search(innerTarget);
 				if (!targetRoom || targetRoom === Rooms.global) return connection.send('|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + '|/text The room "' + innerTarget + '" does not exist.');
 				if (targetRoom.staffRoom && !targetUser.isStaff) return connection.send('|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + '|/text User "' + this.targetUsername + '" requires global auth to join room "' + targetRoom.id + '".');

--- a/config/commands.js
+++ b/config/commands.js
@@ -281,6 +281,7 @@ var commands = exports.commands = {
 	 * Shortcuts
 	 *********************************************************/
 
+	inv: 'invite',
 	invite: function (target, room, user) {
 		target = this.splitTarget(target);
 		if (!this.targetUser) {
@@ -740,6 +741,7 @@ var commands = exports.commands = {
 		this.sendReplyBox(buffer);
 	},
 
+	weaknesses: 'weakness',
 	weak: 'weakness',
 	resist: 'weakness',
 	weakness: function (target, room, user) {


### PR DESCRIPTION
/inv so that people don't need to do /invite
/weaknesses because some people are proper and like to use plural pronunciations for Pokemon (eg. "/weaknesses mamoswine").
It's a small commit, but it'd still be useful in some instances