### PR TITLE
Random Battle: Fix Sylveon getting Cute Charm Hyper Voice

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1457,21 +1457,25 @@ exports.BattleScripts = {
 			delete hasMove[this.getMove(moves[3]).id];
 			moves[3] = 'return';
 			hasMove['return'] = true;
+			counter['ate']++;
 		}
 		if (template.id === 'gardevoirmega' && !counter['ate']) {
 			delete hasMove[this.getMove(moves[3]).id];
 			moves[3] = 'hypervoice';
 			hasMove['hypervoice'] = true;
+			counter['ate']++;
 		}
 		if (template.id === 'salamencemega' && !counter['ate']) {
 			delete hasMove[this.getMove(moves[3]).id];
 			moves[3] = 'return';
 			hasMove['return'] = true;
+			counter['ate']++;
 		}
 		if (template.id === 'sylveon' && !counter['ate']) {
 			delete hasMove[this.getMove(moves[3]).id];
 			moves[3] = 'hypervoice';
 			hasMove['hypervoice'] = true;
+			counter['ate']++;
 		}
 		if (template.requiredMove && !hasMove[toId(template.requiredMove)]) {
 			delete hasMove[this.getMove(moves[3]).id];


### PR DESCRIPTION
Increments the -ate counter when a Normal move is added to Sylveon in the
post-processing step, to prevent Pixilate from being rejected.