### PR TITLE
Fix Thousand Arrows crash when used in chat commands

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1222,7 +1222,10 @@ var commands = exports.commands = {
 			factor = Math.pow(2, totalTypeMod);
 		}
 
-		this.sendReplyBox("" + atkName + " is " + factor + "x effective against " + defName + ".");
+		var hasThousandArrows = source.id === 'thousandarrows' && defender.types.indexOf('Flying') >= 0;
+		var additionalInfo = hasThousandArrows ? "<br>However, Thousand Arrows will be 1x effective on the first hit." : "";
+
+		this.sendReplyBox("" + atkName + " is " + factor + "x effective against " + defName + "." + additionalInfo);
 	},
 	effectivenesshelp: ["/effectiveness [attack], [defender] - Provides the effectiveness of a move or type on another type or a Pok\u00e9mon.",
 		"!effectiveness [attack], [defender] - Shows everyone the effectiveness of a move or type on another type or a Pok\u00e9mon."],
@@ -1237,6 +1240,8 @@ var commands = exports.commands = {
 
 		var dispTable = false;
 		var bestCoverage = {};
+		var hasThousandArrows = false;
+
 		for (var type in Tools.data.TypeChart) {
 			// This command uses -5 to designate immunity
 			bestCoverage[type] = -5;
@@ -1263,6 +1268,7 @@ var commands = exports.commands = {
 			move = Tools.getMove(move);
 			if (move.exists) {
 				if (!move.basePower && !move.basePowerCallback) continue;
+				if (move.id === 'thousandarrows') hasThousandArrows = true;
 				sources.push(move);
 				for (var type in bestCoverage) {
 					if (!Tools.getImmunity(move.type, type) && !move.ignoreImmunity) continue;
@@ -1386,6 +1392,10 @@ var commands = exports.commands = {
 				}
 			}
 			buffer += '</table></div>';
+
+			if (hasThousandArrows) {
+				buffer += "<br><b>Thousand Arrows has neutral type effectiveness on Flying-type Pokemon if not already smacked down.";
+			}
 
 			this.sendReplyBox('Coverage for ' + sources.join(' + ') + ':<br>' + buffer);
 		}

--- a/data/moves.js
+++ b/data/moves.js
@@ -14137,7 +14137,7 @@ exports.BattleMovedex = {
 		basePower: 90,
 		category: "Physical",
 		desc: "This move can hit airborne Pokemon, which includes Flying-type Pokemon, Pokemon with the Ability Levitate, Pokemon holding an Air Balloon, and Pokemon under the effect of Magnet Rise or Telekinesis. If the target is a Flying type and is not already grounded, this move deals neutral damage regardless of its other type(s). This move can hit a target using Bounce, Fly, or Sky Drop. If this move hits a target under the effect of Bounce, Fly, Magnet Rise, or Telekinesis, the effect ends. If the target is a Flying type that has not used Roost this turn or a Pokemon with the Ability Levitate, it loses its immunity to Ground-type attacks and the Ability Arena Trap as long as it remains active. During the effect, Magnet Rise fails for the target and Telekinesis fails against the target.",
-		shortDesc: "Hits adjacent foes, removes Ground immunity.",
+		shortDesc: "Grounds adjacent foes. First hit neutral on Flying.",
 		id: "thousandarrows",
 		isViable: true,
 		name: "Thousand Arrows",

--- a/data/moves.js
+++ b/data/moves.js
@@ -14149,7 +14149,8 @@ exports.BattleMovedex = {
 			if (move.type !== 'Ground') return;
 			var target = this.activeTarget;
 			// only the attack that grounds the target ignores effectiveness
-			if (!this.runEvent('NegateImmunity', target, 'Ground')) return;
+			// if called from a chat plugin, don't ignore effectiveness
+			if (!this.runEvent || !this.runEvent('NegateImmunity', target, 'Ground')) return;
 			if (!this.getImmunity('Ground', target)) return 0;
 		},
 		volatileStatus: 'smackdown',


### PR DESCRIPTION
this.runEvent doesn't exist when the function is run from chat commands,
where 'this' points towards Tools instead of an active battle.