### PR TITLE
Improve report so that the message will be shown

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -95,10 +95,10 @@ var commands = exports.commands = {
 	requesthelp: 'report',
 	report: function (target, room, user) {
 		if (room.id === 'help') {
-			this.sendReply("Ask one of the Mods in the Help room.");
+			this.sendReply("Ask one of the Moderators (@) in the Help room.");
 		} else {
-			this.sendReply("Ask a Mod in the Help room.");
 			this.parse('/join help');
+			user.popup("Ask one of the Moderators (@) in the Help room.");
 		}
 	},
 


### PR DESCRIPTION
Before the message instructing the user to join ask in the help room was not readable since the command was making you join Help immediately.  I did this by changing the way the message gets sent (now as a popup after joining the room). Additionally, I have also slightly changed the message to be more helpful to the user.