### PR TITLE
Super Staff Bros.: Remove a move from %QuoteCS

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -3725,7 +3725,7 @@ exports.BattleScripts = {
 			},
 			'%QuoteCS': {
 				species: 'Skarmory', ability: 'Adaptability', item: 'Life Orb', gender: 'M',
-				moves: ['meteormash', ['bravebird', 'dragonascent'][this.random(2)], 'roost'],
+				moves: ['meteormash', 'bravebird', 'roost'],
 				baseSignatureMove: 'spikes', signatureMove: "Diversify",
 				evs: {hp:248, atk:252, spe:8}, nature: 'Adamant'
 			},


### PR DESCRIPTION
Removed Dragon Ascent so QuoteCS's signature move could allow him to
keep the SpD boost.