### PR TITLE
Refactor command parser and add more APIs

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -328,7 +328,7 @@ var commands = exports.commands = {
 	dt: 'details',
 	details: function (target) {
 		if (!target) return this.parse('/help details');
-		CommandParser.commands.data.apply(this, arguments);
+		this.run('data');
 	},
 	detailshelp: ["/details [pokemon] - Get additional details on this pokemon/item/move/ability/nature.",
 		"!details [pokemon] - Show everyone these details. Requires: + % @ # & ~"],

--- a/commands.js
+++ b/commands.js
@@ -838,7 +838,7 @@ var commands = exports.commands = {
 	hm: 'hourmute',
 	hourmute: function (target) {
 		if (!target) return this.parse('/help hourmute');
-		CommandParser.commands.mute.apply(this, arguments);
+		this.run('mute');
 	},
 	hourmutehelp: ["/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. Requires: % @ # & ~"],
 
@@ -1121,7 +1121,7 @@ var commands = exports.commands = {
 	globaldemote: 'demote',
 	demote: function (target) {
 		if (!target) return this.parse('/help demote');
-		CommandParser.commands.promote.apply(this, arguments);
+		this.run('promote');
 	},
 	demotehelp: ["/demote [username], [group] - Demotes the user to the specified group. Requires: & ~"],
 


### PR DESCRIPTION
- Now using prototype inheritance for contexts
- New APIs: `this.cmdToken` and `this.run()`.
- No docs yet, maybe we want different names?

Results
- op/s improvements ranging from 10% to 50% for commands in this benchmark:
http://hastebin.com/iwodelayuv.js
- I'd assume this improves memory usage and garbage collection as well.