### PR TITLE
Limit the number of battle rooms a user can be in

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -2010,6 +2010,10 @@ var commands = exports.commands = {
 					return false;
 				}
 			}
+			if (user.exceedMaxBattles()) {
+				this.popupReply("Starting a new battle now will exceed the max limit of battles you are allowed to be in.");
+				return false;
+			}
 			Rooms.global.searchBattle(user, target);
 		} else {
 			Rooms.global.cancelSearch(user);
@@ -2033,6 +2037,10 @@ var commands = exports.commands = {
 				this.popupReply("Because moderated chat is set, you must be of rank " + groupName + " or higher to challenge users.");
 				return false;
 			}
+		}
+		if (user.exceedMaxBattles()) {
+			this.popupReply("Starting a new battle now will exceed the max limit of battles you are allowed to be in.");
+			return false;
 		}
 		user.prepBattle(Tools.getFormat(target).id, 'challenge', connection, function (result) {
 			if (result) user.makeChallenge(targetUser, target);
@@ -2071,6 +2079,10 @@ var commands = exports.commands = {
 		if (user.challengesFrom[userid]) format = user.challengesFrom[userid].format;
 		if (!format) {
 			this.popupReply(target + " cancelled their challenge before you could accept it.");
+			return false;
+		}
+		if (user.exceedMaxBattles()) {
+			this.popupReply("Starting a new battle now will exceed the max limit of battle rooms you are allowed to be in.");
 			return false;
 		}
 		user.prepBattle(Tools.getFormat(format).id, 'challenge', connection, function (result) {

--- a/users.js
+++ b/users.js
@@ -1373,6 +1373,10 @@ User = (function () {
 		this.autoconfirmed = '';
 		this.updateIdentity();
 	};
+	User.prototype.exceedMaxBattles = function () {
+		var maxBattleLimit = 20;
+		return Object.keys(this.battles).length >= maxBattleLimit;
+	};
 	User.prototype.tryJoinRoom = function (room, connection) {
 		var roomid = (room && room.id ? room.id : room);
 		room = Rooms.search(room);
@@ -1405,6 +1409,10 @@ User = (function () {
 			if (!this.named) {
 				return null;
 			}
+		}
+		if (this.exceedMaxBattles()) {
+			connection.sendTo(roomid, "|noinit|joinfailed|You have reached the max limit of battles you can be in at the same time.");
+			return false;
 		}
 
 		if (Rooms.aliases[toId(roomid)] === room) {


### PR DESCRIPTION
Stops a player from laddering, sending/accepting challenges, and joining an ongoing battle if they have too many battles open already.

The cap at 20 is random, so please give me something better.