### PR TITLE
Fix the "IgnoreEffectiveness" parameter in pokemon.negateImmunity

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -3159,7 +3159,7 @@ Battle = (function () {
 		// types
 		var totalTypeMod = 0;
 
-		if (target.negateImmunity[move.type] !== 'IgnoreEffectiveness' || this.getImmunity(move.type, target)) {
+		if (target.negateImmunity[move.type] !== 'IgnoreEffectiveness' || !this.getImmunity(move.type, target)) {
 			totalTypeMod = target.runEffectiveness(move);
 		}
 


### PR DESCRIPTION
It wasn't properly ignoring effectiveness if that Pokemon was immune,
instead ignoring effectiveness if it wasn't immune.

(De Moivre's Rule can be so hard to remember sometimes)