### PR TITLE
Make ranks in /groups into proper code.

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -874,14 +874,15 @@ var commands = exports.commands = {
 		this.sendReplyBox("Uptime: <b>" + uptimeText + "</b>");
 	},
 
+	usergroups: 'groups',
 	groups: function (target, room, user) {
 		if (!this.canBroadcast()) return;
 		this.sendReplyBox(
-			"+ <b>Voice</b> - They can use ! commands like !groups, and talk during moderated chat<br />" +
-			"% <b>Driver</b> - The above, and they can mute. Global % can also lock users and check for alts<br />" +
-			"@ <b>Moderator</b> - The above, and they can ban users<br />" +
+			"&plus; <b>Voice</b> - They can use ! commands like !groups, and talk during moderated chat<br />" +
+			"&percnt; <b>Driver</b> - The above, and they can mute. Global % can also lock users and check for alts<br />" +
+			"&commat; <b>Moderator</b> - The above, and they can ban users<br />" +
 			"&amp; <b>Leader</b> - The above, and they can promote to moderator and force ties<br />" +
-			"# <b>Room Owner</b> - They are leaders of the room and can almost totally control it<br />" +
+			"&num; <b>Room Owner</b> - They are leaders of the room and can almost totally control it<br />" +
 			"~ <b>Administrator</b> - They can do anything, like change what this message says"
 		);
 	},


### PR DESCRIPTION
This isn't necessary, but it just makes it more proper if something were to happen. I added ``usergroups`` because it's an alias that goes more in depth of what ``/groups`` is.

This isn't necessary in the other places due to the actual symbol being shown for every rank instead of the HTML code equivalent

(ex. ``/roomhelp`` command)