### PR TITLE
Gen 1 randbats movesets tweaking

### DIFF
--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -1176,8 +1176,11 @@ exports.BattleScripts = {
 							if (hasMove['flamethrower']) rejected = true;
 							break;
 						case 'icebeam':
-							if (hasMove['blizzard']) rejected = true;
+							if (hasMove['blizzard'] && keys[i] !== 'articuno') rejected = true;
 							break;
+						case 'blizzard':
+							if (hasMove['icebeam'] && keys[i] !== 'articuno') rejected = true;
+							break;							
 						// Hydropump and surf are both valid options, just avoid one with eachother.
 						case 'hydropump':
 							if (hasMove['surf']) rejected = true;
@@ -1264,6 +1267,12 @@ exports.BattleScripts = {
 						case 'toxic':
 							if (hasMove['sleeppowder'] || hasMove['stunspore'] || counter['Status'] > 1) rejected = true;
 							break;
+						case 'reflect':
+							if (hasMove['counter']) rejected = true;
+							break;
+						case 'counter':
+							if (hasMove['reflect']) rejected = true;
+							break;							
 						} // End of switch for moveid
 					}
 					if (rejected && j < moveKeys.length) {


### PR DESCRIPTION
prevent counter + reflect (esp. twave/reflect/counter/reflect chansey and possibly clefable/wiggly too) and ice beam + blizzard on the same pokemon (e.g. Lapras would much rather have tbolt/body slam/cray than both ice moves). Articuno still wants both though, and this could probably be extended to other mons (e.g. seadra with both surf and hydro pump).

Also, the superfang condition is completely redundant isn't it?