### PR TITLE
Ban item transfer moves with Leppa Berry

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -488,7 +488,7 @@ exports.BattleFormats = {
 	endlessbattleclause: {
 		effectType: 'Banlist',
 		name: 'Endless Battle Clause',
-		banlist: ['Leppa Berry + Recycle', 'Harvest + Leppa Berry', 'Shadow Tag + Leppa Berry + Trick'],
+		banlist: ['Leppa Berry + Recycle', 'Leppa Berry + Harvest', 'Leppa Berry + Trick', 'Leppa Berry + Switcheroo', 'Leppa Berry + Bestow'],
 		onStart: function () {
 			this.add('rule', 'Endless Battle Clause: Forcing endless battles is banned');
 		}


### PR DESCRIPTION
There is no legitimate reason to give opponent an useful item, none. However, certain group of people found a way to ignore Endless Battle Clause by trapping the opponent using a move, and then tricking them a Leppa Berry.

To finally end this endless battle nonsense, all ways to get Leppa Berry reused or sent to the opponent are now banned including Bestow (to prevent removing an opponent's item using Knock Off, and then sending a replacement).

It's still possible to cause endless battle, but the opponent has to help a person that wants to cause one, by for example holding Leppa Berry on one of its Pokémon (it can be Tricked). It's also possible to cause endless battle without Leppa Berry by recovering more damage than Struggle recoils deals, and Ditto transforming into that Pokémon (as Limi shows in Super Staff Bros.).

This, however is unlikely to be a concern in practice.