### PR TITLE
Move config/commands.js to chat-plugins

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -92,6 +92,8 @@ var commands = exports.commands = {
 			this.sendReply('|raw|' + hiddenrooms);
 		}
 	},
+	whoishelp: ["/whois - Get details on yourself: alts, group, IP address, and rooms.",
+		"/whois [username] - Get details on a username: alts (Requires: % @ & ~), group, IP address (Requires: @ & ~), and rooms."],
 
 	ipsearchall: 'ipsearch',
 	ipsearch: function (target, room, user, connection, cmd) {
@@ -143,6 +145,7 @@ var commands = exports.commands = {
 		}
 		return this.parse('/msg ' + this.targetUsername + ', /invite ' + targetRoom.id);
 	},
+	invitehelp: ["/invite [username], [roomname] - Invites the player [username] to join the room [roomname]."],
 
 	/*********************************************************
 	 * Data Search Tools
@@ -152,8 +155,6 @@ var commands = exports.commands = {
 	stats: 'data',
 	dex: 'data',
 	pokedex: 'data',
-	details: 'data',
-	dt: 'data',
 	data: function (target, room, user, connection, cmd) {
 		if (!this.canBroadcast()) return;
 
@@ -284,6 +285,15 @@ var commands = exports.commands = {
 		}
 		this.sendReply(buffer);
 	},
+	datahelp: ["/data [pokemon/item/move/ability] - Get details on this pokemon/item/move/ability/nature.",
+		"!data [pokemon/item/move/ability] - Show everyone these details. Requires: + % @ & ~"],
+
+	dt: 'details',
+	details: function () {
+		CommandParser.commands.data.apply(this, arguments);
+	},
+	detailshelp: ["/details [pokemon] - Get additional details on this pokemon/item/move/ability/nature.",
+		"!details [pokemon] - Show everyone these details. Requires: + % @ & ~"],
 
 	ds: 'dexsearch',
 	dsearch: 'dexsearch',
@@ -608,6 +618,14 @@ var commands = exports.commands = {
 		}
 		return this.sendReplyBox(resultsStr);
 	},
+	dexsearchhelp: ["/dexsearch [type], [move], [move], ... - Searches for Pokemon that fulfill the selected criteria",
+		"Search categories are: type, tier, color, moves, ability, gen.",
+		"Valid colors are: green, red, blue, white, brown, yellow, purple, pink, gray and black.",
+		"Valid tiers are: Uber/OU/BL/UU/BL2/RU/BL3/NU/PU/NFE/LC/CAP.",
+		"Types must be followed by ' type', e.g., 'dragon type'.",
+		"Parameters can be excluded through the use of '!', e.g., '!water type' excludes all water types.",
+		"The parameter 'mega' can be added to search for Mega Evolutions only, and the parameters 'FE' or 'NFE' can be added to search fully or not-fully evolved Pokemon only.",
+		"The order of the parameters does not matter."],
 
 	ms: 'movesearch',
 	msearch: 'movesearch',
@@ -949,6 +967,13 @@ var commands = exports.commands = {
 		}
 		return this.sendReplyBox(resultsStr);
 	},
+	movesearchhelp: ["/movesearch [parameter], [parameter], [parameter], ... - Searches for moves that fulfill the selected criteria.",
+		"Search categories are: type, category, flag, status inflicted, type boosted, and numeric range for base power, pp, and accuracy.",
+		"Types must be followed by ' type', e.g., 'dragon type'.",
+		"Stat boosts must be preceded with 'boosts ', e.g., 'boosts attack' searches for moves that boost the attack stat.",
+		"Inequality ranges use the characters '>' and '<' though they behave as '≥' and '≤', e.g., 'bp > 100' searches for all moves equal to and greater than 100 base power.",
+		"Parameters can be excluded through the use of '!', e.g., !water type' excludes all water type moves.",
+		"The order of the parameters does not matter."],
 
 	learnset: 'learn',
 	learnall: 'learn',
@@ -1031,6 +1056,8 @@ var commands = exports.commands = {
 		}
 		this.sendReplyBox(buffer);
 	},
+	learnhelp: ["/learn [pokemon], [move, move, ...] - Displays how a Pokemon can learn the given moves, if it can at all.",
+		"!learn [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ & ~"],
 
 	weaknesses: 'weakness',
 	weak: 'weakness',
@@ -1089,6 +1116,10 @@ var commands = exports.commands = {
 		buffer.push('<span class=\"message-effect-immune\">Immunities</span>: ' + (immunities.join(', ') || 'None'));
 		this.sendReplyBox(buffer.join('<br>'));
 	},
+	weaknesshelp: ["/weakness [pokemon] - Provides a Pokemon's resistances, weaknesses, and immunities, ignoring abilities.",
+		"/weakness [type 1]/[type 2] - Provides a type or type combination's resistances, weaknesses, and immunities, ignoring abilities.",
+		"!weakness [pokemon] - Shows everyone a Pokemon's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ & ~",
+		"!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ & ~"],
 
 	eff: 'effectiveness',
 	type: 'effectiveness',
@@ -1151,6 +1182,8 @@ var commands = exports.commands = {
 
 		this.sendReplyBox("" + atkName + " is " + factor + "x effective against " + defName + ".");
 	},
+	effectivenesshelp: ["/effectiveness [attack], [defender] - Provides the effectiveness of a move or type on another type or a Pokémon.",
+		"!effectiveness [attack], [defender] - Shows everyone the effectiveness of a move or type on another type or a Pokémon."],
 
 	/*********************************************************
 	 * Informational commands
@@ -1182,6 +1215,8 @@ var commands = exports.commands = {
 			"~ <b>Administrator</b> - They can do anything, like change what this message says"
 		);
 	},
+	groupshelp: ["/groups - Explains what the + % @ & next to people's names mean.",
+		"!groups - Show everyone that information. Requires: + % @ & ~"],
 
 	repo: 'opensource',
 	repository: 'opensource',
@@ -1196,6 +1231,8 @@ var commands = exports.commands = {
 			"- <a href=\"https://github.com/Zarel/Pokemon-Showdown-Client\">Client source code</a>"
 		);
 	},
+	opensourcehelp: ["/opensource - Links to PS's source code repository.",
+		"!opensource - Show everyone that information. Requires: + % @ & ~"],
 
 	staff: function (target, room, user) {
 		if (!this.canBroadcast()) return;
@@ -1206,6 +1243,8 @@ var commands = exports.commands = {
 		if (!this.canBroadcast()) return;
 		this.sendReplyBox('You can <button name="avatars">change your avatar</button> by clicking on it in the <button name="openOptions"><i class="icon-cog"></i> Options</button> menu in the upper right. Custom avatars are only obtainable by staff.');
 	},
+	avatarshelp: ["/avatars - Explains how to change avatars.",
+		"!avatars - Show everyone that information. Requires: + % @ & ~"],
 
 	introduction: 'intro',
 	intro: function (target, room, user) {
@@ -1218,6 +1257,8 @@ var commands = exports.commands = {
 			"- <a href=\"https://www.smogon.com/xyhub/tiers\">What are the rules for each format? What is 'Sleep Clause'?</a>"
 		);
 	},
+	introhelp: ["/intro - Provides an introduction to competitive pokemon.",
+		"!intro - Show everyone that information. Requires: + % @ & ~"],
 
 	mentoring: 'smogintro',
 	smogonintro: 'smogintro',
@@ -1240,6 +1281,8 @@ var commands = exports.commands = {
 			"- <a href=\"https://pokemonshowdown.com/damagecalc/\">Damage Calculator</a>"
 		);
 	},
+	calchelp: ["/calc - Provides a link to a damage calculator",
+		"!calc - Shows everyone a link to a damage calculator. Requires: + % @ & ~"],
 
 	capintro: 'cap',
 	cap: function (target, room, user) {
@@ -1252,6 +1295,8 @@ var commands = exports.commands = {
 			"- <a href=\"https://www.smogon.com/forums/threads/3512318/#post-5594694\">Sample XY CAP teams</a>"
 		);
 	},
+	caphelp: ["/cap - Provides an introduction to the Create-A-Pokemon project.",
+		"!cap - Show everyone that information. Requires: + % @ & ~"],
 
 	gennext: function (target, room, user) {
 		if (!this.canBroadcast()) return;
@@ -1378,6 +1423,8 @@ var commands = exports.commands = {
 		}
 		this.sendReplyBox(buffer);
 	},
+	othermetashelp: ["/om - Provides links to information on the Other Metagames.",
+		"!om - Show everyone that information. Requires: + % @ & ~"],
 
 	/*formats: 'formathelp',
 	formatshelp: 'formathelp',
@@ -1542,6 +1589,8 @@ var commands = exports.commands = {
 		}
 		this.sendReplyBox(buffer);
 	},
+	faqhelp: ["/faq [theme] - Provides a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them.",
+		"!faq [theme] - Shows everyone a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them. Requires: + % @ & ~"],
 
 	banlists: 'tiers',
 	tier: 'tiers',
@@ -1697,6 +1746,8 @@ var commands = exports.commands = {
 			return this.sendReplyBox("Pokemon, item, move, or ability not found for generation " + generation.toUpperCase() + ".");
 		}
 	},
+	smogdexhelp: ["/analysis [pokemon], [generation] - Links to the Smogon University analysis for this Pokemon in the given generation.",
+		"!analysis [pokemon], [generation] - Shows everyone this link. Requires: + % @ & ~"],
 
 	register: function () {
 		if (!this.canBroadcast()) return;
@@ -1779,6 +1830,8 @@ var commands = exports.commands = {
 		var rand = Math.floor(maxRoll * Math.random()) + 1;
 		return this.sendReplyBox("Random number (1 - " + maxRoll + "): " + rand);
 	},
+	dicehelp: ["/dice [max number] - Randomly picks a number between 1 and the number you choose.",
+		"/dice [number of dice]d[number of sides] - Simulates rolling a number of dice, e.g., /dice 2d4 simulates rolling two 4-sided dice."],
 
 	pr: 'pickrandom',
 	pick: 'pickrandom',
@@ -1788,6 +1841,7 @@ var commands = exports.commands = {
 		if (!this.canBroadcast()) return false;
 		return this.sendReplyBox('<em>We randomly picked:</em> ' + Tools.escapeHTML(options.sample().trim()));
 	},
+	pickrandomhelp: ["/pick [option], [option], ... - Randomly selects an item from a list containing 2 or more elements."],
 
 	showimage: function (target, room, user) {
 		if (!target) return this.parse('/help showimage');
@@ -1801,6 +1855,7 @@ var commands = exports.commands = {
 
 		this.sendReply('|raw|<img src="' + Tools.escapeHTML(targets[0]) + '" alt="" width="' + toId(targets[1]) + '" height="' + toId(targets[2]) + '" />');
 	},
+	showimagehelp: ["/showimage [url], [width], [height] - Show an image. Requires: # & ~"],
 
 	htmlbox: function (target, room, user, connection, cmd, message) {
 		if (!target) return this.parse('/help htmlbox');
@@ -1816,34 +1871,6 @@ var commands = exports.commands = {
 
 		this.sendReplyBox(target);
 	},
+	htmlboxhelp: ["/htmlbox [message] - Displays a message, parsing HTML code contained. Requires: ~ # with global authority"]
 
-	bofrocket: function (target, room, user) {
-		if (room.id !== 'bof') return this.sendReply("The command '/bofrocket' was unrecognized. To send a message starting with '/bofrocket', type '//bofrocket'.");
-		if (!this.can('modchat', null, room)) return;
-		target = this.splitTarget(target);
-		if (!this.targetUser) return this.sendReply("User not found");
-		if (!room.users[this.targetUser.userid]) return this.sendReply("Not in bof");
-		this.targetUser.avatar = '#bofrocket';
-		room.add("" + user.name + " applied bofrocket to " + this.targetUser.name);
-	},
-
-	showtan: function (target, room, user) {
-		if (room.id !== 'showderp') return this.sendReply("The command '/showtan' was unrecognized. To send a message starting with '/showtan', type '//showtan'.");
-		if (!this.can('modchat', null, room)) return;
-		target = this.splitTarget(target);
-		if (!this.targetUser) return this.sendReply("User not found");
-		if (!room.users[this.targetUser.userid]) return this.sendReply("Not a showderper");
-		this.targetUser.avatar = '#showtan';
-		room.add("" + user.name + " applied showtan to affected area of " + this.targetUser.name);
-	},
-
-	cpgtan: function (target, room, user) {
-		if (room.id !== 'cpg') return this.sendReply("The command '/cpgtan' was unrecognized. To send a message starting with '/cpgtan', type '//cpgtan'.");
-		if (!this.can('modchat', null, room)) return;
-		target = this.splitTarget(target);
-		if (!this.targetUser) return this.sendReply("User not found");
-		if (!room.users[this.targetUser.userid]) return this.sendReply("Not a cpger");
-		this.targetUser.avatar = '#cpgtan';
-		room.add("" + user.name + " applied cpgtan to affected area of " + this.targetUser.name);
-	}
 };

--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1,9 +1,9 @@
 /**
- * Commands
+ * Informational Commands
  * Pokemon Showdown - https://pokemonshowdown.com/
  *
- * These are commands. For instance, you can define the command 'whois'
- * here, then use it by typing /whois into Pokemon Showdown.
+ * These are informational commands. For instance, you can define the command
+ * 'whois' here, then use it by typing /whois into Pokemon Showdown.
  *
  * For the API, see chat-plugins/COMMANDS.md
  *
@@ -145,7 +145,7 @@ var commands = exports.commands = {
 	},
 
 	/*********************************************************
-	 * Informational commands
+	 * Data Search Tools
 	 *********************************************************/
 
 	pstats: 'data',
