### PR TITLE
Fix Mold Breaker Knock Off with Sticky Hold

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -7357,9 +7357,8 @@ exports.BattleMovedex = {
 			}
 		},
 		onAfterHit: function (target, source) {
-			if (target.hasAbility('stickyhold')) return;
 			if (source.hp) {
-				var item = target.takeItem();
+				var item = target.takeItem(source);
 				if (item) {
 					this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
 				}

--- a/test/simulator/abilities/stickyhold.js
+++ b/test/simulator/abilities/stickyhold.js
@@ -1,0 +1,40 @@
+var assert = require('assert');
+var battle;
+
+describe('Sticky Hold', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent held items from being stolen by most moves or abilities', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Shuckle', ability: 'stickyhold', item: 'razzberry', moves: ['recover']}]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Fennekin', ability: 'magician', moves: ['grassknot']},
+			{species: 'Smeargle', ability: 'synchronize', moves: ['thief', 'knockoff', 'switcheroo', 'bugbite']}
+		]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'razzberry');
+		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'razzberry');
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'razzberry');
+		battle.choose('p2', 'move 3');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'razzberry');
+		battle.choose('p2', 'move 4');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'razzberry');
+	});
+
+	it('should be bypassed by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Pangoro', ability: 'moldbreaker', moves: ['knockoff']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Shuckle', ability: 'stickyhold', item: 'ironball', moves: ['rest']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].item, '');
+	});
+});

--- a/test/simulator/moves/knockoff.js
+++ b/test/simulator/moves/knockoff.js
@@ -14,6 +14,22 @@ describe('Knock Off', function () {
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 
+	it('should not remove plates from Arceus', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['knockoff']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Arceus", ability: 'download', item: 'flameplate', moves: ['swordsdance']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].item, 'flameplate');
+	});
+
+	it('should not remove drives from Genesect', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['knockoff']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Genesect", ability: 'download', item: 'dousedrive', moves: ['shiftgear']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].item, 'dousedrive');
+	});
+
 	it('should not remove correctly held mega stones', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['knockoff']}]);
@@ -28,5 +44,13 @@ describe('Knock Off', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Scizor", ability: 'technician', item: 'audinite', moves: ['swordsdance']}]);
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].item, '');
+	});
+
+	it('should not remove items if the user faints mid-move', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Shedinja", ability: 'wonderguard', moves: ['knockoff']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Ferrothorn", ability: 'ironbarbs', item: 'rockyhelmet', moves: ['curse']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].item, 'rockyhelmet');
 	});
 });


### PR DESCRIPTION
Knock Off's function call for target.takeItem was written in such a way
that Sticky Hold could not actively notice and trigger its TakeItem event.
This fixes the function to have the handler called properly.