### PR TITLE
Weight Refactor: Do not modify weight in ModifyPokemon

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -353,8 +353,6 @@ BattlePokemon = (function () {
 		return this.details + '|' + this.getHealth(side);
 	};
 	BattlePokemon.prototype.update = function (init) {
-		// reset for Light Metal etc
-		this.weightkg = this.template.weightkg;
 		// reset for diabled moves
 		this.disabledMoves = {};
 		this.negateImmunity = {};
@@ -461,6 +459,12 @@ BattlePokemon = (function () {
 			stat = this.battle.getStatCallback(stat, statName, this, unboosted);
 		}
 		return stat;
+	};
+	BattlePokemon.prototype.getWeight = function () {
+		var weight = this.template.weightkg;
+		weight = this.battle.runEvent('ModifyWeight', this, null, null, weight);
+		if (weight < 0.1) weight = 0.1;
+		return weight;
 	};
 	BattlePokemon.prototype.getMoveData = function (move) {
 		move = this.battle.getMove(move);
@@ -2186,6 +2190,7 @@ Battle = (function () {
 					ModifyAtk: 1, ModifyDef: 1, ModifySpA: 1, ModifySpD: 1, ModifySpe: 1,
 					ModifyBoost: 1,
 					ModifyDamage: 1,
+					ModifyWeight: 1,
 					TryHit: 1,
 					TryHitSide: 1,
 					TrySecondaryHit: 1,

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1037,8 +1037,8 @@ exports.BattleAbilities = {
 	},
 	"heavymetal": {
 		shortDesc: "This Pokemon's weight is doubled.",
-		onModifyPokemon: function (pokemon) {
-			pokemon.weightkg *= 2;
+		onModifyWeight: function (weight) {
+			return weight * 2;
 		},
 		id: "heavymetal",
 		name: "Heavy Metal",
@@ -1342,8 +1342,8 @@ exports.BattleAbilities = {
 	},
 	"lightmetal": {
 		shortDesc: "This Pokemon's weight is halved.",
-		onModifyPokemon: function (pokemon) {
-			pokemon.weightkg /= 2;
+		onModifyWeight: function (weight) {
+			return weight / 2;
 		},
 		id: "lightmetal",
 		name: "Light Metal",

--- a/data/items.js
+++ b/data/items.js
@@ -1486,8 +1486,8 @@ exports.BattleItems = {
 		fling: {
 			basePower: 30
 		},
-		onModifyPokemon: function (pokemon) {
-			pokemon.weightkg /= 2;
+		onModifyWeight: function (weight) {
+			return weight / 2;
 		},
 		num: 539,
 		gen: 5,

--- a/data/moves.js
+++ b/data/moves.js
@@ -688,21 +688,23 @@ exports.BattleMovedex = {
 		effect: {
 			noCopy: true, // doesn't get copied by Baton Pass
 			onStart: function (pokemon) {
-				if (pokemon.weightkg !== 0.1) {
+				if (pokemon.template.weightkg > 0.1) {
 					this.effectData.multiplier = 1;
 					this.add('-start', pokemon, 'Autotomize');
 				}
 			},
 			onRestart: function (pokemon) {
-				if (pokemon.weightkg !== 0.1) {
+				if (pokemon.template.weightkg - (this.effectData.multiplier * 100) > 0.1) {
 					this.effectData.multiplier++;
 					this.add('-start', pokemon, 'Autotomize');
 				}
 			},
-			onModifyPokemon: function (pokemon) {
+			onModifyWeightPriority: 1,
+			onModifyWeight: function (weight, pokemon) {
 				if (this.effectData.multiplier) {
-					pokemon.weightkg -= this.effectData.multiplier * 100;
-					if (pokemon.weightkg < 0.1) pokemon.weightkg = 0.1;
+					weight -= this.effectData.multiplier * 100;
+					if (weight < 0.1) weight = 0.1;
+					return weight;
 				}
 			}
 		},
@@ -5281,23 +5283,24 @@ exports.BattleMovedex = {
 		accuracy: 100,
 		basePower: 0,
 		basePowerCallback: function (pokemon, target) {
-			if (target.weightkg >= 200) {
+			var targetWeight = target.getWeight();
+			if (targetWeight >= 200) {
 				this.debug('120 bp');
 				return 120;
 			}
-			if (target.weightkg >= 100) {
+			if (targetWeight >= 100) {
 				this.debug('100 bp');
 				return 100;
 			}
-			if (target.weightkg >= 50) {
+			if (targetWeight >= 50) {
 				this.debug('80 bp');
 				return 80;
 			}
-			if (target.weightkg >= 25) {
+			if (targetWeight >= 25) {
 				this.debug('60 bp');
 				return 60;
 			}
-			if (target.weightkg >= 10) {
+			if (targetWeight >= 10) {
 				this.debug('40 bp');
 				return 40;
 			}
@@ -6132,8 +6135,8 @@ exports.BattleMovedex = {
 		accuracy: 100,
 		basePower: 0,
 		basePowerCallback: function (pokemon, target) {
-			var targetWeight = target.weightkg;
-			var pokemonWeight = pokemon.weightkg;
+			var targetWeight = target.getWeight();
+			var pokemonWeight = pokemon.getWeight();
 			if (pokemonWeight > targetWeight * 5) {
 				return 120;
 			}
@@ -6186,8 +6189,8 @@ exports.BattleMovedex = {
 		accuracy: 100,
 		basePower: 0,
 		basePowerCallback: function (pokemon, target) {
-			var targetWeight = target.weightkg;
-			var pokemonWeight = pokemon.weightkg;
+			var targetWeight = target.getWeight();
+			var pokemonWeight = pokemon.getWeight();
 			if (pokemonWeight > targetWeight * 5) {
 				return 120;
 			}
@@ -7834,20 +7837,20 @@ exports.BattleMovedex = {
 		accuracy: 100,
 		basePower: 0,
 		basePowerCallback: function (pokemon, target) {
-			var targetWeight = target.weightkg;
-			if (target.weightkg >= 200) {
+			var targetWeight = target.getWeight();
+			if (targetWeight >= 200) {
 				return 120;
 			}
-			if (target.weightkg >= 100) {
+			if (targetWeight >= 100) {
 				return 100;
 			}
-			if (target.weightkg >= 50) {
+			if (targetWeight >= 50) {
 				return 80;
 			}
-			if (target.weightkg >= 25) {
+			if (targetWeight >= 25) {
 				return 60;
 			}
-			if (target.weightkg >= 10) {
+			if (targetWeight >= 10) {
 				return 40;
 			}
 			return 20;
@@ -12511,7 +12514,7 @@ exports.BattleMovedex = {
 				if (target.volatiles['substitute'] || target.side === source.side) {
 					return false;
 				}
-				if (target.weightkg >= 200) {
+				if (target.getWeight() >= 200) {
 					this.add('-fail', target, 'move: Sky Drop', '[heavy]');
 					return null;
 				}

--- a/test/simulator/misc/weight.js
+++ b/test/simulator/misc/weight.js
@@ -1,0 +1,133 @@
+var assert = require('assert');
+var battle;
+
+describe('Heavy Metal', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should double the weight of a Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Simisear", ability: 'heavymetal', moves: ['nastyplot']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', moves: ['grassknot']}]);
+		var basePower = 0;
+		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+			if (eventid === 'BasePower' && effect.id === 'grassknot') {
+				basePower = relayVar;
+			}
+			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
+		};
+		battle.commitDecisions();
+		assert.strictEqual(basePower, 80);
+	});
+
+	it('should be negated by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Simisear", ability: 'heavymetal', moves: ['nastyplot']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'moldbreaker', moves: ['grassknot']}]);
+		var basePower = 0;
+		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+			if (eventid === 'BasePower' && effect.id === 'grassknot') {
+				basePower = relayVar;
+			}
+			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
+		};
+		battle.commitDecisions();
+		assert.strictEqual(basePower, 60);
+	});
+});
+
+describe('Light Metal', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should halve the weight of a Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Registeel", ability: 'lightmetal', moves: ['curse']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', moves: ['grassknot']}]);
+		var basePower = 0;
+		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+			if (eventid === 'BasePower' && effect.id === 'grassknot') {
+				basePower = relayVar;
+			}
+			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
+		};
+		battle.commitDecisions();
+		assert.strictEqual(basePower, 100);
+	});
+
+	it('should be negated by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Registeel", ability: 'lightmetal', moves: ['splash']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'moldbreaker', moves: ['grassknot']}]);
+		var basePower = 0;
+		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+			if (eventid === 'BasePower' && effect.id === 'grassknot') {
+				basePower = relayVar;
+			}
+			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
+		};
+		battle.commitDecisions();
+		assert.strictEqual(basePower, 120);
+	});
+});
+
+describe('Float Stone', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should halve the weight of a Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Registeel", ability: 'clearbody', item: 'floatstone', moves: ['curse']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', moves: ['grassknot']}]);
+		var basePower = 0;
+		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+			if (eventid === 'BasePower' && effect.id === 'grassknot') {
+				basePower = relayVar;
+			}
+			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
+		};
+		battle.commitDecisions();
+		assert.strictEqual(basePower, 100);
+	});
+});
+
+describe('Autotomize', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should reduce the weight of a Pokemon by 100 kg with each use', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Registeel", ability: 'clearbody', moves: ['autotomize']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot']}]);
+		var basePower = 0;
+		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+			if (eventid === 'BasePower' && effect.id === 'grassknot') {
+				basePower = relayVar;
+			}
+			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
+		};
+		battle.commitDecisions();
+		assert.strictEqual(basePower, 100);
+		battle.commitDecisions();
+		assert.strictEqual(basePower, 20);
+	});
+
+	it('should factor into weight before Heavy Metal does', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lairon", ability: 'heavymetal', moves: ['autotomize']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot']}]);
+		var basePower = 0;
+		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+			if (eventid === 'BasePower' && effect.id === 'grassknot') {
+				basePower = relayVar;
+			}
+			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
+		};
+		battle.commitDecisions();
+		assert.strictEqual(basePower, 60);
+	});
+});


### PR DESCRIPTION
Added a new event, `ModifyWeight`, to deal with weight changes from items,
abilities, and moves. Add a function `getWeight` to call the event and
return a Pokemon's current weight.