### PR TITLE
Battle refactor: New function isGrounded(), bug fixes

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -1256,6 +1256,21 @@ BattlePokemon = (function () {
 		if (this.battle.gen >= 5) return ['Normal'];
 		return ['???'];
 	};
+	BattlePokemon.prototype.isGrounded = function () {
+		if (!this.hasType('Flying') && this.battle.runEvent('Immunity', this, null, null, 'Ground')) return true;
+		return !!(this.hasItem('ironball') || this.volatiles['ingrain'] || this.volatiles['smackdown'] || this.battle.getPseudoWeather('gravity'));
+	};
+	BattlePokemon.prototype.isSemiInvulnerable = function () {
+		if (this.volatiles['fly'] || this.volatiles['bounce'] || this.volatiles['skydrop'] || this.volatiles['dive'] || this.volatiles['dig'] || this.volatiles['phantomforce'] || this.volatiles['shadowforce']) {
+			return true;
+		}
+		for (var i = 0; i < this.side.foe.active.length; i++) {
+			if (this.side.foe.active[i].volatiles['skydrop'] && this.side.foe.active[i].volatiles['skydrop'].source === this) {
+				return true;
+			}
+		}
+		return false;
+	};
 	BattlePokemon.prototype.runEffectiveness = function (move) {
 		var totalTypeMod = 0;
 		var types = this.getTypes();

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -147,20 +147,18 @@ exports.BattleAbilities = {
 		num: 107
 	},
 	"arenatrap": {
-		desc: "Prevents adjacent opposing Pokemon from choosing to switch out unless they are immune to trapping or have immunity to Ground.",
-		shortDesc: "Prevents adjacent foes from choosing to switch unless they are immune to Ground.",
+		desc: "Prevents adjacent opposing Pokemon from choosing to switch out unless they are immune to trapping or are airborne.",
+		shortDesc: "Prevents adjacent foes from choosing to switch unless they are airborne.",
 		onFoeModifyPokemon: function (pokemon) {
 			if (!this.isAdjacent(pokemon, this.effectData.target)) return;
-			if (!pokemon.runImmunity('Ground', false)) return;
-			if (!pokemon.hasType('Flying') || pokemon.hasItem('ironball') || this.getPseudoWeather('gravity') || pokemon.volatiles['ingrain']) {
+			if (pokemon.isGrounded()) {
 				pokemon.tryTrap(true);
 			}
 		},
 		onFoeMaybeTrapPokemon: function (pokemon, source) {
 			if (!source) source = this.effectData.target;
 			if (!this.isAdjacent(pokemon, source)) return;
-			if (!pokemon.runImmunity('Ground', false)) return;
-			if (!pokemon.hasType('Flying') || pokemon.hasItem('ironball') || this.getPseudoWeather('gravity') || pokemon.volatiles['ingrain']) {
+			if (pokemon.isGrounded()) {
 				pokemon.maybeTrapped = true;
 			}
 		},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -249,7 +249,7 @@ exports.BattleScripts = {
 			}
 		}
 		if (move.ohko) { // bypasses accuracy modifiers
-			if (!target.volatiles['bounce'] && !target.volatiles['dig'] && !target.volatiles['dive'] && !target.volatiles['fly'] && !target.volatiles['phantomforce'] && !target.volatiles['shadowforce'] && !target.volatiles['skydrop']) {
+			if (!target.isSemiInvulnerable()) {
 				accuracy = 30;
 				if (pokemon.level >= target.level) {
 					accuracy += (pokemon.level - target.level);

--- a/test/simulator/abilities/arenatrap.js
+++ b/test/simulator/abilities/arenatrap.js
@@ -1,0 +1,55 @@
+var assert = require('assert');
+var battle;
+
+describe('Arena Trap', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent grounded Pokemon that are not immune to trapping from switching out normally', function () {
+		this.timeout(0);
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Dugtrio", ability: 'arenatrap', moves: ['snore', 'telekinesis', 'gravity']}]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Tornadus", ability: 'defiant', moves: ['tailwind']},
+			{species: "Heatran", ability: 'flashfire', item: 'airballoon', moves: ['roar']},
+			{species: "Claydol", ability: 'levitate', moves: ['rest']},
+			{species: "Dusknoir", ability: 'frisk', moves: ['rest']},
+			{species: "Magnezone", ability: 'magnetpull', moves: ['magnetrise']},
+			{species: "Vaporeon", ability: 'waterabsorb', moves: ['roar']}
+		]);
+		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'heatran');
+		battle.choose('p2', 'switch 3');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'claydol');
+		battle.choose('p2', 'switch 4');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'dusknoir');
+		battle.choose('p2', 'switch 5');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'magnezone');
+		battle.choose('p2', 'switch 6');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'magnezone');
+		battle.commitDecisions();
+		battle.choose('p2', 'switch 6');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'vaporeon');
+		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'vaporeon');
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].volatiles['telekinesis']);
+		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'tornadus');
+		battle.choose('p1', 'move 3');
+		battle.commitDecisions();
+		battle.choose('p2', 'switch 4');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].template.speciesid, 'tornadus');
+	});
+});

