### PR TITLE
Change starthunt separator to |.

### DIFF
--- a/chat-plugins/scavengers.js
+++ b/chat-plugins/scavengers.js
@@ -34,7 +34,7 @@ exports.commands = {
 		if (room.id !== 'scavengers') return this.sendReply('This command can only be used in the Scavengers room.');
 		if (!this.can('mute', null, room)) return false;
 		if (scavengers.status === 'on') return this.sendReply('There is already an active scavenger hunt.');
-		var targets = target.split(',');
+		var targets = target.split(target.indexOf('|') > -1 ? '|' : ',');
 		if (!targets[0] || !targets[1] || !targets[2] || !targets[3] || !targets[4] || !targets[5] || targets[6]) {
 			return this.sendReply('You must specify three hints and three answers.');
 		}


### PR DESCRIPTION
This frees "," to be used in hunt questions.

![](http://embed.gyazo.com/f91fa20d6afd82ff69364a75e45943a2.gif)