### PR TITLE
Fix Demote Locking/banning users

### DIFF
--- a/users.js
+++ b/users.js
@@ -1158,6 +1158,7 @@ User = (function () {
 		var removed = [];
 		if (usergroups[userid]) {
 			removed.push(usergroups[userid].charAt(0));
+			usergroups[userid] = ' ';
 			exportUsergroups();
 		}
 		for (var i = 0; i < Rooms.global.chatRooms.length; i++) {


### PR DESCRIPTION
According to resource monitor Locking/banning is implied that it will demote both the target users global and room auth, where as currently it only demotes the target user from roomauth, this commit fixes it to demote the user from both room and global auth.