### PR TITLE
Fixed problems with guessing in question giveaways.

### DIFF
--- a/chat-plugins/wifi.js
+++ b/chat-plugins/wifi.js
@@ -7,6 +7,7 @@
 // checks whether any alt of the user is present in list.
 function checkAllAlts(user, list) {
 	for (var prevName in user.prevNames) {
+		if (prevName === user.userid) continue;
 		if (prevName in list) return 'previous name ' + prevName;
 	}
 	var alts = user.getAlts().map(toId);


### PR DESCRIPTION
Users weren't able to guess more than once in a question giveaway because their current name was in their list of previous names.
http://prntscr.com/6c5r4p

Added a line of code to fix that problem. Thanks to Cranham (and maybe a few others too) for pointing this out originally, btw.