### PR TITLE
Battle refactor: No longer reset ignore in Battle#update

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -210,8 +210,6 @@ BattlePokemon = (function () {
 		this.weight = this.template.weight;
 		this.weightkg = this.template.weightkg;
 
-		this.ignore = {};
-
 		this.baseAbility = toId(set.ability);
 		this.ability = this.baseAbility;
 		this.item = toId(set.item);
@@ -369,8 +367,6 @@ BattlePokemon = (function () {
 		this.negateImmunity = {};
 		this.trapped = this.maybeTrapped = false;
 		this.maybeDisabled = false;
-		// reset for ignore settings
-		this.ignore = {};
 		for (var i in this.moveset) {
 			if (this.moveset[i]) this.moveset[i].disabled = false;
 		}
@@ -513,6 +509,12 @@ BattlePokemon = (function () {
 			}
 		}
 		return null;
+	};
+	BattlePokemon.prototype.ignoringAbility = function () {
+		return !!this.volatiles['gastroacid'];
+	};
+	BattlePokemon.prototype.ignoringItem = function () {
+		return !!(this.hasAbility('klutz') || this.volatiles['embargo'] || this.battle.pseudoWeather['magicroom']);
 	};
 	BattlePokemon.prototype.deductPP = function (move, amount, source) {
 		move = this.battle.getMove(move);
@@ -1078,7 +1080,7 @@ BattlePokemon = (function () {
 		return this.battle.getItem(this.item);
 	};
 	BattlePokemon.prototype.hasItem = function (item) {
-		if (this.ignore['Item']) return false;
+		if (this.ignoringItem()) return false;
 		var ownItem = this.item;
 		if (!Array.isArray(item)) {
 			return ownItem === toId(item);
@@ -1110,7 +1112,7 @@ BattlePokemon = (function () {
 	};
 	BattlePokemon.prototype.hasAbility = function (ability) {
 		if (!this.isActive && this.battle.gen >= 5) return false;
-		if (this.ignore['Ability']) return false;
+		if (this.ignoringAbility()) return false;
 		var ownAbility = this.ability;
 		if (!Array.isArray(ability)) {
 			return ownAbility === toId(ability);
@@ -2038,8 +2040,12 @@ Battle = (function () {
 			// it's changed; call it off
 			return relayVar;
 		}
-		if (target.ignore && target.ignore[effect.effectType] && target.ignore[effect.effectType] !== 'A') {
-			this.debug(eventid + ' handler suppressed by Gastro Acid, Klutz or Magic Room');
+		if (eventid !== 'Start' && effect.effectType === 'Item' && (target instanceof BattlePokemon) && target.ignoringItem()) {
+			this.debug(eventid + ' handler suppressed by Embargo, Klutz or Magic Room');
+			return relayVar;
+		}
+		if (eventid !== 'End' && effect.effectType === 'Ability' && (target instanceof BattlePokemon) && target.ignoringAbility()) {
+			this.debug(eventid + ' handler suppressed by Gastro Acid');
 			return relayVar;
 		}
 		if (effect.effectType === 'Weather' && eventid !== 'TryWeather' && !this.runEvent('TryWeather', target)) {
@@ -2211,7 +2217,7 @@ Battle = (function () {
 				// it's changed; call it off
 				continue;
 			}
-			if (thing.ignore && thing.ignore[status.effectType] === 'A') {
+			if (status.effectType === 'Ability' && this.activePokemon && this.activePokemon !== target && !target.ignoringAbility() && this.activePokemon.getAbility().stopAttackEvents) {
 				// ignore attacking events
 				var AttackingEvents = {
 					BeforeMove: 1,
@@ -2243,9 +2249,14 @@ Battle = (function () {
 					}
 					continue;
 				}
-			} else if (thing.ignore && thing.ignore[status.effectType]) {
+			} else if (eventid !== 'Start' && status.effectType === 'Item' && (thing instanceof BattlePokemon) && thing.ignoringItem()) {
 				if (eventid !== 'ModifyPokemon' && eventid !== 'Update') {
-					this.debug(eventid + ' handler suppressed by Gastro Acid, Klutz or Magic Room');
+					this.debug(eventid + ' handler suppressed by Embargo, Klutz or Magic Room');
+				}
+				continue;
+			} else if (eventid !== 'End' && status.effectType === 'Ability' && (thing instanceof BattlePokemon) && thing.ignoringAbility()) {
+				if (eventid !== 'ModifyPokemon' && eventid !== 'Update') {
+					this.debug(eventid + ' handler suppressed by Gastro Acid');
 				}
 				continue;
 			}

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -520,7 +520,7 @@ exports.BattleAbilities = {
 				for (var j = 0; j < this.sides[i].active.length; j++) {
 					var target = this.sides[i].active[j];
 					if (target === pokemon) continue;
-					if (target && target.hp && target.ability === 'deltastream' && target.ignore['Ability'] !== true) {
+					if (target && target.hp && target.hasAbility('deltastream')) {
 						this.weatherData.source = target;
 						return;
 					}
@@ -548,7 +548,7 @@ exports.BattleAbilities = {
 				for (var j = 0; j < this.sides[i].active.length; j++) {
 					var target = this.sides[i].active[j];
 					if (target === pokemon) continue;
-					if (target && target.hp && target.ability === 'desolateland' && target.ignore['Ability'] !== true) {
+					if (target && target.hp && target.hasAbility('desolateland')) {
 						this.weatherData.source = target;
 						return;
 					}
@@ -1303,11 +1303,7 @@ exports.BattleAbilities = {
 	"klutz": {
 		desc: "This Pokemon's held item has no effect. This Pokemon cannot use Fling successfully. Macho Brace, Power Anklet, Power Band, Power Belt, Power Bracer, Power Lens, and Power Weight still have their effects.",
 		shortDesc: "This Pokemon's held item has no effect, except Macho Brace. Fling cannot be used.",
-		onModifyPokemonPriority: 1,
-		onModifyPokemon: function (pokemon) {
-			if (pokemon.getItem().megaEvolves) return;
-			pokemon.ignore['Item'] = true;
-		},
+		// Item suppression implemented in BattlePokemon.ignoringItem() within battle-engine.js
 		id: "klutz",
 		name: "Klutz",
 		rating: -1,
@@ -1556,18 +1552,7 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Mold Breaker');
 		},
-		onAllyModifyPokemonPriority: 100,
-		onAllyModifyPokemon: function (pokemon) {
-			if (this.activePokemon === this.effectData.target && pokemon !== this.activePokemon) {
-				pokemon.ignore['Ability'] = 'A';
-			}
-		},
-		onFoeModifyPokemonPriority: 100,
-		onFoeModifyPokemon: function (pokemon) {
-			if (this.activePokemon === this.effectData.target) {
-				pokemon.ignore['Ability'] = 'A';
-			}
-		},
+		stopAttackEvents: true,
 		id: "moldbreaker",
 		name: "Mold Breaker",
 		rating: 3.5,
@@ -2003,7 +1988,7 @@ exports.BattleAbilities = {
 				for (var j = 0; j < this.sides[i].active.length; j++) {
 					var target = this.sides[i].active[j];
 					if (target === pokemon) continue;
-					if (target && target.hp && target.ability === 'primordialsea' && target.ignore['Ability'] !== true) {
+					if (target && target.hp && target.hasAbility('primordialsea')) {
 						this.weatherData.source = target;
 						return;
 					}
@@ -2827,16 +2812,7 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Teravolt');
 		},
-		onAllyModifyPokemon: function (pokemon) {
-			if (this.activePokemon === this.effectData.target && pokemon !== this.activePokemon) {
-				pokemon.ignore['Ability'] = 'A';
-			}
-		},
-		onFoeModifyPokemon: function (pokemon) {
-			if (this.activePokemon === this.effectData.target) {
-				pokemon.ignore['Ability'] = 'A';
-			}
-		},
+		stopAttackEvents: true,
 		id: "teravolt",
 		name: "Teravolt",
 		rating: 3.5,
@@ -2977,16 +2953,7 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Turboblaze');
 		},
-		onAllyModifyPokemon: function (pokemon) {
-			if (this.activePokemon === this.effectData.target && pokemon !== this.activePokemon) {
-				pokemon.ignore['Ability'] = 'A';
-			}
-		},
-		onFoeModifyPokemon: function (pokemon) {
-			if (this.activePokemon === this.effectData.target) {
-				pokemon.ignore['Ability'] = 'A';
-			}
-		},
+		stopAttackEvents: true,
 		id: "turboblaze",
 		name: "Turboblaze",
 		rating: 3.5,

--- a/data/items.js
+++ b/data/items.js
@@ -123,7 +123,9 @@ exports.BattleItems = {
 			basePower: 10
 		},
 		onStart: function (target) {
-			this.add('-item', target, 'Air Balloon');
+			if (!target.ignoringItem()) {
+				this.add('-item', target, 'Air Balloon');
+			}
 		},
 		onImmunity: function (type) {
 			if (type === 'Ground') return false;

--- a/data/moves.js
+++ b/data/moves.js
@@ -3483,14 +3483,10 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-start', pokemon, 'Embargo');
 			},
+			// Item suppression implemented in BattlePokemon.ignoringItem() within battle-engine.js
 			onResidualOrder: 18,
 			onEnd: function (pokemon) {
 				this.add('-end', pokemon, 'Embargo');
-			},
-			onModifyPokemonPriority: 1,
-			onModifyPokemon: function (pokemon) {
-				if (pokemon.getItem().megaEvolves) return;
-				pokemon.ignore['Item'] = true;
 			}
 		},
 		secondary: false,
@@ -4414,7 +4410,7 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		beforeMoveCallback: function (pokemon) {
-			if (pokemon.ignore['Item']) return;
+			if (pokemon.ignoringItem()) return;
 			var item = pokemon.getItem();
 			var noFling = item.onTakeItem && item.onTakeItem(item, pokemon) === false;
 			if (item.fling && !noFling) {
@@ -5050,13 +5046,10 @@ exports.BattleMovedex = {
 			}
 		},
 		effect: {
+			// Ability suppression implemented in BattlePokemon.ignoringAbility() within battle-engine.js
 			onStart: function (pokemon) {
 				this.add('-endability', pokemon);
 				this.singleEvent('End', this.getAbility(pokemon.ability), pokemon.abilityData, pokemon, pokemon, 'gastroacid');
-			},
-			onModifyPokemonPriority: 2,
-			onModifyPokemon: function (pokemon) {
-				pokemon.ignore['Ability'] = true;
 			}
 		},
 		secondary: false,
@@ -7955,11 +7948,7 @@ exports.BattleMovedex = {
 			onStart: function (target, source) {
 				this.add('-fieldstart', 'move: Magic Room', '[of] ' + source);
 			},
-			onModifyPokemonPriority: 1,
-			onModifyPokemon: function (pokemon) {
-				if (pokemon.getItem().megaEvolves) return;
-				pokemon.ignore['Item'] = true;
-			},
+			// Item suppression implemented in BattlePokemon.ignoringItem() within battle-engine.js
 			onResidualOrder: 25,
 			onEnd: function () {
 				this.add('-fieldend', 'move: Magic Room', '[of] ' + this.effectData.source);

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -260,7 +260,7 @@ exports.BattleStatuses = {
 				pokemon.removeVolatile('choicelock');
 				return;
 			}
-			if (pokemon.ignore['Item']) {
+			if (pokemon.ignoringItem()) {
 				return;
 			}
 			var moves = pokemon.moveset;
@@ -628,7 +628,7 @@ exports.BattleStatuses = {
 		onSwitchIn: function (pokemon) {
 			var type = 'Normal';
 			if (pokemon.ability === 'multitype') {
-				type = this.runEvent('Plate', pokemon);
+				type = pokemon.getItem().onPlate;
 				if (!type || type === true) {
 					type = 'Normal';
 				}

--- a/mods/gennext/statuses.js
+++ b/mods/gennext/statuses.js
@@ -111,7 +111,7 @@ exports.BattleStatuses = {
 	unown: {
 		// Unown: Shadow Tag
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -127,7 +127,7 @@ exports.BattleStatuses = {
 	bronzong: {
 		// Bronzong: Heatproof
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -139,7 +139,7 @@ exports.BattleStatuses = {
 	weezing: {
 		// Weezing: Aftermath
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -151,7 +151,7 @@ exports.BattleStatuses = {
 	flygon: {
 		// Flygon: Compoundeyes
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -163,7 +163,7 @@ exports.BattleStatuses = {
 	eelektross: {
 		// Eelektross: Poison Heal
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -175,7 +175,7 @@ exports.BattleStatuses = {
 	claydol: {
 		// Claydol: Filter
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -187,7 +187,7 @@ exports.BattleStatuses = {
 	gengar: {
 		// Gengar: Cursed Body
 		onImmunity: function (type, pokemon) {
-			if (pokemon.template.id !== 'gengarmega' && type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (pokemon.template.id !== 'gengarmega' && type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -199,7 +199,7 @@ exports.BattleStatuses = {
 	mismagius: {
 		// Mismagius: Cursed Body
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -211,7 +211,7 @@ exports.BattleStatuses = {
 	mesprit: {
 		// Mesprit: Serene Grace
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -223,7 +223,7 @@ exports.BattleStatuses = {
 	uxie: {
 		// Uxie: Synchronize
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -235,7 +235,7 @@ exports.BattleStatuses = {
 	azelf: {
 		// Azelf: Steadfast
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -247,7 +247,7 @@ exports.BattleStatuses = {
 	hydreigon: {
 		// Hydreigon: Sheer Force
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {
@@ -270,7 +270,7 @@ exports.BattleStatuses = {
 			}
 		},
 		onImmunity: function (type, pokemon) {
-			if (type === 'Ground' && pokemon.ignore['Ability'] !== 'A') return false;
+			if (type === 'Ground' && !pokemon.ignoringAbility()) return false;
 		},
 		onStart: function (pokemon) {
 			if (pokemon.ability === 'levitate') {

--- a/test/simulator/abilities/klutz.js
+++ b/test/simulator/abilities/klutz.js
@@ -1,0 +1,50 @@
+var assert = require('assert');
+var battle;
+
+describe('Klutz', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should negate residual healing events', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'leftovers', moves: ['bellydrum']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Giratina", ability: 'pressure', moves: ['shadowsneak']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, Math.ceil(battle.p1.active[0].maxhp / 2));
+	});
+
+	it('should prevent items from being consumed', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", level: 1, ability: 'klutz', item: 'sitrusberry', moves: ['endure']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['psychic']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, 1);
+		assert.strictEqual(battle.p1.active[0].item, 'sitrusberry');
+	});
+
+	it('should ignore the effects of items that disable moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'assaultvest', moves: ['protect']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['psychic']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].lastMove, 'protect');
+	});
+
+	it('should cause Fling to fail', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'seaincense', moves: ['fling']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['calmmind']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'seaincense');
+	});
+
+	it('should not prevent Pokemon from Mega Evolving', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'lopunnite', moves: ['protect']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['calmmind']}]);
+		battle.choose('p1', 'move 1 mega');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].template.speciesid, 'lopunnymega');
+	});
+});

--- a/test/simulator/moves/embargo.js
+++ b/test/simulator/moves/embargo.js
@@ -1,0 +1,53 @@
+var assert = require('assert');
+var battle;
+
+describe('Embargo', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should negate residual healing events', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'leftovers', moves: ['bellydrum']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Giratina", ability: 'pressure', moves: ['embargo']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, Math.ceil(battle.p1.active[0].maxhp / 2));
+	});
+
+	it('should prevent items from being consumed', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'chopleberry', moves: ['bulkup']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['embargo', 'lowkick']}]);
+		battle.commitDecisions();
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'chopleberry');
+	});
+
+	it('should ignore the effects of items that disable moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'assaultvest', moves: ['protect']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['embargo']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].lastMove, 'protect');
+	});
+
+	it('should cause Fling to fail', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'seaincense', moves: ['fling']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['embargo']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'seaincense');
+	});
+
+	it('should not prevent Pokemon from Mega Evolving', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'lopunnite', moves: ['bulkup']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['embargo', 'rest']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 1 mega');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].template.speciesid, 'lopunnymega');
+	});
+});

--- a/test/simulator/moves/magicroom.js
+++ b/test/simulator/moves/magicroom.js
@@ -1,0 +1,51 @@
+var assert = require('assert');
+var battle;
+
+describe('Magic Room', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should negate residual healing events', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'leftovers', moves: ['bellydrum']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Giratina", ability: 'pressure', moves: ['magicroom']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, Math.ceil(battle.p1.active[0].maxhp / 2));
+	});
+
+	it('should prevent items from being consumed', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'chopleberry', moves: ['magicroom']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['lowkick']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'chopleberry');
+	});
+
+	it('should ignore the effects of items that disable moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'assaultvest', moves: ['protect']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['magicroom']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].lastMove, 'protect');
+	});
+
+	it('should cause Fling to fail', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'seaincense', moves: ['fling']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['magicroom']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'seaincense');
+	});
+
+	it('should not prevent Pokemon from Mega Evolving', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'lopunnite', moves: ['bulkup']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['magicroom', 'rest']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 1 mega');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].template.speciesid, 'lopunnymega');
+	});
+});


### PR DESCRIPTION
Instead, the relevant abilities that set ignore do so upon Start/End events.

---

It's worth noting that even though this passes the tests I set up, **it's not actually complete.**
Specifically, I don't know how to implement Baton Pass with Embargo/Gastro Acid and
would appreciate if someone had insight on the best way to manage that.

@Marty-D for move mechanic verification
@Zarel for NEXT verification since I don't know how you want the intrinsics working

## Once again, do not merge yet because I'm still figuring out how to make Baton Pass work