### PR TITLE
Disable deprecated engineStrict

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "engines": {
     "node": "> 0.10.1"
   },
-  "engineStrict": true,
   "main": "app.js",
   "scripts": {
     "start": "node app.js",


### PR DESCRIPTION
In newest version of npm, this makes depreciation warnings.

See npm/npm#7171 for justification of removal of this feature from npm.