### PR TITLE
Make sure the flags object always exists in moveData

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -329,6 +329,7 @@ exports.BattleScripts = {
 		move = this.getMoveCopy(move);
 
 		if (!moveData) moveData = move;
+		if (!moveData.flags) moveData.flags = {};
 		var hitResult = true;
 
 		// TryHit events:


### PR DESCRIPTION
Fixes the Bide crash, although Bide maybe should also have the flags object in its moveData when it unleashes.