### PR TITLE
Bug fix: unblock PMs for staff on name change

### DIFF
--- a/users.js
+++ b/users.js
@@ -1024,9 +1024,9 @@ User = (function () {
 			// rename success
 			this.isSysop = isSysop;
 			if (avatar) this.avatar = avatar;
-			if (this.ignorePMs && this.can('lock') && !this.can('bypassall')) this.ignorePMs = false;
 			if (this.forceRename(name, registered)) {
 				Rooms.global.checkAutojoin(this);
+				if (this.ignorePMs && this.can('lock') && !this.can('bypassall')) this.ignorePMs = false;
 				return true;
 			}
 			return false;


### PR DESCRIPTION
`this.can('lock')` was checking if the original username was able to lock rather than the username being switched to. putting after `this.forceRename()` seems to ensure that the user has the correct permissions when the checks if their PMs should be unblocked happens.