### PR TITLE
Fix PP deduction interactions with Pressure

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1961,9 +1961,9 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Pressure');
 		},
-		onSourceDeductPP: function (pp, target, source) {
+		onDeductPP: function (target, source) {
 			if (target.side === source.side) return;
-			return pp + 1;
+			return 1;
 		},
 		id: "pressure",
 		name: "Pressure",

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -98,6 +98,18 @@ exports.BattleScripts = {
 			return true;
 		}
 
+		var targets = pokemon.getMoveTargets(move, target);
+		var extraPP = 0;
+		for (var i = 0; i < targets.length; i++) {
+			var ppDrop = this.singleEvent('DeductPP', targets[i].getAbility(), targets[i].abilityData, targets[i], pokemon, move);
+			if (ppDrop !== true) {
+				extraPP += ppDrop || 0;
+			}
+		}
+		if (extraPP > 0) {
+			pokemon.deductPP(move, extraPP);
+		}
+
 		if (!this.runEvent('TryMove', pokemon, target, move)) {
 			return true;
 		}
@@ -111,22 +123,6 @@ exports.BattleScripts = {
 			damage = this.tryMoveHit(target, pokemon, move);
 			if (damage || damage === 0 || damage === undefined) moveResult = true;
 		} else if (move.target === 'allAdjacent' || move.target === 'allAdjacentFoes') {
-			var targets = [];
-			if (move.target === 'allAdjacent') {
-				var allyActive = pokemon.side.active;
-				for (var i = 0; i < allyActive.length; i++) {
-					if (allyActive[i] && Math.abs(i - pokemon.position) <= 1 && i !== pokemon.position && !allyActive[i].fainted) {
-						targets.push(allyActive[i]);
-					}
-				}
-			}
-			var foeActive = pokemon.side.foe.active;
-			var foePosition = foeActive.length - pokemon.position - 1;
-			for (var i = 0; i < foeActive.length; i++) {
-				if (foeActive[i] && Math.abs(i - foePosition) <= 1 && !foeActive[i].fainted) {
-					targets.push(foeActive[i]);
-				}
-			}
 			if (move.selfdestruct) {
 				this.faint(pokemon, pokemon, move);
 			}
@@ -144,10 +140,7 @@ exports.BattleScripts = {
 			}
 			if (!pokemon.hp) pokemon.faint();
 		} else {
-			if (target.fainted && target.side !== pokemon.side) {
-				// if a targeted foe faints, the move is retargeted
-				target = this.resolveTarget(pokemon, move);
-			}
+			target = targets[0];
 			var lacksTarget = target.fainted;
 			if (!lacksTarget) {
 				if (move.target === 'adjacentFoe' || move.target === 'adjacentAlly' || move.target === 'normal' || move.target === 'randomNormal') {
@@ -158,9 +151,6 @@ exports.BattleScripts = {
 				this.attrLastMove('[notarget]');
 				this.add('-notarget');
 				return true;
-			}
-			if (target.side.active.length > 1) {
-				target = this.runEvent('RedirectTarget', pokemon, pokemon, move, target);
 			}
 			damage = this.tryMoveHit(target, pokemon, move);
 			if (damage || damage === 0 || damage === undefined) moveResult = true;

--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -106,9 +106,9 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Pressure');
 		},
-		onSourceDeductPP: function (pp, target, source) {
+		onDeductPP: function (target, source) {
 			if (target === source) return;
-			return pp + 1;
+			return 1;
 		},
 		id: "pressure",
 		name: "Pressure",

--- a/test/simulator/abilities/pressure.js
+++ b/test/simulator/abilities/pressure.js
@@ -13,7 +13,7 @@ describe('Pressure', function () {
 			{species: "Talonflame", ability: 'galewings', moves: ['peck']}
 		]);
 		battle.join('p2', 'Guest 2', 1, [
-			{species: "Giratina", ability: 'pressure', moves: ['rest']},
+			{species: "Giratina", ability: 'defiant', moves: ['rest']},
 			{species: "Talonflame", ability: 'galewings', moves: ['peck']}
 		]);
 		battle.commitDecisions(); // Team Preview
@@ -24,7 +24,7 @@ describe('Pressure', function () {
 		assert.strictEqual(battle.p2.active[1].getMoveData(move).pp, 54);
 	});
 
-	it.skip('should deduct PP if moves are redirected to the user', function () {
+	it('should deduct PP if moves are redirected to the user', function () {
 		battle = BattleEngine.Battle.construct('battle-pressure-redirect', 'doublescustomgame');
 		battle.join('p1', 'Guest 1', 1, [
 			{species: "Giratina", ability: 'pressure', moves: ['followme']},
@@ -45,7 +45,7 @@ describe('Pressure', function () {
 	it('should deduct PP even if the move fails or misses', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: "Giratina", ability: 'pressure', item: 'laggingtail', moves: ['mistyterrain', 'shadowforce']}]);
-		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['doubleedge', 'spore', 'moonblast']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'desolateland', moves: ['doubleedge', 'spore', 'moonblast', 'surf']}]);
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].getMoveData(Tools.getMove('doubleedge')).pp, 22);
 		battle.choose('p1', 'move 2');
@@ -54,9 +54,12 @@ describe('Pressure', function () {
 		battle.choose('p2', 'move 3');
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].getMoveData(Tools.getMove('moonblast')).pp, 22);
+		battle.choose('p2', 'move 4');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].getMoveData(Tools.getMove('surf')).pp, 22);
 	});
 
-	it.skip('should deduct PP for each Pressure Pokemon targetted', function () {
+	it('should deduct PP for each Pressure Pokemon targetted', function () {
 		battle = BattleEngine.Battle.construct('battle-pressure-multi', 'triplescustomgame');
 		battle.join('p1', 'Guest 1', 1, [
 			{species: "Giratina", ability: 'pressure', moves: ['rest']},
@@ -71,7 +74,7 @@ describe('Pressure', function () {
 		battle.commitDecisions(); // Team Preview
 		battle.commitDecisions();
 		assert.strictEqual(battle.p2.active[0].getMoveData(Tools.getMove('hail')).pp, 12);
-		assert.strictEqual(battle.p2.active[1].getMoveData(Tools.getMove('spikes')).pp, 12);
+		assert.strictEqual(battle.p2.active[1].getMoveData(Tools.getMove('spikes')).pp, 28);
 		assert.strictEqual(battle.p2.active[2].getMoveData(Tools.getMove('rockslide')).pp, 13);
 	});
 });
@@ -98,7 +101,7 @@ describe('Pressure [Gen 4]', function () {
 		assert.strictEqual(battle.p2.active[1].getMoveData(move).pp, 54);
 	});
 
-	it.skip('should deduct PP if moves are redirected to the user', function () {
+	it('should deduct PP if moves are redirected to the user', function () {
 		battle = BattleEngine.Battle.construct('battle-dpp-pressure-redirect', 'gen4doublescustomgame');
 		battle.join('p1', 'Guest 1', 1, [
 			{species: "Giratina", ability: 'pressure', moves: ['followme']},
@@ -108,7 +111,6 @@ describe('Pressure [Gen 4]', function () {
 			{species: "Clefable", ability: 'magicguard', moves: ['followme']},
 			{species: "Ho-Oh", ability: 'pressure', moves: ['peck']}
 		]);
-		battle.commitDecisions(); // Team Preview
 		battle.choose('p1', 'move 1, move 1 2');
 		battle.choose('p2', 'move 1, move 1 2');
 		var move = Tools.getMove('peck');
@@ -127,7 +129,7 @@ describe('Pressure [Gen 4]', function () {
 		assert.strictEqual(battle.p2.active[0].getMoveData(Tools.getMove('dragonpulse')).pp, 14);
 	});
 
-	it.skip('should deduct PP for each Pressure Pokemon targetted', function () {
+	it('should deduct PP for each Pressure Pokemon targetted', function () {
 		battle = BattleEngine.Battle.construct('battle-dpp-pressure-multi', 'gen4doublescustomgame');
 		battle.join('p1', 'Guest 1', 1, [
 			{species: "Palkia", ability: 'pressure', moves: ['rest']},

--- a/test/simulator/moves/followme.js
+++ b/test/simulator/moves/followme.js
@@ -18,14 +18,32 @@ describe('Follow Me', function () {
 			{species: 'Kadabra', ability: 'synchronize', moves: ['lowkick']},
 			{species: 'Alakazam', ability: 'synchronize', moves: ['lowkick']}
 		]);
-		battle.commitDecisions();
+		battle.commitDecisions(); // Team Preview
 		var hitCount = 0;
-		battle.p1.active[0].damage = function () {
-			hitCount++;
-			return BattleEngine.BattlePokemon.prototype.damage.apply(this, arguments);
-		};
+		battle.on('Damage', battle.getFormat(), function (damage, pokemon) {
+			if (pokemon.template.speciesid === 'clefable') {
+				hitCount++;
+			}
+		});
 		battle.choose('p2', 'move 1 2, move 1 2, move 1 2');
 		battle.commitDecisions();
 		assert.strictEqual(hitCount, 2);
+	});
+
+	it('should not redirect self-targetting moves', function () {
+		battle = BattleEngine.Battle.construct('battle-followme-self', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Clefable', ability: 'unaware', moves: ['followme']},
+			{species: 'Clefairy', ability: 'unaware', moves: ['softboiled']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Alakazam', ability: 'synchronize', moves: ['howl']},
+			{species: 'Kadabra', ability: 'synchronize', moves: ['howl']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].boosts['atk'], 0);
+		assert.strictEqual(battle.p2.active[0].boosts['atk'], 1);
+		assert.strictEqual(battle.p2.active[1].boosts['atk'], 1);
 	});
 });


### PR DESCRIPTION
Changed BattlePokemon#deductPP to accept multiple targets, and run the
DeductPP event on each one.

Moved the deductPP function call into useMove so it can accurately query
all targets for the move instead of just one.

---

It's an ugly solution, but it's the only one I could think of that would actually work...