### PR TITLE
Add an alias for /userauth

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -531,6 +531,7 @@ var commands = exports.commands = {
 		connection.popup(buffer.join("\n\n"));
 	},
 
+	auth: 'userauth',
 	userauth: function (target, room, user, connection) {
 		var targetId = toId(target) || user.userid;
 		var targetUser = Users.getExact(targetId);


### PR DESCRIPTION
Well it seems logical to do ``/auth <user>`` and have it have the same effect as ``/userauth <user>``