### PR TITLE
Fix some Mold Breaker bugs with drag-out moves

### DIFF
--- a/test/simulator/abilities/levitate.js
+++ b/test/simulator/abilities/levitate.js
@@ -1,0 +1,70 @@
+var assert = require('assert');
+var battle;
+
+describe('Levitate', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should give the user an immunity to Ground-type moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Rotom', ability: 'levitate', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Aggron', ability: 'sturdy', moves: ['earthquake']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should make the user airborne', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Unown', ability: 'levitate', moves: ['spore']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Espeon', ability: 'magicbounce', moves: ['electricterrain']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, 'slp');
+	});
+
+	it('should have its Ground immunity bypassed by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['earthquake']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should have its airborne property bypassed by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']},
+			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['roar', 'spikes']}]);
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should not have its airborne property bypassed by Mold Breaker if it switches out via Eject Button', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Cresselia', ability: 'levitate', item: 'ejectbutton', moves: ['sleeptalk']},
+			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['tackle', 'spikes']}]);
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		battle.commitDecisions();
+		battle.choose('p1', 'switch 2');
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should not have its airborne property bypassed by Mold Breaker if that Pokemon is no longer active', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Forretress', ability: 'levitate', item: 'redcard', moves: ['spikes']}]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Haxorus', ability: 'moldbreaker', item: 'laggingtail', moves: ['tackle']},
+			{species: 'Rotom', ability: 'levitate', moves: ['rest']}
+		]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+});

--- a/test/simulator/abilities/magicguard.js
+++ b/test/simulator/abilities/magicguard.js
@@ -1,0 +1,37 @@
+var assert = require('assert');
+var battle;
+
+describe('Magic Guard', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent all non-attack damage', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']},
+			{species: 'Clefable', ability: 'magicguard', item: 'lifeorb', moves: ['doubleedge']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'roughskin', moves: ['spikes', 'toxic']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'switch 2');
+		battle.choose('p2', 'move 2');
+		assert.strictEqual(battle.p1.active[0].status, 'tox');
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should not be bypassed by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']},
+			{species: 'Clefable', ability: 'magicguard', moves: ['doubleedge']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['stealthrock', 'roar']}]);
+		battle.commitDecisions();
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+});

--- a/test/simulator/abilities/sturdy.js
+++ b/test/simulator/abilities/sturdy.js
@@ -1,0 +1,57 @@
+var assert = require('assert');
+var battle;
+
+describe('Sturdy', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should give the user an immunity to OHKO moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Aron', level: 1, ability: 'sturdy',  moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Kyogre', ability: 'noguard', moves: ['sheercold']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should allow its user to survive an attack from full HP', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Paras', ability: 'sturdy', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Charizard', ability: 'drought', moves: ['fusionflare']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, 1);
+	});
+
+	it('should allow its user to survive a confusion damage hit from full HP', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'sturdy', moves: ['absorb']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Klefki', ability: 'prankster', moves: ['confuseray']}]);
+		battle.seed = [1, 2, 3, 4];
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, 1);
+	});
+
+	it('should not trigger on recoil damage', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'sturdy', moves: ['doubleedge']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Klefki', ability: 'prankster', moves: ['reflect']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, 0);
+	});
+
+	it('should not trigger on residual damage', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'sturdy', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'infiltrator', moves: ['toxic']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, 0);
+	});
+
+	it('should be bypassed by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Paras', ability: 'sturdy', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Reshiram', ability: 'turboblaze', moves: ['fusionflare']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, 0);
+	});
+});

--- a/test/simulator/items/focussash.js
+++ b/test/simulator/items/focussash.js
@@ -1,0 +1,45 @@
+var assert = require('assert');
+var battle;
+
+describe('Focus Sash', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should be consumed and allow its user to survive an attack from full HP', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Paras', ability: 'dryskin', item: 'focussash', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Delphox', ability: 'magician', moves: ['incinerate']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, '');
+		assert.strictEqual(battle.p1.active[0].hp, 1);
+	});
+
+	it('should be consumed and allow its user to survive a confusion damage hit from full HP', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['absorb']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Klefki', ability: 'prankster', moves: ['confuseray']}]);
+		battle.seed = [1, 2, 3, 4];
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, '');
+		assert.strictEqual(battle.p1.active[0].hp, 1);
+	});
+
+	it('should not trigger on recoil damage', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['doubleedge']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Klefki', ability: 'prankster', moves: ['reflect']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'focussash');
+		assert.strictEqual(battle.p1.active[0].hp, 0);
+	});
+
+	it('should not trigger on residual damage', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'infiltrator', moves: ['toxic']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'focussash');
+		assert.strictEqual(battle.p1.active[0].hp, 0);
+	});
+});


### PR DESCRIPTION
- Process the 'runSwitch' decision directly in Battle#dragIn in gen
  5 and up. This allows the Pokemon executing the phazing move to
  remain as battle.activePokemon for the duration of the dragging
  action. This fixes Mold Breaker's interaction when moves that drag
  out Pokemon are used.
- Add a check for battle.activePokemon.isActive in the Mold Breaker
  ability negation check to prevent glitches with Mold Breaker and
  Red Card.
- Remove Damage/SubDamage from Mold Breaker's check and instead add
  an additional check for the Damage event specifically to use extra
  criteria. This fixes its interaction with Magic Guard.

====

Technically still waiting for @Marty-D to verify my assumption of the given scenario is correct: if a Pokemon with Mold Breaker hits a Red Card and a Levitate Pokemon is dragged in, the new Pokemon shouldn't be affected by Spikes. I could be wrong, though.

Alternatively, something could be completely wrong with this refactor, especially the part when I removed Mold Breaker's ability to inherently block the `Damage` event. ~~If there's a better solution I'm definitely open to it.~~ A flash of inspiration brought me to a better solution.