### PR TITLE
Update package.json contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,14 @@
       "name": "Bill Meltsner",
       "email": "bill@meltsner.com",
       "url": "http://www.meltsner.com"
+    },
+    {
+      "name": "Juanma Serrano",
+      "email": "juanmadss@gmail.com"
     }
   ],
   "private": true,
+  "license": "MIT",
   "devDependencies": {
     "cache-swap": "~0.2.0",
     "gulp": "~3.8.7",


### PR DESCRIPTION
Package json has no specification for retired staff members.
Adding staff members to contributors array in package.json.

I'm adding a PR on this since I want @Zarel to review this, as well as other members might want an e-mail or website to be added.