### PR TITLE
Use special command for room intro.

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -1475,21 +1475,11 @@ var ChatRoom = (function () {
 		this.send(update);
 	};
 	ChatRoom.prototype.getIntroMessage = function () {
-		if (this.modchat && this.introMessage) {
-			return '\n|raw|<div class="infobox"><div' + (!this.isOfficial ? ' class="infobox-limited"' : '') + '>' + this.introMessage + '</div>' +
-				'<br />' +
-				'<div class="broadcast-red">' +
-				'Must be rank ' + this.modchat + ' or higher to talk right now.' +
-				'</div></div>';
+		if (this.modchat || this.introMessage) {
+			var modchat = this.modchat || '';
+			var official = this.isOfficial ? '1' : '';
+			return '\n|roomintro|' + modchat + '|' + official + '|' + this.introMessage;
 		}
-
-		if (this.modchat) {
-			return '\n|raw|<div class="infobox"><div class="broadcast-red">' +
-				'Must be rank ' + this.modchat + ' or higher to talk right now.' +
-				'</div></div>';
-		}
-
-		if (this.introMessage) return '\n|raw|<div class="infobox infobox-limited">' + this.introMessage + '</div>';
 
 		return '';
 	};


### PR DESCRIPTION
This prevents abuse of `</div>` in room intros to avoid height limit. Depends on Zarel/Pokemon-Showdown-Client#351 to work.