### PR TITLE
Fix Smack Down and Thousand Arrows' interaction with Fly/Bounce

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -12565,6 +12565,7 @@ exports.BattleMovedex = {
 				if (pokemon.removeVolatile('fly') || pokemon.removeVolatile('bounce')) {
 					applies = true;
 					this.cancelMove(pokemon);
+					pokemon.removeVolatile('twoturnmove');
 				}
 				if (pokemon.volatiles['magnetrise']) {
 					applies = true;


### PR DESCRIPTION
They were forcing the Pokemon to attempt to use Fly/Bounce again.