### PR TITLE
check affectedByImmunities in /eff

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -1192,7 +1192,8 @@ var commands = exports.commands = {
 		if (!this.canBroadcast()) return;
 
 		var factor = 0;
-		if (Tools.getImmunity(source.type || source, defender)) {
+		if (source.category === "Status" && !source.affectedByImmunities) factor = 1;
+		if (Tools.getImmunity(source.type || source, defender) || source.affectedByImmunities === false) {
 			var totalTypeMod = 0;
 			if (source.effectType !== 'Move' || source.basePower || source.basePowerCallback) {
 				for (var i = 0; i < defender.types.length; i++) {


### PR DESCRIPTION
removes minor confusion with some status moves such as Confuse Ray returning with x0 effectiveness as well as the two special cases of Bide and Future Sight. This still does not fix moves which modify immunity from returning correctly such as Thousand Arrows, but all such moves state they remove immunity in their descriptions.