### PR TITLE
Send -end message when Flash Fire volatile disappears

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -753,6 +753,9 @@ exports.BattleAbilities = {
 					this.debug('Flash Fire boost');
 					return this.chainModify(1.5);
 				}
+			},
+			onEnd: function (target) {
+				this.add('-end', target, 'ability: Flash Fire', '[silent]');
 			}
 		},
 		id: "flashfire",


### PR DESCRIPTION
Relevant for when the Pokemon with an active Flash Fire boost has its
ability changed or suppressed.