### PR TITLE
Fix Thousand Arrows test

### DIFF
--- a/test/simulator/moves/thousandarrows.js
+++ b/test/simulator/moves/thousandarrows.js
@@ -44,6 +44,7 @@ describe('Thousand Arrows', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'aurabreak', moves: ['thousandarrows', 'earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Eelektross", ability: 'levitate', item: 'weaknesspolicy', moves: ['thunderwave']}]);
+		battle.seed = [0, 0, 0, 0];
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].boosts.atk, 2);
 		assert.strictEqual(battle.p2.active[0].boosts.spa, 2);


### PR DESCRIPTION
Zygarde's Thousand Arrows will KO Eelektross if it gets a critical hit,
meaning that the Weakness Policy being used to check if the move was
super-effective will not activate. Fixed by initializing the battle with a
seed that does not result in a critical hit from Thousand Arrows.