### PR TITLE
Random Battles: Remove flame charge from Ho-oh

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -2076,7 +2076,7 @@ exports.BattleFormatsData = {
 		tier: "Uber"
 	},
 	hooh: {
-		randomBattleMoves: ["substitute","sacredfire","bravebird","earthquake","roost","toxic","flamecharge"],
+		randomBattleMoves: ["substitute","sacredfire","bravebird","earthquake","roost","toxic"],
 		randomDoubleBattleMoves: ["substitute","sacredfire","bravebird","earthquake","roost","toxic","tailwind","skydrop","protect"],
 		eventPokemon: [
 			{"generation":3,"level":70,"moves":["swift","sunnyday","fireblast","recover"]},


### PR DESCRIPTION
There's absolutely no reason for Ho-oh to ever have flame charge over sacred fire, when sacred fire is clearly the obvious choice and Ho-oh will not benefit much from flame charges boosts.