### PR TITLE
Random Double Battle: Update Huntail, Remove Icy Wind/HP-Ice check

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -2979,7 +2979,7 @@ exports.BattleFormatsData = {
 	},
 	huntail: {
 		randomBattleMoves: ["shellsmash","waterfall","icebeam","batonpass","suckerpunch"],
-		randomDoubleBattleMoves: ["shellsmash","return","hydropump","batonpass","suckerpunch","protect"],
+		randomDoubleBattleMoves: ["shellsmash","waterfall","icefang","batonpass","suckerpunch","protect"],
 		tier: "PU"
 	},
 	gorebyss: {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2533,9 +2533,6 @@ exports.BattleScripts = {
 				case 'darkpulse':
 					if (hasMove['crunch'] && setupType !== 'Special') rejected = true;
 					break;
-				case 'hiddenpowerice':
-					if (hasMove['icywind']) rejected = true;
-					break;
 				case 'quickattack':
 					if (hasMove['feint']) rejected = true;
 					break;


### PR DESCRIPTION
The Doubles EV generator means it's more beneficial to give Huntail all
Physical moves (252 Atk Ice Fang outdamages 0 SpA Ice Beam, for example)

Remove Icy Wind/HP-Ice redundancy check because Keldeo no longer has
Hidden Power Ice on its random battle sets.