### PR TITLE
Fix Mold Breaker's interaction with Unaware

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2233,7 +2233,7 @@ Battle = (function () {
 				// it's changed; call it off
 				continue;
 			}
-			if (status.effectType === 'Ability' && this.activePokemon && this.activePokemon !== target && !target.ignoringAbility() && this.activePokemon.getAbility().stopAttackEvents) {
+			if (status.effectType === 'Ability' && this.activePokemon && this.activePokemon !== thing && !this.activePokemon.ignoringAbility() && this.activePokemon.getAbility().stopAttackEvents) {
 				// ignore attacking events
 				var AttackingEvents = {
 					BeforeMove: 1,

--- a/test/simulator/abilities/multiscale.js
+++ b/test/simulator/abilities/multiscale.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var battle;
+
+describe('Multiscale', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should halve damage when it is at full health', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['splash']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moxie', moves: ['incinerate']}]);
+		var damage, curhp;
+		var pokemon = battle.p1.active[0];
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		damage = pokemon.maxhp - pokemon.hp;
+		curhp = pokemon.hp;
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		assert.strictEqual(damage, battle.modify(curhp - pokemon.hp, 0.5));
+	});
+
+	it('should be ignored by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['splash']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moldbreaker', moves: ['incinerate']}]);
+		var damage, curhp;
+		var pokemon = battle.p1.active[0];
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		damage = pokemon.maxhp - pokemon.hp;
+		curhp = pokemon.hp;
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		assert.strictEqual(curhp - pokemon.hp, damage);
+	});
+});

--- a/test/simulator/abilities/thickfat.js
+++ b/test/simulator/abilities/thickfat.js
@@ -1,0 +1,42 @@
+var assert = require('assert');
+var battle;
+
+describe('Thick Fat', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should halve damage from Fire- or Ice-type attacks', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'thickfat', moves: ['splash']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Nidoking", ability: 'sheerforce', moves: ['incinerate', 'icebeam']}]);
+		var damage;
+		var pokemon = battle.p1.active[0];
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		damage = pokemon.maxhp - pokemon.hp;
+		assert.ok(damage >= 29 && damage <= 35);
+		pokemon.hp = pokemon.maxhp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		damage = pokemon.maxhp - pokemon.hp;
+		assert.ok(damage >= 56 && damage <= 66);
+	});
+
+	it('should be ignored by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'thickfat', moves: ['splash']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Nidoking", ability: 'moldbreaker', moves: ['incinerate', 'icebeam']}]);
+		var damage;
+		var pokemon = battle.p1.active[0];
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		damage = pokemon.maxhp - pokemon.hp;
+		assert.ok(damage >= 57 && damage <= 68);
+		pokemon.hp = pokemon.maxhp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		damage = pokemon.maxhp - pokemon.hp;
+		assert.ok(damage >= 85 && damage <= 101);
+	});
+});

--- a/test/simulator/abilities/unaware.js
+++ b/test/simulator/abilities/unaware.js
@@ -1,0 +1,82 @@
+var assert = require('assert');
+var battle;
+
+describe('Unaware', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should ignore attack stage changes when Pokemon with it are attacked', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['softboiled']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Hariyama', ability: 'thickfat', moves: ['vitalthrow', 'bellydrum']}]);
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		var pokemon = battle.p1.active[0];
+		var damage = pokemon.maxhp - pokemon.hp;
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		assert.strictEqual(pokemon.maxhp - pokemon.hp, damage);
+	});
+
+	it('should not ignore attack stage changes when Pokemon with it attack', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['moonblast', 'nastyplot']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'prankster', moves: ['splash']}]);
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		var pokemon = battle.p2.active[0];
+		var damage = pokemon.maxhp - pokemon.hp;
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		pokemon.hp = pokemon.maxhp;
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
+	});
+
+	it('should ignore defense stage changes when Pokemon with it attack', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['moonblast']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Hariyama', ability: 'thickfat', item: 'laggingtail', moves: ['amnesia']}]);
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		var pokemon = battle.p2.active[0];
+		var damage = pokemon.maxhp - pokemon.hp;
+		pokemon.hp = pokemon.maxhp;
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		assert.strictEqual(pokemon.maxhp - pokemon.hp, damage);
+	});
+
+	it('should not ignore defense stage changes when Pokemon with it are attacked', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['irondefense']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'clearbody', moves: ['shadowsneak']}]);
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		var pokemon = battle.p1.active[0];
+		var damage = pokemon.maxhp - pokemon.hp;
+		pokemon.hp = pokemon.maxhp;
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
+	});
+
+	it('should be negated by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['splash']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['shadowsneak']}]);
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		var pokemon = battle.p1.active[0];
+		var damage = pokemon.maxhp - pokemon.hp;
+		battle.boost({atk: 2}, battle.p2.active[0]);
+		pokemon.hp = pokemon.maxhp;
+		battle.seed = [0, 0, 0, 0];
+		battle.commitDecisions();
+		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
+	});
+});

--- a/test/simulator/moves/electricterrain.js
+++ b/test/simulator/moves/electricterrain.js
@@ -68,7 +68,7 @@ describe('Electric Terrain', function () {
 
 	it('should cause Rest to fail on grounded Pokemon', function () {
 		battle = BattleEngine.Battle.construct();
-		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'rest']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'shellarmor', moves: ['electricterrain', 'rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest']}]);
 		battle.commitDecisions();
 		battle.choose('p1', 'move 2');

--- a/test/simulator/moves/thousandarrows.js
+++ b/test/simulator/moves/thousandarrows.js
@@ -20,7 +20,7 @@ describe('Thousand Arrows', function () {
 	it('should ignore type effectiveness on the first hit against Flying-type Pokemon', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows']}]);
-		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'pressure', item: 'weaknesspolicy', moves: ['recover']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'shellarmor', item: 'weaknesspolicy', moves: ['recover']}]);
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].boosts.atk, 0);
 		assert.strictEqual(battle.p2.active[0].boosts.spa, 0);


### PR DESCRIPTION
It should compare this.activePokemon to "thing", which is the Pokemon that
is holding the Ability being processed, not "target".

Also fixed random typo where Mold Breaker might succeed even if the
ability were supressed.