### PR TITLE
Random Battle: Remove Shell Smash from Magcargo

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1882,8 +1882,8 @@ exports.BattleFormatsData = {
 		tier: "LC"
 	},
 	magcargo: {
-		randomBattleMoves: ["recover","lavaplume","toxic","hiddenpowergrass","stealthrock","fireblast","earthpower","shellsmash","ancientpower"],
-		randomDoubleBattleMoves: ["protect","heatwave","willowisp","shellsmash","hiddenpowergrass","ancientpower","stealthrock","fireblast","earthpower"],
+		randomBattleMoves: ["recover","lavaplume","toxic","hiddenpowergrass","stealthrock","fireblast","earthpower","ancientpower"],
+		randomDoubleBattleMoves: ["protect","heatwave","willowisp","hiddenpowergrass","ancientpower","stealthrock","fireblast","earthpower"],
 		eventPokemon: [
 			{"generation":3,"level":38,"moves":["refresh","heatwave","earthquake","flamethrower"]}
 		],


### PR DESCRIPTION
Its speed is not high enough to take advantage of it and therefore could
die easily before it can get an attack off.

---

Just something that was mentioned yesterday in PS Staff chat.