### PR TITLE
The Studio plugin: fix io.js crashes

### DIFF
--- a/chat-plugins/thestudio.js
+++ b/chat-plugins/thestudio.js
@@ -4,6 +4,8 @@
  * Only works in a room with the id 'thestudio'
  */
 
+if (!Array.from) require('es6-shim');
+
 function toArtistId(artist) { // toId would return '' for foreign/sadistic artists
 	return artist.toLowerCase().replace(/\s/g, '').replace(/\b&\b/g, '');
 }


### PR DESCRIPTION
Running the server on io.js never requires es6-shim since it already
supports Maps, but doesn't support Array.from(), which this uses.