### PR TITLE
Make Explosion + Rapid Spin illegal on Cloyster

### DIFF
--- a/mods/gen2/rulesets.js
+++ b/mods/gen2/rulesets.js
@@ -126,7 +126,8 @@ exports.BattleFormats = {
 			'Sleep Powder + Perish Song + Mean Look',
 			'Sleep Powder + Perish Song + Spider Web',
 			'Spore + Perish Song + Mean Look',
-			'Spore + Perish Song + Spider Web'
+			'Spore + Perish Song + Spider Web',
+			'Cloyster + Explosion + Rapid Spin'
 		],
 		validateSet: function (set) {
 			// limit one of each move in Standard


### PR DESCRIPTION
Explosion is illegal with Rapid Spin because Rapid Spin is an Egg Move in Gen 2, but it doesn't exist in Gen 1 (where Cloyster learns Explosion), so the two are impossible to get on one set together.