### PR TITLE
Chat plugins: mute/lock checks, add remaining help docs...

### DIFF
--- a/chat-plugins/thehappyplace.js
+++ b/chat-plugins/thehappyplace.js
@@ -10,28 +10,35 @@ exports.commands = {
 	quoteoftheday: 'qotd',
 	qotd: function (target, room, user) {
 		if (room.id !== 'thehappyplace') return this.sendReply("This command can only be used in The Happy Place.");
-		if (!this.canBroadcast() || !room.chatRoomData) return;
+		if (!room.chatRoomData) return;
 		if (!target) {
+			if (!this.canBroadcast()) return;
 			if (!room.chatRoomData.quote) return this.sendReplyBox("The Quote of the Day has not been set.");
-			return this.sendReplyBox("The current <strong>'Inspirational Quote of the Day'</strong> is:<br />" + room.chatRoomData.quote);
+			return this.sendReplyBox(
+				"The current <strong>Inspirational Quote of the Day</strong> is:<br />" +
+				"\"" + room.chatRoomData.quote + "\""
+			);
 		}
 		if (!this.can('declare', null, room)) return false;
 		if (target === 'off' || target === 'disable' || target === 'reset') {
 			if (!room.chatRoomData.quote) return this.sendReply("The Quote of the Day has already been reset.");
 			delete room.chatRoomData.quote;
 			this.sendReply("The Quote of the Day was reset by " + Tools.escapeHTML(user.name) + ".");
-			this.logModCommand(user.name + " has reset the Quote of the Day.");
+			this.logModCommand(user.name + " reset the Quote of the Day.");
 			Rooms.global.writeChatRoomData();
 			return;
 		}
 		room.chatRoomData.quote = Tools.escapeHTML(target);
-		room.addRaw(
-			'<div class="broadcast-green">' +
-				"<p><strong>The 'Inspirational Quote of the Day' has been updated by " + Tools.escapeHTML(user.name) + ".</strong></p>" +
-				"<p>Quote: " + room.chatRoomData.quote + '</p>' +
-			'</div>'
-		);
-		this.logModCommand(Tools.escapeHTML(user.name) + " has updated the quote of the day to: " + room.chatRoomData.quote);
 		Rooms.global.writeChatRoomData();
-	}
+		room.addRaw(
+			"<div class=\"broadcast-blue\"><strong>The Inspirational Quote of the Day has been updated by " + Tools.escapeHTML(user.name) + ".</strong><br />" +
+			"Quote: " + room.chatRoomData.quote + "</div>"
+		);
+		this.logModCommand(Tools.escapeHTML(user.name) + " updated the quote of the day to \"" + room.chatRoomData.quote + "\".");
+	},
+	quoteofthedayhelp: 'qotdhelp',
+	qotdhelp: [
+		"/qotd - View the current Inspirational Quote of the Day.",
+		"/qotd [quote] - Set the Inspirational Quote of the Dat. Requires: # & ~"
+	]
 };

