### PR TITLE
Gen 2 Random Battle: Fix Move Rejection Phase

### DIFF
--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -962,16 +962,24 @@ exports.BattleScripts = {
 		var setupType = '';
 		var item = 'leftovers';
 		var ivs = {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30};
-		var hasHP = false;
 
 		var j = 0;
 		do {
+			// Keep track of all moves we have:
 			hasMove = {};
+			for (var k = 0; k < moves.length; k++) {
+				if (moves[k].substr(0, 11) === 'hiddenpower') {
+					hasMove['hiddenpower'] = true;
+				} else {
+					hasMove[moves[k]] = true;
+				}
+			}
+
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.length < 4 && moveKeys.length) {
 				var moveid = this.sampleNoReplace(moveKeys);
 				if (moveid.substr(0, 11) === 'hiddenpower') {
-					if (hasHP || hasMove['hiddenpower']) continue;
+					if (hasMove['hiddenpower']) continue;
 					hasMove['hiddenpower'] = true;
 				} else {
 					hasMove[moveid] = true;
@@ -1012,7 +1020,6 @@ exports.BattleScripts = {
 					}
 					moveid = 'hiddenpower';
 				}
-				if (hasMove[moveid]) rejected = true;
 				if (!template.essentialMove || moveid !== template.essentialMove) {
 					var isSetup = false;
 
@@ -1120,7 +1127,6 @@ exports.BattleScripts = {
 					moves.splice(k, 1);
 					break;
 				}
-				if (moveid === 'hiddenpower') hasHP = true;
 				counter[move.category]++;
 			} // End of for
 		} while (moves.length < 4 && j < moveKeys.length);


### PR DESCRIPTION
hasMove was not tracking moves properly, instead keeping all moves ever
added in the object even if they were rejected. Also, there was a line of
code that caused all moves to be flagged as rejected.