### PR TITLE
Trivia plugin: fix crash in timer mode scoring

### DIFF
--- a/chat-plugins/trivia.js
+++ b/chat-plugins/trivia.js
@@ -180,7 +180,7 @@ var Trivia = (function () {
 		scoreData.correctAnswers++;
 		if (this.mode === 'timer') {
 			var points = 5 - ~~((Date.now() - this.askedAt) / (3 * 1000));
-			if (points > 0) {
+			if (points > 0 && points < 6) {
 				scoreData.score += points;
 				scoreData.points = points;
 			}


### PR DESCRIPTION
Theoretically, it's possible to get over 5 points from answering if the
answer was sent before the current question's askedAt is reassigned.