### PR TITLE
Un-hardcode Rock Head in favor of an onDamage handler

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2151,7 +2151,9 @@ exports.BattleAbilities = {
 	"rockhead": {
 		desc: "This Pokemon does not take recoil damage besides Struggle, Life Orb, and crash damage.",
 		shortDesc: "This Pokemon does not take recoil damage besides Struggle/Life Orb/crash damage.",
-		// Implemented in scripts.js
+		onDamage: function (damage, target, source, effect) {
+			if (effect.id === 'recoil' && this.activeMove.id !== 'struggle') return null;
+		},
 		id: "rockhead",
 		name: "Rock Head",
 		rating: 3,

--- a/data/moves.js
+++ b/data/moves.js
@@ -13486,7 +13486,7 @@ exports.BattleMovedex = {
 				} else {
 					this.add('-activate', target, 'Substitute', '[damage]');
 				}
-				if (move.recoil && (!source.hasAbility('rockhead') || move.id === 'struggle')) {
+				if (move.recoil) {
 					this.damage(Math.round(damage * move.recoil[0] / move.recoil[1]), source, target, 'recoil');
 				}
 				if (move.drain) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -314,7 +314,7 @@ exports.BattleScripts = {
 			totalDamage = damage;
 		}
 
-		if (move.recoil && (!pokemon.hasAbility('rockhead') || move.id === 'struggle')) {
+		if (move.recoil) {
 			this.damage(this.clampIntRange(Math.round(totalDamage * move.recoil[0] / move.recoil[1]), 1), pokemon, target, 'recoil');
 		}
 

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -869,7 +869,7 @@ exports.BattleMovedex = {
 				} else {
 					this.add('-activate', target, 'Substitute', '[damage]');
 				}
-				if (move.recoil && (!source.hasAbility('rockhead') || move.id === 'struggle')) {
+				if (move.recoil) {
 					this.damage(Math.round(damage * move.recoil[0] / move.recoil[1]), source, target, 'recoil');
 				}
 				if (move.drain) {

--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -314,11 +314,8 @@ exports.BattleAbilities = {
 	},
 	"rockhead": {
 		inherit: true,
-		onModifyMove: function (move) {
-			delete move.recoil;
-		},
 		onDamage: function (damage, target, source, effect) {
-			if (effect && effect.id === 'lifeorb') return false;
+			if (effect && effect.id in {lifeorb: 1, recoil: 1}) return false;
 		}
 	},
 	"download": {

--- a/test/simulator/abilities/rockhead.js
+++ b/test/simulator/abilities/rockhead.js
@@ -1,0 +1,41 @@
+var assert = require('assert');
+var battle;
+
+describe('Rock Head', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should block recoil from most moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Aerodactyl', ability: 'rockhead', moves: ['doubleedge']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'clearbody', moves: ['rest']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should not block recoil if the ability is disabled/removed mid-attack', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Aerodactyl', ability: 'rockhead', moves: ['doubleedge']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'mummy', moves: ['rest']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should not block recoil from Struggle', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Aerodactyl', ability: 'rockhead', moves: ['roost']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Sableye', ability: 'prankster', moves: ['taunt']}]);
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should not block crash damage', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Rampardos', ability: 'rockhead', moves: ['jumpkick']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Sableye', ability: 'prankster', moves: ['taunt']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+});

--- a/test/simulator/abilities/sheerforce.js
+++ b/test/simulator/abilities/sheerforce.js
@@ -14,9 +14,28 @@ describe('Sheer Force', function () {
 		assert.strictEqual(battle.p1.active[0].hp, 281);
 	});
 
+	it('should eliminate secondary effects from moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', moves: ['zapcannon']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Machamp', ability: 'noguard', moves: ['bulkup']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, '');
+	});
+
+	it('should not eliminate Life Orb recoil if the ability is disabled/removed mid-attack', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['lockon', 'dynamicpunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Scyther', ability: 'mummy', moves: ['irondefense']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.ok(!battle.p2.active[0].volatiles['confusion']);
+		assert.strictEqual(battle.p1.active[0].hp, 281);
+	});
+
 	it('should eliminate Life Orb recoil in a move with secondary effects', function () {
 		battle = BattleEngine.Battle.construct();
-		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', moves: ['bodyslam']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['bodyslam']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Lapras', ability: 'shellarmor', item: 'laggingtail', moves: ['rest']}]);
 		battle.commitDecisions();
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);

--- a/test/simulator/moves/substitute.js
+++ b/test/simulator/moves/substitute.js
@@ -35,6 +35,39 @@ describe('Substitute', function () {
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 	});
 
+	it('should not block recoil damage', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['substitute', 'doubleedge']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['nastyplot']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		var pokemon = battle.p1.active[0];
+		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
+	});
+
+	it('should cause recoil damage from an opponent\'s moves to be based on damage dealt to the substitute', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['substitute']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'noguard', moves: ['nastyplot', 'lightofruin']}]);
+		battle.commitDecisions();
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		var pokemon = battle.p2.active[0];
+		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.ceil(Math.floor(battle.p1.active[0].maxhp / 4) / 2));
+	});
+
+	it('should cause recovery from an opponent\'s draining moves to be based on damage dealt to the substitute', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Zangoose', ability: 'pressure', moves: ['substitute']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Zangoose', ability: 'noguard', moves: ['bellydrum', 'drainpunch']}]);
+		battle.commitDecisions();
+		var hp = battle.p2.active[0].hp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp - hp, Math.ceil(Math.floor(battle.p1.active[0].maxhp / 4) / 2));
+	});
+
 	it('should block most status moves targetting the user', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'noguard', moves: ['substitute']}]);


### PR DESCRIPTION
Instead of having a hardcode in scripts.js that people needed to
reference, it seemed more intuitive to take advantage of the Damage
event instead, and have Rock Head negate damage within the event.

Fixed a minor Gen-NEXT Rock Head bug that was basically the same
as our old Rock Head + Mummy bug.

Also, fixed up a Sheer Force test (the Sheer Force Pokemon didn't
have a Life Orb so the test checking for the negation of Life Orb recoil
would pass even if Sheer Force wasn't coded correctly.

---

This PR could also be titled "I'm bored at work"

I was planning to un-hardcode Sheer Force too but that one wasn't
being very cooperative.