### PR TITLE
Random Battle: Change lowest-priority Life Orb check

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1767,7 +1767,7 @@ exports.BattleScripts = {
 			item = 'Leftovers';
 		} else if (this.getImmunity('Ground', template) && this.getEffectiveness('Ground', template) >= 1 && ability !== 'Levitate' && ability !== 'Solid Rock' && !hasMove['magnetrise']) {
 			item = 'Air Balloon';
-		} else if (counter.Status <= 1 && ability !== 'Sturdy') {
+		} else if (counter.Status <= 1 && ability !== 'Sturdy' && template.baseStats.spe * Math.max(template.baseStats.atk, template.baseStats.spa) >= template.baseStats.hp * Math.max(template.baseStats.def, template.baseStats.spd)) {
 			item = 'Life Orb';
 		} else {
 			item = 'Leftovers';
@@ -3041,7 +3041,7 @@ exports.BattleScripts = {
 			// Holistic judgment. Don't boost Protean as much as Parental Bond
 			bst += 0.3 * (evs.atk > evs.spa ? template.baseStats.atk : template.baseStats.spa);
 		} else if (templateAbility === 'Fur Coat') {
-			bst += template.baseStats.def ;
+			bst += template.baseStats.def;
 		}
 		if (item === 'Eviolite') {
 			bst += 0.5 * (template.baseStats.def + template.baseStats.spd);


### PR DESCRIPTION
Bulkier Pokemon reject the final Life Orb check in favor of Leftovers.
Influenced primarily by X-Act's Base Stat Rankings, but with a simplified
check in place of his Offense-Defense Balance calculations.

Influenced by Briyella noting the occasional presence of LO Quagsire or
LO Pelipper without recovery. This is the only plausible check that would
give Pelipper a Life Orb if it didn't have Roost. Although, perhaps it should
be set up so that Quagsire never gets Life Orb?