### PR TITLE
Add Infinity and 0 aliases for /tour autodq off

### DIFF
--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -794,6 +794,7 @@ var commands = {
 			if (params.length < 1) {
 				return this.sendReply("Usage: " + cmd + " <minutes|off>");
 			}
+			if (params[0].toLowerCase() === 'infinity' || params[0] === '0') params[0] = 'off';
 			var timeout = params[0].toLowerCase() === 'off' ? Infinity : params[0];
 			if (tournament.setAutoDisqualifyTimeout(timeout * 60 * 1000, this)) {
 				this.privateModCommand("(The tournament auto disqualify timeout was set to " + params[0] + " by " + user.name + ")");


### PR DESCRIPTION
Infinity and -Infinity are no longer valid settings. The command now
uses 0 instead of Infinity to turn off the timer.