### PR TITLE
Random Double Battle: Remove Blizzard from Articuno

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1393,7 +1393,7 @@ exports.BattleFormatsData = {
 	},
 	articuno: {
 		randomBattleMoves: ["icebeam","roost","freezedry","toxic","substitute","hurricane"],
-		randomDoubleBattleMoves: ["freezedry","roost","protect","blizzard","substitute","hurricane","tailwind"],
+		randomDoubleBattleMoves: ["freezedry","roost","protect","substitute","hurricane","tailwind"],
 		eventPokemon: [
 			{"generation":3,"level":70,"moves":["agility","mindreader","icebeam","reflect"]},
 			{"generation":3,"level":50,"moves":["icebeam","healbell","extrasensory","haze"]}


### PR DESCRIPTION
It's not worth the low accuracy just to be able to hit both opponents. Better to stick to its Freeze-Dry for coverage, and Hurricane for the high power option.