### PR TITLE
Battle Engine no longer sets EVs to 84 with blank EV sets

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -258,7 +258,7 @@ BattlePokemon = (function () {
 		this.canMegaEvo = this.battle.canMegaEvo(this);
 
 		if (!this.set.evs) {
-			this.set.evs = {hp: 84, atk: 84, def: 84, spa: 84, spd: 84, spe: 84};
+			this.set.evs = {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
 		}
 		if (!this.set.ivs) {
 			this.set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};

--- a/test/simulator/abilities/sheerforce.js
+++ b/test/simulator/abilities/sheerforce.js
@@ -11,7 +11,7 @@ describe('Sheer Force', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Lapras', ability: 'shellarmor', item: 'laggingtail', moves: ['rest']}]);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].hp, 281);
+		assert.strictEqual(battle.p1.active[0].hp, 262);
 	});
 
 	it('should eliminate secondary effects from moves', function () {
@@ -30,7 +30,7 @@ describe('Sheer Force', function () {
 		battle.choose('p1', 'move 2');
 		battle.commitDecisions();
 		assert.ok(!battle.p2.active[0].volatiles['confusion']);
-		assert.strictEqual(battle.p1.active[0].hp, 281);
+		assert.strictEqual(battle.p1.active[0].hp, 262);
 	});
 
 	it('should eliminate Life Orb recoil in a move with secondary effects', function () {

--- a/test/simulator/items/leftovers.js
+++ b/test/simulator/items/leftovers.js
@@ -16,12 +16,12 @@ describe('Leftovers - GSC', function () {
 			{species: "Miltank", moves: ['seismictoss']}
 		]);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].hp, 614);
+		assert.strictEqual(battle.p1.active[0].hp, 591);
 
 		battle.choose('p1', 'switch 2');
 		battle.commitDecisions();
 
 		battle.choose('p1', 'switch 2');
-		assert.strictEqual(battle.p1.active[0].hp, 656);
+		assert.strictEqual(battle.p1.active[0].hp, 631);
 	});
 });


### PR DESCRIPTION
This system is problematic for people who enter games without having
filled out their EVs, as their stats will not reflect the stats shown
in the teambuilder and can influence damage calculations, resulting in
many erroneous bug reports.

---

@Zarel since he was the one who mentioned that it needed to be changed.