### PR TITLE
Random Double Battle: Update Sharpedo

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -2604,7 +2604,7 @@ exports.BattleFormatsData = {
 	},
 	sharpedo: {
 		randomBattleMoves: ["protect","icebeam","crunch","earthquake","waterfall","destinybond"],
-		randomDoubleBattleMoves: ["protect","hydropump","surf","icebeam","crunch","earthquake","waterfall","darkpulse","destinybond"],
+		randomDoubleBattleMoves: ["protect","icebeam","crunch","earthquake","waterfall","destinybond"],
 		tier: "UU"
 	},
 	sharpedomega: {


### PR DESCRIPTION
The Double Battle EV generator is different from that for Singles, and
makes it less beneficial to have mixed moves.

(Maybe it should keep Ice Beam and remove Hydro Pump instead)