### PR TITLE
Add option for Mocha tests to use event handlers

### DIFF
--- a/test/simulator/misc/eventemitter.js
+++ b/test/simulator/misc/eventemitter.js
@@ -1,0 +1,59 @@
+var assert = require('assert');
+var battle;
+
+describe('Battle#on', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should allow the addition of one or more event handlers to the battle engine', function () {
+		battle = BattleEngine.Battle.construct('battle-1', 'customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['peck']}]);
+		battle.commitDecisions(); // Team Preview
+		var eventCount = 0;
+		var eventCount2 = 0;
+		battle.on('Hit', battle.getFormat(), function () {
+			eventCount++;
+		});
+		battle.on('Hit', battle.getFormat(), function () {
+			eventCount++;
+			eventCount2++;
+		});
+		battle.on('ModifyDamage', battle.getFormat(), function () {
+			return 5;
+		});
+		battle.commitDecisions();
+		assert.strictEqual(eventCount, 4);
+		assert.strictEqual(eventCount2, 2);
+		assert.strictEqual(battle.p1.active[0].maxhp - battle.p1.active[0].hp, 5);
+	});
+
+	it('should support and resolve priorities correctly', function () {
+		battle = BattleEngine.Battle.construct('battle-2', 'customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['peck']}]);
+		battle.commitDecisions(); // Team Preview
+		var eventCount = 0;
+		var callback = function (count) {
+			return function () {
+				assert.strictEqual(eventCount, count);
+				eventCount++;
+			};
+		};
+		for (var i = 0; i < 9; i++) {
+			battle.on('ModifyDamage', battle.getFormat(), -i, callback(i));
+		}
+		battle.commitDecisions();
+		assert.strictEqual(eventCount, 9);
+	});
+
+	it('should throw if a callback is not given for the event handler', function () {
+		battle = BattleEngine.Battle.construct('battle-3', 'customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['peck']}]);
+		assert.throws(battle.on, TypeError);
+		assert.throws(function () {battle.on('Hit');}, TypeError);
+		assert.throws(function () {battle.on('Hit', battle.getFormat());}, TypeError);
+	});
+});

