### PR TITLE
Battle refactor: No longer reset negated immunity in pokemon.update()

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -136,8 +136,8 @@ exports.Formats = [
 			this.p2.pokemon = this.p2.pokemon.slice(0, 3);
 			this.p2.pokemonLeft = this.p2.pokemon.length;
 		},
-		onModifyPokemon: function (pokemon) {
-			pokemon.negateImmunity['Type'] = true;
+		onNegateImmunity: function (pokemon, type) {
+			if (type in this.data.TypeChart && this.runEvent('Immunity', pokemon, null, null, type)) return false;
 		},
 		onEffectiveness: function (typeMod, target, type, move) {
 			// The effectiveness of Freeze Dry on Water isn't reverted
@@ -500,8 +500,8 @@ exports.Formats = [
 			'Ho-Oh', 'Kyogre', 'Kyurem-Black', 'Kyurem-White', 'Lugia', 'Mewtwo', 'Palkia', 'Rayquaza', 'Reshiram', 'Serperior',
 			'Shaymin-Sky', 'Snorlax', 'Xerneas', 'Yveltal', 'Zekrom', 'Gengarite', 'Kangaskhanite', 'Salamencite', 'Soul Dew'
 		],
-		onModifyPokemon: function (pokemon) {
-			pokemon.negateImmunity['Type'] = true;
+		onNegateImmunity: function (pokemon, type) {
+			if (type in this.data.TypeChart && this.runEvent('Immunity', pokemon, null, null, type)) return false;
 		},
 		onEffectiveness: function (typeMod, target, type, move) {
 			// The effectiveness of Freeze Dry on Water isn't reverted

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -3126,7 +3126,7 @@ exports.BattleAbilities = {
 		onTryHit: function (target, source, move) {
 			if (target === source || move.category === 'Status' || move.type === '???' || move.id === 'struggle' || move.isFutureMove) return;
 			this.debug('Wonder Guard immunity: ' + move.id);
-			if ((target.negateImmunity[move.type] === 'IgnoreEffectiveness' && !this.getImmunity(move.type, target)) || target.runEffectiveness(move) <= 0) {
+			if (target.runEffectiveness(move) <= 0) {
 				this.add('-activate', target, 'ability: Wonder Guard');
 				return null;
 			}

--- a/data/items.js
+++ b/data/items.js
@@ -2024,9 +2024,12 @@ exports.BattleItems = {
 		fling: {
 			basePower: 130
 		},
-		onModifyPokemon: function (pokemon) {
-			if (pokemon.negateImmunity['Ground']) return;
-			pokemon.negateImmunity['Ground'] = 'IgnoreEffectiveness';
+		onEffectiveness: function (typeMod, target, type, move) {
+			if (target.volatiles['ingrain'] || target.volatiles['smackdown'] || this.getPseudoWeather('gravity')) return;
+			if (move.type === 'Ground' && !this.getImmunity(move.type, target)) return 0;
+		},
+		onNegateImmunity: function (pokemon, type) {
+			if (type === 'Ground') return false;
 		},
 		onModifySpe: function (speMod) {
 			return this.chain(speMod, 0.5);
@@ -3659,8 +3662,8 @@ exports.BattleItems = {
 		fling: {
 			basePower: 10
 		},
-		onModifyPokemon: function (pokemon) {
-			pokemon.negateImmunity['Type'] = true;
+		onNegateImmunity: function (pokemon, type) {
+			if (type in this.data.TypeChart && this.runEvent('Immunity', pokemon, null, null, type)) return false;
 		},
 		num: 543,
 		gen: 5,

--- a/data/moves.js
+++ b/data/moves.js
@@ -4702,11 +4702,8 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-start', pokemon, 'Foresight');
 			},
-			onModifyPokemon: function (pokemon) {
-				if (pokemon.hasType('Ghost')) {
-					pokemon.negateImmunity['Normal'] = true;
-					pokemon.negateImmunity['Fighting'] = true;
-				}
+			onNegateImmunity: function (pokemon, type) {
+				if (pokemon.hasType('Ghost') && type in {'Normal': 1, 'Fighting': 1}) return false;
 			},
 			onModifyBoost: function (boosts) {
 				if (boosts.evasion && boosts.evasion > 0) {
@@ -5401,7 +5398,6 @@ exports.BattleMovedex = {
 			},
 			onModifyPokemonPriority: 100,
 			onModifyPokemon: function (pokemon) {
-				pokemon.negateImmunity['Ground'] = true;
 				var applies = false;
 				if (pokemon.removeVolatile('bounce') || pokemon.removeVolatile('fly')) {
 					applies = true;
@@ -5427,6 +5423,9 @@ exports.BattleMovedex = {
 					delete pokemon.volatiles['telekinesis'];
 				}
 				if (applies) this.add('-activate', pokemon, 'Gravity');
+			},
+			onNegateImmunity: function (pokemon, type) {
+				if (type === 'Ground') return false;
 			},
 			onBeforeMovePriority: 6,
 			onBeforeMove: function (pokemon, target, move) {
@@ -7104,8 +7103,10 @@ exports.BattleMovedex = {
 				this.heal(pokemon.maxhp / 16);
 			},
 			onModifyPokemon: function (pokemon) {
-				pokemon.negateImmunity['Ground'] = true;
 				pokemon.tryTrap();
+			},
+			onNegateImmunity: function (pokemon, type) {
+				if (type === 'Ground') return false;
 			},
 			onDragOut: function (pokemon) {
 				this.add('-activate', pokemon, 'move: Ingrain');
@@ -8605,8 +8606,8 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-start', pokemon, 'Miracle Eye');
 			},
-			onModifyPokemon: function (pokemon) {
-				if (pokemon.hasType('Dark')) pokemon.negateImmunity['Psychic'] = true;
+			onNegateImmunity: function (pokemon, type) {
+				if (pokemon.hasType('Dark') && type === 'Psychic') return false;
 			},
 			onModifyBoost: function (boosts) {
 				if (boosts.evasion && boosts.evasion > 0) {
@@ -12572,7 +12573,8 @@ exports.BattleMovedex = {
 		effect: {
 			onStart: function (pokemon) {
 				var applies = false;
-				if ((pokemon.hasType('Flying') && !pokemon.volatiles['roost']) || pokemon.hasAbility('levitate')) applies = true;
+				if (pokemon.hasType('Flying') || pokemon.hasAbility('levitate')) applies = true;
+				if (pokemon.hasItem('ironball') || pokemon.volatiles['ingrain'] || this.getPseudoWeather('gravity')) applies = false;
 				if (pokemon.removeVolatile('fly') || pokemon.removeVolatile('bounce')) {
 					applies = true;
 					this.cancelMove(pokemon);
@@ -12595,9 +12597,8 @@ exports.BattleMovedex = {
 					this.add('-start', pokemon, 'Smack Down');
 				}
 			},
-			onModifyPokemonPriority: 100,
-			onModifyPokemon: function (pokemon) {
-				pokemon.negateImmunity['Ground'] = true;
+			onNegateImmunity: function (pokemon, type) {
+				if (type === 'Ground') return false;
 			}
 		},
 		secondary: false,
@@ -14145,10 +14146,12 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, nonsky: 1},
 		isUnreleased: true,
-		onTryHit: function (target) {
+		onEffectiveness: function (typeMod, type, move) {
+			if (move.type !== 'Ground') return;
+			var target = this.activeTarget;
 			// only the attack that grounds the target ignores effectiveness
-			if (target.negateImmunity['Ground']) return;
-			target.negateImmunity['Ground'] = 'IgnoreEffectiveness';
+			if (!this.runEvent('NegateImmunity', target, 'Ground')) return;
+			if (!this.getImmunity('Ground', target)) return 0;
 		},
 		volatileStatus: 'smackdown',
 		ignoreImmunity: {'Ground': true},

--- a/mods/gen4/items.js
+++ b/mods/gen4/items.js
@@ -107,9 +107,7 @@ exports.BattleItems = {
 	},
 	"ironball": {
 		inherit: true,
-		onModifyPokemon: function (pokemon) {
-			pokemon.negateImmunity['Ground'] = true;
-		},
+		onEffectiveness: function () {},
 		desc: "Holder's Speed is halved and it becomes grounded."
 	},
 	"lifeorb": {

--- a/test/simulator/abilities/wonderguard.js
+++ b/test/simulator/abilities/wonderguard.js
@@ -1,0 +1,45 @@
+var assert = require('assert');
+var battle;
+
+describe('Wonder Guard', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should make the user immune to damaging attacks that are not super effective', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Aerodactyl", ability: 'wonderguard', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['knockoff', 'flamethrower', 'thousandarrows', 'moonblast']}]);
+		for (var i = 1; i <= 4; i++) {
+			battle.choose('p2', 'move ' + i);
+			battle.commitDecisions();
+			assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		}
+	});
+
+	it('should not make the user immune to status moves', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Abra", ability: 'wonderguard', moves: ['teleport']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'noguard', moves: ['poisongas', 'screech', 'healpulse', 'gastroacid']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, 'psn');
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].boosts['def'], -2);
+		battle.choose('p2', 'move 3');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].maxhp - battle.p1.active[0].hp, Math.floor(battle.p1.active[0].maxhp / 8));
+		battle.choose('p2', 'move 4');
+		battle.commitDecisions();
+		assert.ok(battle.p1.active[0].volatiles['gastroacid']);
+		assert.ok(!battle.p1.active[0].hasAbility('wonderguard'));
+	});
+
+	it('should be bypassed by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Zekrom", ability: 'wonderguard', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Reshiram", ability: 'turboblaze', moves: ['fusionflare']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+});

--- a/test/simulator/items/ironball.js
+++ b/test/simulator/items/ironball.js
@@ -33,12 +33,12 @@ describe('Iron Ball', function () {
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
-	it.skip('should not deal neutral type effectiveness to Flying-type Pokemon in Gravity', function () {
+	it('should not deal neutral type effectiveness to Flying-type Pokemon in Gravity', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake', 'gravity']}]);
 		battle.join('p2', 'Guest 2', 1, [
-			{species: "Aerodactyl", ability: 'pressure', item: 'ironball', moves: ['stealthrock']},
-			{species: "Tropius", ability: 'harvest', item: 'ironball', moves: ['leechseed']}
+			{species: "Aerodactyl", ability: 'shellarmor', item: 'ironball', moves: ['stealthrock']},
+			{species: "Tropius", ability: 'shellarmor', item: 'ironball', moves: ['leechseed']}
 		]);
 		// Set up Gravity
 		battle.choose('p1', 'move 2');

--- a/test/simulator/moves/ingrain.js
+++ b/test/simulator/moves/ingrain.js
@@ -1,0 +1,41 @@
+var assert = require('assert');
+var battle;
+
+describe('Ingrain', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should heal the user by 1/16 of its max HP at the end of each turn', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Cradily', ability: 'stormdrain', moves: ['ingrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Miltank', ability: 'thickfat', moves: ['seismictoss']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].hp, Math.floor(battle.p1.active[0].maxhp * 17 / 16) - 100);
+	});
+
+	it('should prevent the user from being forced out or switching out', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Cradily', ability: 'stormdrain', moves: ['ingrain']},
+			{species: 'Pikachu', ability: 'static', moves: ['thunder']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Arcanine', ability: 'flashfire', moves: ['roar']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].speciesid, 'cradily');
+		battle.choose('p1', 'switch 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].speciesid, 'cradily');
+	});
+
+	it('should remove the users\' Ground immunities', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Tropius', ability: 'harvest', moves: ['earthquake', 'ingrain']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Carnivine', ability: 'levitate', moves: ['earthquake', 'ingrain']}]);
+		battle.choose('p1', 'move 2');
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+});

--- a/test/simulator/moves/thousandarrows.js
+++ b/test/simulator/moves/thousandarrows.js
@@ -29,31 +29,31 @@ describe('Thousand Arrows', function () {
 		assert.strictEqual(battle.p2.active[0].boosts.spa, 2);
 	});
 
-	it.skip('should not ignore type effectiveness on the first hit against Flying-type Pokemon with Ring Target', function () {
+	it('should not ignore type effectiveness on the first hit against Flying-type Pokemon with Ring Target', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'wonderguard', item: 'ringtarget', moves: ['recover']}]);
 		battle.commitDecisions();
-		assert.notStrictEqual(battle.p2.active.hp, battle.p2.active.maxhp);
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
-	it.skip('should have its effects against Flying-type Pokemon rendered null by Iron Ball', function () {
+	it('should not ground or deal neutral damage to Flying-type Pokemon holding an Iron Ball', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'mudslap']}]);
-		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'wonderguard', item: 'ironball', moves: ['recover', 'trick']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'shellarmor', item: 'ironball', moves: ['recover', 'trick']}]);
 		battle.commitDecisions();
 		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		var hp = battle.p2.active[0].hp;
 		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
-		battle.choose('p1', 'move 1');
+		battle.choose('p1', 'move 2');
 		battle.choose('p2', 'move 2');
 		assert.strictEqual(hp, battle.p2.active[0].hp);
 	});
 
-	it.skip('should have its effects against Flying-type Pokemon rendered null by Gravity', function () {
+	it('should not ground or deal neutral damage to Flying-type Pokemon affected by Gravity', function () {
 		battle = BattleEngine.Battle.construct();
-		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'mudslap']}]);
-		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'wonderguard', item: 'ironball', moves: ['recover', 'gravity']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'shellarmor', moves: ['recover', 'gravity']}]);
 		battle.choose('p1', 'move 2');
 		battle.choose('p2', 'move 2');
 		// During Gravity, Thousand Arrows can be super effective but once it ends has to be neutral for one hit


### PR DESCRIPTION
Replace the pokemon.negateImmunity object with a new `NegateImmunity`
event that handles all the immunity negation.

Also deprecate 'IgnoreEffectiveness' in favor of having relevant moves
and items use `Effectiveness` event handlers instead.