### PR TITLE
Fire Blast on Ninetales and Vulpix

### DIFF
--- a/mods/gen1/formats-data.js
+++ b/mods/gen1/formats-data.js
@@ -162,11 +162,13 @@ exports.BattleFormatsData = {
 		tier: "UU"
 	},
 	vulpix: {
-		randomBattleMoves: ["bodyslam","confuseray","fireblast","reflect","toxic"],
+		randomBattleMoves: ["bodyslam","confuseray","reflect","toxic"],
+		essentialMove: "fireblast",
 		tier: "LC"
 	},
 	ninetales: {
-		randomBattleMoves: ["fireblast","bodyslam","confuseray","doubleedge","hyperbeam","reflect","toxic"],
+		randomBattleMoves: ["bodyslam","confuseray","doubleedge","hyperbeam","reflect","toxic"],
+		essentialMove: "fireblast",
 		tier: "UU"
 	},
 	jigglypuff: {


### PR DESCRIPTION
These two Pokémon have a rather low Attack stat, and are not able to compete without their STAB Fire move.