### PR TITLE
Introduce cache for syntax testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /config/*
 /logs/*
 /node_modules
+/gulp-cache
 npm-debug.log
 
 # boilerplate #

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
 cache:
   directories:
     - node_modules
+    - gulp-cache

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
   ],
   "private": true,
   "devDependencies": {
+    "cache-swap": "~0.2.0",
     "gulp": "~3.8.7",
+    "gulp-cache": "~0.2.8",
     "gulp-jshint": "git://github.com/spalger/gulp-jshint#c18df3a11",
     "gulp-jscs": "~1.4.0",
     "gulp-replace": "~0.5.1",


### PR DESCRIPTION
This cache is quite awful (welcome to the world of Node.js, I guess), but at least it works. It has few flaws, like not being able to GC unused cache files. Still, has to work for now. Changes syntax test times from 10 minutes on my very slow laptop to 0.6 seconds.

(I wonder how this will work with Travis...)

Later I will try to figure out why JSHint is so unbelievably slow.