--- a/test/simulator/abilities/arenatrap.js
+++ b/test/simulator/abilities/arenatrap.js
@@ -42,7 +42,6 @@ describe('Arena Trap', function () {
 		assert.strictEqual(battle.p2.active[0].template.speciesid, 'vaporeon');
 		battle.choose('p1', 'move 2');
 		battle.commitDecisions();
-		assert.ok(battle.p2.active[0].volatiles['telekinesis']);
 		battle.choose('p2', 'switch 2');
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].template.speciesid, 'tornadus');

--- a/test/simulator/misc/inversebattle.js
+++ b/test/simulator/misc/inversebattle.js
@@ -1,0 +1,68 @@
+var battle;
+var assert = require('assert');
+
+describe('Inverse Battle', function () {
+	var battleCounter = 0;
+
+	beforeEach(function () {
+		battle = BattleEngine.Battle.construct('battle-inverse-' + battleCounter++, 'inversebattle');
+	});
+
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should change natural resistances into weaknesses', function () {
+		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['vitalthrow']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Scyther", ability: 'swarm', moves: ['roost']}]);
+		battle.commitDecisions();
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+	});
+
+	it('should change natural weaknesses into resistances', function () {
+		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['vitalthrow']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Absol", ability: 'pressure', moves: ['leer']}]);
+		battle.commitDecisions();
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+	});
+
+	it('should negate natural immunities and make them weaknesses', function () {
+		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['vitalthrow']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Dusknoir", ability: 'frisk', moves: ['rest']}]);
+		battle.commitDecisions();
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not affect ability-based immunities', function () {
+		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['earthquake']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Mismagius", ability: 'levitate', moves: ['shadowsneak']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not affect the type effectiveness of Freeze Dry on Water-type Pokemon', function () {
+		battle.join('p1', 'Guest 1', 1, [{species: "Lapras", ability: 'waterabsorb', moves: ['freezedry']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Floatzel", ability: 'waterveil', moves: ['aquajet']}]);
+		battle.commitDecisions();
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+	});
+
+	it('should not affect the "ungrounded" state of Flying-type Pokemon', function () {
+		battle.join('p1', 'Guest 1', 1, [{species: "Parasect", ability: 'dryskin', moves: ['spore']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Talonflame", ability: 'galewings', moves: ['mistyterrain']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, 'slp');
+	});
+});

--- a/test/simulator/moves/electricterrain.js
+++ b/test/simulator/moves/electricterrain.js
@@ -1,0 +1,99 @@
+var assert = require('assert');
+var battle;
+
+describe('Electric Terrain', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should change the current terrain to Electric Terrain for five turns', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'electricterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]);
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('electricterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('electricterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('electricterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('electricterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain(''));
+	});
+
+	it('should increase the base power of Electric-type attacks used by grounded Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Thundurus", ability: 'defiant', moves: ['thunderwave']}]);
+		battle.commitDecisions();
+		var basePower;
+		var move = Tools.getMove('thunderbolt');
+		basePower = battle.runEvent('BasePower', battle.p1.active[0], battle.p2.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, battle.modify(move.basePower, 1.5));
+		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, move.basePower);
+	});
+
+	it('should prevent moves from putting grounded Pokemon to sleep', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'spore']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Abra", ability: 'magicguard', moves: ['telekinesis', 'spore']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].status, 'slp');
+		assert.strictEqual(battle.p2.active[0].status, '');
+	});
+
+	it('should not remove active non-volatile statuses from grounded Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['sleeptalk', 'electricterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Whimsicott", ability: 'prankster', moves: ['spore']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, 'slp');
+	});
+
+	it('should prevent Yawn from putting grounded Pokemon to sleep, and cause Yawn to fail', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'yawn']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['yawn']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, '');
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
+	});
+
+	it('should cause Rest to fail on grounded Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'rest']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not affect Pokemon in a semi-invulnerable state', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['yawn', 'skydrop']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['yawn', 'electricterrain']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].status, 'slp');
+		assert.strictEqual(battle.p2.active[0].status, 'slp');
+	});
+
+	it('should cause Nature Power to become Thunderbolt', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Shuckle", ability: 'sturdy', moves: ['naturepower']}]);
+		battle.commitDecisions();
+		var resultMove = toId(battle.log[battle.lastMoveLine].split('|')[3]);
+		assert.strictEqual(resultMove, 'thunderbolt');
+	});
+});

