### PR TITLE
Add 'unaway' and 'unrangelock' aliases

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -190,6 +190,7 @@ var commands = exports.commands = {
 		this.parse('/blockpms ' + target);
 	},
 
+	unaway: 'back',
 	back: function () {
 		this.parse('/unblockpms');
 		this.parse('/unblockchallenges');
@@ -983,6 +984,7 @@ var commands = exports.commands = {
 		this.addModCommand("" + user.name + " temporarily locked the range " + range + ".");
 	},
 
+	unrangelock: 'rangeunlock',
 	rangeunlock: function (target, room, user) {
 		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
 		if (!target) return this.sendReply("Please specify a range to unlock.");


### PR DESCRIPTION
In general if a command `/X` can be "reversed", the name for reversing it should be `/unX` for consistency. This adds an alias `/unaway` for `/back`, and `/unrangelock` for `/rangeunlock`.