### PR TITLE
Fix ModifyBoost crashes

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -230,7 +230,7 @@ exports.BattleScripts = {
 		var boosts, boost;
 		if (accuracy !== true) {
 			if (!move.ignoreAccuracy) {
-				boosts = this.runEvent('ModifyBoost', pokemon, null, null, Object.clone(this.boosts));
+				boosts = this.runEvent('ModifyBoost', pokemon, null, null, Object.clone(pokemon.boosts));
 				boost = this.clampIntRange(boosts['accuracy'], -6, 6);
 				if (boost > 0) {
 					accuracy *= boostTable[boost];
@@ -239,7 +239,7 @@ exports.BattleScripts = {
 				}
 			}
 			if (!move.ignoreEvasion) {
-				boosts = this.runEvent('ModifyBoost', pokemon, null, null, Object.clone(this.boosts));
+				boosts = this.runEvent('ModifyBoost', target, null, null, Object.clone(target.boosts));
 				boost = this.clampIntRange(boosts['evasion'], -6, 6);
 				if (boost > 0) {
 					accuracy /= boostTable[boost];


### PR DESCRIPTION
ModifyBoost events called for accuracy and evasion were sending the wrong
object as the relay variable.

Fixes the Gen 4 Simple crash.