### PR TITLE
Add tests for type-immunity negating moves and items

### DIFF
--- a/test/simulator/items/ironball.js
+++ b/test/simulator/items/ironball.js
@@ -1,0 +1,58 @@
+var battle;
+var assert = require('assert');
+
+describe('Iron Ball', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should reduce halve the holder\'s speed', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', item: 'ironball', moves: ['bestow']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Aerodactyl", ability: 'pressure', moves: ['stealthrock']}]);
+		var speed = battle.p2.active[0].getStat('spe');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].getStat('spe'), battle.modify(speed, 0.5));
+	});
+
+	it('should negate Ground immunities and deal neutral type effectiveness to Flying-type Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake']}]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Aerodactyl", ability: 'pressure', item: 'ironball', moves: ['stealthrock']},
+			{species: "Tropius", ability: 'harvest', item: 'ironball', moves: ['leechseed']}
+		]);
+		battle.commitDecisions();
+		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
+		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should negate artificial Ground immunities and deal normal type effectiveness', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake']}]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Rotom", ability: 'levitate', item: 'ironball', moves: ['rest']},
+			{species: "Parasect", ability: 'levitate', item: 'ironball', moves: ['rest']}
+		]);
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should ground Pokemon that are airborne', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['spore']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Thundurus", ability: 'prankster', item: 'ironball', moves: ['electricterrain']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, '');
+	});
+});

--- a/test/simulator/items/ringtarget.js
+++ b/test/simulator/items/ringtarget.js
@@ -1,0 +1,43 @@
+var battle;
+var assert = require('assert');
+
+describe('Ring Target', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should negate natural immunities and deal normal type effectiveness with the other type(s)', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['earthquake', 'vitalthrow', 'shadowball', 'psychic']}]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Thundurus", ability: 'prankster', item: 'ringtarget', moves: ['rest']},
+			{species: "Drifblim", ability: 'unburden', item: 'ringtarget', moves: ['rest']},
+			{species: "Girafarig", ability: 'innerfocus', item: 'ringtarget', moves: ['rest']},
+			{species: "Absol", ability: 'superluck', item: 'ringtarget', moves: ['rest']}
+		]);
+		battle.seed = [0, 0, 0, 1];
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'switch 2');
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		battle.choose('p1', 'move 3');
+		battle.choose('p2', 'switch 3');
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		battle.choose('p1', 'move 4');
+		battle.choose('p2', 'switch 4');
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not affect ability-based immunities', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['earthquake']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Mismagius", ability: 'levitate', item: 'ringtarget', moves: ['shadowsneak']}]);
+		battle.commitDecisions();
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+});

--- a/test/simulator/moves/foresight.js
+++ b/test/simulator/moves/foresight.js
@@ -1,0 +1,47 @@
+var battle;
+var assert = require('assert');
+
+describe('Foresight', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should negate Normal and Fighting immunities', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['foresight', 'vitalthrow', 'tackle']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Dusknoir", ability: 'prankster', moves: ['recover']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		battle.choose('p1', 'move 3');
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should ignore the effect of positive evasion stat stages', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['avalanche', 'foresight']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Forretress", ability: 'sturdy', moves: ['synthesis']}]);
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		battle.boost({evasion: 6}, battle.p2.active[0]);
+		for (var i = 0; i < 16; i++) {
+			battle.commitDecisions();
+			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		}
+	});
+
+	it('should not ignore the effect of negative evasion stat stages', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['zapcannon', 'dynamicpunch', 'foresight']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Zapdos", ability: 'owntempo', moves: ['roost']}]);
+		battle.choose('p1', 'move 3');
+		battle.commitDecisions();
+		battle.boost({spe: 6, evasion: -6}, battle.p2.active[0]);
+		for (var i = 0; i < 16; i++) {
+			battle.commitDecisions();
+			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		}
+	});
+});

--- a/test/simulator/moves/miracleeye.js
+++ b/test/simulator/moves/miracleeye.js
@@ -1,0 +1,44 @@
+var battle;
+var assert = require('assert');
+
+describe('Miracle Eye', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should negate Psychic immunities', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['miracleeye', 'psychic']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Darkrai", ability: 'baddreams', moves: ['nastyplot']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should ignore the effect of positive evasion stat stages', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['avalanche', 'miracleeye']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Forretress", ability: 'sturdy', moves: ['synthesis']}]);
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		battle.boost({evasion: 6}, battle.p2.active[0]);
+		for (var i = 0; i < 16; i++) {
+			battle.commitDecisions();
+			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		}
+	});
+
+	it('should not ignore the effect of negative evasion stat stages', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['zapcannon', 'dynamicpunch', 'miracleeye']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Zapdos", ability: 'owntempo', moves: ['roost']}]);
+		battle.choose('p1', 'move 3');
+		battle.commitDecisions();
+		battle.boost({spe: 6, evasion: -6}, battle.p2.active[0]);
+		for (var i = 0; i < 16; i++) {
+			battle.commitDecisions();
+			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		}
+	});
+});


### PR DESCRIPTION
I found these sitting around uncommitted on my computer today. I suspect I was planning to refactor `pokemon.negateImmunity` out of `ModifyPokemon` but that can come later.