### PR TITLE
Allow level 9999 Pokemon in battles

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -188,7 +188,7 @@ BattlePokemon = (function () {
 		this.moveset = [];
 		this.baseMoveset = [];
 
-		this.level = this.battle.clampIntRange(set.forcedLevel || set.level || 100, 1, 1000);
+		this.level = this.battle.clampIntRange(set.forcedLevel || set.level || 100, 1, 9999);
 
 		var genders = {M:'M', F:'F'};
 		this.gender = this.template.gender || genders[set.gender] || (Math.random() * 2 < 1 ? 'M' : 'F');


### PR DESCRIPTION
b922ae2f introduced possibility of using Pokemon over level 1000 in custom battles. However, this doesn't work in practice, because battle engine limits level to 1000. This commit fixes what b922ae2f should have done all along.