### PR TITLE
Cut down on debug messages emitted in runEvent

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2418,7 +2418,7 @@ Battle = (function () {
 		}
 
 		if (!thing.getStatus) {
-			this.debug(JSON.stringify(thing));
+			//this.debug(JSON.stringify(thing));
 			return statuses;
 		}
 		var status = thing.getStatus();


### PR DESCRIPTION
This line of code was emitting a lot of debug messages that are presented
without context and can be confusing to viewers of the battle log.