### PR TITLE
make getLearnset a tool

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -683,17 +683,7 @@ var commands = exports.commands = {
 
 				case 'compileLearnsets':
 					for (var mon in dex) {
-						var template = dex[mon];
-						if (!template.learnset) template = Tools.getTemplate(template.baseSpecies);
-						if (!template.learnset) continue;
-						var fullLearnset = template.learnset;
-						while (template.prevo) {
-							template = Tools.getTemplate(template.prevo);
-							for (var move in template.learnset) {
-								if (!fullLearnset[move]) fullLearnset[move] = template.learnset[move];
-							}
-						}
-						dex[mon].learnset = fullLearnset;
+						dex[mon].learnset = Tools.getLearnset(dex[mon]);
 					}
 					break;
 
@@ -854,15 +844,8 @@ var commands = exports.commands = {
 			var template = Tools.getTemplate(target);
 			if (template.exists) {
 				if (Object.size(lsetData) !== 0) return this.sendReplyBox("A search can only include one Pokemon learnset.");
-				if (!template.learnset) template = Tools.getTemplate(template.baseSpecies);
-				lsetData = template.learnset;
+				lsetData = Tools.getLearnset(template);
 				targetMon = template.name;
-				while (template.prevo) {
-					template = Tools.getTemplate(template.prevo);
-					for (var move in template.learnset) {
-						if (!lsetData[move]) lsetData[move] = template.learnset[move];
-					}
-				}
 				continue;
 			}
 

--- a/tools.js
+++ b/tools.js
@@ -573,6 +573,36 @@ module.exports = (function () {
 		return banlistTable;
 	};
 
+	Tools.prototype.getLearnset = function (pokemon) {
+		// This combines the learnsets of a Pokemon with it's baseform and prevos
+		var template;
+		if (typeof pokemon === 'object') {
+			template = pokemon;
+		} else {
+			template = this.getTemplate(pokemon);
+		}
+		if (!template.learnset) template = this.getTemplate(template.baseSpecies);
+		if (!template.learnset) return false;
+
+		var lsetData = template.learnset;
+		if (template.baseSpecies !== template.species) {
+			// This is for Pokemon that have different learnsets for different forms
+			template = this.getTemplate(template.baseSpecies);
+			for (var move in template.learnset) {
+				if (!lsetData[move]) lsetData[move] = template.learnset[move];
+			}
+		}
+		while (template.prevo) {
+			// Add moves carried over from preevos
+			template = this.getTemplate(template.prevo);
+			for (var move in template.learnset) {
+				if (!lsetData[move]) lsetData[move] = template.learnset[move];
+			}
+		}
+
+		return lsetData;
+	};
+
 	Tools.prototype.levenshtein = function (s, t, l) { // s = string 1, t = string 2, l = limit
 		// Original levenshtein distance function by James Westgate, turned out to be the fastest
 		var d = []; // 2d matrix


### PR DESCRIPTION
Moves the method used to create the full learnset for a Pokemon to `tools.js`. While only currently used in /dexsearch and /movesearch, I could see it potentially having uses elsewhere.

This also adds an additional check for alternate forms who have learnset entries which fixes a very minor bug with Pumpkaboo-Super.