### PR TITLE
Fix Leppa Berry protocol message

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -2309,7 +2309,7 @@ exports.BattleItems = {
 			}
 			move.pp += 10;
 			if (move.pp > move.maxpp) move.pp = move.maxpp;
-			this.add('-activate', pokemon, 'item: Leppa Berry', 'move: ' + move.name);
+			this.add('-activate', pokemon, 'item: Leppa Berry', move.id);
 		},
 		num: 154,
 		gen: 3,


### PR DESCRIPTION
Apparently the move data that stores PP doesn't have a "name" property.