### PR TITLE
Random Battle: Slightly tweak Hidden Power rejection check

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1404,7 +1404,7 @@ exports.BattleScripts = {
 				}
 
 				// Hidden Power isn't good enough for most cases with Special setup
-				if (counter.setupType === 'Special' && move.id === 'hiddenpower' && counter['Special'] <= 2 && !hasType[move.type] && (!hasMove['shadowball'] || move.type !== 'Fighting') && (!hasType['Electric'] || move.type !== 'Ice') && template.species !== 'Lilligant') {
+				if (counter.setupType === 'Special' && move.id === 'hiddenpower' && counter['Special'] <= 2 && (!hasMove['shadowball'] || move.type !== 'Fighting') && (!hasType['Electric'] || move.type !== 'Ice') && template.species !== 'Lilligant') {
 					rejected = true;
 				}
 


### PR DESCRIPTION
STAB Hidden Power without the Pokemon's other STAB can be bad. Instead,
check for EdgeQuake (Rock+Ground) as an acceptance criteria (for Lunatone)

As suggested by @TheImmortal in #1810 