--- a/chat-plugins/thestudio.js
+++ b/chat-plugins/thestudio.js
@@ -30,12 +30,13 @@ if (theStudio && !theStudio.plugin) {
 var commands = {
 	start: function (target, room, user) {
 		if (room.id !== 'thestudio' || !room.chatRoomData || !this.can('mute', null, room)) return false;
-		if (artistOfTheDay.pendingNominations) return this.sendReply('Nominations for the Artist of the Day are already in progress.');
+		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
+		if (artistOfTheDay.pendingNominations) return this.sendReply("Nominations for the Artist of the Day are already in progress.");
 
 		var nominations = artistOfTheDay.nominations;
 		var prenominations = room.chatRoomData.prenominations;
 		if (prenominations && prenominations.length) {
-			for (var i = prenominations.length; i--;) {
+			for (var i = 0; i < prenominations.length; i++) {
 				var prenomination = prenominations[i];
 				nominations.set(Users.get(prenomination[0].userid) || prenomination[0], prenomination[1]);
 			}
@@ -44,15 +45,19 @@ var commands = {
 		artistOfTheDay.pendingNominations = true;
 		room.chatRoomData.prenominations = [];
 		Rooms.global.writeChatRoomData();
-		room.addRaw('<div class="broadcast-blue"><strong>Nominations for the Artist of the Day have begun!</strong><br />' +
-		            'Use /aotd nom to nominate an artist.</div>');
-		this.privateModCommand('(' + user.name + ' began nominations for the Artist of the Day.)');
+		room.addRaw(
+			"<div class=\"broadcast-blue\"><strong>Nominations for the Artist of the Day have begun!</strong><br />" +
+		        "Use /aotd nom to nominate an artist.</div>"
+		);
+		this.privateModCommand("(" + user.name + " began nominations for the Artist of the Day.)");
 	},
+	starthelp: ["/aotd start - Start nominations for the Artist of the Day. Requires: % @ # & ~"],
 
 	end: function (target, room, user) {
 		if (room.id !== 'thestudio' || !room.chatRoomData || !this.can('mute', null, room)) return false;
-		if (!artistOfTheDay.pendingNominations) return this.sendReply('Nominations for the Artist of the Day are not in progress.');
-		if (!artistOfTheDay.nominations.size) return this.sendReply('No nominations have been submitted yet.');
+		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
+		if (!artistOfTheDay.pendingNominations) return this.sendReply("Nominations for the Artist of the Day are not in progress.");
+		if (!artistOfTheDay.nominations.size) return this.sendReply("No nominations have been submitted yet.");
 
 		var nominations = toArrayOfArrays(artistOfTheDay.nominations);
 		var artist = nominations[~~Math.random(nominations.length)][0];
@@ -61,157 +66,183 @@ var commands = {
 		artistOfTheDay.removedNominators = [];
 		room.chatRoomData.artistOfTheDay = artist;
 		Rooms.global.writeChatRoomData();
-		room.addRaw('<div class="broadcast-blue"><strong>Nominations for the Artist of the Day have ended!</strong><br />' +
-		            'Randomly selected artist: ' + Tools.escapeHTML(artist) + '</div>');
-		this.privateModCommand('(' + user.name + ' ended nominations for the Artist of the Day.)');
+		room.addRaw(
+			"<div class=\"broadcast-blue\"><strong>Nominations for the Artist of the Day have ended!</strong><br />" +
+		        "Randomly selected artist: " + Tools.escapeHTML(artist) + "</div>"
+		);
+		this.privateModCommand("(" + user.name + " ended nominations for the Artist of the Day.)");
 	},
+	endhelp: ["/aotd end - End nominations for the Artist of the Day and set it to a randomly selected artist. Requires: % @ # & ~"],
 
 	prenom: function (target, room, user) {
 		if (room.id !== 'thestudio' || !room.chatRoomData || !target) return false;
-		if (artistOfTheDay.pendingNominations) return this.sendReply('Nominations for the Artist of the Day are in progress.');
+		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
+		if (artistOfTheDay.pendingNominations) return this.sendReply("Nominations for the Artist of the Day are in progress.");
 		if (!room.chatRoomData.prenominations) room.chatRoomData.prenominations = [];
 
 		var userid = user.userid;
 		var ips = user.ips;
 		var prenominationId = toArtistId(target);
-		if (!prenominationId) return this.sendReply('' + target + ' is not a valid artist name.');
-		if (room.chatRoomData.artistOfTheDay && toArtistId(room.chatRoomData.artistOfTheDay) === prenominationId) return this.sendReply('' + target + ' is already the current Artist of the Day.');
+		if (!prenominationId) return this.sendReply("" + target + " is not a valid artist name.");
+		if (room.chatRoomData.artistOfTheDay && toArtistId(room.chatRoomData.artistOfTheDay) === prenominationId) return this.sendReply("" + target + " is already the current Artist of the Day.");
 
 		var prenominations = room.chatRoomData.prenominations;
 		var prenominationIndex = -1;
 		var latestIp = user.latestIp;
-		for (var i = prenominations.length; i--;) {
-			if (toArtistId(prenominations[i][1]) === prenominationId) return this.sendReply('' + target + ' has already been prenominated.');
+		for (var i = 0; i < prenominations.length; i++) {
+			if (toArtistId(prenominations[i][1]) === prenominationId) return this.sendReply("" + target + " has already been prenominated.");
 
 			if (prenominationIndex < 0) {
 				var prenominator = prenominations[i][0];
-				if (prenominator.userid === userid || prenominator.ips[latestIp]) prenominationIndex = i;
+				if (prenominator.userid === userid || prenominator.ips[latestIp]) {
+					prenominationIndex = i;
+					break;
+				}
 			}
 		}
 
 		if (prenominationIndex > -1) {
 			prenominations[prenominationIndex][1] = target;
 			Rooms.global.writeChatRoomData();
-			return this.sendReply('Your prenomination was changed to ' + target + '.');
+			return this.sendReply("Your prenomination was changed to " + target + ".");
 		}
 
 		prenominations.push([{name: user.name, userid: userid, ips: user.ips}, target]);
 		Rooms.global.writeChatRoomData();
-		this.sendReply('' + target + ' was submitted for the next nomination period for the Artist of the Day.');
+		this.sendReply("" + target + " was submitted for the next nomination period for the Artist of the Day.");
 	},
+	prenomhelp: ["/aotd prenom [artist] - Nominate an artist for the Artist of the Day between nomination periods."],
 
 	nom: function (target, room, user) {
 		if (room.id !== 'thestudio' || !room.chatRoomData || !target) return false;
-		if (!artistOfTheDay.pendingNominations) return this.sendReply('Nominations for the Artist of the Day are not in progress.');
+		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
+		if (!artistOfTheDay.pendingNominations) return this.sendReply("Nominations for the Artist of the Day are not in progress.");
 
 		var removedNominators = artistOfTheDay.removedNominators;
-		if (removedNominators.indexOf(user) > -1) return this.sendReply('Since your nomination has been removed, you cannot submit another artist until the next round.');
+		if (removedNominators.indexOf(user) > -1) return this.sendReply("Since your nomination has been removed, you cannot submit another artist until the next round.");
 
 		var alts = user.getAlts();
-		for (var i = removedNominators.length; i--;) {
-			if (alts.indexOf(removedNominators[i].name) > -1) return this.sendReply('Since your nomination has been removed, you cannot submit another artist until the next round.');
+		for (var i = 0; i < removedNominators.length; i++) {
+			if (alts.indexOf(removedNominators[i].name) > -1) return this.sendReply("Since your nomination has been removed, you cannot submit another artist until the next round.");
 		}
 
 		var nominationId = toArtistId(target);
-		if (room.chatRoomData.artistOfTheDay && toArtistId(room.chatRoomData.artistOfTheDay) === nominationId) return this.sendReply('' + target + ' was the last Artist of the Day.');
+		if (room.chatRoomData.artistOfTheDay && toArtistId(room.chatRoomData.artistOfTheDay) === nominationId) return this.sendReply("" + target + " was the last Artist of the Day.");
 
 		var userid = user.userid;
 		var latestIp = user.latestIp;
 		for (var data, nominationsIterator = artistOfTheDay.nominations.entries(); !!(data = nominationsIterator.next().value);) { // replace with for-of loop once available
 			var nominator = data[0];
-			if (nominator.ips[latestIp] && nominator.userid !== userid || alts.indexOf(nominator.name) > -1) return this.sendReply('You have already submitted a nomination for the Artist of the Day under the name ' + nominator.name + '.');
-			if (toArtistId(data[1]) === nominationId) return this.sendReply('' + target + ' has already been nominated.');
+			if (nominator.ips[latestIp] && nominator.userid !== userid || alts.indexOf(nominator.name) > -1) return this.sendReply("You have already submitted a nomination for the Artist of the Day under the name " + nominator.name + ".");
+			if (toArtistId(data[1]) === nominationId) return this.sendReply("" + target + " has already been nominated.");
 		}
 
-		var response = '' + user.name + (artistOfTheDay.nominations.has(user) ? ' changed their nomination from ' + artistOfTheDay.nominations.get(user) + ' to ' + target + '.' : ' nominated ' + target + ' for the Artist of the Day.');
+		var response = "" + user.name + (artistOfTheDay.nominations.has(user) ? " changed their nomination from " + artistOfTheDay.nominations.get(user) + " to " + target + "." : " nominated " + target + " for the Artist of the Day.");
 		artistOfTheDay.nominations.set(user, target);
-		this.send(response);
+		room.add(response);
 	},
+	nomhelp: ["/aotd nom [artist] - Nominate an artist for the Artist of the Day."],
 
 	viewnoms: function (target, room, user) {
 		if (room.id !== 'thestudio' || !room.chatRoomData) return false;
 
-		var buffer = '';
+		var buffer = "";
 		if (!artistOfTheDay.pendingNominations) {
 			if (!user.can('mute', null, room)) return false;
 
 			var prenominations = room.chatRoomData.prenominations;
-			if (!prenominations || !prenominations.length) return this.sendReplyBox('No prenominations have been submitted yet.');
+			if (!prenominations || !prenominations.length) return this.sendReplyBox("No prenominations have been submitted yet.");
 
-			var i = prenominations.length;
-			buffer += 'Current prenominations:';
-			while (i--) {
-				buffer += '<br />- ' + Tools.escapeHTML(prenominations[i][1]) + ' (submitted by ' + Tools.escapeHTML(prenominations[i][0].name) + ')';
+			prenominations = prenominations.sort(function (a, b) {
+				if (a[1] > b[1]) return 1;
+				if (a[1] < b[1]) return -1;
+				return 0;
+			});
+
+			buffer += "Current prenominations:";
+			for (var i = 0; i < prenominations.length; i++) {
+				buffer += "<br />" +
+					"- " + Tools.escapeHTML(prenominations[i][1]) + " (submitted by " + Tools.escapeHTML(prenominations[i][0].name) + ")";
 			}
 			return this.sendReplyBox(buffer);
 		}
 
 		if (!this.canBroadcast()) return false;
-		if (!artistOfTheDay.nominations.size) return this.sendReplyBox('No nominations have been submitted yet.');
+		if (!artistOfTheDay.nominations.size) return this.sendReplyBox("No nominations have been submitted yet.");
 
 		var nominations = toArrayOfArrays(artistOfTheDay.nominations).sort(function (a, b) {
-			if (a[1] < b[1]) return 1;
-			if (a[1] > b[1]) return -1;
+			if (a[1] > b[1]) return 1;
+			if (a[1] < b[1]) return -1;
 			return 0;
 		});
-		var i = nominations.length;
-		buffer += 'Current nominations:';
-		while (i--) {
-			buffer += '<br />- ' + Tools.escapeHTML(nominations[i][0]) + ' (submitted by ' + Tools.escapeHTML(nominations[i][1].name) + ')';
+
+		buffer += "Current nominations:";
+		for (var i = 0; i < nominations.length; i++) {
+			buffer += "<br />" +
+				"- " + Tools.escapeHTML(nominations[i][0]) + " (submitted by " + Tools.escapeHTML(nominations[i][1].name) + ")";
 		}
+
 		this.sendReplyBox(buffer);
 	},
+	viewnomshelp: ["/aotd viewnoms - View the current nominations for the Artist of the Day. Requires: % @ # & ~"],
 
 	removenom: function (target, room, user) {
 		if (room.id !== 'thestudio' || !room.chatRoomData || !target || !this.can('mute', null, room)) return false;
-		if (!artistOfTheDay.pendingNominations) return this.sendReply('Nominations for the Artist of the Day are not in progress.');
-		if (!artistOfTheDay.nominations.size) return this.sendReply('No nominations have been submitted yet.');
+		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
+		if (!artistOfTheDay.pendingNominations) return this.sendReply("Nominations for the Artist of the Day are not in progress.");
+		if (!artistOfTheDay.nominations.size) return this.sendReply("No nominations have been submitted yet.");
 
 		target = this.splitTarget(target);
 		var name = this.targetUsername;
 		var userid = toId(name);
-		if (!userid) return this.sendReply('"' + name + '" is not a valid username.');
+		if (!userid) return this.sendReply("'" + name + "' is not a valid username.");
 
 		for (var nominator, nominatorsIterator = artistOfTheDay.nominations.keys(); !!(nominator = nominatorsIterator.next().value);) { // replace with for-of loop once available
 			if (nominator.userid === userid) {
 				artistOfTheDay.nominations.delete(nominator);
 				artistOfTheDay.removedNominators.push(nominator);
-				return this.privateModCommand('(' + user.name + ' removed ' + nominator.name + '\'s nomination for the Artist of the Day.)');
+				return this.privateModCommand("(" + user.name + " removed " + nominator.name + "'s nomination for the Artist of the Day.)");
 			}
 		}
 
-		this.sendReply('User "' + name + '" has no nomination for the Artist of the Day.');
+		this.sendReply("User '" + name + "' has no nomination for the Artist of the Day.");
 	},
+	removenomhelp: ["/aotd removenom [username] - Remove a user\'s nomination for the Artist of the Day and prevent them from voting again until the next round. Requires: % @ # & ~"],
 
 	set: function (target, room, user) {
 		if (room.id !== 'thestudio' || !room.chatRoomData || !this.can('mute', null, room)) return false;
-		if (!toId(target)) return this.sendReply('No valid artist was specified.');
-		if (artistOfTheDay.pendingNominations) return this.sendReply('The Artist of the Day cannot be set while nominations are in progress.');
+		if ((user.locked || user.mutedRooms[room.id]) && !user.can('bypassall')) return this.sendReply("You cannot do this while unable to talk.");
+		if (!toId(target)) return this.sendReply("No valid artist was specified.");
+		if (artistOfTheDay.pendingNominations) return this.sendReply("The Artist of the Day cannot be set while nominations are in progress.");
 
 		room.chatRoomData.artistOfTheDay = target;
 		Rooms.global.writeChatRoomData();
-		this.privateModCommand('(' + user.name + ' set the Artist of the Day to ' + target + '.)');
+		this.privateModCommand("(" + user.name + " set the Artist of the Day to " + target + ".)");
 	},
+	sethelp: ["/aotd set [artist] - Set the Artist of the Day. Requires: % @ # & ~"],
 
 	'': function (target, room) {
 		if (room.id !== 'thestudio' || !room.chatRoomData || !this.canBroadcast()) return false;
-		this.sendReplyBox('The Artist of the Day ' + (room.chatRoomData.artistOfTheDay ? 'is ' + room.chatRoomData.artistOfTheDay + '.' : 'has not been set yet.'));
+		this.sendReplyBox("The Artist of the Day " + (room.chatRoomData.artistOfTheDay ? "is " + room.chatRoomData.artistOfTheDay + "." : "has not been set yet."));
 	},
 
 	help: function (target, room) {
 		if (room.id !== 'thestudio' || !room.chatRoomData || !this.canBroadcast()) return false;
-		this.sendReplyBox('The Studio: Artist of the Day plugin commands:<br />' +
-		                  '- /aotd - View the Artist of the Day.<br />' +
-				  '- /aotd start - Start nominations for the Artist of the Day. Requires: % @ # & ~<br />' +
-				  '- /aotd nom - Nominate an artist for the Artist of the Day.<br />' +
-				  '- /aotd viewnoms - View the current nominations for the Artist of the Day. Requires: % @ # & ~<br />' +
-				  '- /aotd removenom [username] - Remove a user\'s nomination for the Artist of the Day and prevent them from voting again until the next round. Requires: % @ # & ~<br />' +
-				  '- /aotd end - End nominations for the Artist of the Day and set it to a randomly selected artist. Requires: % @ # & ~<br />' +
-				  '- /aotd prenom - Nominate an artist for the Artist of the Day between nomination periods.<br />' +
-				  '- /aotd set [artist] - Set the Artist of the Day. Requires: % @ # & ~');
+		this.sendReply("Use /help aotd to view help for all commands, or /help aotd [command] for help on a specific command.");
 	}
 };
 
 exports.commands = {
-	aotd: commands
+	aotd: commands,
+	aotdhelp: [
+		"The Studio: Artist of the Day plugin commands:",
+		"- /aotd - View the Artist of the Day.",
+		"- /aotd start - Start nominations for the Artist of the Day. Requires: % @ # & ~",
+		"- /aotd nom [artist] - Nominate an artist for the Artist of the Day.",
+		"- /aotd viewnoms - View the current nominations for the Artist of the Day. Requires: % @ # & ~",
+		"- /aotd removenom [username] - Remove a user's nomination for the Artist of the Day and prevent them from voting again until the next round. Requires: % @ # & ~",
+		"- /aotd end - End nominations for the Artist of the Day and set it to a randomly selected artist. Requires: % @ # & ~",
+		"- /aotd prenom [artist] - Nominate an artist for the Artist of the Day between nomination periods.",
+		"- /aotd set [artist] - Set the Artist of the Day. Requires: % @ # & ~"
+	]
 };


### PR DESCRIPTION
Letting users that can't talk use certain plugin commands is fine and all until they find a way to spam with them.

- Remove redundant this.canBroadcast call in /qotd
- Use ``broadcast-blue`` instead of ``broadcast-green`` when setting the Inspirational Quote of the day with /qotd
- /aotd viewnoms sorts the prenomination list like it already does with the nomination list
- /trivia qs acknowledges that Video Games is a real category
- Responses suggesting to use the deprecated /trivia help command suggest /help trivia instead
- Add style fixes used in the Trivia to the The Happy Place and The Studio
  plugins