### PR TITLE
Use 0.0.0.0 if Config.bindaddress is missing.

### DIFF
--- a/sockets.js
+++ b/sockets.js
@@ -427,17 +427,17 @@ if (cluster.isMaster) {
 		});
 	});
 	server.installHandlers(app, {});
-	if (Config.bindaddress === '0.0.0.0') Config.bindaddress = undefined;
-	app.listen(Config.port, Config.bindaddress || undefined);
-	console.log('Worker ' + cluster.worker.id + ' now listening on ' + (Config.bindaddress || '*') + ':' + Config.port);
+	if (!Config.bindaddress) Config.bindaddress = '0.0.0.0';
+	app.listen(Config.port, Config.bindaddress);
+	console.log('Worker ' + cluster.worker.id + ' now listening on ' + Config.bindaddress + ':' + Config.port);
 
 	if (appssl) {
 		server.installHandlers(appssl, {});
-		appssl.listen(Config.ssl.port);
+		appssl.listen(Config.ssl.port, Config.bindaddress);
 		console.log('Worker ' + cluster.worker.id + ' now listening for SSL on port ' + Config.ssl.port);
 	}
 
-	console.log('Test your server at http://' + (Config.bindaddress || 'localhost') + ':' + Config.port);
+	console.log('Test your server at http://' + (Config.bindaddress === '0.0.0.0' ? 'localhost' : Config.bindaddress) + ':' + Config.port);
 
 	require('./repl.js').start('sockets-', cluster.worker.id + '-' + process.pid, function (cmd) { return eval(cmd); });
 }


### PR DESCRIPTION
This is because io.js tries ipv6 first, which the rest of PS does not support very well. Using 0.0.0.0 forces ipv4.

It seems silly that the previous line checks for 0.0.0.0 and sets to undefined, but different default values are used in different contexts.

I'm applying this patch to main immediately, but I'd like a review before merging into the repo. Particularly, does the SSL case not need to bind on `Config.bindaddress`? This surprises me.