### PR TITLE
Refactor disabling moves, other miscellaneous bug fixes

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -362,8 +362,6 @@ BattlePokemon = (function () {
 		return this.details + '|' + this.getHealth(side);
 	};
 	BattlePokemon.prototype.update = function (init) {
-		// reset for diabled moves
-		this.disabledMoves = {};
 		this.negateImmunity = {};
 		this.trapped = this.maybeTrapped = false;
 		this.maybeDisabled = false;
@@ -2709,6 +2707,8 @@ Battle = (function () {
 				pokemon.moveThisTurn = '';
 				pokemon.usedItemThisTurn = false;
 				pokemon.newlySwitched = false;
+				pokemon.disabledMoves = {};
+				this.runEvent('DisableMove', pokemon);
 				if (pokemon.lastAttackedBy) {
 					if (pokemon.lastAttackedBy.pokemon.isActive) {
 						pokemon.lastAttackedBy.thisTurn = false;

--- a/data/items.js
+++ b/data/items.js
@@ -102,6 +102,9 @@ exports.BattleItems = {
 				pokemon.eatItem();
 			}
 		},
+		onEatItem: function (item, pokemon) {
+			if (!this.runEvent('TryHeal', pokemon)) return false;
+		},
 		onEat: function (pokemon) {
 			this.heal(pokemon.maxhp / 8);
 			if (pokemon.getNature().minus === 'spd') {
@@ -351,7 +354,7 @@ exports.BattleItems = {
 		},
 		onUpdate: function (pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
-				if (pokemon.useItem()) {
+				if (this.runEvent('TryHeal', pokemon) && pokemon.useItem()) {
 					this.heal(20);
 				}
 			}
@@ -1285,6 +1288,9 @@ exports.BattleItems = {
 				}
 			}
 		},
+		onEatItem: function (item, pokemon) {
+			if (!this.runEvent('TryHeal', pokemon)) return false;
+		},
 		onEat: function (pokemon) {
 			this.heal(pokemon.maxhp / 4);
 		},
@@ -1390,6 +1396,9 @@ exports.BattleItems = {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
 			}
+		},
+		onEatItem: function (item, pokemon) {
+			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat: function (pokemon) {
 			this.heal(pokemon.maxhp / 8);
@@ -1920,6 +1929,9 @@ exports.BattleItems = {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
 			}
+		},
+		onEatItem: function (item, pokemon) {
+			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat: function (pokemon) {
 			this.heal(pokemon.maxhp / 8);
@@ -2574,6 +2586,9 @@ exports.BattleItems = {
 				pokemon.eatItem();
 			}
 		},
+		onEatItem: function (item, pokemon) {
+			if (!this.runEvent('TryHeal', pokemon)) return false;
+		},
 		onEat: function (pokemon) {
 			this.heal(pokemon.maxhp / 8);
 			if (pokemon.getNature().minus === 'spe') {
@@ -3098,6 +3113,9 @@ exports.BattleItems = {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
 			}
+		},
+		onEatItem: function (item, pokemon) {
+			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat: function (pokemon) {
 			this.heal(10);
@@ -4061,6 +4079,9 @@ exports.BattleItems = {
 				pokemon.eatItem();
 			}
 		},
+		onEatItem: function (item, pokemon) {
+			if (!this.runEvent('TryHeal', pokemon)) return false;
+		},
 		onEat: function (pokemon) {
 			this.heal(pokemon.maxhp / 4);
 		},
@@ -4718,6 +4739,9 @@ exports.BattleItems = {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
 			}
+		},
+		onEatItem: function (item, pokemon) {
+			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat: function (pokemon) {
 			this.heal(pokemon.maxhp / 8);

--- a/data/items.js
+++ b/data/items.js
@@ -253,7 +253,7 @@ exports.BattleItems = {
 		onModifySpD: function (spd) {
 			return this.chainModify(1.5);
 		},
-		onModifyPokemon: function (pokemon) {
+		onDisableMove: function (pokemon) {
 			var moves = pokemon.moveset;
 			for (var i = 0; i < moves.length; i++) {
 				if (this.getMove(moves[i].move).category === 'Status') {

--- a/data/moves.js
+++ b/data/moves.js
@@ -5394,6 +5394,7 @@ exports.BattleMovedex = {
 				if (pokemon.removeVolatile('bounce') || pokemon.removeVolatile('fly')) {
 					applies = true;
 					this.cancelMove(pokemon);
+					pokemon.removeVolatile('twoturnmove');
 				}
 				if (pokemon.volatiles['skydrop']) {
 					applies = true;

--- a/data/moves.js
+++ b/data/moves.js
@@ -2682,7 +2682,7 @@ exports.BattleMovedex = {
 					return false;
 				}
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				var moves = pokemon.moveset;
 				for (var i = 0; i < moves.length; i++) {
 					if (moves[i].id === this.effectData.move) {
@@ -3553,7 +3553,7 @@ exports.BattleMovedex = {
 			onEnd: function (target) {
 				this.add('-end', target, 'Encore');
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				if (!this.effectData.move || !pokemon.hasMove(this.effectData.move)) {
 					return;
 				}
@@ -5383,13 +5383,15 @@ exports.BattleMovedex = {
 				if (typeof accuracy !== 'number') return;
 				return accuracy * 5 / 3;
 			},
-			onModifyPokemonPriority: 100,
-			onModifyPokemon: function (pokemon) {
-				pokemon.negateImmunity['Ground'] = true;
+			onDisableMove: function (pokemon) {
 				var disabledMoves = {bounce:1, fly:1, flyingpress:1, highjumpkick:1, jumpkick:1, magnetrise:1, skydrop:1, splash:1, telekinesis:1};
 				for (var m in disabledMoves) {
 					pokemon.disableMove(m);
 				}
+			},
+			onModifyPokemonPriority: 100,
+			onModifyPokemon: function (pokemon) {
+				pokemon.negateImmunity['Ground'] = true;
 				var applies = false;
 				if (pokemon.removeVolatile('bounce') || pokemon.removeVolatile('fly')) {
 					applies = true;
@@ -5847,7 +5849,7 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-start', pokemon, 'move: Heal Block');
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				var disabledMoves = {healingwish:1, lunardance:1, rest:1, swallow:1, wish:1};
 				var move;
 				for (var i = 0; i < pokemon.moveset.length; i++) {
@@ -6993,7 +6995,7 @@ exports.BattleMovedex = {
 			onStart: function (target) {
 				this.add('-start', target, 'move: Imprison');
 			},
-			onFoeModifyPokemon: function (pokemon) {
+			onFoeDisableMove: function (pokemon) {
 				var foeMoves = this.effectData.source.moveset;
 				for (var f = 0; f < foeMoves.length; f++) {
 					pokemon.disableMove(foeMoves[f].id, true);
@@ -13960,7 +13962,7 @@ exports.BattleMovedex = {
 			onEnd: function (target) {
 				this.add('-end', target, 'move: Taunt');
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				var moves = pokemon.moveset;
 				for (var i = 0; i < moves.length; i++) {
 					if (this.getMove(moves[i].move).category === 'Status') {
@@ -14359,7 +14361,7 @@ exports.BattleMovedex = {
 			onEnd: function (pokemon) {
 				this.add('-end', pokemon, 'Torment');
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				if (pokemon.lastMove !== 'struggle') pokemon.disableMove(pokemon.lastMove);
 			}
 		},

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -255,7 +255,7 @@ exports.BattleStatuses = {
 			if (!this.activeMove.id || this.activeMove.sourceEffect && this.activeMove.sourceEffect !== this.activeMove.id) return false;
 			this.effectData.move = this.activeMove.id;
 		},
-		onModifyPokemon: function (pokemon) {
+		onDisableMove: function (pokemon) {
 			if (!pokemon.getItem().isChoice || !pokemon.hasMove(this.effectData.move)) {
 				pokemon.removeVolatile('choicelock');
 				return;

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -89,7 +89,7 @@ exports.BattleMovedex = {
 				this.add('-activate', pokemon, 'Bide');
 				return false;
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				if (!pokemon.hasMove('bide')) {
 					return;
 				}
@@ -265,7 +265,7 @@ exports.BattleMovedex = {
 					return false;
 				}
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				var moves = pokemon.moveset;
 				for (var i = 0; i < moves.length; i++) {
 					if (moves[i].id === this.effectData.move) {

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -64,7 +64,7 @@ exports.BattleMovedex = {
 			onEnd: function (target) {
 				this.add('-end', target, 'Encore');
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				if (!this.effectData.move || !pokemon.hasMove(this.effectData.move)) {
 					return;
 				}

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -177,7 +177,7 @@ exports.BattleMovedex = {
 					return false;
 				}
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				var moves = pokemon.moveset;
 				for (var i = 0; i < moves.length; i++) {
 					if (moves[i].id === this.effectData.move) {
@@ -243,7 +243,7 @@ exports.BattleMovedex = {
 			onEnd: function (target) {
 				this.add('-end', target, 'Encore');
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				if (!this.effectData.move || !pokemon.hasMove(this.effectData.move)) {
 					return;
 				}
@@ -628,7 +628,7 @@ exports.BattleMovedex = {
 			onEnd: function (target) {
 				this.add('-end', target, 'move: Taunt');
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				var moves = pokemon.moveset;
 				for (var i = 0; i < moves.length; i++) {
 					if (this.getMove(moves[i].move).category === 'Status') {

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -476,7 +476,45 @@ exports.BattleMovedex = {
 	},
 	healblock: {
 		inherit: true,
-		flags: {protect: 1, mirror: 1}
+		flags: {protect: 1, mirror: 1},
+		effect: {
+			duration: 5,
+			durationCallback: function (target, source, effect) {
+				if (source && source.hasAbility('persistent')) {
+					return 7;
+				}
+				return 5;
+			},
+			onStart: function (pokemon) {
+				this.add('-start', pokemon, 'move: Heal Block');
+			},
+			onDisableMove: function (pokemon) {
+				var disabledMoves = {healingwish:1, lunardance:1, rest:1, swallow:1, wish:1};
+				var moves = pokemon.moveset;
+				for (var i = 0; i < moves.length; i++) {
+					if (disabledMoves[moves[i].id] || this.getMove(moves[i].id).heal) {
+						pokemon.disableMove(moves[i].id);
+					}
+				}
+			},
+			onBeforeMovePriority: 6,
+			onBeforeMove: function (pokemon, target, move) {
+				var disabledMoves = {healingwish:1, lunardance:1, rest:1, swallow:1, wish:1};
+				if (disabledMoves[move.id] || move.heal) {
+					this.add('cant', pokemon, 'move: Heal Block', move);
+					return false;
+				}
+			},
+			onResidualOrder: 17,
+			onEnd: function (pokemon) {
+				this.add('-end', pokemon, 'move: Heal Block');
+			},
+			onTryHeal: function (damage, pokemon, source, effect) {
+				if (effect && (effect.id === 'drain' || effect.id === 'leechseed' || effect.id === 'wish')) {
+					return false;
+				}
+			}
+		}
 	},
 	healingwish: {
 		inherit: true,

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -281,7 +281,7 @@ exports.BattleMovedex = {
 					return false;
 				}
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				var moves = pokemon.moveset;
 				for (var i = 0; i < moves.length; i++) {
 					if (moves[i].id === this.effectData.move) {

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -343,7 +343,7 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-start', pokemon, 'move: Heal Block');
 			},
-			onModifyPokemon: function (pokemon) {
+			onDisableMove: function (pokemon) {
 				var disabledMoves = {healingwish:1, lunardance:1, rest:1, swallow:1, wish:1};
 				var moves = pokemon.moveset;
 				for (var i = 0; i < moves.length; i++) {

--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -534,7 +534,7 @@ exports.BattleAbilities = {
 		onStart: function (target) {
 			this.add('-start', target, 'move: Imprison');
 		},
-		onFoeModifyPokemon: function (pokemon) {
+		onFoeDisableMove: function (pokemon) {
 			var foeMoves = this.effectData.target.moveset;
 			for (var f = 0; f < foeMoves.length; f++) {
 				pokemon.disableMove(foeMoves[f].id, true);

--- a/test/simulator/items/assaultvest.js
+++ b/test/simulator/items/assaultvest.js
@@ -1,0 +1,25 @@
+var assert = require('assert');
+var battle;
+
+describe('Assault Vest', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should disable the use of Status moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Abra', ability: 'synchronize', moves: ['teleport']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', item: 'assaultvest', moves: ['teleport']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+	});
+
+	it('should not prevent the use of Status moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Lopunny', ability: 'klutz', item: 'assaultvest', moves: ['trick']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', item: 'ironball', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].boosts['spa'], 1);
+		assert.strictEqual(battle.p2.active[0].boosts['spd'], 1);
+	});
+});

--- a/test/simulator/moves/disable.js
+++ b/test/simulator/moves/disable.js
@@ -1,0 +1,17 @@
+var assert = require('assert');
+var battle;
+
+describe('Disable', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent the use of the target\'s last move', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Abra', ability: 'synchronize', item: 'laggingtail', moves: ['disable']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['teleport']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+	});
+});

--- a/test/simulator/moves/gravity.js
+++ b/test/simulator/moves/gravity.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+var battle;
+
+describe('Gravity', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should ground Flying-type Pokemon and remove their Ground immunity', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Aerodactyl', ability: 'pressure', moves: ['gravity']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Aron', ability: 'sturdy', moves: ['earthpower']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should ground Pokemon with Levitate and remove their Ground immunity', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Rotom', ability: 'levitate', moves: ['gravity']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Aron', ability: 'sturdy', moves: ['earthpower']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should interrupt and disable the use of airborne moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['gravity']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Aerodactyl', ability: 'pressure', moves: ['fly']}]);
+		battle.commitDecisions();
+		assert.ok(!battle.p2.active[0].volatiles['twoturnmove']);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+	});
+});

--- a/test/simulator/moves/healblock.js
+++ b/test/simulator/moves/healblock.js
@@ -1,0 +1,215 @@
+var assert = require('assert');
+var battle;
+
+describe('Heal Block', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent Pokemon from gaining HP from residual recovery items', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Hippowdon', ability: 'sandstream', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should prevent Pokemon from consuming HP recovery items', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Pansage', ability: 'gluttony', item: 'berryjuice', moves: ['bellydrum']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].item, 'berryjuice');
+		assert.strictEqual(battle.p2.active[0].hp, Math.ceil(battle.p2.active[0].maxhp / 2));
+	});
+
+	it('should disable the use of healing moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Cresselia', ability: 'levitate', moves: ['recover']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+	});
+
+	it('should prevent Pokemon from using draining moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['gigadrain']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should prevent abilities from recovering HP', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock', 'surf']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind']}]);
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p2.active[0].hp, hp);
+	});
+
+	it('should prevent Leech Seed from healing HP', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Starmie', ability: 'noguard', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed']}]);
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, hp);
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+});
+
+describe('Heal Block - BW', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent Pokemon from gaining HP from residual recovery items', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-items-bw', 'gen5customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Hippowdon', ability: 'sandstream', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should prevent Pokemon from consuming HP recovery items', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-consume-bw', 'gen5customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Pansage', ability: 'gluttony', item: 'sitrusberry', moves: ['bellydrum']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].item, 'sitrusberry');
+		assert.strictEqual(battle.p2.active[0].hp, Math.ceil(battle.p2.active[0].maxhp / 2));
+	});
+
+	it('should disable the use of healing moves', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-moves-bw', 'gen5customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Cresselia', ability: 'levitate', moves: ['recover']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+	});
+
+	it('should prevent abilities from recovering HP', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-ability-bw', 'gen5customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock', 'surf']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p2.active[0].hp, hp);
+	});
+
+	it('should prevent draining moves from healing HP', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-drain-bw', 'gen5customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'gigadrain']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, hp);
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should prevent Leech Seed from healing HP', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-leechseed-bw', 'gen5customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Starmie', ability: 'noguard', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed']}]);
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, hp);
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+});
+
+describe('Heal Block - DPPt', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should disable the use of healing moves', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-moves-dpp', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Cresselia', ability: 'levitate', moves: ['recover']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+	});
+
+	it('should block the effect of Wish', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-moves-dpp', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Deoxys', ability: 'pressure', moves: ['wish']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should prevent draining moves from healing HP', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-drain-bw', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'gigadrain']}]);
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, hp);
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should allow HP recovery items to activate', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-items-dpp', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['healblock', 'shadowball']}]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Abra', level: 1, ability: 'synchronize', item: 'leftovers', moves: ['teleport', 'endure']},
+			{species: 'Abra', level: 1, ability: 'synchronize', item: 'sitrusberry', moves: ['teleport', 'endure']}
+		]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.notStrictEqual(battle.p2.active[0].hp, 1);
+		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p2.active[0].item, '');
+		assert.notStrictEqual(battle.p2.active[0].hp, 1);
+	});
+
+	it('should allow abilities that recover HP to activate', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-ability-dpp', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'keeneye', moves: ['healblock', 'surf']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind']}]);
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.notStrictEqual(battle.p2.active[0].hp, hp);
+	});
+
+	it('should prevent Leech Seed from healing HP', function () {
+		battle = BattleEngine.Battle.construct('battle-healblock-leechseed-dpp', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Starmie', ability: 'noguard', moves: ['healblock']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed']}]);
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, hp);
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+});

--- a/test/simulator/moves/imprison.js
+++ b/test/simulator/moves/imprison.js
@@ -1,0 +1,17 @@
+var assert = require('assert');
+var battle;
+
+describe('Imprison', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent foes from using moves that the user knows', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Abra', ability: 'prankster', moves: ['imprison', 'teleport']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['teleport', 'confusion']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].lastMove, 'confusion');
+	});
+});

--- a/test/simulator/moves/taunt.js
+++ b/test/simulator/moves/taunt.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+var battle;
+
+describe('Taunt', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent the target from using Status moves and disable them', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['taunt']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
+		assert.strictEqual(battle.p2.active[0].boosts['spd'], 0);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+	});
+});


### PR DESCRIPTION
The intention for this event is to remove the move disabling code away
from ModifyPokemon and to an event that can be run a fewer number of
times. Since the disabledMoves index is used to gray-out moves that cannot
be used, and not for any other purpose, there is no need for the related
code to be run at the ModifyPokemon timing, instead working better as a
once per turn event.

-----

This is another one of those giant refactors, so naturally I'll be nervous about
it no matter how well it seems to go.

Code ostensibly works, and passes the regressions I set up, but I don't have 
a full understanding of all the mechanics for moves, and the oldgens 
regressions are non-existent right now. Tagging @Joimer for his expertise
in all things oldgens. Also @Slayer95 for current gen stuff (especially Imprison)

Also, Bulbapedia reports that Heal Block stops Water Absorb entirely, so can
I have @Marty-D double-check and verify that? The tests I have relating to
that are being skipped right now.

@Zarel because I don't really have any idea on how NEXT Telepathy works.