### PR TITLE
Fix /effectiveness chat command crash

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -1281,7 +1281,7 @@ var commands = exports.commands = {
 
 		var factor = 0;
 		if (source.category === "Status" && (source.ignoreImmunity === true || source.ignoreImmunity[source.type])) factor = 1;
-		if (Tools.getImmunity(source.type || source, defender) || source.ignoreImmunity === true || source.ignoreImmunity[source.type]) {
+		if (Tools.getImmunity(source.type || source, defender) || source.ignoreImmunity && (source.ignoreImmunity === true || source.ignoreImmunity[source.type])) {
 			var totalTypeMod = 0;
 			if (source.effectType !== 'Move' || source.basePower || source.basePowerCallback) {
 				for (var i = 0; i < defender.types.length; i++) {


### PR DESCRIPTION
Entering a type as the source instead of a move resulted in a crash as the
program attempted to read a nonexistent `ignoreImmunity` property.

No fix needed on L1283 because `souce.category` won't exist for pure type
effectiveness checks anyways and `Tools#getMove` always fills in `ignoreImmunity`.