### PR TITLE
Gen 3 Doom Desire and Future Sight bugs

### DIFF
--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -196,9 +196,23 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: 85,
 		basePower: 120,
-		onModifyMove: function (move) {
-			move.type = '???';
-		}
+		onTryHit: function (target, source) {
+				source.side.addSideCondition('futuremove');
+				if (source.side.sideConditions['futuremove'].positions.[source.position]) {
+					return false;
+				}
+				source.side.sideConditions['futuremove'].positions[source.position] = {
+				duration: 3,
+				move: 'doomdesire',
+				targetPosition: target.position,
+				source: source,
+				moveData: {
+					basePower: 120,
+					category: "Physical",
+					type: '???'
+				}
+				}
+		};
 	},
 	dreameater: {
 		inherit: true,
@@ -340,9 +354,23 @@ exports.BattleMovedex = {
 		accuracy: 90,
 		basePower: 80,
 		pp: 15,
-		onModifyMove: function (move) {
-			move.type = '???';
-		}
+		onTryHit: function (target, source) {
+				source.side.addSideCondition('futuremove');
+				if (source.side.sideConditions['futuremove'].positions.[source.position]) {
+					return false;
+				}
+				source.side.sideConditions['futuremove'].positions[source.position] = {
+				duration: 3,
+				move: 'futuresight',
+				targetPosition: target.position,
+				source: source,
+				moveData: {
+					basePower: 80,
+					category: 'Special',
+					type: '???'
+				}
+				}
+		};
 	},
 	gigadrain: {
 		inherit: true,

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -212,7 +212,7 @@ exports.BattleMovedex = {
 					type: '???'
 				}
 				}
-		};
+		}
 	},
 	dreameater: {
 		inherit: true,
@@ -370,7 +370,7 @@ exports.BattleMovedex = {
 					type: '???'
 				}
 				}
-		};
+		}
 	},
 	gigadrain: {
 		inherit: true,


### PR DESCRIPTION
Modifying the move does not modify the side condition that actually causes the damage unfortunately, so what we were getting was a special, 140 BP Steel-type damage from Doom Desire and a 100 BP Psychic-type damage from Future Sight. This is just a quick fix for the most part, (there are probably more efficient ways of doing this) as I am not the most proficient person when it comes to Java and especially PS! Java. All I did was add and edit the side condition that causes the damage to fit what the moves did in Gen 3.