### PR TITLE
Random Battle: Update Baton Pass conditions, modify movesets

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1317,7 +1317,7 @@ exports.BattleFormatsData = {
 		tier: "PU"
 	},
 	glaceon: {
-		randomBattleMoves: ["icebeam","hiddenpowerground","shadowball","healbell","batonpass","toxic"],
+		randomBattleMoves: ["icebeam","hiddenpowerground","shadowball","healbell","wish","protect","toxic"],
 		randomDoubleBattleMoves: ["icebeam","hiddenpowerground","shadowball","wish","protect","healbell","helpinghand"],
 		eventPokemon: [
 			{"generation":5,"level":10,"gender":"M","isHidden":true,"moves":["tailwhip","tackle","helpinghand","sandattack"]},
@@ -4396,7 +4396,7 @@ exports.BattleFormatsData = {
 		tier: "PU"
 	},
 	emolga: {
-		randomBattleMoves: ["agility","chargebeam","batonpass","substitute","thunderbolt","airslash","roost"],
+		randomBattleMoves: ["encore","chargebeam","batonpass","substitute","thunderbolt","airslash","roost"],
 		randomDoubleBattleMoves: ["helpinghand","tailwind","encore","substitute","thunderbolt","airslash","roost","protect"],
 		tier: "PU"
 	},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1116,7 +1116,7 @@ exports.BattleScripts = {
 					if (!hasMove['cosmicpower'] && !setupType) rejected = true;
 					break;
 				case 'batonpass':
-					if (!setupType && !hasMove['substitute'] && !hasMove['protect'] && !hasMove['cosmicpower']) rejected = true;
+					if (!setupType && !hasMove['substitute'] && !hasMove['cosmicpower'] && !hasMove['wish'] && !counter['speedsetup'] && template.abilities[0] !== 'Speed Boost' && template.abilities['H'] !== 'Speed Boost') rejected = true;
 					break;
 
 				// We only need to set up once
@@ -1380,7 +1380,7 @@ exports.BattleScripts = {
 				// This move doesn't satisfy our setup requirements:
 				if (setupType && setupType !== 'Mixed' && move.category !== setupType && counter[setupType] < 2) {
 					// Mono-attacking with setup and RestTalk is allowed
-					if (!hasMove['rest'] || !hasMove['sleeptalk']) rejected = true;
+					if (!isSetup && moveid !== 'rest' && moveid !== 'sleeptalk') rejected = true;
 				}
 
 				// Hidden Power isn't good enough
@@ -2357,7 +2357,7 @@ exports.BattleScripts = {
 					if (!hasMove['cosmicpower'] && !setupType) rejected = true;
 					break;
 				case 'batonpass':
-					if (!setupType && !hasMove['substitute'] && !hasMove['cosmicpower']) rejected = true;
+					if (!setupType && !hasMove['substitute'] && !hasMove['cosmicpower'] && !counter['speedsetup'] && template.abilities[0] !== 'Speed Boost' && template.abilities['H'] !== 'Speed Boost') rejected = true;
 					break;
 
 				// we only need to set up once


### PR DESCRIPTION
- Accept Baton Pass with Wish and Pokemon with Speed Boost.
- Removed Baton Pass from Glaceon in favor if Wish and Protect.
- Removed Agility from Emolga since it doesn't need it; added Encore.