### PR TITLE
Improve /dexsearch performance

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -570,7 +570,7 @@ var commands = exports.commands = {
 			}
 		}
 
-		for (var search in {'moves':1, 'recovery':1, 'types':1, 'ability':1, 'tier':1, 'gen':1, 'color':1}) {
+		for (var search in {'gen':1, 'tier':1, 'color':1, 'types':1, 'ability':1, 'moves':1, 'recovery':1}) {
 			if (!searches[search]) continue;
 			switch (search) {
 				case 'types':


### PR DESCRIPTION
Search based on the least costly parameter first to remove pokemon that doesn't match as early as possible, so the moves/recovery sections have less searching to do. Single parameter searches remains largely the same though.

I saw, at best, a 20% improvement when I used a search meant to be better on this one. Average improvements got anything from 0 to 10%, depending on how many different parameters were added. (This was using a pretty old computer as host, so these numbers might be much smaller)



