### PR TITLE
Further upgrade status move tests

### DIFF
--- a/test/simulator/misc/statusmoves.js
+++ b/test/simulator/misc/statusmoves.js
@@ -33,12 +33,15 @@ describe('Most status moves', function () {
 	});
 
 	it('should fail when the opposing Pokemon is immune to the status effect it sets', function () {
+		this.timeout(0);
+
 		battle = BattleEngine.Battle.construct();
-		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'noguard', moves: ['thunderwave', 'willowisp', 'poisongas', 'toxic']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'noguard', item: 'laggingtail', moves: ['thunderwave', 'willowisp', 'poisongas', 'toxic']}]);
 		battle.join('p2', 'Guest 2', 1, [
 			{species: "Zapdos", ability: 'pressure', moves: ['charge']},
 			{species: "Emboar", ability: 'blaze', moves: ['sleeptalk']},
-			{species: "Muk", ability: 'stench', moves: ['shadowsneak']}
+			{species: "Muk", ability: 'stench', moves: ['shadowsneak']},
+			{species: "Aron", ability: 'sturdy', moves: ['magnetrise']}
 		]);
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].status, '');
@@ -55,27 +58,35 @@ describe('Most status moves', function () {
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].status, '');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		battle.choose('p1', 'move 3');
+		battle.choose('p2', 'switch 4');
+		assert.strictEqual(battle.p2.active[0].status, '');
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		battle.choose('p1', 'move 4');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, '');
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 	});
 });
 
-describe('Thunder Wave, poison-inflicting status moves', function () {
+describe('Poison-inflicting status moves [Gen 2]', function () {
 	afterEach(function () {
 		battle.destroy();
 	});
 
 	it('should not ignore type immunities', function () {
-		battle = BattleEngine.Battle.construct();
-		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'noguard', moves: ['thunderwave', 'poisongas', 'toxic']}]);
-		battle.join('p2', 'Guest 2', 1, [
-			{species: "Hippowdon", ability: 'sandforce', moves: ['slackoff']},
-			{species: "Registeel", ability: 'clearbody', moves: ['sleeptalk']}
-		]);
+		battle = BattleEngine.Battle.construct('battle-gsc-psn-steel', 'gen2customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", moves: ['poisonpowder', 'poisongas', 'toxic']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Magneton", moves: ['sleeptalk']}]);
+		// Set all moves to perfect accuracy
+		battle.on('Accuracy', battle.getFormat(), true);
+
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].status, '');
 		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].status, '');
-		battle.choose('p1', 'move 2');
+		battle.choose('p1', 'move 3');
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].status, '');
 	});

--- a/test/simulator/moves/glare.js
+++ b/test/simulator/moves/glare.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var battle;
+
+describe('Glare', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should inflict paralysis on its target', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Arbok", ability: 'noguard', moves: ['glare']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Ekans", ability: 'sturdy', moves: ['bulkup']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, 'par');
+	});
+
+	it('should ignore natural type immunities', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Arbok", ability: 'noguard', moves: ['glare']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Gengar", ability: 'blaze', moves: ['bulkup']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, 'par');
+	});
+});
+
+describe('Glare [Gen 3]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should not ignore natural type immunities', function () {
+		battle = BattleEngine.Battle.construct('battle-rse-glare-ghosts', 'gen3customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: "Arbok", ability: 'noguard', moves: ['glare']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Gengar", ability: 'blaze', moves: ['bulkup']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, '');
+	});
+});

--- a/test/simulator/moves/thunderwave.js
+++ b/test/simulator/moves/thunderwave.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var battle;
+
+describe('Thunder Wave', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should inflict paralysis on its target', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'quickfeet', moves: ['thunderwave']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Vaporeon", ability: 'hydration', moves: ['aquaring']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, 'par');
+	});
+
+	it('should not ignore natural type immunities', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'quickfeet', moves: ['thunderwave']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Hippowdon", ability: 'sandforce', moves: ['slackoff']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].status, '');
+	});
+});


### PR DESCRIPTION
I could have pushed this directly into the main code, but wanted to discuss part of the naming schema we use for our Mocha describe functions when testing oldgen behavior.

For a lot of the old tests, the describes have been in the format `describe('FEATURE - GEN')`, which means if the test fails, you get a message like so:

> Battle simulation Moves Chatter - BW should not pierce through substitutes

The positioning of the hyphen implies that "BW should not pierce through substitutes", which makes no sense. As seen in this pull request, I'm basically proposing that the generation that we're testing for be placed in parentheses instead of using a hyphen as the separator (I've already done this in a few earlier PRs as well, such as #1971).