--- a/test/simulator/moves/grassyterrain.js
+++ b/test/simulator/moves/grassyterrain.js
@@ -1,0 +1,80 @@
+var assert = require('assert');
+var battle;
+
+describe('Grassy Terrain', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should change the current terrain to Grassy Terrain for five turns', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'grassyterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]);
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('grassyterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('grassyterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('grassyterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('grassyterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain(''));
+	});
+
+	it('should halve the base power of Earthquake, Bulldoze, Magnitude', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Shaymin", ability: 'naturalcure', moves: ['grassyterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Shaymin-Sky", ability: 'serenegrace', moves: ['leechseed']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], Tools.getMove('earthquake'), 100, true), 50);
+		assert.strictEqual(battle.runEvent('BasePower', battle.p1.active[0], battle.p2.active[0], Tools.getMove('earthquake'), 100, true), 50);
+		assert.strictEqual(battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], Tools.getMove('bulldoze'), 60, true), 30);
+		assert.strictEqual(battle.runEvent('BasePower', battle.p1.active[0], battle.p2.active[0], Tools.getMove('bulldoze'), 60, true), 30);
+	});
+
+	it('should increase the base power of Grass-type attacks used by grounded Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Shaymin", ability: 'naturalcure', moves: ['grassyterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Shaymin-Sky", ability: 'serenegrace', moves: ['leechseed']}]);
+		battle.commitDecisions();
+		var basePower;
+		var move = Tools.getMove('gigadrain');
+		basePower = battle.runEvent('BasePower', battle.p1.active[0], battle.p2.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, battle.modify(move.basePower, 1.5));
+		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, move.basePower);
+	});
+
+	it('should heal grounded Pokemon by 1/16 of their max HP', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Shaymin", ability: 'naturalcure', moves: ['grassyterrain', 'dragonrage']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Magneton", ability: 'magnetpull', moves: ['magnetrise', 'dragonrage']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp - 40 + Math.floor(battle.p1.active[0].maxhp / 16));
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp - 40);
+	});
+
+	it('should not affect Pokemon in a semi-invulnerable state', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['dragonrage', 'skydrop']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['dragonrage', 'grassyterrain']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp - 40);
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp - 40);
+	});
+
+	it('should cause Nature Power to become Energy Ball', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Whimsicott", ability: 'prankster', moves: ['grassyterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Shuckle", ability: 'sturdy', moves: ['naturepower']}]);
+		battle.commitDecisions();
+		var resultMove = toId(battle.log[battle.lastMoveLine].split('|')[3]);
+		assert.strictEqual(resultMove, 'energyball');
+	});
+});

--- a/test/simulator/moves/mistyterrain.js
+++ b/test/simulator/moves/mistyterrain.js
@@ -1,0 +1,101 @@
+var assert = require('assert');
+var battle;
+
+describe('Misty Terrain', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should change the current terrain to Misty Terrain for five turns', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'mistyterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]);
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('mistyterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('mistyterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('mistyterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain('mistyterrain'));
+		battle.commitDecisions();
+		assert.ok(battle.isTerrain(''));
+	});
+
+	it('should halve the base power of Dragon-type attacks on grounded Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Shaymin", ability: 'naturalcure', moves: ['mistyterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Shaymin-Sky", ability: 'serenegrace', moves: ['leechseed']}]);
+		battle.commitDecisions();
+		var basePower;
+		var move = Tools.getMove('dragonpulse');
+		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, battle.modify(move.basePower, 0.5));
+		basePower = battle.runEvent('BasePower', battle.p1.active[0], battle.p2.active[0], move, move.basePower, true);
+		assert.strictEqual(basePower, move.basePower);
+	});
+
+	it('should prevent moves from setting non-volatile status on grounded Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'toxic']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Machamp", ability: 'noguard', item: 'airballoon', moves: ['bulkup', 'toxic']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].status, '');
+		assert.strictEqual(battle.p2.active[0].status, 'tox');
+	});
+
+	it('should not remove active non-volatile statuses from grounded Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mistyterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Crobat", ability: 'infiltrator', moves: ['toxic']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, 'tox');
+	});
+
+	it('should prevent Yawn from putting grounded Pokemon to sleep, but not cause Yawn to fail', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'yawn']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['yawn']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, '');
+		var dataLine = battle.log[battle.lastMoveLine + 1].split('|');
+		assert.strictEqual(dataLine[1], '-start');
+		assert.ok(toId(dataLine[3]).endsWith('yawn'));
+	});
+
+	it('should cause Rest to fail on grounded Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'rest']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not affect Pokemon in a semi-invulnerable state', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['yawn', 'skydrop']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['yawn', 'mistyterrain']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].status, 'slp');
+		assert.strictEqual(battle.p2.active[0].status, 'slp');
+	});
+
+	it('should cause Nature Power to become Moonblast', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Whimsicott", ability: 'prankster', moves: ['mistyterrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Shuckle", ability: 'sturdy', moves: ['naturepower']}]);
+		battle.commitDecisions();
+		var resultMove = toId(battle.log[battle.lastMoveLine].split('|')[3]);
+		assert.strictEqual(resultMove, 'moonblast');
+	});
+});


### PR DESCRIPTION
Added BattlePokemon#isGrounded to check for the grounded-ness of a
Pokemon. Also BattlePokemon#inSemiInvulnerableState for whether a Pokemon
is in the first turn of a two-turn move that makes them semi-invulnerable.

Fixed Terrain bugs involving Pokemon in a semi-invulnerable state.

Fixed Misty Terrain bug that was causing Rest and the effect of Yawn to
put Pokemon to sleep.

Fixed Misty Terrain bug that was causing Yawn to fail.

Fixed Electric Terrain bug that was causing Yawn to succeed.