### PR TITLE
Implement optional scouting protection for tournaments

### DIFF
--- a/users.js
+++ b/users.js
@@ -1328,7 +1328,16 @@ User = (function () {
 				return false;
 			}
 		}
-		if (room.modjoin && !this.can('bypassall')) {
+		var bypassAll = this.can('bypassall');
+		if (room.tour && !bypassAll) {
+			var tour = room.tour.tour;
+			var errorMessage = tour.onBattleJoin(room, this);
+			if (errorMessage) {
+				connection.sendTo(roomid, "|noinit|joinfailed|" + errorMessage);
+				return false;
+			}
+		}
+		if (room.modjoin && !bypassAll) {
 			var userGroup = this.group;
 			if (room.auth) {
 				if (room.isPrivate === true) {


### PR DESCRIPTION
Tournaments room on main Showdown server has a rule that disallows scouting in a tournament. New users to a room don't often know about that rule, and they get disqualified, and as a result they complain about being disqualified claiming that "opponent hacked to cause them to forfeit".

This commmit enforces that rule when specified for a tournament (it's completely optional to specify it), so a new user wouldn't accidentally scout.

Depends on Zarel/Pokemon-Showdown-Client#459 to work.