### PR TITLE
Improved /weak targeting

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1065,7 +1065,8 @@ var commands = exports.commands = {
 	weakness: function (target, room, user) {
 		if (!target) return this.parse('/help weakness');
 		if (!this.canBroadcast()) return;
-		var targets = target.split(/[ ,\/]/);
+		target = target.trim();
+		var targets = target.split(/ ?[,\/ ] ?/);
 
 		var pokemon = Tools.getTemplate(target);
 		var type1 = Tools.getType(targets[0]);
@@ -1073,7 +1074,7 @@ var commands = exports.commands = {
 
 		if (pokemon.exists) {
 			target = pokemon.species;
-		} else if (type1.exists && type2.exists) {
+		} else if (type1.exists && type2.exists && type1 !== type2) {
 			pokemon = {types: [type1.id, type2.id]};
 			target = type1.id + "/" + type2.id;
 		} else if (type1.exists) {


### PR DESCRIPTION
If spaces aren't being used as the target split, remove them. This allows the syntax `/weak fire / grass` to work. Also checking for double typing because we don't know the full implications of what that would mean. (request by @Ridaz)