### PR TITLE
Configure Mocha to use the Min reporter

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 test/*.js test/application/*.js test/dev-tools/*/*.js
--R dot
+-R min
 -u bdd


### PR DESCRIPTION
With the number of tests added to the server steadily increasing, even the
Dots reporter can take up quite a bit of space.

It was going to be Nyan but Nyan doesn't work well in Travis.