### PR TITLE
Standard Weather always fails to activate when Primal Weather is active

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -517,6 +517,9 @@ exports.BattleAbilities = {
 		onStart: function (source) {
 			this.setWeather('deltastream');
 		},
+		onAnySetWeather: function (target, source, weather) {
+			if (this.getWeather().id === 'deltastream' && !(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
+		},
 		onEnd: function (pokemon) {
 			if (this.weatherData.source !== pokemon) return;
 			for (var i = 0; i < this.sides.length; i++) {
@@ -541,6 +544,9 @@ exports.BattleAbilities = {
 		shortDesc: "On switch-in, extremely harsh sunlight begins until this Ability is not active in battle.",
 		onStart: function (source) {
 			this.setWeather('desolateland');
+		},
+		onAnySetWeather: function (target, source, weather) {
+			if (this.getWeather().id === 'desolateland' && !(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
 		},
 		onEnd: function (pokemon) {
 			if (this.weatherData.source !== pokemon) return;
@@ -1993,6 +1999,9 @@ exports.BattleAbilities = {
 		shortDesc: "On switch-in, heavy rain begins until this Ability is not active in battle.",
 		onStart: function (source) {
 			this.setWeather('primordialsea');
+		},
+		onAnySetWeather: function (target, source, weather) {
+			if (this.getWeather().id === 'primordialsea' && !(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
 		},
 		onEnd: function (pokemon) {
 			if (this.weatherData.source !== pokemon) return;

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -444,9 +444,6 @@ exports.BattleStatuses = {
 				return this.chainModify(1.5);
 			}
 		},
-		onSetWeather: function (target, source, weather) {
-			if (!(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
-		},
 		onStart: function () {
 			this.add('-weather', 'PrimordialSea');
 		},
@@ -513,9 +510,6 @@ exports.BattleStatuses = {
 				this.debug('Sunny Day fire boost');
 				return this.chainModify(1.5);
 			}
-		},
-		onSetWeather: function (target, source, weather) {
-			if (!(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
 		},
 		onStart: function () {
 			this.add('-weather', 'DesolateLand');
@@ -606,9 +600,6 @@ exports.BattleStatuses = {
 				this.add('-activate', '', 'deltastream');
 				return 0;
 			}
-		},
-		onSetWeather: function (target, source, weather) {
-			if (!(weather.id in {desolateland:1, primordialsea:1, deltastream:1})) return false;
 		},
 		onStart: function () {
 			this.add('-weather', 'DeltaStream');

--- a/test/simulator/abilities/cloudnine.js
+++ b/test/simulator/abilities/cloudnine.js
@@ -1,0 +1,86 @@
+var assert = require('assert');
+var battle;
+
+describe('Cloud Nine', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should treat the weather as none for the purposes of formes, moves and abilities', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['sunnyday']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Cherrim', ability: 'flowergift', item: 'laggingtail', moves: ['solarbeam']}]);
+		battle.commitDecisions();
+		assert.ok(battle.isWeather('', battle.p2.active[0]));
+		assert.strictEqual(battle.p2.active[0].template.species, 'Cherrim');
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should negate the effects of Sun on Fire-type and Water-type attacks', function () {
+		battle = BattleEngine.Battle.construct();
+		var move, basePower;
+		battle.join('p1', 'Guest 1', 1, [{species: 'Groudon', ability: 'drought', moves: ['rest']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		move = Tools.getMove('firepledge');
+		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, move.basePower);
+		move = Tools.getMove('waterpledge');
+		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, move.basePower);
+	});
+
+	it('should negate the effects of Rain on Fire-type and Water-type attacks', function () {
+		battle = BattleEngine.Battle.construct();
+		var move, basePower;
+		battle.join('p1', 'Guest 1', 1, [{species: 'Kyogre', ability: 'drizzle', moves: ['rest']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		move = Tools.getMove('firepledge');
+		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, move.basePower);
+		move = Tools.getMove('waterpledge');
+		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, move.basePower);
+	});
+
+	it('should negate the damage-dealing effects of Sandstorm', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Tyranitar', ability: 'sandstream', moves: ['dragondance']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should negate the damage-dealing effects of Hail', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Abomasnow', ability: 'snowwarning', moves: ['rest']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not negate Desolate Land\'s ability to prevent other weathers from activating', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Groudon', ability: 'desolateland', moves: ['sunnyday']}]);
+		battle.commitDecisions();
+		assert.ok(battle.weather, 'desolateland');
+	});
+
+	it('should not negate Primordial Sea\'s ability to prevent other weathers from activating', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Kyogre', ability: 'primordialsea', moves: ['sunnyday']}]);
+		battle.commitDecisions();
+		assert.ok(battle.weather, 'primordialsea');
+	});
+
+	it('should not negate Delta Stream\'s ability to prevent other weathers from activating', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Rayquaza', ability: 'deltastream', moves: ['sunnyday']}]);
+		battle.commitDecisions();
+		assert.ok(battle.weather, 'deltastream');
+	});
+});


### PR DESCRIPTION
Old implementation allowed Pokemon to use a standard weather move like
Rain Dance successfully against a primal weather like Harsh Sun if a
Pokemon with Cloud Nine or Air Lock was active.