### PR TITLE
Make Explosion + Rapid Spin illegal on Cloyster in GSC

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -4248,7 +4248,7 @@ exports.Formats = [
 
 		mod: 'gen2',
 		ruleset: ['Pokemon', 'Standard'],
-		banlist: ['Uber']
+		banlist: ['Uber',  'Cloyster + Explosion + Rapid Spin']
 	},
 	{
 		name: "[Gen 2] Random Battle",


### PR DESCRIPTION
Explosion is illegal with Rapid Spin because Rapid Spin is an Egg Move in Gen 2, but it doesn't exist in Gen 1 (where Cloyster learns Explosion), so the two are impossible to get on one set together.