### PR TITLE
Send '|deinit' message when trying to hardlink to room aliases

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -694,6 +694,10 @@ var commands = exports.commands = {
 			}
 		}
 
+		if (toId(target) in Rooms.aliases) {
+			connection.send(">" + toId(target) + "\n|deinit");
+		}
+
 		var joinResult = user.joinRoom(targetRoom, connection);
 		if (!joinResult) {
 			if (joinResult === null) {


### PR DESCRIPTION
Fixes the problem with room alias "ghost rooms".