--- a/test/simulator/misc/weight.js
+++ b/test/simulator/misc/weight.js
@@ -7,31 +7,31 @@ describe('Heavy Metal', function () {
 	});
 
 	it('should double the weight of a Pokemon', function () {
-		battle = BattleEngine.Battle.construct();
+		battle = BattleEngine.Battle.construct('battle-heavy', 'customgame');
 		battle.join('p1', 'Guest 1', 1, [{species: "Simisear", ability: 'heavymetal', moves: ['nastyplot']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', moves: ['grassknot']}]);
+		battle.commitDecisions(); // Team Preview
 		var basePower = 0;
-		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
-			if (eventid === 'BasePower' && effect.id === 'grassknot') {
-				basePower = relayVar;
+		battle.on('BasePower', battle.getFormat(), function (bp, attacker, defender, move) {
+			if (move.id === 'grassknot') {
+				basePower = bp;
 			}
-			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
-		};
+		});
 		battle.commitDecisions();
 		assert.strictEqual(basePower, 80);
 	});
 
 	it('should be negated by Mold Breaker', function () {
-		battle = BattleEngine.Battle.construct();
+		battle = BattleEngine.Battle.construct('battle-heavy-moldbreaker', 'customgame');
 		battle.join('p1', 'Guest 1', 1, [{species: "Simisear", ability: 'heavymetal', moves: ['nastyplot']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'moldbreaker', moves: ['grassknot']}]);
+		battle.commitDecisions(); // Team Preview
 		var basePower = 0;
-		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
-			if (eventid === 'BasePower' && effect.id === 'grassknot') {
-				basePower = relayVar;
+		battle.on('BasePower', battle.getFormat(), function (bp, attacker, defender, move) {
+			if (move.id === 'grassknot') {
+				basePower = bp;
 			}
-			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
-		};
+		});
 		battle.commitDecisions();
 		assert.strictEqual(basePower, 60);
 	});
@@ -43,31 +43,31 @@ describe('Light Metal', function () {
 	});
 
 	it('should halve the weight of a Pokemon', function () {
-		battle = BattleEngine.Battle.construct();
+		battle = BattleEngine.Battle.construct('battle-light', 'customgame');
 		battle.join('p1', 'Guest 1', 1, [{species: "Registeel", ability: 'lightmetal', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', moves: ['grassknot']}]);
+		battle.commitDecisions(); // Team Preview
 		var basePower = 0;
-		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
-			if (eventid === 'BasePower' && effect.id === 'grassknot') {
-				basePower = relayVar;
+		battle.on('BasePower', battle.getFormat(), function (bp, attacker, defender, move) {
+			if (move.id === 'grassknot') {
+				basePower = bp;
 			}
-			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
-		};
+		});
 		battle.commitDecisions();
 		assert.strictEqual(basePower, 100);
 	});
 
 	it('should be negated by Mold Breaker', function () {
-		battle = BattleEngine.Battle.construct();
+		battle = BattleEngine.Battle.construct('battle-light-moldbreaker', 'customgame');
 		battle.join('p1', 'Guest 1', 1, [{species: "Registeel", ability: 'lightmetal', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'moldbreaker', moves: ['grassknot']}]);
+		battle.commitDecisions(); // Team Preview
 		var basePower = 0;
-		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
-			if (eventid === 'BasePower' && effect.id === 'grassknot') {
-				basePower = relayVar;
+		battle.on('BasePower', battle.getFormat(), function (bp, attacker, defender, move) {
+			if (move.id === 'grassknot') {
+				basePower = bp;
 			}
-			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
-		};
+		});
 		battle.commitDecisions();
 		assert.strictEqual(basePower, 120);
 	});
@@ -79,16 +79,16 @@ describe('Float Stone', function () {
 	});
 
 	it('should halve the weight of a Pokemon', function () {
-		battle = BattleEngine.Battle.construct();
+		battle = BattleEngine.Battle.construct('battle-floatstone', 'customgame');
 		battle.join('p1', 'Guest 1', 1, [{species: "Registeel", ability: 'clearbody', item: 'floatstone', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', moves: ['grassknot']}]);
+		battle.commitDecisions(); // Team Preview
 		var basePower = 0;
-		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
-			if (eventid === 'BasePower' && effect.id === 'grassknot') {
-				basePower = relayVar;
+		battle.on('BasePower', battle.getFormat(), function (bp, attacker, defender, move) {
+			if (move.id === 'grassknot') {
+				basePower = bp;
 			}
-			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
-		};
+		});
 		battle.commitDecisions();
 		assert.strictEqual(basePower, 100);
 	});
@@ -100,16 +100,16 @@ describe('Autotomize', function () {
 	});
 
 	it('should reduce the weight of a Pokemon by 100 kg with each use', function () {
-		battle = BattleEngine.Battle.construct();
+		battle = BattleEngine.Battle.construct('battle-autotomize', 'customgame');
 		battle.join('p1', 'Guest 1', 1, [{species: "Registeel", ability: 'clearbody', moves: ['autotomize']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot']}]);
+		battle.commitDecisions(); // Team Preview
 		var basePower = 0;
-		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
-			if (eventid === 'BasePower' && effect.id === 'grassknot') {
-				basePower = relayVar;
+		battle.on('BasePower', battle.getFormat(), function (bp, attacker, defender, move) {
+			if (move.id === 'grassknot') {
+				basePower = bp;
 			}
-			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
-		};
+		});
 		battle.commitDecisions();
 		assert.strictEqual(basePower, 100);
 		battle.commitDecisions();
@@ -117,16 +117,16 @@ describe('Autotomize', function () {
 	});
 
 	it('should factor into weight before Heavy Metal does', function () {
-		battle = BattleEngine.Battle.construct();
+		battle = BattleEngine.Battle.construct('battle-heavy-autotomize', 'customgame');
 		battle.join('p1', 'Guest 1', 1, [{species: "Lairon", ability: 'heavymetal', moves: ['autotomize']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot']}]);
+		battle.commitDecisions(); // Team Preview
 		var basePower = 0;
-		battle.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
-			if (eventid === 'BasePower' && effect.id === 'grassknot') {
-				basePower = relayVar;
+		battle.on('BasePower', battle.getFormat(), function (bp, attacker, defender, move) {
+			if (move.id === 'grassknot') {
+				basePower = bp;
 			}
-			return BattleEngine.Battle.prototype.runEvent.apply(this, arguments);
-		};
+		});
 		battle.commitDecisions();
 		assert.strictEqual(basePower, 60);
 	});


### PR DESCRIPTION
Creates an option `battle.test` that Mocha tests can use to create their
own temporary event handlers that can get picked up.

At any rate, it's more efficient than hotpatching the getEvent function.

---

@Zarel @Slayer95 @TheImmortal 

I'm also very sleepy and this could be prone to tons of error.

`battle.getRelevantEventsInner` is set to "borrow" the format data when
resolving `battle.test` event handlers because like, it's part of this custom
one-use format??? idk if it's a good idea good night everybody