### PR TITLE
Fix ignoreImmunity crashes in earlier gens

### DIFF
--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -704,7 +704,7 @@ exports.BattleScripts = {
 		};
 
 		// Let's see if the target is immune to the move.
-		if (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type]) {
+		if (!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) {
 			if (!target.runImmunity(move.type, true)) {
 				return false;
 			}

--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -286,7 +286,7 @@ exports.BattleScripts = {
 		};
 
 		// Let's test for immunities.
-		if (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type]) {
+		if (!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) {
 			if (!target.runImmunity(move.type, true)) {
 				return false;
 			}

--- a/mods/stadium/scripts.js
+++ b/mods/stadium/scripts.js
@@ -398,7 +398,7 @@ exports.BattleScripts = {
 		};
 
 		// Let's see if the target is immune to the move.
-		if (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type]) {
+		if (!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) {
 			if (!target.runImmunity(move.type, true)) {
 				return false;
 			}


### PR DESCRIPTION
Unlike battle-engine.js, old gens did not check if move.ignoreImmunity was
undefined/false in their getDamage functions, causing crashes when numbers
were passed in to the function.