### PR TITLE
Boost time limit for JSHint.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ function transformLet () {
 
 function lint (jsHintOptions, jscsOptions) {
 	return lazypipe()
-		.pipe(jshint.bind(jshint, jsHintOptions, {timeout: 150000}))
+		.pipe(jshint.bind(jshint, jsHintOptions, {timeout: 300000}))
 		.pipe(jscs.bind(jscs, jscsOptions))();
 }
 


### PR DESCRIPTION
This fixes tests on Travis, because Travis is so slow.