### PR TITLE
Random Battle: Improve Hidden Power rejection check

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1403,8 +1403,8 @@ exports.BattleScripts = {
 					if (!isSetup && moveid !== 'rest' && moveid !== 'sleeptalk') rejected = true;
 				}
 
-				// Hidden Power isn't good enough
-				if (counter.setupType === 'Special' && move.id === 'hiddenpower' && counter['Special'] <= 2 && (!hasMove['shadowball'] || move.type !== 'Fighting')) {
+				// Hidden Power isn't good enough for most cases with Special setup
+				if (counter.setupType === 'Special' && move.id === 'hiddenpower' && counter['Special'] <= 2 && !hasType[move.type] && (!hasMove['shadowball'] || move.type !== 'Fighting') && (!hasType['Electric'] || move.type !== 'Ice') && template.species !== 'Lilligant') {
 					rejected = true;
 				}
 


### PR DESCRIPTION
There are a few Pokemon that set up but have very few viable moves and must
rely on Hidden Power for coverage, like Lilligant.

@TheImmortal, please discuss this with me, since there are also many Pokemon
that set up but don't appreciate having a STAB move plus a weak Hidden Power
as their only attacking moves (which is why you put this case in in the first place).
Is there a better criteria we can use to get this working? Lilligant almost always
has bad sets because of this line.