### PR TITLE
Random Battle: Allow Mono-Fire attacks on Mono-Poison Pokemon

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -3873,8 +3873,8 @@ exports.BattleFormatsData = {
 		requiredItem: "Icicle Plate"
 	},
 	arceuspoison: {
-		randomBattleMoves: ["calmmind","sludgebomb","fireblast","recover","willowisp","defog","thunderwave"],
-		randomDoubleBattleMoves: ["calmmind","judgment","sludgebomb","heatwave","recover","willowisp","protect","earthpower"],
+		randomBattleMoves: ["calmmind","judgment","fireblast","recover","willowisp","defog","thunderwave"],
+		randomDoubleBattleMoves: ["calmmind","judgment","heatwave","recover","willowisp","protect","earthpower"],
 		requiredItem: "Toxic Plate"
 	},
 	arceuspsychic: {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1418,9 +1418,10 @@ exports.BattleScripts = {
 									if (hasType['Normal'] && template.types.length === 1) {
 										// Mono-Ice is acceptable for special attacking Normal types that lack Boomburst and Hyper Voice
 										if (counter.Physical >= 2 || movePool.indexOf('boomburst') > -1 || movePool.indexOf('hypervoice') > -1) replace = true;
-									} else {
-										replace = true;
 									}
+								} else if (damagingType === 'Fire') {
+									// Mono-Fire is acceptable for pure Poison types that aren't Arceus
+									if (template.baseSpecies === 'Arceus' || !hasType['Poison'] || template.types.length !== 1) replace = true;
 								} else {
 									replace = true;
 								}


### PR DESCRIPTION
Mostly affects Muk and Weezing, maybe more.

Also updated Arceus-Poison to not use Sludge Bomb (Judgment is better,
obviously)