### PR TITLE
Reduce /ds and /ms output clutter

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -744,12 +744,12 @@ var commands = exports.commands = {
 		});
 		var resultsStr = "";
 		if (results.length > 0) {
-			if (showAll || results.length <= output) {
+			if (showAll || results.length <= output + 5) {
 				results.sort();
 				resultsStr = results.join(", ");
 			} else {
 				results.randomize();
-				resultsStr = results.slice(0, 10).join(", ") + ", and " + string(results.length - output) + " more. Redo the search with 'all' as a search parameter to show all results.";
+				resultsStr = results.slice(0, 10).join(", ") + ", and " + string(results.length - output) + " more. <font color=#999999>Redo the search with 'all' as a search parameter to show all results.</font>";
 			}
 		} else {
 			resultsStr = "No Pokémon found.";
@@ -1066,12 +1066,12 @@ var commands = exports.commands = {
 			results.push(dex[move].name);
 		}
 		if (results.length > 0) {
-			if (showAll || results.length <= output) {
+			if (showAll || results.length <= output + 5) {
 				results.sort();
 				resultsStr = results.join(", ");
 			} else {
 				results.randomize();
-				resultsStr = results.slice(0, 10).join(", ") + ", and " + string(results.length - output) + " more. Redo the search with 'all' as a search parameter to show all results.";
+				resultsStr = results.slice(0, 10).join(", ") + ", and " + string(results.length - output) + " more. <font color=#999999>Redo the search with 'all' as a search parameter to show all results.</font>";
 			}
 		} else {
 			resultsStr = "No moves found.";


### PR DESCRIPTION
Most of the time this message is showing up is because the command is being broadcasted making it irrelevant and just causing clutter.

http://puu.sh/h4nRL.png

This commit also contains another minor change wherein the two commands can output up to 5 additional matches (currently 15) if that is all the matches. This would make the output the same length, if not shorter, than the output if it were to limit it to 10.