### PR TITLE
Refactor /ds to compile learnsets from prevos and certain baseSpecies

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -702,6 +702,29 @@ exports.commands = {
 			results.push(dex[mon].species);
 		}
 
+		let moveGroups = searches
+			.filter(function (alts) {
+				return Object.any(alts.moves, function (move, isSearch) {
+					return isSearch;
+				});
+			})
+			.map(function (alts) {
+				return Object.keys(alts.moves);
+			});
+		if (moveGroups.length >= 2) {
+			results = results.filter(function (mon) {
+				let lsetData = {fastCheck: true, set: {}};
+				for (let group = 0; group < moveGroups.length; group++) {
+					for (let i = 0; i < moveGroups[group].length; i++) {
+						let problem = TeamValidator.checkLearnsetSync('anythinggoes', moveGroups[group][i], mon, lsetData);
+						if (!problem) break;
+						if (i === moveGroups[group].length - 1) return;
+					}
+				}
+				return true;
+			});
+		}
+
 		if (randomOutput && randomOutput < results.length) {
 			results = results.randomize().slice(0, randomOutput);
 		}

--- a/team-validator.js
+++ b/team-validator.js
@@ -693,9 +693,9 @@ Validator = (function () {
 					} else if (learned.charAt(1) === 'E') {
 						// egg moves:
 						//   only if that was the source
-						if (learned.charAt(0) === '6') {
+						if (learned.charAt(0) === '6' || lsetData.fastCheck) {
 							// gen 6 doesn't have egg move incompatibilities except for certain cases with baby Pokemon
-							learned = '6E' + (template.prevo ? template.id : '');
+							learned = learned.charAt(0) + 'E' + (template.prevo ? template.id : '');
 							sources.push(learned);
 							continue;
 						}


### PR DESCRIPTION
This PR fixes [this][1] issue from the Bug Reports topic and employs @TheImmortal's suggested approach from #1877.

(Someone should attest that the refactor's execution speed is acceptable.)

  [1]: http://www.smogon.com/forums/threads/bug-reports-v2-0-read-op-before-posting.3469932/page-212#post-6214252