### PR TITLE
/randompokemon mode for /dexsearch

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -306,7 +306,7 @@ var commands = exports.commands = {
 
 	ds: 'dexsearch',
 	dsearch: 'dexsearch',
-	dexsearch: function (target, room, user) {
+	dexsearch: function (target, room, user, connection, cmd) {
 		if (!this.canBroadcast()) return;
 
 		if (!target) return this.parse('/help dexsearch');
@@ -318,6 +318,7 @@ var commands = exports.commands = {
 		var showAll = false;
 		var megaSearch = null;
 		var output = 10;
+		var randomOutput = 0;
 		var categories = ['gen', 'tier', 'color', 'types', 'ability', 'stats', 'compileLearnsets', 'moves', 'recovery', 'priority'];
 
 		for (var i = 0; i < targets.length; i++) {
@@ -363,6 +364,11 @@ var commands = exports.commands = {
 			if (target === 'all') {
 				if (this.broadcasting) return this.sendReplyBox("A search with the parameter 'all' cannot be broadcast.");
 				showAll = true;
+				continue;
+			}
+
+			if (target.substr(0, 6) === 'random' && cmd === 'randpoke') {
+				randomOutput = parseInt(target.substr(6));
 				continue;
 			}
 
@@ -614,6 +620,10 @@ var commands = exports.commands = {
 			results.push(dex[mon].species);
 		}
 
+		if (randomOutput && randomOutput < results.length) {
+			results = results.randomize().slice(0, randomOutput);
+		}
+
 		var resultsStr = "";
 		if (results.length > 0) {
 			if (showAll || results.length <= output + 5) {
@@ -635,6 +645,32 @@ var commands = exports.commands = {
 		"Parameters can be excluded through the use of '!', e.g., '!water type' excludes all water types.",
 		"The parameter 'mega' can be added to search for Mega Evolutions only, and the parameters 'FE' or 'NFE' can be added to search fully or not-fully evolved Pokemon only.",
 		"The order of the parameters does not matter."],
+
+	rollpokemon: 'randompokemon',
+	randpoke: 'randompokemon',
+	randompokemon: function (target, room, user, connection, cmd) {
+		var targets = target.split(",");
+		var targetsBuffer = [];
+		var qty;
+		for (var i = 0; i < targets.length; i++) {
+			if (!targets[i]) continue;
+			var num = Number(targets[i]);
+			if (Number.isInteger(num)) {
+				if (qty) return this.sendReply("Only specify the number of Pokemon once.");
+				qty = num;
+				if (qty < 1 || 15 < qty) return this.sendReply("Number of random Pokemon must be between 1 and 15.");
+				targetsBuffer.push("random" + qty);
+			} else {
+				targetsBuffer.push(targets[i]);
+			}
+		}
+		if (!qty) targetsBuffer.push("random1");
+
+		CommandParser.commands.dexsearch.call(this, targetsBuffer.join(","), room, user, connection, "randpoke");
+	},
+	randompokemonhelp: ["/randompokemon - Generates random Pokemon based on given search conditions.",
+		"/randompokemon uses the same parameters as /dexsearch (see '/help ds').",
+		"Adding a number as a parameter returns that many random Pokemon, e.g., '/randpoke 6' returns 6 random Pokemon."],
 
 	ms: 'movesearch',
 	msearch: 'movesearch',


### PR DESCRIPTION
Calls `/dexsearch` and returns a random Pokemon that would have been included in the results. Without arguments it calls one random Pokemon, otherwise an integer is read as the number of random Pokemon desired (forces "gen" to be used if a gen parameter is desired) and all other parameters are assumed to be used in the dexsearch search.