### PR TITLE
Fix Quash interaction with self-switching moves

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2726,7 +2726,7 @@ Battle = (function () {
 		}
 		this.add('switch', pokemon, pokemon.getDetails);
 		pokemon.update();
-		this.addQueue({pokemon: pokemon, choice: 'runSwitch'});
+		this.prioritizeQueue({pokemon: pokemon, choice: 'runSwitch'});
 	};
 	Battle.prototype.canSwitch = function (side) {
 		var canSwitchIn = [];
@@ -2795,7 +2795,7 @@ Battle = (function () {
 				this.singleEvent('Start', pokemon.getItem(), pokemon.itemData, pokemon);
 			}
 		} else {
-			this.addQueue({pokemon: pokemon, choice: 'runSwitch'});
+			this.prioritizeQueue({pokemon: pokemon, choice: 'runSwitch'});
 		}
 		return true;
 	};

--- a/data/moves.js
+++ b/data/moves.js
@@ -10472,6 +10472,7 @@ exports.BattleMovedex = {
 			if (target.side.active.length < 2) return false; // fails in singles
 			var decision = this.willMove(target);
 			if (decision) {
+				decision.priority = -7.1;
 				this.cancelMove(target);
 				for (var i = this.queue.length - 1; i >= 0; i--) {
 					if (this.queue[i].choice === 'residual') {

--- a/test/simulator/moves/quash.js
+++ b/test/simulator/moves/quash.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var battle;
+
+describe('Quash', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should cause the target to move last if it has not moved yet', function () {
+		battle = BattleEngine.Battle.construct('battle-quash-1', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Sableye", ability: 'prankster', moves: ['quash']},
+			{species: "Aggron", ability: 'sturdy', moves: ['earthquake']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Arceus", ability: 'multitype', moves: ['voltswitch']},
+			{species: "Aerodactyl", ability: 'unnerve', moves: ['swift']},
+			{species: "Rotom", ability: 'levitate', moves: ['thunderbolt']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.choose('p1', 'move 1 2, move 1');
+		battle.choose('p2', 'move 1 2, move 1');
+		battle.choose('p2', 'switch 3, pass'); // Volt Switch
+		assert.strictEqual(battle.log[battle.lastMoveLine].split('|')[3], 'Swift');
+	});
+
+	it('should not cause the target to move again if it has already moved', function () {
+		battle = BattleEngine.Battle.construct('battle-quash-2', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Sableye", ability: 'prankster', moves: ['quash']},
+			{species: "Aggron", ability: 'sturdy', moves: ['earthquake']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Arceus", ability: 'multitype', moves: ['voltswitch']},
+			{species: "Aerodactyl", ability: 'unnerve', moves: ['extremespeed']},
+			{species: "Rotom", ability: 'levitate', moves: ['thunderbolt']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.choose('p1', 'move 1 2, move 1');
+		battle.choose('p2', 'move 1 2, move 1 1');
+		battle.choose('p2', 'switch 3, pass'); // Volt Switch
+		assert.notStrictEqual(battle.log[battle.lastMoveLine].split('|')[3], 'Extremespeed');
+	});
+});


### PR DESCRIPTION
Give the move demoted by Quash a negative priority when rearranging it in
the queue so that it does not get re-sorted to its original position when
self switch moves run.