### PR TITLE
Revert changes to tools.js

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -536,8 +536,8 @@ module.exports = (function () {
 					banlistTable[toId(subformat.banlist[i])] = subformat.name || true;
 
 					var complexList;
-					if (subformat.banlist[i].includes('+')) {
-						if (subformat.banlist[i].includes('++')) {
+					if (subformat.banlist[i].indexOf('++')) {
+						if (subformat.banlist[i].indexOf('++')) {
 							complexList = subformat.banlist[i].split('++');
 							for (var j = 0; j < complexList.length; j++) {
 								complexList[j] = toId(complexList[j]);


### PR DESCRIPTION
The change of at 539 in the solaris fox patch caused a type error which messed with team validation and caused challenges to fail. Reverting seemed to correct the issue.