### PR TITLE
Generation 3-4: Actually fix Lightning Rod/Storm Drain

### DIFF
--- a/mods/gen3/abilities.js
+++ b/mods/gen3/abilities.js
@@ -47,7 +47,13 @@ exports.BattleAbilities = {
 	"lightningrod": {
 		desc: "During double battles, this Pokemon draws any single-target Electric-type attack to itself. If an opponent uses an Electric-type attack that affects multiple Pokemon, those targets will be hit. This ability does not affect Electric Hidden Power or Judgment.",
 		shortDesc: "This Pokemon draws opposing Electric moves to itself.",
-		onTryHit: function () {},
+		onFoeRedirectTargetPriority: 1,
+		onFoeRedirectTarget: function (target, source, source2, move) {
+			if (move.type !== 'Electric') return;
+			if (this.validTarget(this.effectData.target, source, move.target)) {
+				return this.effectData.target;
+			}
+		},
 		id: "lightningrod",
 		name: "Lightning Rod",
 		rating: 3.5,

--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -21,13 +21,11 @@ exports.BattleAbilities = {
 		}
 	},
 	"lightningrod": {
+		inherit: true,
 		desc: "During double battles, this Pokemon draws any single-target Electric-type attack to itself. If an opponent uses an Electric-type attack that affects multiple Pokemon, those targets will be hit. This ability does not affect Electric Hidden Power or Judgment.",
 		shortDesc: "This Pokemon draws Electric moves to itself.",
 		onTryHit: function () {},
-		id: "lightningrod",
-		name: "Lightning Rod",
-		rating: 0,
-		num: 32
+		rating: 0
 	},
 	"magicguard": {
 		//desc: "",
@@ -111,13 +109,11 @@ exports.BattleAbilities = {
 		num: 1
 	},
 	"stormdrain": {
+		inherit: true,
 		desc: "During double battles, this Pokemon draws any single-target Water-type attack to itself. If an opponent uses an Water-type attack that affects multiple Pokemon, those targets will be hit. This ability does not affect Water Hidden Power, Judgment or Weather Ball.",
 		shortDesc: "This Pokemon draws Water moves to itself.",
 		onTryHit: function () {},
-		id: "stormdrain",
-		name: "Storm Drain",
-		rating: 0,
-		num: 114
+		rating: 0
 	},
 	"sturdy": {
 		desc: "This Pokemon is immune to OHKO moves.",


### PR DESCRIPTION
Accidentally removed Gen 3's implementation, so it is reverted.

Set Gen 4 to inherit the redirection from Gen 5+.