### PR TITLE
Random Battle: Update Ambipom

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1582,7 +1582,11 @@ exports.BattleScripts = {
 			if (abilities.indexOf('Unburden') > -1 && hasMove['acrobatics']) {
 				ability = 'Unburden';
 			}
-			if (template.id === 'combee') {
+			if (template.id === 'ambipom' && !counter['technician']) {
+				// If it doesn't qualify for Technician, Skill Link is useless on it
+				// Might as well give it Pickup just in case
+				ability = 'Pickup';
+			} else if (template.id === 'combee') {
 				// Combee always gets Hustle but its only physical move is Endeavor, which loses accuracy
 				ability = 'Honey Gather';
 			} else if (template.id === 'lopunny' && hasMove['switcheroo'] && this.random(3)) {
@@ -2783,7 +2787,11 @@ exports.BattleScripts = {
 			if (abilities.indexOf('Intimidate') > -1 || template.id === 'mawilemega') {
 				ability = 'Intimidate';
 			}
-			if (template.id === 'unfezant') {
+			if (template.id === 'ambipom' && !counter['technician']) {
+				// If it doesn't qualify for Technician, Skill Link is useless on it
+				// Might as well give it Pickup just in case
+				ability = 'Pickup';
+			} else if (template.id === 'unfezant') {
 				ability = 'Super Luck';
 			}
 		}


### PR DESCRIPTION
If Ambipom doesn't have any Technician moves, give it Pickup instead of
Skill Link because Skill Link is useless on it and it might as well have
a slight chance of recovering an item if its item is lost because of Knock Off.

(I was considering having Acrobatics not count as a Technician move since
it's almost always a 110 BP move, but then I remembered that if it's Tricked
a Choice item or something then it'll drop back down to 55 BP and qualify
for the ability. Also, Pickup would mess Acrobatics up.)