@@ -1152,6 +1152,10 @@ var commands = exports.commands = {
 		this.sendReplyBox("" + atkName + " is " + factor + "x effective against " + defName + ".");
 	},
 
+	/*********************************************************
+	 * Informational commands
+	 *********************************************************/
+
 	uptime: function (target, room, user) {
 		if (!this.canBroadcast()) return;
 		var uptime = process.uptime();
@@ -1694,6 +1698,11 @@ var commands = exports.commands = {
 		}
 	},
 
+	register: function () {
+		if (!this.canBroadcast()) return;
+		this.sendReplyBox('You will be prompted to register upon winning a rated battle. Alternatively, there is a register button in the <button name="openOptions"><i class="icon-cog"></i> Options</button> menu in the upper right.');
+	},
+
 	/*********************************************************
 	 * Miscellaneous commands
 	 *********************************************************/
@@ -1780,24 +1789,6 @@ var commands = exports.commands = {
 		return this.sendReplyBox('<em>We randomly picked:</em> ' + Tools.escapeHTML(options.sample().trim()));
 	},
 
-	register: function () {
-		if (!this.canBroadcast()) return;
-		this.sendReplyBox('You will be prompted to register upon winning a rated battle. Alternatively, there is a register button in the <button name="openOptions"><i class="icon-cog"></i> Options</button> menu in the upper right.');
-	},
-
-	lobbychat: function (target, room, user, connection) {
-		if (!Rooms.lobby) return this.popupReply("This server doesn't have a lobby.");
-		target = toId(target);
-		if (target === 'off') {
-			user.leaveRoom(Rooms.lobby, connection.socket);
-			connection.send('|users|');
-			this.sendReply("You are now blocking lobby chat.");
-		} else {
-			user.joinRoom(Rooms.lobby, connection);
-			this.sendReply("You are now receiving lobby chat.");
-		}
-	},
-
 	showimage: function (target, room, user) {
 		if (!target) return this.parse('/help showimage');
 		if (!this.can('declare', null, room)) return false;
@@ -1826,363 +1817,33 @@ var commands = exports.commands = {
 		this.sendReplyBox(target);
 	},
 
-	a: function (target, room, user) {
-		if (!this.can('rawpacket')) return false;
-		// secret sysop command
-		room.add(target);
+	bofrocket: function (target, room, user) {
+		if (room.id !== 'bof') return this.sendReply("The command '/bofrocket' was unrecognized. To send a message starting with '/bofrocket', type '//bofrocket'.");
+		if (!this.can('modchat', null, room)) return;
+		target = this.splitTarget(target);
+		if (!this.targetUser) return this.sendReply("User not found");
+		if (!room.users[this.targetUser.userid]) return this.sendReply("Not in bof");
+		this.targetUser.avatar = '#bofrocket';
+		room.add("" + user.name + " applied bofrocket to " + this.targetUser.name);
 	},
 
-	/*********************************************************
-	 * Help commands
-	 *********************************************************/
+	showtan: function (target, room, user) {
+		if (room.id !== 'showderp') return this.sendReply("The command '/showtan' was unrecognized. To send a message starting with '/showtan', type '//showtan'.");
+		if (!this.can('modchat', null, room)) return;
+		target = this.splitTarget(target);
+		if (!this.targetUser) return this.sendReply("User not found");
+		if (!room.users[this.targetUser.userid]) return this.sendReply("Not a showderper");
+		this.targetUser.avatar = '#showtan';
+		room.add("" + user.name + " applied showtan to affected area of " + this.targetUser.name);
+	},
 
-	commands: 'help',
-	h: 'help',
-	'?': 'help',
-	help: function (target, room, user) {
-		target = target.toLowerCase();
-		var matched = false;
-		if (target === 'msg' || target === 'pm' || target === 'whisper' || target === 'w') {
-			matched = true;
-			this.sendReply("/msg OR /whisper OR /w [username], [message] - Send a private message.");
-		}
-		if (target === 'r' || target === 'reply') {
-			matched = true;
-			this.sendReply("/reply OR /r [message] - Send a private message to the last person you received a message from, or sent a message to.");
-		}
-		if (target === 'avatar') {
-			matched = true;
-			this.sendReply("/avatar [new avatar number] - Change your trainer sprite.");
-		}
-		if (target === 'whois' || target === 'alts' || target === 'ip' || target === 'rooms') {
-			matched = true;
-			this.sendReply("/whois - Get details on yourself: alts, group, IP address, and rooms.");
-			this.sendReply("/whois [username] - Get details on a username: alts (Requires: % @ & ~), group, IP address (Requires: @ & ~), and rooms.");
-		}
-		if (target === 'data') {
-			matched = true;
-			this.sendReply("/data [pokemon/item/move/ability] - Get details on this pokemon/item/move/ability/nature.");
-			this.sendReply("!data [pokemon/item/move/ability] - Show everyone these details. Requires: + % @ & ~");
-		}
-		if (target === 'details' || target === 'dt') {
-			matched = true;
-			this.sendReply("/details [pokemon] - Get additional details on this pokemon/item/move/ability/nature.");
-			this.sendReply("!details [pokemon] - Show everyone these details. Requires: + % @ & ~");
-		}
-		if (target === 'analysis') {
-			matched = true;
-			this.sendReply("/analysis [pokemon], [generation] - Links to the Smogon University analysis for this Pokemon in the given generation.");
-			this.sendReply("!analysis [pokemon], [generation] - Shows everyone this link. Requires: + % @ & ~");
-		}
-		if (target === 'groups') {
-			matched = true;
-			this.sendReply("/groups - Explains what the + % @ & next to people's names mean.");
-			this.sendReply("!groups - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'opensource') {
-			matched = true;
-			this.sendReply("/opensource - Links to PS's source code repository.");
-			this.sendReply("!opensource - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'avatars') {
-			matched = true;
-			this.sendReply("/avatars - Explains how to change avatars.");
-			this.sendReply("!avatars - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'intro') {
-			matched = true;
-			this.sendReply("/intro - Provides an introduction to competitive pokemon.");
-			this.sendReply("!intro - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'cap') {
-			matched = true;
-			this.sendReply("/cap - Provides an introduction to the Create-A-Pokemon project.");
-			this.sendReply("!cap - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'om') {
-			matched = true;
-			this.sendReply("/om - Provides links to information on the Other Metagames.");
-			this.sendReply("!om - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'learn' || target === 'learnset' || target === 'learnall') {
-			matched = true;
-			this.sendReply("/learn [pokemon], [move, move, ...] - Displays how a Pokemon can learn the given moves, if it can at all.");
-			this.sendReply("!learn [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'calc' || target === 'calculator') {
-			matched = true;
-			this.sendReply("/calc - Provides a link to a damage calculator");
-			this.sendReply("!calc - Shows everyone a link to a damage calculator. Requires: + % @ & ~");
-		}
-		if (target === 'away' || target === 'idle') {
-			matched = true;
-			this.sendReply("/away - Blocks challenges and private messages. Unblock them with /back.");
-		}
-		if (target === 'blockchallenges') {
-			matched = true;
-			this.sendReply("/blockchallenges - Blocks challenges so no one can challenge you. Unblock them with /unblockchallenges.");
-		}
-		if (target === 'blockpms' || target === 'ignorepms') {
-			matched = true;
-			this.sendReply("/blockpms - Blocks private messages. Unblock them with /unignorepms.");
-		}
-		if (target === 'back') {
-			matched = true;
-			this.sendReply("/back - Unblocks challenges and/or private messages, if either are blocked.");
-		}
-		if (target === 'unblockchallenges' || target === 'allowchallenges') {
-			matched = true;
-			this.sendReply("/unblockchallenges - Unblocks challenges so you can be challenged again. Block them with /blockchallenges.");
-		}
-		if (target === 'unblockpms' || target === 'unignorepms') {
-			matched = true;
-			this.sendReply("/unblockpms - Unblocks private messages. Block them with /blockpms.");
-		}
-		if (target === 'faq') {
-			matched = true;
-			this.sendReply("/faq [theme] - Provides a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them.");
-			this.sendReply("!faq [theme] - Shows everyone a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them. Requires: + % @ & ~");
-		}
-		if (target === 'effectiveness' || target === 'matchup' || target === 'eff' || target === 'type') {
-			matched = true;
-			this.sendReply("/effectiveness [attack], [defender] - Provides the effectiveness of a move or type on another type or a Pokémon.");
-			this.sendReply("!effectiveness [attack], [defender] - Shows everyone the effectiveness of a move or type on another type or a Pokémon.");
-		}
-		if (target === 'weakness' || target === 'weaknesses' || target === 'weak' || target === 'resist') {
-			matched = true;
-			this.sendReply("/weakness [pokemon] - Provides a Pokemon's resistances, weaknesses, and immunities, ignoring abilities.");
-			this.sendReply("/weakness [type 1]/[type 2] - Provides a type or type combination's resistances, weaknesses, and immunities, ignoring abilities.");
-			this.sendReply("!weakness [pokemon] - Shows everyone a Pokemon's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ & ~");
-			this.sendReply("!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ & ~");
-		}
-		if (target === 'dexsearch' || target === 'dsearch' || target === 'ds') {
-			matched = true;
-			this.sendReply("/dexsearch [type], [move], [move], ... - Searches for Pokemon that fulfill the selected criteria.");
-			this.sendReply("Search categories are: type, tier, color, moves, ability, gen.");
-			this.sendReply("Valid colors are: green, red, blue, white, brown, yellow, purple, pink, gray and black.");
-			this.sendReply("Valid tiers are: Uber/OU/BL/UU/BL2/RU/BL3/NU/PU/NFE/LC/CAP.");
-			this.sendReply("Types must be followed by ' type', e.g., 'dragon type'.");
-			this.sendReply("Parameters can be excluded through the use of '!', e.g., '!water type' excludes all water types.");
-			this.sendReply("The parameter 'mega' can be added to search for Mega Evolutions only, and the parameters 'FE' or 'NFE' can be added to search fully or not-fully evolved Pokemon only.");
-			this.sendReply("The order of the parameters does not matter.");
-		}
-		if (target === 'movesearch' || target === 'msearch' || target === 'ms') {
-			matched = true;
-			this.sendReply("/movesearch [parameter], [parameter], [parameter], ... - Searches for moves that fulfill the selected criteria.");
-			this.sendReply("Search categories are: type, category, flag, status inflicted, type boosted, and numeric range for base power, pp, and accuracy.");
-			this.sendReply("Types must be followed by ' type', e.g., 'dragon type'.");
-			this.sendReply("Stat boosts must be preceded with 'boosts ', e.g., 'boosts attack' searches for moves that boost the attack stat.");
-			this.sendReply("Inequality ranges use the characters '>' and '<' though they behave as '≥' and '≤', e.g., 'bp > 100' searches for all moves equal to and greater than 100 base power.");
-			this.sendReply("Parameters can be excluded through the use of '!', e.g., !water type' excludes all water type moves.");
-			this.sendReply("The order of the parameters does not matter.");
-		}
-		if (target === 'dice' || target === 'roll') {
-			matched = true;
-			this.sendReply("/dice [optional max number] - Randomly picks a number between 1 and 6, or between 1 and the number you choose.");
-			this.sendReply("/dice [number of dice]d[number of sides] - Simulates rolling a number of dice, e.g., /dice 2d4 simulates rolling two 4-sided dice.");
-		}
-		if (target === 'pick' || target === 'pickrandom') {
-			matched = true;
-			this.sendReply("/pick [option], [option], ... - Randomly selects an item from a list containing 2 or more elements.");
-		}
-		if (target === 'invite') {
-			matched = true;
-			this.sendReply("/invite [username], [roomname] - Invites the player [username] to join the room [roomname].");
-		}
-		if (target === 'addplayer') {
-			matched = true;
-			this.sendReply("/addplayer [username] - Allow the specified user to join the battle as a player.");
-		}
-
-		// driver commands
-		if (target === 'lock' || target === 'l') {
-			matched = true;
-			this.sendReply("/lock OR /l [username], [reason] - Locks the user from talking in all chats. Requires: % @ & ~");
-		}
-		if (target === 'unlock') {
-			matched = true;
-			this.sendReply("/unlock [username] - Unlocks the user. Requires: % @ & ~");
-		}
-		if (target === 'redirect' || target === 'redir') {
-			matched = true;
-			this.sendReply("/redirect OR /redir [username], [roomname] - Attempts to redirect the user [username] to the room [roomname]. Requires: % @ & ~");
-		}
-		if (target === 'modnote') {
-			matched = true;
-			this.sendReply("/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ & ~");
-		}
-		if (target === 'forcerename' || target === 'fr') {
-			matched = true;
-			this.sendReply("/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. Requires: % @ & ~");
-		}
-		if (target === 'kickbattle') {
-			matched = true;
-			this.sendReply("/kickbattle [username], [reason] - Kicks a user from a battle with reason. Requires: % @ & ~");
-		}
-		if (target === 'warn' || target === 'k') {
-			matched = true;
-			this.sendReply("/warn OR /k [username], [reason] - Warns a user showing them the Pokemon Showdown Rules and [reason] in an overlay. Requires: % @ & ~");
-		}
-		if (target === 'modlog') {
-			matched = true;
-			this.sendReply("/modlog [roomid|all], [n] - Roomid defaults to current room. If n is a number or omitted, display the last n lines of the moderator log. Defaults to 15. If n is not a number, search the moderator log for 'n' on room's log [roomid]. If you set [all] as [roomid], searches for 'n' on all rooms's logs. Requires: % @ & ~");
-		}
-		if (target === 'mute' || target === 'm') {
-			matched = true;
-			this.sendReply("/mute OR /m [username], [reason] - Mutes a user with reason for 7 minutes. Requires: % @ & ~");
-		}
-		if (target === 'hourmute' || target === 'hm') {
-			matched = true;
-			this.sendReply("/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. Requires: % @ & ~");
-		}
-		if (target === 'unmute' || target === 'um') {
-			matched = true;
-			this.sendReply("/unmute [username] - Removes mute from user. Requires: % @ & ~");
-		}
-
-		// mod commands
-		if (target === 'roomban' || target === 'rb') {
-			matched = true;
-			this.sendReply("/roomban [username] - Bans the user from the room you are in. Requires: @ & ~");
-		}
-		if (target === 'roomunban') {
-			matched = true;
-			this.sendReply("/roomunban [username] - Unbans the user from the room you are in. Requires: @ & ~");
-		}
-		if (target === 'ban' || target === 'b') {
-			matched = true;
-			this.sendReply("/ban OR /b [username], [reason] - Kick user from all rooms and ban user's IP address with reason. Requires: @ & ~");
-		}
-		if (target === 'unban') {
-			matched = true;
-			this.sendReply("/unban [username] - Unban a user. Requires: @ & ~");
-		}
-
-		// RO commands
-		if (target === 'showimage') {
-			matched = true;
-			this.sendReply("/showimage [url], [width], [height] - Show an image. Requires: # & ~");
-		}
-		if (target === 'roompromote') {
-			matched = true;
-			this.sendReply("/roompromote [username], [group] - Promotes the user to the specified group or next ranked group. Requires: @ # & ~");
-		}
-		if (target === 'roomdemote') {
-			matched = true;
-			this.sendReply("/roomdemote [username], [group] - Demotes the user to the specified group or previous ranked group. Requires: @ # & ~");
-		}
-
-		// leader commands
-		if (target === 'banip') {
-			matched = true;
-			this.sendReply("/banip [ip] - Kick users on this IP or IP range from all rooms and bans it. Accepts wildcards to ban ranges. Requires: & ~");
-		}
-		if (target === 'unbanip') {
-			matched = true;
-			this.sendReply("/unbanip [ip] - Kick users on this IP or IP range from all rooms and bans it. Accepts wildcards to ban ranges. Requires: & ~");
-		}
-		if (target === 'unbanall') {
-			matched = true;
-			this.sendReply("/unbanall - Unban all IP addresses. Requires: & ~");
-		}
-		if (target === 'promote') {
-			matched = true;
-			this.sendReply("/promote [username], [group] - Promotes the user to the specified group or next ranked group. Requires: & ~");
-		}
-		if (target === 'demote') {
-			matched = true;
-			this.sendReply("/demote [username], [group] - Demotes the user to the specified group or previous ranked group. Requires: & ~");
-		}
-		if (target === 'forcetie') {
-			matched = true;
-			this.sendReply("/forcetie - Forces the current match to tie. Requires: & ~");
-		}
-		if (target === 'declare') {
-			matched = true;
-			this.sendReply("/declare [message] - Anonymously announces a message. Requires: & ~");
-		}
-
-		// admin commands
-		if (target === 'chatdeclare' || target === 'cdeclare') {
-			matched = true;
-			this.sendReply("/cdeclare [message] - Anonymously announces a message to all chatrooms on the server. Requires: ~");
-		}
-		if (target === 'globaldeclare' || target === 'gdeclare') {
-			matched = true;
-			this.sendReply("/globaldeclare [message] - Anonymously announces a message to every room on the server. Requires: ~");
-		}
-		if (target === 'htmlbox') {
-			matched = true;
-			this.sendReply("/htmlbox [message] - Displays a message, parsing HTML code contained. Requires: ~ # with global authority");
-		}
-		if (target === 'announce' || target === 'wall') {
-			matched = true;
-			this.sendReply("/announce OR /wall [message] - Makes an announcement. Requires: % @ & ~");
-		}
-		if (target === 'modchat') {
-			matched = true;
-			this.sendReply("/modchat [off/autoconfirmed/+/%/@/&/~] - Set the level of moderated chat. Requires: @ for off/autoconfirmed/+ options, & ~ for all the options");
-		}
-		if (target === 'hotpatch') {
-			matched = true;
-			this.sendReply("Hot-patching the game engine allows you to update parts of Showdown without interrupting currently-running battles. Requires: ~");
-			this.sendReply("Hot-patching has greater memory requirements than restarting.");
-			this.sendReply("/hotpatch chat - reload chat-commands.js");
-			this.sendReply("/hotpatch battles - spawn new simulator processes");
-			this.sendReply("/hotpatch formats - reload the tools.js tree, rebuild and rebroad the formats list, and also spawn new simulator processes");
-		}
-		if (target === 'lockdown') {
-			matched = true;
-			this.sendReply("/lockdown - locks down the server, which prevents new battles from starting so that the server can eventually be restarted. Requires: ~");
-		}
-		if (target === 'kill') {
-			matched = true;
-			this.sendReply("/kill - kills the server. Can't be done unless the server is in lockdown state. Requires: ~");
-		}
-		if (target === 'loadbanlist') {
-			matched = true;
-			this.sendReply("/loadbanlist - Loads the bans located at ipbans.txt. The command is executed automatically at startup. Requires: ~");
-		}
-		if (target === 'makechatroom') {
-			matched = true;
-			this.sendReply("/makechatroom [roomname] - Creates a new room named [roomname]. Requires: ~");
-		}
-		if (target === 'deregisterchatroom') {
-			matched = true;
-			this.sendReply("/deregisterchatroom [roomname] - Deletes room [roomname] after the next server restart. Requires: ~");
-		}
-		if (target === 'roomowner') {
-			matched = true;
-			this.sendReply("/roomowner [username] - Appoints [username] as a room owner. Removes official status. Requires: ~");
-		}
-		if (target === 'roomdeowner') {
-			matched = true;
-			this.sendReply("/roomdeowner [username] - Removes [username]'s status as a room owner. Requires: ~");
-		}
-		if (target === 'privateroom' || target === 'hiddenroom') {
-			matched = true;
-			this.sendReply("/privateroom [on/off] - Makes or unmakes a room private. Requires: ~");
-			this.sendReply("/hiddenroom [on/off] - Makes or unmakes a room hidden. Hidden rooms will maintain global ranks of users. Requires: \u2605 ~");
-		}
-
-		// overall
-		if (target === 'help' || target === 'h' || target === '?' || target === 'commands') {
-			matched = true;
-			this.sendReply("/help OR /h OR /? - Gives you help.");
-		}
-		if (!target) {
-			this.sendReply("COMMANDS: /nick, /avatar, /rating, /whois, /msg, /reply, /ignore, /away, /back, /timestamps, /highlight");
-			this.sendReply("INFORMATIONAL COMMANDS: /data, /dexsearch, /movesearch, /groups, /opensource, /avatars, /faq, /rules, /intro, /tiers, /othermetas, /learn, /analysis, /calc (replace / with ! to broadcast. Broadcasting requires: + % @ & ~)");
-			if (user.group !== Config.groupsranking[0]) {
-				this.sendReply("DRIVER COMMANDS: /warn, /mute, /unmute, /alts, /forcerename, /modlog, /lock, /unlock, /announce, /redirect");
-				this.sendReply("MODERATOR COMMANDS: /ban, /unban, /ip");
-				this.sendReply("LEADER COMMANDS: /declare, /forcetie, /forcewin, /promote, /demote, /banip, /unbanall");
-			}
-			this.sendReply("For an overview of room commands, use /roomhelp");
-			this.sendReply("For details of a specific command, use something like: /help data");
-		} else if (!matched) {
-			this.sendReply("Help for the command '" + target + "' was not found. Try /help for general help");
-		}
+	cpgtan: function (target, room, user) {
+		if (room.id !== 'cpg') return this.sendReply("The command '/cpgtan' was unrecognized. To send a message starting with '/cpgtan', type '//cpgtan'.");
+		if (!this.can('modchat', null, room)) return;
+		target = this.splitTarget(target);
+		if (!this.targetUser) return this.sendReply("User not found");
+		if (!room.users[this.targetUser.userid]) return this.sendReply("Not a cpger");
+		this.targetUser.avatar = '#cpgtan';
+		room.add("" + user.name + " applied cpgtan to affected area of " + this.targetUser.name);
 	}
-
 };

--- a/command-parser.js
+++ b/command-parser.js
@@ -7,9 +7,9 @@
  *
  * Individual commands are put in:
  *   commands.js - "core" commands that shouldn't be modified
- *   config/commands.js - other commands that can be safely modified
+ *   chat-plugins/ - other commands that can be safely modified
  *
- * The command API is (mostly) documented in config/commands.js
+ * The command API is (mostly) documented in chat-plugins/COMMANDS.md
  *
  * @license MIT license
  */
@@ -37,11 +37,6 @@ var fs = require('fs');
  *********************************************************/
 
 var commands = exports.commands = require('./commands.js').commands;
-
-var customCommands = require('./config/commands.js');
-if (customCommands && customCommands.commands) {
-	Object.merge(commands, customCommands.commands);
-}
 
 // Install plug-in commands
 

--- a/commands.js
+++ b/commands.js
@@ -86,6 +86,7 @@ var commands = exports.commands = {
 				'|raw|<img src="//play.pokemonshowdown.com/sprites/trainers/' + avatar + '.png" alt="" width="80" height="80" />');
 		}
 	},
+	avatarhelp: ["/avatar [new avatar number] - Change your trainer sprite."],
 
 	logout: function (target, room, user) {
 		user.resetName();
@@ -104,6 +105,7 @@ var commands = exports.commands = {
 		}
 		return this.parse('/msg ' + (user.lastPM || '') + ', ' + target);
 	},
+	replyhelp: ["/reply OR /r [message] - Send a private message to the last person you received a message from, or sent a message to."],
 
 	pm: 'msg',
 	whisper: 'msg',
@@ -188,6 +190,7 @@ var commands = exports.commands = {
 		targetUser.lastPM = user.userid;
 		user.lastPM = targetUser.userid;
 	},
+	msghelp: ["/msg OR /whisper OR /w [username], [message] - Send a private message."],
 
 	blockpm: 'ignorepms',
 	blockpms: 'ignorepms',
@@ -202,6 +205,7 @@ var commands = exports.commands = {
 		}
 		return this.sendReply("You are now blocking private messages, except from staff.");
 	},
+	ignorepmshelp: ["/blockpms - Blocks private messages. Unblock them with /unignorepms."],
 
 	unblockpm: 'unignorepms',
 	unblockpms: 'unignorepms',
@@ -211,18 +215,21 @@ var commands = exports.commands = {
 		user.ignorePMs = false;
 		return this.sendReply("You are no longer blocking private messages.");
 	},
+	unignorepmshelp: ["/unblockpms - Unblocks private messages. Block them with /blockpms."],
 
 	idle: 'away',
 	away: function (target, room, user) {
 		this.parse('/blockchallenges');
 		this.parse('/blockpms ' + target);
 	},
+	awayhelp: ["/away - Blocks challenges and private messages. Unblock them with /back."],
 
 	unaway: 'back',
 	back: function () {
 		this.parse('/unblockpms');
 		this.parse('/unblockchallenges');
 	},
+	backhelp: ["/back - Unblocks challenges and/or private messages, if either are blocked."],
 
 	makechatroom: function (target, room, user) {
 		if (!this.can('makeroom')) return;
@@ -242,6 +249,7 @@ var commands = exports.commands = {
 		}
 		return this.sendReply("An error occurred while trying to create the room '" + target + "'.");
 	},
+	makechatroomhelp: ["/makechatroom [roomname] - Creates a new room named [roomname]. Requires: ~"],
 
 	deregisterchatroom: function (target, room, user) {
 		if (!this.can('makeroom')) return;
@@ -257,6 +265,7 @@ var commands = exports.commands = {
 		}
 		return this.sendReply("The room '" + target + "' isn't registered.");
 	},
+	deregisterchatroomhelp: ["/deregisterchatroom [roomname] - Deletes room [roomname] after the next server restart. Requires: ~"],
 
 	hideroom: 'privateroom',
 	hiddenroom: 'privateroom',
@@ -294,6 +303,8 @@ var commands = exports.commands = {
 			}
 		}
 	},
+	privateroomhelp: ["/privateroom [on/off] - Makes or unmakes a room private. Requires: ~",
+		"/hiddenroom [on/off] - Makes or unmakes a room hidden. Hidden rooms will maintain global ranks of users. Requires: \u2605 ~"],
 
 	modjoin: function (target, room, user) {
 		if (!this.can('privateroom', null, room)) return;
@@ -466,6 +477,7 @@ var commands = exports.commands = {
 		room.onUpdateIdentity(targetUser);
 		Rooms.global.writeChatRoomData();
 	},
+	roomownerhelp: ["/roomowner [username] - Appoints [username] as a room owner. Removes official status. Requires: ~"],
 
 	roomdeowner: 'deroomowner',
 	deroomowner: function (target, room, user) {
@@ -488,6 +500,7 @@ var commands = exports.commands = {
 			Rooms.global.writeChatRoomData();
 		}
 	},
+	deroomownerhelp: ["/roomdeowner [username] - Removes [username]'s status as a room owner. Requires: ~"],
 
 	roomdemote: 'roompromote',
 	roompromote: function (target, room, user, connection, cmd) {
@@ -547,6 +560,8 @@ var commands = exports.commands = {
 		if (targetUser) targetUser.updateIdentity(room.id);
 		if (room.chatRoomData) Rooms.global.writeChatRoomData();
 	},
+	roompromotehelp: ["/roompromote [username], [group] - Promotes the user to the specified group or next ranked group. Requires: @ # & ~"],
+	roomdemotehelp: ["/roomdemote [username], [group] - Demotes the user to the specified group or previous ranked group. Requires: @ # & ~"],
 
 	roomauth: function (target, room, user, connection) {
 		var targetRoom = room;
@@ -644,6 +659,7 @@ var commands = exports.commands = {
 		}
 		this.add('|unlink|' + this.getLastIdOf(targetUser));
 	},
+	roombanhelp: ["/roomban [username] - Bans the user from the room you are in. Requires: @ & ~"],
 
 	unroomban: 'roomunban',
 	roomunban: function (target, room, user, connection) {
@@ -665,6 +681,7 @@ var commands = exports.commands = {
 		if (targetUser) targetUser.popup("" + user.name + " has unbanned you from the room " + room.id + ".");
 		this.addModCommand("" + unbannedUserid + " was unbanned from room " + room.id + " by " + user.name + ".");
 	},
+	roomunbanhelp: ["/roomunban [username] - Unbans the user from the room you are in. Requires: @ & ~"],
 
 	autojoin: function (target, room, user, connection) {
 		Rooms.global.autojoinRooms(user, connection);
@@ -747,6 +764,7 @@ var commands = exports.commands = {
 		targetUser.send('|c|~|/warn ' + target);
 		this.add('|unlink|' + this.getLastIdOf(targetUser));
 	},
+	warnhelp: ["/warn OR /k [username], [reason] - Warns a user showing them the Pokemon Showdown Rules and [reason] in an overlay. Requires: % @ & ~"],
 
 	redirect: 'redir',
 	redir: function (target, room, user, connection) {
@@ -774,9 +792,8 @@ var commands = exports.commands = {
 		this.addModCommand("" + targetUser.name + " was redirected to " + roomName + " by " + user.name + ".");
 		targetUser.leaveRoom(room);
 	},
+	redirhelp: ["/redirect OR /redir [username], [roomname] - Attempts to redirect the user [username] to the room [roomname]. Requires: % @ & ~"],
 
-	hm: 'mute',
-	hourmute: 'mute',
 	m: 'mute',
 	mute: function (target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help mute');
@@ -808,6 +825,13 @@ var commands = exports.commands = {
 
 		targetUser.mute(room.id, muteDuration, true);
 	},
+	mutehelp: ["/mute OR /m [username], [reason] - Mutes a user with reason for 7 minutes. Requires: % @ & ~"],
+
+	hm: 'hourmute',
+	hourmute: function () {
+		CommandParser.commands.mute.apply(this, arguments);
+	},
+	hourmutehelp: ["/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. Requires: % @ & ~"],
 
 	um: 'unmute',
 	unmute: function (target, room, user) {
@@ -825,6 +849,7 @@ var commands = exports.commands = {
 
 		targetUser.unmute(room.id);
 	},
+	unmutehelp: ["/unmute [username] - Removes mute from user. Requires: % @ & ~"],
 
 	l: 'lock',
 	ipmute: 'lock',
@@ -864,6 +889,7 @@ var commands = exports.commands = {
 
 		targetUser.lock();
 	},
+	lockhelp: ["/lock OR /l [username], [reason] - Locks the user from talking in all chats. Requires: % @ & ~"],
 
 	unlock: function (target, room, user) {
 		if (!target) return this.parse('/help unlock');
@@ -881,6 +907,7 @@ var commands = exports.commands = {
 			this.sendReply("User '" + target + "' is not locked.");
 		}
 	},
+	unlockhelp: ["/unlock [username] - Unlocks the user. Requires: % @ & ~"],
 
 	b: 'ban',
 	ban: function (target, room, user) {
@@ -922,6 +949,7 @@ var commands = exports.commands = {
 		this.add('|unlink|hide|' + this.getLastIdOf(targetUser));
 		targetUser.ban();
 	},
+	banhelp: ["/ban OR /b [username], [reason] - Kick user from all rooms and ban user's IP address with reason. Requires: @ & ~"],
 
 	unban: function (target, room, user) {
 		if (!target) return this.parse('/help unban');
@@ -936,6 +964,7 @@ var commands = exports.commands = {
 			this.sendReply("User '" + target + "' is not banned.");
 		}
 	},
+	unbanhelp: ["/unban [username] - Unban a user. Requires: @ & ~"],
 
 	unbanall: function (target, room, user) {
 		if (!this.can('rangeban')) return false;
@@ -949,6 +978,7 @@ var commands = exports.commands = {
 		}
 		this.addModCommand("All bans and locks have been lifted by " + user.name + ".");
 	},
+	unbanallhelp: ["/unbanall - Unban all IP addresses. Requires: & ~"],
 
 	banip: function (target, room, user) {
 		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
@@ -962,6 +992,7 @@ var commands = exports.commands = {
 		Users.bannedIps[target] = '#ipban';
 		this.addModCommand("" + user.name + " temporarily banned the " + (target.charAt(target.length - 1) === '*' ? "IP range" : "IP") + ": " + target);
 	},
+	baniphelp: ["/banip [ip] - Kick users on this IP or IP range from all rooms and bans it. Accepts wildcards to ban ranges. Requires: & ~"],
 
 	unbanip: function (target, room, user) {
 		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
@@ -976,6 +1007,7 @@ var commands = exports.commands = {
 		delete Users.bannedIps[target];
 		this.addModCommand("" + user.name + " unbanned the " + (target.charAt(target.length - 1) === '*' ? "IP range" : "IP") + ": " + target);
 	},
+	unbaniphelp: ["/unbanip [ip] - Kick users on this IP or IP range from all rooms and bans it. Accepts wildcards to ban ranges. Requires: & ~"],
 
 	rangelock: function (target, room, user) {
 		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
@@ -1018,10 +1050,9 @@ var commands = exports.commands = {
 		if (!this.can('receiveauthmessages', null, room)) return false;
 		return this.privateModCommand("(" + user.name + " notes: " + target + ")");
 	},
+	modnotehelp: ["/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ & ~"],
 
-	globaldemote: 'promote',
 	globalpromote: 'promote',
-	demote: 'promote',
 	promote: function (target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help promote');
 
@@ -1062,6 +1093,13 @@ var commands = exports.commands = {
 
 		if (targetUser) targetUser.updateIdentity();
 	},
+	promotehelp: ["/promote [username], [group] - Promotes the user to the specified group or next ranked group. Requires: & ~"],
+
+	globaldemote: 'demote',
+	demote: function () {
+		CommandParser.commands.promote.apply(this, arguments);
+	},
+	demotehelp: ["/demote [username], [group] - Demotes the user to the specified group or previous ranked group. Requires: & ~"],
 
 	forcepromote: function (target, room, user) {
 		// warning: never document this command in /help
@@ -1139,6 +1177,7 @@ var commands = exports.commands = {
 			Rooms.global.writeChatRoomData();
 		}
 	},
+	modchathelp: ["/modchat [off/autoconfirmed/+/%/@/&/~] - Set the level of moderated chat. Requires: @ for off/autoconfirmed/+ options, & ~ for all the options"],
 
 	declare: function (target, room, user) {
 		if (!target) return this.parse('/help declare');
@@ -1149,6 +1188,7 @@ var commands = exports.commands = {
 		this.add('|raw|<div class="broadcast-blue"><b>' + Tools.escapeHTML(target) + '</b></div>');
 		this.logModCommand(user.name + " declared " + target);
 	},
+	declarehelp: ["/declare [message] - Anonymously announces a message. Requires: & ~"],
 
 	htmldeclare: function (target, room, user) {
 		if (!target) return this.parse('/help htmldeclare');
@@ -1170,6 +1210,7 @@ var commands = exports.commands = {
 		}
 		this.logModCommand(user.name + " globally declared " + target);
 	},
+	globaldeclarehelp: ["/globaldeclare [message] - Anonymously announces a message to every room on the server. Requires: ~"],
 
 	cdeclare: 'chatdeclare',
 	chatdeclare: function (target, room, user) {
@@ -1181,6 +1222,7 @@ var commands = exports.commands = {
 		}
 		this.logModCommand(user.name + " globally declared (chat level) " + target);
 	},
+	chatdeclarehelp: ["/cdeclare [message] - Anonymously announces a message to all chatrooms on the server. Requires: ~"],
 
 	wall: 'announce',
 	announce: function (target, room, user) {
@@ -1193,6 +1235,7 @@ var commands = exports.commands = {
 
 		return '/announce ' + target;
 	},
+	announcehelp: ["/announce OR /wall [message] - Makes an announcement. Requires: % @ & ~"],
 
 	fr: 'forcerename',
 	forcerename: function (target, room, user) {
@@ -1218,6 +1261,7 @@ var commands = exports.commands = {
 		targetUser.resetName();
 		targetUser.send("|nametaken||" + user.name + " considers your name inappropriate" + (reason ? ": " + reason : "."));
 	},
+	forcerenamehelp: ["/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. Requires: % @ & ~"],
 
 	modlog: function (target, room, user, connection) {
 		var lines = 0;
@@ -1301,6 +1345,9 @@ var commands = exports.commands = {
 			}
 		});
 	},
+	modloghelp: ["/modlog [roomid|all], [n] - Roomid defaults to current room.",
+		"If n is a number or omitted, display the last n lines of the moderator log. Defaults to 15.",
+		"If n is not a number, search the moderator log for 'n' on room's log [roomid]. If you set [all] as [roomid], searches for 'n' on all rooms's logs. Requires: % @ & ~"],
 
 	/*********************************************************
 	 * Server management commands
@@ -1372,6 +1419,11 @@ var commands = exports.commands = {
 		}
 		this.sendReply("Your hot-patch command was unrecognized.");
 	},
+	hotpatchhelp: ["Hot-patching the game engine allows you to update parts of Showdown without interrupting currently-running battles. Requires: ~",
+		"Hot-patching has greater memory requirements than restarting.",
+		"/hotpatch chat - reload chat-commands.js",
+		"/hotpatch battles - spawn new simulator processes",
+		"/hotpatch formats - reload the tools.js tree, rebuild and rebroad the formats list, and also spawn new simulator processes"],
 
 	savelearnsets: function (target, room, user) {
 		if (!this.can('hotpatch')) return false;
@@ -1418,6 +1470,7 @@ var commands = exports.commands = {
 
 		this.logEntry(user.name + " used /lockdown");
 	},
+	lockdownhelp: ["/lockdown - locks down the server, which prevents new battles from starting so that the server can eventually be restarted. Requires: ~"],
 
 	prelockdown: function (target, room, user) {
 		if (!this.can('lockdown')) return false;
@@ -1517,6 +1570,7 @@ var commands = exports.commands = {
 			process.exit();
 		}, 10000);
 	},
+	killhelp: ["/kill - kills the server. Can't be done unless the server is in lockdown state. Requires: ~"],
 
 	loadbanlist: function (target, room, user, connection) {
 		if (!this.can('hotpatch')) return false;
@@ -1539,6 +1593,7 @@ var commands = exports.commands = {
 			connection.sendTo(room, "ipbans.txt has been reloaded.");
 		});
 	},
+	loadbanlisthelp: ["/loadbanlist - Loads the bans located at ipbans.txt. The command is executed automatically at startup. Requires: ~"],
 
 	refreshpage: function (target, room, user) {
 		if (!this.can('hotpatch')) return false;
@@ -1809,6 +1864,7 @@ var commands = exports.commands = {
 		room.auth[targetUser.userid] = '\u2605';
 		this.addModCommand("" + name  + " was promoted to Player by " + user.name + ".");
 	},
+	addplayerhelp: ["/addplayer [username] - Allow the specified user to join the battle as a player."],
 
 	joinbattle: function (target, room, user) {
 		if (!room.joinBattle) return this.sendReply("You can only do this in battle rooms.");
@@ -1840,6 +1896,7 @@ var commands = exports.commands = {
 			this.sendReply("/kickbattle - User isn't in battle.");
 		}
 	},
+	kickbattlehelp: ["/kickbattle [username], [reason] - Kicks a user from a battle with reason. Requires: % @ & ~"],
 
 	kickinactive: function (target, room, user) {
 		if (room.requestKickInactive) {
@@ -1902,6 +1959,7 @@ var commands = exports.commands = {
 			this.logModCommand(user.name + " forced a win for " + target + ".");
 		}
 	},
+	forcewinhelp: ["/forcetie - Forces the current match to tie. Requires: & ~"],
 
 	/*********************************************************
 	 * Challenging and searching commands
@@ -1955,6 +2013,7 @@ var commands = exports.commands = {
 		user.blockChallenges = true;
 		this.sendReply("You are now blocking all incoming challenge requests.");
 	},
+	blockchallengeshelp: ["/blockchallenges - Blocks challenges so no one can challenge you. Unblock them with /unblockchallenges."],
 
 	unbch: 'allowchallenges',
 	unblockchall: 'allowchallenges',
@@ -1965,6 +2024,7 @@ var commands = exports.commands = {
 		user.blockChallenges = false;
 		this.sendReply("You are available for challenges from now on.");
 	},
+	allowchallengeshelp: ["/unblockchallenges - Unblocks challenges so you can be challenged again. Block them with /blockchallenges."],
 
 	cchall: 'cancelChallenge',
 	cancelchallenge: function (target, room, user) {
@@ -2086,338 +2146,13 @@ var commands = exports.commands = {
 	'?': 'help',
 	help: function (target, room, user) {
 		target = target.toLowerCase();
-		var matched = false;
-		if (target === 'msg' || target === 'pm' || target === 'whisper' || target === 'w') {
-			matched = true;
-			this.sendReply("/msg OR /whisper OR /w [username], [message] - Send a private message.");
-		}
-		if (target === 'r' || target === 'reply') {
-			matched = true;
-			this.sendReply("/reply OR /r [message] - Send a private message to the last person you received a message from, or sent a message to.");
-		}
-		if (target === 'avatar') {
-			matched = true;
-			this.sendReply("/avatar [new avatar number] - Change your trainer sprite.");
-		}
-		if (target === 'whois' || target === 'alts' || target === 'ip' || target === 'rooms') {
-			matched = true;
-			this.sendReply("/whois - Get details on yourself: alts, group, IP address, and rooms.");
-			this.sendReply("/whois [username] - Get details on a username: alts (Requires: % @ & ~), group, IP address (Requires: @ & ~), and rooms.");
-		}
-		if (target === 'data') {
-			matched = true;
-			this.sendReply("/data [pokemon/item/move/ability] - Get details on this pokemon/item/move/ability/nature.");
-			this.sendReply("!data [pokemon/item/move/ability] - Show everyone these details. Requires: + % @ & ~");
-		}
-		if (target === 'details' || target === 'dt') {
-			matched = true;
-			this.sendReply("/details [pokemon] - Get additional details on this pokemon/item/move/ability/nature.");
-			this.sendReply("!details [pokemon] - Show everyone these details. Requires: + % @ & ~");
-		}
-		if (target === 'analysis') {
-			matched = true;
-			this.sendReply("/analysis [pokemon], [generation] - Links to the Smogon University analysis for this Pokemon in the given generation.");
-			this.sendReply("!analysis [pokemon], [generation] - Shows everyone this link. Requires: + % @ & ~");
-		}
-		if (target === 'groups') {
-			matched = true;
-			this.sendReply("/groups - Explains what the + % @ & next to people's names mean.");
-			this.sendReply("!groups - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'opensource') {
-			matched = true;
-			this.sendReply("/opensource - Links to PS's source code repository.");
-			this.sendReply("!opensource - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'avatars') {
-			matched = true;
-			this.sendReply("/avatars - Explains how to change avatars.");
-			this.sendReply("!avatars - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'intro') {
-			matched = true;
-			this.sendReply("/intro - Provides an introduction to competitive pokemon.");
-			this.sendReply("!intro - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'cap') {
-			matched = true;
-			this.sendReply("/cap - Provides an introduction to the Create-A-Pokemon project.");
-			this.sendReply("!cap - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'om') {
-			matched = true;
-			this.sendReply("/om - Provides links to information on the Other Metagames.");
-			this.sendReply("!om - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'learn' || target === 'learnset' || target === 'learnall') {
-			matched = true;
-			this.sendReply("/learn [pokemon], [move, move, ...] - Displays how a Pokemon can learn the given moves, if it can at all.");
-			this.sendReply("!learn [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ & ~");
-		}
-		if (target === 'calc' || target === 'calculator') {
-			matched = true;
-			this.sendReply("/calc - Provides a link to a damage calculator");
-			this.sendReply("!calc - Shows everyone a link to a damage calculator. Requires: + % @ & ~");
-		}
-		if (target === 'away' || target === 'idle') {
-			matched = true;
-			this.sendReply("/away - Blocks challenges and private messages. Unblock them with /back.");
-		}
-		if (target === 'blockchallenges') {
-			matched = true;
-			this.sendReply("/blockchallenges - Blocks challenges so no one can challenge you. Unblock them with /unblockchallenges.");
-		}
-		if (target === 'blockpms' || target === 'ignorepms') {
-			matched = true;
-			this.sendReply("/blockpms - Blocks private messages. Unblock them with /unignorepms.");
-		}
-		if (target === 'back') {
-			matched = true;
-			this.sendReply("/back - Unblocks challenges and/or private messages, if either are blocked.");
-		}
-		if (target === 'unblockchallenges' || target === 'allowchallenges') {
-			matched = true;
-			this.sendReply("/unblockchallenges - Unblocks challenges so you can be challenged again. Block them with /blockchallenges.");
-		}
-		if (target === 'unblockpms' || target === 'unignorepms') {
-			matched = true;
-			this.sendReply("/unblockpms - Unblocks private messages. Block them with /blockpms.");
-		}
-		if (target === 'faq') {
-			matched = true;
-			this.sendReply("/faq [theme] - Provides a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them.");
-			this.sendReply("!faq [theme] - Shows everyone a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them. Requires: + % @ & ~");
-		}
-		if (target === 'effectiveness' || target === 'matchup' || target === 'eff' || target === 'type') {
-			matched = true;
-			this.sendReply("/effectiveness [attack], [defender] - Provides the effectiveness of a move or type on another type or a Pokémon.");
-			this.sendReply("!effectiveness [attack], [defender] - Shows everyone the effectiveness of a move or type on another type or a Pokémon.");
-		}
-		if (target === 'weakness' || target === 'weaknesses' || target === 'weak' || target === 'resist') {
-			matched = true;
-			this.sendReply("/weakness [pokemon] - Provides a Pokemon's resistances, weaknesses, and immunities, ignoring abilities.");
-			this.sendReply("/weakness [type 1]/[type 2] - Provides a type or type combination's resistances, weaknesses, and immunities, ignoring abilities.");
-			this.sendReply("!weakness [pokemon] - Shows everyone a Pokemon's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ & ~");
-			this.sendReply("!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ & ~");
-		}
-		if (target === 'dexsearch' || target === 'dsearch' || target === 'ds') {
-			matched = true;
-			this.sendReply("/dexsearch [type], [move], [move], ... - Searches for Pokemon that fulfill the selected criteria.");
-			this.sendReply("Search categories are: type, tier, color, moves, ability, gen.");
-			this.sendReply("Valid colors are: green, red, blue, white, brown, yellow, purple, pink, gray and black.");
-			this.sendReply("Valid tiers are: Uber/OU/BL/UU/BL2/RU/BL3/NU/PU/NFE/LC/CAP.");
-			this.sendReply("Types must be followed by ' type', e.g., 'dragon type'.");
-			this.sendReply("Parameters can be excluded through the use of '!', e.g., '!water type' excludes all water types.");
-			this.sendReply("The parameter 'mega' can be added to search for Mega Evolutions only, and the parameters 'FE' or 'NFE' can be added to search fully or not-fully evolved Pokemon only.");
-			this.sendReply("The order of the parameters does not matter.");
-		}
-		if (target === 'movesearch' || target === 'msearch' || target === 'ms') {
-			matched = true;
-			this.sendReply("/movesearch [parameter], [parameter], [parameter], ... - Searches for moves that fulfill the selected criteria.");
-			this.sendReply("Search categories are: type, category, flag, status inflicted, type boosted, and numeric range for base power, pp, and accuracy.");
-			this.sendReply("Types must be followed by ' type', e.g., 'dragon type'.");
-			this.sendReply("Stat boosts must be preceded with 'boosts ', e.g., 'boosts attack' searches for moves that boost the attack stat.");
-			this.sendReply("Inequality ranges use the characters '>' and '<' though they behave as '≥' and '≤', e.g., 'bp > 100' searches for all moves equal to and greater than 100 base power.");
-			this.sendReply("Parameters can be excluded through the use of '!', e.g., !water type' excludes all water type moves.");
-			this.sendReply("The order of the parameters does not matter.");
-		}
-		if (target === 'dice' || target === 'roll') {
-			matched = true;
-			this.sendReply("/dice [optional max number] - Randomly picks a number between 1 and 6, or between 1 and the number you choose.");
-			this.sendReply("/dice [number of dice]d[number of sides] - Simulates rolling a number of dice, e.g., /dice 2d4 simulates rolling two 4-sided dice.");
-		}
-		if (target === 'pick' || target === 'pickrandom') {
-			matched = true;
-			this.sendReply("/pick [option], [option], ... - Randomly selects an item from a list containing 2 or more elements.");
-		}
-		if (target === 'invite') {
-			matched = true;
-			this.sendReply("/invite [username], [roomname] - Invites the player [username] to join the room [roomname].");
-		}
-		if (target === 'addplayer') {
-			matched = true;
-			this.sendReply("/addplayer [username] - Allow the specified user to join the battle as a player.");
-		}
-
-		// driver commands
-		if (target === 'lock' || target === 'l') {
-			matched = true;
-			this.sendReply("/lock OR /l [username], [reason] - Locks the user from talking in all chats. Requires: % @ & ~");
-		}
-		if (target === 'unlock') {
-			matched = true;
-			this.sendReply("/unlock [username] - Unlocks the user. Requires: % @ & ~");
-		}
-		if (target === 'redirect' || target === 'redir') {
-			matched = true;
-			this.sendReply("/redirect OR /redir [username], [roomname] - Attempts to redirect the user [username] to the room [roomname]. Requires: % @ & ~");
-		}
-		if (target === 'modnote') {
-			matched = true;
-			this.sendReply("/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ & ~");
-		}
-		if (target === 'forcerename' || target === 'fr') {
-			matched = true;
-			this.sendReply("/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. Requires: % @ & ~");
-		}
-		if (target === 'kickbattle') {
-			matched = true;
-			this.sendReply("/kickbattle [username], [reason] - Kicks a user from a battle with reason. Requires: % @ & ~");
-		}
-		if (target === 'warn' || target === 'k') {
-			matched = true;
-			this.sendReply("/warn OR /k [username], [reason] - Warns a user showing them the Pokemon Showdown Rules and [reason] in an overlay. Requires: % @ & ~");
-		}
-		if (target === 'modlog') {
-			matched = true;
-			this.sendReply("/modlog [roomid|all], [n] - Roomid defaults to current room. If n is a number or omitted, display the last n lines of the moderator log. Defaults to 15. If n is not a number, search the moderator log for 'n' on room's log [roomid]. If you set [all] as [roomid], searches for 'n' on all rooms's logs. Requires: % @ & ~");
-		}
-		if (target === 'mute' || target === 'm') {
-			matched = true;
-			this.sendReply("/mute OR /m [username], [reason] - Mutes a user with reason for 7 minutes. Requires: % @ & ~");
-		}
-		if (target === 'hourmute' || target === 'hm') {
-			matched = true;
-			this.sendReply("/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. Requires: % @ & ~");
-		}
-		if (target === 'unmute' || target === 'um') {
-			matched = true;
-			this.sendReply("/unmute [username] - Removes mute from user. Requires: % @ & ~");
-		}
-
-		// mod commands
-		if (target === 'roomban' || target === 'rb') {
-			matched = true;
-			this.sendReply("/roomban [username] - Bans the user from the room you are in. Requires: @ & ~");
-		}
-		if (target === 'roomunban') {
-			matched = true;
-			this.sendReply("/roomunban [username] - Unbans the user from the room you are in. Requires: @ & ~");
-		}
-		if (target === 'ban' || target === 'b') {
-			matched = true;
-			this.sendReply("/ban OR /b [username], [reason] - Kick user from all rooms and ban user's IP address with reason. Requires: @ & ~");
-		}
-		if (target === 'unban') {
-			matched = true;
-			this.sendReply("/unban [username] - Unban a user. Requires: @ & ~");
-		}
-
-		// RO commands
-		if (target === 'showimage') {
-			matched = true;
-			this.sendReply("/showimage [url], [width], [height] - Show an image. Requires: # & ~");
-		}
-		if (target === 'roompromote') {
-			matched = true;
-			this.sendReply("/roompromote [username], [group] - Promotes the user to the specified group or next ranked group. Requires: @ # & ~");
-		}
-		if (target === 'roomdemote') {
-			matched = true;
-			this.sendReply("/roomdemote [username], [group] - Demotes the user to the specified group or previous ranked group. Requires: @ # & ~");
-		}
-
-		// leader commands
-		if (target === 'banip') {
-			matched = true;
-			this.sendReply("/banip [ip] - Kick users on this IP or IP range from all rooms and bans it. Accepts wildcards to ban ranges. Requires: & ~");
-		}
-		if (target === 'unbanip') {
-			matched = true;
-			this.sendReply("/unbanip [ip] - Kick users on this IP or IP range from all rooms and bans it. Accepts wildcards to ban ranges. Requires: & ~");
-		}
-		if (target === 'unbanall') {
-			matched = true;
-			this.sendReply("/unbanall - Unban all IP addresses. Requires: & ~");
-		}
-		if (target === 'promote') {
-			matched = true;
-			this.sendReply("/promote [username], [group] - Promotes the user to the specified group or next ranked group. Requires: & ~");
-		}
-		if (target === 'demote') {
-			matched = true;
-			this.sendReply("/demote [username], [group] - Demotes the user to the specified group or previous ranked group. Requires: & ~");
-		}
-		if (target === 'forcetie') {
-			matched = true;
-			this.sendReply("/forcetie - Forces the current match to tie. Requires: & ~");
-		}
-		if (target === 'declare') {
-			matched = true;
-			this.sendReply("/declare [message] - Anonymously announces a message. Requires: & ~");
-		}
-
-		// admin commands
-		if (target === 'chatdeclare' || target === 'cdeclare') {
-			matched = true;
-			this.sendReply("/cdeclare [message] - Anonymously announces a message to all chatrooms on the server. Requires: ~");
-		}
-		if (target === 'globaldeclare' || target === 'gdeclare') {
-			matched = true;
-			this.sendReply("/globaldeclare [message] - Anonymously announces a message to every room on the server. Requires: ~");
-		}
-		if (target === 'htmlbox') {
-			matched = true;
-			this.sendReply("/htmlbox [message] - Displays a message, parsing HTML code contained. Requires: ~ # with global authority");
-		}
-		if (target === 'announce' || target === 'wall') {
-			matched = true;
-			this.sendReply("/announce OR /wall [message] - Makes an announcement. Requires: % @ & ~");
-		}
-		if (target === 'modchat') {
-			matched = true;
-			this.sendReply("/modchat [off/autoconfirmed/+/%/@/&/~] - Set the level of moderated chat. Requires: @ for off/autoconfirmed/+ options, & ~ for all the options");
-		}
-		if (target === 'hotpatch') {
-			matched = true;
-			this.sendReply("Hot-patching the game engine allows you to update parts of Showdown without interrupting currently-running battles. Requires: ~");
-			this.sendReply("Hot-patching has greater memory requirements than restarting.");
-			this.sendReply("/hotpatch chat - reload chat-commands.js");
-			this.sendReply("/hotpatch battles - spawn new simulator processes");
-			this.sendReply("/hotpatch formats - reload the tools.js tree, rebuild and rebroad the formats list, and also spawn new simulator processes");
-		}
-		if (target === 'lockdown') {
-			matched = true;
-			this.sendReply("/lockdown - locks down the server, which prevents new battles from starting so that the server can eventually be restarted. Requires: ~");
-		}
-		if (target === 'kill') {
-			matched = true;
-			this.sendReply("/kill - kills the server. Can't be done unless the server is in lockdown state. Requires: ~");
-		}
-		if (target === 'loadbanlist') {
-			matched = true;
-			this.sendReply("/loadbanlist - Loads the bans located at ipbans.txt. The command is executed automatically at startup. Requires: ~");
-		}
-		if (target === 'makechatroom') {
-			matched = true;
-			this.sendReply("/makechatroom [roomname] - Creates a new room named [roomname]. Requires: ~");
-		}
-		if (target === 'deregisterchatroom') {
-			matched = true;
-			this.sendReply("/deregisterchatroom [roomname] - Deletes room [roomname] after the next server restart. Requires: ~");
-		}
-		if (target === 'roomowner') {
-			matched = true;
-			this.sendReply("/roomowner [username] - Appoints [username] as a room owner. Removes official status. Requires: ~");
-		}
-		if (target === 'roomdeowner') {
-			matched = true;
-			this.sendReply("/roomdeowner [username] - Removes [username]'s status as a room owner. Requires: ~");
-		}
-		if (target === 'privateroom' || target === 'hiddenroom') {
-			matched = true;
-			this.sendReply("/privateroom [on/off] - Makes or unmakes a room private. Requires: ~");
-			this.sendReply("/hiddenroom [on/off] - Makes or unmakes a room hidden. Hidden rooms will maintain global ranks of users. Requires: \u2605 ~");
-		}
 
 		// overall
 		if (target === 'help' || target === 'h' || target === '?' || target === 'commands') {
-			matched = true;
 			this.sendReply("/help OR /h OR /? - Gives you help.");
-		}
-		if (!target) {
+		} else if (!target) {
 			this.sendReply("COMMANDS: /nick, /avatar, /rating, /whois, /msg, /reply, /ignore, /away, /back, /timestamps, /highlight");
-			this.sendReply("INFORMATIONAL COMMANDS: /data, /dexsearch, /movesearch, /groups, /opensource, /avatars, /faq, /rules, /intro, /tiers, /othermetas, /learn, /analysis, /calc (replace / with ! to broadcast. Broadcasting requires: + % @ & ~)");
+			this.sendReply("INFORMATIONAL COMMANDS: /data, /dexsearch, /movesearch, /groups, /faq, /rules, /intro, /tiers, /othermetas, /learn, /analysis, /calc (replace / with ! to broadcast. Broadcasting requires: + % @ & ~)");
 			if (user.group !== Config.groupsranking[0]) {
 				this.sendReply("DRIVER COMMANDS: /warn, /mute, /unmute, /alts, /forcerename, /modlog, /lock, /unlock, /announce, /redirect");
 				this.sendReply("MODERATOR COMMANDS: /ban, /unban, /ip");
@@ -2425,8 +2160,46 @@ var commands = exports.commands = {
 			}
 			this.sendReply("For an overview of room commands, use /roomhelp");
 			this.sendReply("For details of a specific command, use something like: /help data");
-		} else if (!matched) {
-			this.sendReply("Help for the command '" + target + "' was not found. Try /help for general help");
+		} else {
+			var altCommandHelp;
+			var helpCmd;
+			var targets = target.split(' ');
+			if (typeof commands[target] === 'string') {
+				// If a function changes with command name, help for that command name will be searched first.
+				altCommandHelp = target + 'help';
+				if (altCommandHelp in commands) {
+					helpCmd = altCommandHelp;
+				} else {
+					helpCmd = commands[target] + 'help';
+				}
+			} else if (targets.length > 1 && typeof commands[targets[0]] === 'object') {
+				// Handle internal namespace commands
+				var helpCmd = targets[targets.length - 1] + 'help';
+				var namespace = commands[targets[0]];
+				for (var i = 1; i < targets.length - 1; i++) {
+					if (!namespace[targets[i]]) return this.sendReply("Help for the command '" + target + "' was not found. Try /help for general help");
+					namespace = namespace[targets[i]];
+				}
+				if (typeof namespace[helpCmd] === 'object') {
+					return this.sendReply(namespace[helpCmd].join('\n'));
+				} else if (typeof namespace[helpCmd] === 'function') {
+					return this.parse('/' + targets.slice(0, targets.length - 1).concat(helpCmd).join(' '));
+				} else {
+					return this.sendReply("Help for the command '" + target + "' was not found. Try /help for general help");
+				}
+			} else {
+				helpCmd = target + 'help';
+			}
+			if (helpCmd in commands) {
+				if (typeof commands[helpCmd] === 'function') {
+					// If the help command is a function, parse it instead
+					this.parse('/' + helpCmd);
+				} else if (Array.isArray(commands[helpCmd])) {
+					this.sendReply(commands[helpCmd].join('\n'));
+				}
+			} else {
+				this.sendReply("Help for the command '" + target + "' was not found. Try /help for general help");
+			}
 		}
 	}
 

--- a/commands.js
+++ b/commands.js
@@ -2069,6 +2069,365 @@ var commands = exports.commands = {
 			}
 		}
 		user.rename(targetName, targetToken, targetAuth, connection);
+	},
+
+	a: function (target, room, user) {
+		if (!this.can('rawpacket')) return false;
+		// secret sysop command
+		room.add(target);
+	},
+
+	/*********************************************************
+	 * Help commands
+	 *********************************************************/
+
+	commands: 'help',
+	h: 'help',
+	'?': 'help',
+	help: function (target, room, user) {
+		target = target.toLowerCase();
+		var matched = false;
+		if (target === 'msg' || target === 'pm' || target === 'whisper' || target === 'w') {
+			matched = true;
+			this.sendReply("/msg OR /whisper OR /w [username], [message] - Send a private message.");
+		}
+		if (target === 'r' || target === 'reply') {
+			matched = true;
+			this.sendReply("/reply OR /r [message] - Send a private message to the last person you received a message from, or sent a message to.");
+		}
+		if (target === 'avatar') {
+			matched = true;
+			this.sendReply("/avatar [new avatar number] - Change your trainer sprite.");
+		}
+		if (target === 'whois' || target === 'alts' || target === 'ip' || target === 'rooms') {
+			matched = true;
+			this.sendReply("/whois - Get details on yourself: alts, group, IP address, and rooms.");
+			this.sendReply("/whois [username] - Get details on a username: alts (Requires: % @ & ~), group, IP address (Requires: @ & ~), and rooms.");
+		}
+		if (target === 'data') {
+			matched = true;
+			this.sendReply("/data [pokemon/item/move/ability] - Get details on this pokemon/item/move/ability/nature.");
+			this.sendReply("!data [pokemon/item/move/ability] - Show everyone these details. Requires: + % @ & ~");
+		}
+		if (target === 'details' || target === 'dt') {
+			matched = true;
+			this.sendReply("/details [pokemon] - Get additional details on this pokemon/item/move/ability/nature.");
+			this.sendReply("!details [pokemon] - Show everyone these details. Requires: + % @ & ~");
+		}
+		if (target === 'analysis') {
+			matched = true;
+			this.sendReply("/analysis [pokemon], [generation] - Links to the Smogon University analysis for this Pokemon in the given generation.");
+			this.sendReply("!analysis [pokemon], [generation] - Shows everyone this link. Requires: + % @ & ~");
+		}
+		if (target === 'groups') {
+			matched = true;
+			this.sendReply("/groups - Explains what the + % @ & next to people's names mean.");
+			this.sendReply("!groups - Show everyone that information. Requires: + % @ & ~");
+		}
+		if (target === 'opensource') {
+			matched = true;
+			this.sendReply("/opensource - Links to PS's source code repository.");
+			this.sendReply("!opensource - Show everyone that information. Requires: + % @ & ~");
+		}
+		if (target === 'avatars') {
+			matched = true;
+			this.sendReply("/avatars - Explains how to change avatars.");
+			this.sendReply("!avatars - Show everyone that information. Requires: + % @ & ~");
+		}
+		if (target === 'intro') {
+			matched = true;
+			this.sendReply("/intro - Provides an introduction to competitive pokemon.");
+			this.sendReply("!intro - Show everyone that information. Requires: + % @ & ~");
+		}
+		if (target === 'cap') {
+			matched = true;
+			this.sendReply("/cap - Provides an introduction to the Create-A-Pokemon project.");
+			this.sendReply("!cap - Show everyone that information. Requires: + % @ & ~");
+		}
+		if (target === 'om') {
+			matched = true;
+			this.sendReply("/om - Provides links to information on the Other Metagames.");
+			this.sendReply("!om - Show everyone that information. Requires: + % @ & ~");
+		}
+		if (target === 'learn' || target === 'learnset' || target === 'learnall') {
+			matched = true;
+			this.sendReply("/learn [pokemon], [move, move, ...] - Displays how a Pokemon can learn the given moves, if it can at all.");
+			this.sendReply("!learn [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ & ~");
+		}
+		if (target === 'calc' || target === 'calculator') {
+			matched = true;
+			this.sendReply("/calc - Provides a link to a damage calculator");
+			this.sendReply("!calc - Shows everyone a link to a damage calculator. Requires: + % @ & ~");
+		}
+		if (target === 'away' || target === 'idle') {
+			matched = true;
+			this.sendReply("/away - Blocks challenges and private messages. Unblock them with /back.");
+		}
+		if (target === 'blockchallenges') {
+			matched = true;
+			this.sendReply("/blockchallenges - Blocks challenges so no one can challenge you. Unblock them with /unblockchallenges.");
+		}
+		if (target === 'blockpms' || target === 'ignorepms') {
+			matched = true;
+			this.sendReply("/blockpms - Blocks private messages. Unblock them with /unignorepms.");
+		}
+		if (target === 'back') {
+			matched = true;
+			this.sendReply("/back - Unblocks challenges and/or private messages, if either are blocked.");
+		}
+		if (target === 'unblockchallenges' || target === 'allowchallenges') {
+			matched = true;
+			this.sendReply("/unblockchallenges - Unblocks challenges so you can be challenged again. Block them with /blockchallenges.");
+		}
+		if (target === 'unblockpms' || target === 'unignorepms') {
+			matched = true;
+			this.sendReply("/unblockpms - Unblocks private messages. Block them with /blockpms.");
+		}
+		if (target === 'faq') {
+			matched = true;
+			this.sendReply("/faq [theme] - Provides a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them.");
+			this.sendReply("!faq [theme] - Shows everyone a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them. Requires: + % @ & ~");
+		}
+		if (target === 'effectiveness' || target === 'matchup' || target === 'eff' || target === 'type') {
+			matched = true;
+			this.sendReply("/effectiveness [attack], [defender] - Provides the effectiveness of a move or type on another type or a Pokémon.");
+			this.sendReply("!effectiveness [attack], [defender] - Shows everyone the effectiveness of a move or type on another type or a Pokémon.");
+		}
+		if (target === 'weakness' || target === 'weaknesses' || target === 'weak' || target === 'resist') {
+			matched = true;
+			this.sendReply("/weakness [pokemon] - Provides a Pokemon's resistances, weaknesses, and immunities, ignoring abilities.");
+			this.sendReply("/weakness [type 1]/[type 2] - Provides a type or type combination's resistances, weaknesses, and immunities, ignoring abilities.");
+			this.sendReply("!weakness [pokemon] - Shows everyone a Pokemon's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ & ~");
+			this.sendReply("!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ & ~");
+		}
+		if (target === 'dexsearch' || target === 'dsearch' || target === 'ds') {
+			matched = true;
+			this.sendReply("/dexsearch [type], [move], [move], ... - Searches for Pokemon that fulfill the selected criteria.");
+			this.sendReply("Search categories are: type, tier, color, moves, ability, gen.");
+			this.sendReply("Valid colors are: green, red, blue, white, brown, yellow, purple, pink, gray and black.");
+			this.sendReply("Valid tiers are: Uber/OU/BL/UU/BL2/RU/BL3/NU/PU/NFE/LC/CAP.");
+			this.sendReply("Types must be followed by ' type', e.g., 'dragon type'.");
+			this.sendReply("Parameters can be excluded through the use of '!', e.g., '!water type' excludes all water types.");
+			this.sendReply("The parameter 'mega' can be added to search for Mega Evolutions only, and the parameters 'FE' or 'NFE' can be added to search fully or not-fully evolved Pokemon only.");
+			this.sendReply("The order of the parameters does not matter.");
+		}
+		if (target === 'movesearch' || target === 'msearch' || target === 'ms') {
+			matched = true;
+			this.sendReply("/movesearch [parameter], [parameter], [parameter], ... - Searches for moves that fulfill the selected criteria.");
+			this.sendReply("Search categories are: type, category, flag, status inflicted, type boosted, and numeric range for base power, pp, and accuracy.");
+			this.sendReply("Types must be followed by ' type', e.g., 'dragon type'.");
+			this.sendReply("Stat boosts must be preceded with 'boosts ', e.g., 'boosts attack' searches for moves that boost the attack stat.");
+			this.sendReply("Inequality ranges use the characters '>' and '<' though they behave as '≥' and '≤', e.g., 'bp > 100' searches for all moves equal to and greater than 100 base power.");
+			this.sendReply("Parameters can be excluded through the use of '!', e.g., !water type' excludes all water type moves.");
+			this.sendReply("The order of the parameters does not matter.");
+		}
+		if (target === 'dice' || target === 'roll') {
+			matched = true;
+			this.sendReply("/dice [optional max number] - Randomly picks a number between 1 and 6, or between 1 and the number you choose.");
+			this.sendReply("/dice [number of dice]d[number of sides] - Simulates rolling a number of dice, e.g., /dice 2d4 simulates rolling two 4-sided dice.");
+		}
+		if (target === 'pick' || target === 'pickrandom') {
+			matched = true;
+			this.sendReply("/pick [option], [option], ... - Randomly selects an item from a list containing 2 or more elements.");
+		}
+		if (target === 'invite') {
+			matched = true;
+			this.sendReply("/invite [username], [roomname] - Invites the player [username] to join the room [roomname].");
+		}
+		if (target === 'addplayer') {
+			matched = true;
+			this.sendReply("/addplayer [username] - Allow the specified user to join the battle as a player.");
+		}
+
+		// driver commands
+		if (target === 'lock' || target === 'l') {
+			matched = true;
+			this.sendReply("/lock OR /l [username], [reason] - Locks the user from talking in all chats. Requires: % @ & ~");
+		}
+		if (target === 'unlock') {
+			matched = true;
+			this.sendReply("/unlock [username] - Unlocks the user. Requires: % @ & ~");
+		}
+		if (target === 'redirect' || target === 'redir') {
+			matched = true;
+			this.sendReply("/redirect OR /redir [username], [roomname] - Attempts to redirect the user [username] to the room [roomname]. Requires: % @ & ~");
+		}
+		if (target === 'modnote') {
+			matched = true;
+			this.sendReply("/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ & ~");
+		}
+		if (target === 'forcerename' || target === 'fr') {
+			matched = true;
+			this.sendReply("/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. Requires: % @ & ~");
+		}
+		if (target === 'kickbattle') {
+			matched = true;
+			this.sendReply("/kickbattle [username], [reason] - Kicks a user from a battle with reason. Requires: % @ & ~");
+		}
+		if (target === 'warn' || target === 'k') {
+			matched = true;
+			this.sendReply("/warn OR /k [username], [reason] - Warns a user showing them the Pokemon Showdown Rules and [reason] in an overlay. Requires: % @ & ~");
+		}
+		if (target === 'modlog') {
+			matched = true;
+			this.sendReply("/modlog [roomid|all], [n] - Roomid defaults to current room. If n is a number or omitted, display the last n lines of the moderator log. Defaults to 15. If n is not a number, search the moderator log for 'n' on room's log [roomid]. If you set [all] as [roomid], searches for 'n' on all rooms's logs. Requires: % @ & ~");
+		}
+		if (target === 'mute' || target === 'm') {
+			matched = true;
+			this.sendReply("/mute OR /m [username], [reason] - Mutes a user with reason for 7 minutes. Requires: % @ & ~");
+		}
+		if (target === 'hourmute' || target === 'hm') {
+			matched = true;
+			this.sendReply("/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. Requires: % @ & ~");
+		}
+		if (target === 'unmute' || target === 'um') {
+			matched = true;
+			this.sendReply("/unmute [username] - Removes mute from user. Requires: % @ & ~");
+		}
+
+		// mod commands
+		if (target === 'roomban' || target === 'rb') {
+			matched = true;
+			this.sendReply("/roomban [username] - Bans the user from the room you are in. Requires: @ & ~");
+		}
+		if (target === 'roomunban') {
+			matched = true;
+			this.sendReply("/roomunban [username] - Unbans the user from the room you are in. Requires: @ & ~");
+		}
+		if (target === 'ban' || target === 'b') {
+			matched = true;
+			this.sendReply("/ban OR /b [username], [reason] - Kick user from all rooms and ban user's IP address with reason. Requires: @ & ~");
+		}
+		if (target === 'unban') {
+			matched = true;
+			this.sendReply("/unban [username] - Unban a user. Requires: @ & ~");
+		}
+
+		// RO commands
+		if (target === 'showimage') {
+			matched = true;
+			this.sendReply("/showimage [url], [width], [height] - Show an image. Requires: # & ~");
+		}
+		if (target === 'roompromote') {
+			matched = true;
+			this.sendReply("/roompromote [username], [group] - Promotes the user to the specified group or next ranked group. Requires: @ # & ~");
+		}
+		if (target === 'roomdemote') {
+			matched = true;
+			this.sendReply("/roomdemote [username], [group] - Demotes the user to the specified group or previous ranked group. Requires: @ # & ~");
+		}
+
+		// leader commands
+		if (target === 'banip') {
+			matched = true;
+			this.sendReply("/banip [ip] - Kick users on this IP or IP range from all rooms and bans it. Accepts wildcards to ban ranges. Requires: & ~");
+		}
+		if (target === 'unbanip') {
+			matched = true;
+			this.sendReply("/unbanip [ip] - Kick users on this IP or IP range from all rooms and bans it. Accepts wildcards to ban ranges. Requires: & ~");
+		}
+		if (target === 'unbanall') {
+			matched = true;
+			this.sendReply("/unbanall - Unban all IP addresses. Requires: & ~");
+		}
+		if (target === 'promote') {
+			matched = true;
+			this.sendReply("/promote [username], [group] - Promotes the user to the specified group or next ranked group. Requires: & ~");
+		}
+		if (target === 'demote') {
+			matched = true;
+			this.sendReply("/demote [username], [group] - Demotes the user to the specified group or previous ranked group. Requires: & ~");
+		}
+		if (target === 'forcetie') {
+			matched = true;
+			this.sendReply("/forcetie - Forces the current match to tie. Requires: & ~");
+		}
+		if (target === 'declare') {
+			matched = true;
+			this.sendReply("/declare [message] - Anonymously announces a message. Requires: & ~");
+		}
+
+		// admin commands
+		if (target === 'chatdeclare' || target === 'cdeclare') {
+			matched = true;
+			this.sendReply("/cdeclare [message] - Anonymously announces a message to all chatrooms on the server. Requires: ~");
+		}
+		if (target === 'globaldeclare' || target === 'gdeclare') {
+			matched = true;
+			this.sendReply("/globaldeclare [message] - Anonymously announces a message to every room on the server. Requires: ~");
+		}
+		if (target === 'htmlbox') {
+			matched = true;
+			this.sendReply("/htmlbox [message] - Displays a message, parsing HTML code contained. Requires: ~ # with global authority");
+		}
+		if (target === 'announce' || target === 'wall') {
+			matched = true;
+			this.sendReply("/announce OR /wall [message] - Makes an announcement. Requires: % @ & ~");
+		}
+		if (target === 'modchat') {
+			matched = true;
+			this.sendReply("/modchat [off/autoconfirmed/+/%/@/&/~] - Set the level of moderated chat. Requires: @ for off/autoconfirmed/+ options, & ~ for all the options");
+		}
+		if (target === 'hotpatch') {
+			matched = true;
+			this.sendReply("Hot-patching the game engine allows you to update parts of Showdown without interrupting currently-running battles. Requires: ~");
+			this.sendReply("Hot-patching has greater memory requirements than restarting.");
+			this.sendReply("/hotpatch chat - reload chat-commands.js");
+			this.sendReply("/hotpatch battles - spawn new simulator processes");
+			this.sendReply("/hotpatch formats - reload the tools.js tree, rebuild and rebroad the formats list, and also spawn new simulator processes");
+		}
+		if (target === 'lockdown') {
+			matched = true;
+			this.sendReply("/lockdown - locks down the server, which prevents new battles from starting so that the server can eventually be restarted. Requires: ~");
+		}
+		if (target === 'kill') {
+			matched = true;
+			this.sendReply("/kill - kills the server. Can't be done unless the server is in lockdown state. Requires: ~");
+		}
+		if (target === 'loadbanlist') {
+			matched = true;
+			this.sendReply("/loadbanlist - Loads the bans located at ipbans.txt. The command is executed automatically at startup. Requires: ~");
+		}
+		if (target === 'makechatroom') {
+			matched = true;
+			this.sendReply("/makechatroom [roomname] - Creates a new room named [roomname]. Requires: ~");
+		}
+		if (target === 'deregisterchatroom') {
+			matched = true;
+			this.sendReply("/deregisterchatroom [roomname] - Deletes room [roomname] after the next server restart. Requires: ~");
+		}
+		if (target === 'roomowner') {
+			matched = true;
+			this.sendReply("/roomowner [username] - Appoints [username] as a room owner. Removes official status. Requires: ~");
+		}
+		if (target === 'roomdeowner') {
+			matched = true;
+			this.sendReply("/roomdeowner [username] - Removes [username]'s status as a room owner. Requires: ~");
+		}
+		if (target === 'privateroom' || target === 'hiddenroom') {
+			matched = true;
+			this.sendReply("/privateroom [on/off] - Makes or unmakes a room private. Requires: ~");
+			this.sendReply("/hiddenroom [on/off] - Makes or unmakes a room hidden. Hidden rooms will maintain global ranks of users. Requires: \u2605 ~");
+		}
+
+		// overall
+		if (target === 'help' || target === 'h' || target === '?' || target === 'commands') {
+			matched = true;
+			this.sendReply("/help OR /h OR /? - Gives you help.");
+		}
+		if (!target) {
+			this.sendReply("COMMANDS: /nick, /avatar, /rating, /whois, /msg, /reply, /ignore, /away, /back, /timestamps, /highlight");
+			this.sendReply("INFORMATIONAL COMMANDS: /data, /dexsearch, /movesearch, /groups, /opensource, /avatars, /faq, /rules, /intro, /tiers, /othermetas, /learn, /analysis, /calc (replace / with ! to broadcast. Broadcasting requires: + % @ & ~)");
+			if (user.group !== Config.groupsranking[0]) {
+				this.sendReply("DRIVER COMMANDS: /warn, /mute, /unmute, /alts, /forcerename, /modlog, /lock, /unlock, /announce, /redirect");
+				this.sendReply("MODERATOR COMMANDS: /ban, /unban, /ip");
+				this.sendReply("LEADER COMMANDS: /declare, /forcetie, /forcewin, /promote, /demote, /banip, /unbanall");
+			}
+			this.sendReply("For an overview of room commands, use /roomhelp");
+			this.sendReply("For details of a specific command, use something like: /help data");
+		} else if (!matched) {
+			this.sendReply("Help for the command '" + target + "' was not found. Try /help for general help");
+		}
 	}
 
 };


### PR DESCRIPTION
```config/commands.js``` moved to ```chat-plugins/info.js```.

```/help``` and ```/a``` moved to ```commands.js```.

```/lobbychat``` removed entirely.

```/help``` refactored so that command help information can be written next to the commands themselves. This means that ```commands.js``` will not have to be modified at all for adding custom commands and can remain for core functionality online.

API documentation moved to ```chat-plugins/COMMANDS.md```.