### PR TITLE
Improve error handling for login server requests

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -539,7 +539,7 @@ var GlobalRoom = (function () {
 		var self = this;
 		user.doWithMMR(formatid, function (mmr, error) {
 			if (error) {
-				user.popup("Connection to ladder server failed with error: " + error + "; please try again later");
+				user.popup("Connection to ladder server failed with error: " + error.message + "; please try again later");
 				return;
 			}
 			newSearch.rating = mmr;
@@ -908,7 +908,7 @@ var BattleRoom = (function () {
 						return;
 					}
 					if (!data) {
-						self.addRaw('Ladder (probably) updated, but score could not be retrieved (' + error + ').');
+						self.addRaw('Ladder (probably) updated, but score could not be retrieved (' + error.message + ').');
 						// log the battle anyway
 						if (!Tools.getFormat(self.format).noLog) {
 							self.logBattle(p1score);

--- a/users.js
+++ b/users.js
@@ -1258,22 +1258,15 @@ User = (function () {
 			format: formatid,
 			user: userid
 		}, function (data, statusCode, error) {
-			var mmr = 1000;
-			error = (error || true);
-			if (data) {
-				if (data.errorip) {
-					self.popup("This server's request IP " + data.errorip + " is not a registered server.");
-					return;
-				}
-				mmr = parseInt(data, 10);
-				if (!isNaN(mmr) && self.userid === userid) {
-					error = false;
-					self.mmrCache[formatid] = mmr;
-				} else {
-					mmr = 1000;
-				}
-			}
-			callback(mmr, error);
+			if (!data) return callback(1000, error || new Error("No data received"));
+			if (data.errorip) return self.popup("This server's request IP " + data.errorip + " is not a registered server.");
+
+			var mmr = parseInt(data, 10);
+			if (isNaN(mmr)) return callback(1000, error || new Error("Invalid rating"));
+			if (self.userid !== userid) return callback(1000, new Error("Expired rating"));
+
+			self.mmrCache[formatid] = mmr;
+			callback(mmr, null);
 		});
 	};
 	User.prototype.cacheMMR = function (formatid, mmr) {


### PR DESCRIPTION
- Make sure that error parameters are all instances of `Error`.
- `parseJSON` now distinguishes `null` values from invalid syntax, by returning an object with relevant information.
- Request timeouts are now handled by node built-in `setTimeout` method, and use custom `TimeoutError` (exported from `LoginServer` for debugging).


This helped figure out the crash mentioned at https://github.com/Zarel/Pokemon-Showdown/pull/1910#issuecomment-109660338