### PR TITLE
Generation 4: Fix Simple

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -409,6 +409,7 @@ BattlePokemon = (function () {
 
 		// stat boosts
 		// boost = this.boosts[statName];
+		boost = this.battle.runEvent('ModifyBoost', this, statName, null, boost);
 		var boostTable = [1, 1.5, 2, 2.5, 3, 3.5, 4];
 		if (boost > 6) boost = 6;
 		if (boost < -6) boost = -6;
@@ -438,6 +439,7 @@ BattlePokemon = (function () {
 		// stat boosts
 		if (!unboosted) {
 			var boost = this.boosts[statName];
+			boost = this.battle.runEvent('ModifyBoost', this, statName, null, boost);
 			var boostTable = [1, 1.5, 2, 2.5, 3, 3.5, 4];
 			if (boost > 6) boost = 6;
 			if (boost < -6) boost = -6;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -227,21 +227,26 @@ exports.BattleScripts = {
 
 		// calculate true accuracy
 		var accuracy = move.accuracy;
+		var boost;
 		if (accuracy !== true) {
 			var targetAbilityIgnoreAccuracy = !target.ignore['Ability'] && target.getAbility().ignoreAccuracy;
 			if (!move.ignoreAccuracy && !targetAbilityIgnoreAccuracy) {
-				if (pokemon.boosts.accuracy > 0) {
-					accuracy *= boostTable[pokemon.boosts.accuracy];
+				boost = this.runEvent('ModifyBoost', pokemon, 'accuracy', null, pokemon.boosts.accuracy);
+				boost = this.clampIntRange(boost, -6, 6);
+				if (boost > 0) {
+					accuracy *= boostTable[boost];
 				} else {
-					accuracy /= boostTable[-pokemon.boosts.accuracy];
+					accuracy /= boostTable[-boost];
 				}
 			}
 			var pokemonAbilityIgnoreEvasion = !pokemon.ignore['Ability'] && pokemon.getAbility().ignoreEvasion;
 			if (!move.ignoreEvasion && !pokemonAbilityIgnoreEvasion) {
-				if (target.boosts.evasion > 0 && !move.ignorePositiveEvasion) {
-					accuracy /= boostTable[target.boosts.evasion];
-				} else if (target.boosts.evasion < 0) {
-					accuracy *= boostTable[-target.boosts.evasion];
+				boost = this.runEvent('ModifyBoost', pokemon, 'evasion', null, target.boosts.evasion);
+				boost = this.clampIntRange(boost, -6, 6);
+				if (boost > 0 && !move.ignorePositiveEvasion) {
+					accuracy /= boostTable[boost];
+				} else if (boost < 0) {
+					accuracy *= boostTable[-boost];
 				}
 			}
 		}

--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -102,6 +102,16 @@ exports.BattleAbilities = {
 		rating: 0,
 		num: 57
 	},
+	"simple": {
+		shortDesc: "If this Pokemon's stat stages are raised or lowered, the effect is doubled instead.",
+		onModifyBoost: function () {
+			return this.chainModify(2);
+		},
+		id: "simple",
+		name: "Simple",
+		rating: 4,
+		num: 86
+	},
 	"stench": {
 		desc: "No in-battle effect.",
 		shortDesc: "No in-battle effect.",

--- a/test/simulator/abilities/simple.js
+++ b/test/simulator/abilities/simple.js
@@ -1,0 +1,57 @@
+var assert = require('assert');
+var battle;
+
+describe('Simple', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should double all stat boosts', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Bibarel", ability: 'simple', moves: ['curse']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moxie', moves: ['splash']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].boosts['atk'], 2);
+		assert.strictEqual(battle.p1.active[0].boosts['def'], 2);
+		assert.strictEqual(battle.p1.active[0].boosts['spe'], -2);
+	});
+});
+
+describe('Simple - DPP', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should double the effect of stat boosts', function () {
+		battle = BattleEngine.Battle.construct('battle-simple-dpp-boosts', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: "Bibarel", ability: 'simple', moves: ['defensecurl']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moxie', moves: ['splash']}]);
+		var defense = battle.p1.active[0].getStat('def');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].boosts['def'], 1);
+		assert.strictEqual(battle.p1.active[0].getStat('def'), 2 * defense);
+	});
+
+	it('should double the effect of stat boosts passed by Baton Pass', function () {
+		battle = BattleEngine.Battle.construct('battle-simple-dpp-batonpass', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Sableye", ability: 'prankster', moves: ['batonpass']},
+			{species: "Bibarel", ability: 'simple', moves: ['protect']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'intimidate', moves: ['splash']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'switch 2');
+		assert.strictEqual(battle.p1.active[0].boosts['atk'], -1);
+		assert.strictEqual(battle.p1.active[0].getStat('atk'), Math.floor(0.5 * battle.p1.active[0].getStat('atk', true)));
+	});
+
+	it ('should be suppressed by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct('battle-simple-dpp-moldbreaker', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: "Bibarel", ability: 'simple', moves: ['defensecurl']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Haxorus", ability: 'moldbreaker', item: 'laggingtail', moves: ['earthquake']}]);
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		var hploss = battle.p1.active[0].maxhp - battle.p1.active[0].hp;
+		assert(hploss >= 102 && hploss <= 120);
+	});
+});


### PR DESCRIPTION
In Generation 4, Simple did not double stat boosts as they changed.
Instead, it treated each stat boost as if it had twice the effect.
Reimplemented the deprecated ModifyBoost event, but with slightly
different functionality as before; it now modifies the live boosts so that
they work properly with Simple.