### PR TITLE
Slightly tweak Misty Terrain

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -8787,7 +8787,7 @@ exports.BattleMovedex = {
 				return false;
 			},
 			onBasePower: function (basePower, attacker, defender, move) {
-				if (move.type === 'Dragon' && defender.isGrounded()) {
+				if (move.type === 'Dragon' && defender.isGrounded() && !defender.isSemiInvulnerable()) {
 					this.debug('misty terrain weaken');
 					return this.chainModify(0.5);
 				}


### PR DESCRIPTION
It would have halved damage from Dragon moves against semi-invulnerable
Pokemon if No Guard or Lock On was involved.