### PR TITLE
Acid, Aurora Beam, Bubble and Bubblebeam effect chance fix

### DIFF
--- a/mods/stadium/moves.js
+++ b/mods/stadium/moves.js
@@ -2,7 +2,7 @@ exports.BattleMovedex = {
 	"acid": {
 		inherit: true,
 		secondary: {
-			chance: 20,
+			chance: 33,
 			boosts: {
 				def: -1
 			}
@@ -11,7 +11,7 @@ exports.BattleMovedex = {
 	aurorabeam: {
 		inherit: true,
 		secondary: {
-			chance: 30,
+			chance: 33,
 			boosts: {
 				atk: -1
 			}
@@ -21,10 +21,19 @@ exports.BattleMovedex = {
 		inherit: true,
 		onBeforeMove: function () {}
 	},
+	bubble: {
+		inherit: true,
+		secondary: {
+			chance: 33,
+			boosts: {
+				spe: -1
+			}
+		}
+	},
 	bubblebeam: {
 		inherit: true,
 		secondary: {
-			chance: 30,
+			chance: 33,
 			boosts: {
 				spe: -1
 			}


### PR DESCRIPTION
http://datacrystal.romhacking.net/wiki/Pokémon_Stadium:ROM_map#Acid.2C_Aurora_Beam.2C_Bubble.2C_Bubblebeam.2C_Psychic
Acid, Aurora Beam, Bubble and Bubblebeam have a 33.2% chance to lower the target's stat one level. My apologies for the previous commit.