### PR TITLE
Flash Fire boost disappears when the ability is removed

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -735,6 +735,9 @@ exports.BattleAbilities = {
 				return null;
 			}
 		},
+		onEnd: function (pokemon) {
+			pokemon.removeVolatile('flashfire');
+		},
 		effect: {
 			noCopy: true, // doesn't get copied by Baton Pass
 			onStart: function (target) {
@@ -3016,12 +3019,11 @@ exports.BattleAbilities = {
 		onTakeItem: function (item, pokemon) {
 			pokemon.addVolatile('unburden');
 		},
+		onEnd: function (pokemon) {
+			pokemon.removeVolatile('unburden');
+		},
 		effect: {
 			onModifySpe: function (speMod, pokemon) {
-				if (pokemon.ignore['Ability'] === true || pokemon.ability !== 'unburden') {
-					pokemon.removeVolatile('unburden');
-					return;
-				}
 				if (!pokemon.item) {
 					return this.chain(speMod, 2);
 				}


### PR DESCRIPTION
Added onEnd event to Flash Fire (and Unburden) to check for when the
ability disappears.

Verified by @Marty-D, but should probably wait for his double-checking again