### PR TITLE
Make Explosion + Rapid Spin illegal on Cloyster in GSC

### DIFF
--- a/mods/gen2/rulesets.js
+++ b/mods/gen2/rulesets.js
@@ -126,7 +126,8 @@ exports.BattleFormats = {
 			'Sleep Powder + Perish Song + Mean Look',
 			'Sleep Powder + Perish Song + Spider Web',
 			'Spore + Perish Song + Mean Look',
-			'Spore + Perish Song + Spider Web'
+			'Spore + Perish Song + Spider Web',
+			'Cloyster + Explosion + Rapid Spin'
 		],
 		validateSet: function (set) {
 			// limit one of each move in Standard


### PR DESCRIPTION
Unable to be on the same set. Gen 1 TM + Gen 2 Egg move.