### PR TITLE
Hidden Type: custom type can no longer be copied

### DIFF
--- a/mods/hiddentype/moves.js
+++ b/mods/hiddentype/moves.js
@@ -1,0 +1,33 @@
+exports.BattleMovedex = {
+	reflecttype: {
+		inherit: true,
+		onHit: function (target, source) {
+			if (source.template && source.template.num === 493) return false;
+			this.add('-start', source, 'typechange', '[from] move: Reflect Type', '[of] ' + target);
+
+			var typeMap = {};
+			source.typesData = [];
+			for (var i = 0, l = target.typesData.length; i < l; i++) {
+				var typeData = target.typesData[i];
+				if (typeMap[typeData.type]) continue;
+				typeMap[typeData.type] = true;
+
+				if (typeData.isCustom) {
+					source.typesData.push({
+						type: source.baseHpType,
+						suppressed: false,
+						isAdded: typeData.isAdded,
+						isCustom: true
+					});
+				} else {
+					if (typeData.suppressed) continue;
+					source.typesData.push({
+						type: typeData.type,
+						suppressed: false,
+						isAdded: typeData.isAdded
+					});
+				}
+			}
+		}
+	}
+};

--- a/mods/hiddentype/scripts.js
+++ b/mods/hiddentype/scripts.js
@@ -15,11 +15,12 @@ exports.BattleScripts = {
 					isAdded: false
 				});
 			}
-			if (this.types.indexOf(this.hpType) === -1) {
+			if (this.types.indexOf(this.baseHpType) === -1) {
 				this.typesData.push({
-					type: this.hpType,
+					type: this.baseHpType,
 					suppressed: false,
-					isAdded: true
+					isAdded: true,
+					isCustom: true
 				});
 			}
 
@@ -36,6 +37,73 @@ exports.BattleScripts = {
 				}
 				this.speed = this.stats.spe;
 			}
+			return true;
+		},
+		transformInto: function (pokemon, user) {
+			var template = pokemon.template;
+			if (pokemon.fainted || pokemon.illusion || (pokemon.volatiles['substitute'] && this.battle.gen >= 5)) {
+				return false;
+			}
+			if (!template.abilities || (pokemon && pokemon.transformed && this.battle.gen >= 2) || (user && user.transformed && this.battle.gen >= 5)) {
+				return false;
+			}
+			if (!this.formeChange(template, true)) {
+				return false;
+			}
+			this.transformed = true;
+			var typeMap = {};
+			this.typesData = [];
+			for (var i = 0, l = pokemon.typesData.length; i < l; i++) {
+				var typeData = pokemon.typesData[i];
+				if (typeMap[typeData.type]) continue;
+				typeMap[typeData.type] = true;
+
+				if (typeData.isCustom) {
+					this.typesData.push({
+						type: this.baseHpType,
+						suppressed: false,
+						isAdded: typeData.isAdded,
+						isCustom: true
+					});
+				} else {
+					this.typesData.push({
+						type: typeData.type,
+						suppressed: false,
+						isAdded: typeData.isAdded
+					});
+				}
+			}
+			for (var statName in this.stats) {
+				this.stats[statName] = pokemon.stats[statName];
+			}
+			this.moveset = [];
+			this.moves = [];
+			this.set.ivs = (this.battle.gen >= 5 ? this.set.ivs : pokemon.set.ivs);
+			this.hpType = (this.battle.gen >= 5 ? this.hpType : pokemon.hpType);
+			this.hpPower = (this.battle.gen >= 5 ? this.hpPower : pokemon.hpPower);
+			for (var i = 0; i < pokemon.moveset.length; i++) {
+				var move = this.battle.getMove(this.set.moves[i]);
+				var moveData = pokemon.moveset[i];
+				var moveName = moveData.move;
+				if (moveData.id === 'hiddenpower') {
+					moveName = 'Hidden Power ' + this.hpType;
+				}
+				this.moveset.push({
+					move: moveName,
+					id: moveData.id,
+					pp: move.noPPBoosts ? moveData.maxpp : 5,
+					maxpp: this.battle.gen >= 5 ? (move.noPPBoosts ? moveData.maxpp : 5) : (this.battle.gen <= 2 ? move.pp : moveData.maxpp),
+					target: moveData.target,
+					disabled: false
+				});
+				this.moves.push(toId(moveName));
+			}
+			for (var j in pokemon.boosts) {
+				this.boosts[j] = pokemon.boosts[j];
+			}
+			this.battle.add('-transform', this, pokemon);
+			this.setAbility(pokemon.ability);
+			this.update();
 			return true;
 		}
 	}


### PR DESCRIPTION
- Transform and Reflect Type will replace it by the source hidden type.
- Adds a flag `isCustom` to the type data.