### PR TITLE
Various item removal fixes

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2057,7 +2057,7 @@ Battle = (function () {
 			// it's changed; call it off
 			return relayVar;
 		}
-		if (eventid !== 'Start' && effect.effectType === 'Item' && (target instanceof BattlePokemon) && target.ignoringItem()) {
+		if (eventid !== 'Start' && eventid !== 'TakeItem' && effect.effectType === 'Item' && (target instanceof BattlePokemon) && target.ignoringItem()) {
 			this.debug(eventid + ' handler suppressed by Embargo, Klutz or Magic Room');
 			return relayVar;
 		}
@@ -2243,7 +2243,6 @@ Battle = (function () {
 					Accuracy: 1,
 					RedirectTarget: 1,
 					Heal: 1,
-					TakeItem: 1,
 					SetStatus: 1,
 					CriticalHit: 1,
 					ModifyPokemon: 1,
@@ -2268,7 +2267,7 @@ Battle = (function () {
 					continue;
 				}
 			}
-			if (eventid !== 'Start' && status.effectType === 'Item' && (thing instanceof BattlePokemon) && thing.ignoringItem()) {
+			if (eventid !== 'Start' && eventid !== 'TakeItem' && status.effectType === 'Item' && (thing instanceof BattlePokemon) && thing.ignoringItem()) {
 				if (eventid !== 'ModifyPokemon' && eventid !== 'Update') {
 					this.debug(eventid + ' handler suppressed by Embargo, Klutz or Magic Room');
 				}

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2584,7 +2584,8 @@ exports.BattleAbilities = {
 	"stickyhold": {
 		shortDesc: "This Pokemon cannot lose its held item due to another Pokemon's attack.",
 		onTakeItem: function (item, pokemon, source) {
-			if (source && source !== pokemon) {
+			if (this.suppressingAttackEvents() && pokemon !== this.activePokemon) return;
+			if ((source && source !== pokemon) || this.activeMove.id === 'knockoff') {
 				this.add('-activate', pokemon, 'ability: Sticky Hold');
 				return false;
 			}

--- a/data/items.js
+++ b/data/items.js
@@ -2615,7 +2615,8 @@ exports.BattleItems = {
 		name: "Mail",
 		spritenum: 403,
 		onTakeItem: function (item, source) {
-			if (!this.activeMove || this.activeMove.id !== 'knockoff') return false;
+			if (!this.activeMove) return false;
+			if (this.activeMove.id !== 'knockoff' && this.activeMove.id !== 'thief' && this.activeMove.id !== 'covet') return false;
 		},
 		isUnreleased: true,
 		gen: 2,

--- a/data/moves.js
+++ b/data/moves.js
@@ -7358,7 +7358,7 @@ exports.BattleMovedex = {
 		},
 		onAfterHit: function (target, source) {
 			if (source.hp) {
-				var item = target.takeItem(source);
+				var item = target.takeItem();
 				if (item) {
 					this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
 				}

--- a/test/simulator/abilities/klutz.js
+++ b/test/simulator/abilities/klutz.js
@@ -31,6 +31,14 @@ describe('Klutz', function () {
 		assert.strictEqual(battle.p1.active[0].lastMove, 'protect');
 	});
 
+	it('should not ignore item effects that prevent item removal', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Genesect", ability: 'klutz', item: 'dousedrive', moves: ['calmmind']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['trick']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, 'dousedrive');
+	});
+
 	it('should cause Fling to fail', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'seaincense', moves: ['fling']}]);

--- a/test/simulator/abilities/unburden.js
+++ b/test/simulator/abilities/unburden.js
@@ -51,6 +51,15 @@ describe('Unburden', function () {
 		assert.strictEqual(battle.p1.active[0].getStat('spe'), 2 * speed);
 	});
 
+	it('should not be suppressed by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['leechseed']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Scizor', ability: 'moldbreaker', moves: ['knockoff']}]);
+		var speed = battle.p1.active[0].getStat('spe');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].getStat('spe'), 2 * speed);
+	});
+
 	it('should lose the boost when it gains a new item', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Hitmonlee', ability: 'unburden', item: 'fightinggem', moves: ['machpunch']}]);

--- a/test/simulator/items/drives.js
+++ b/test/simulator/items/drives.js
@@ -1,0 +1,60 @@
+var assert = require('assert');
+var battle;
+var drives = ['Burn Drive', 'Chill Drive', 'Douse Drive', 'Shock Drive'];
+
+describe('Drives', function () {
+	for (var i = 0; i < drives.length; i++) {
+		describe(drives[i], function () {
+			var id = drives[i].replace(/\W+/g, '').toLowerCase();
+
+			afterEach(function () {
+				battle.destroy();
+			});
+
+			it('should not be stolen or removed if held by a Genesect', function () {
+				battle = BattleEngine.Battle.construct();
+				battle.join('p1', 'Guest 1', 1, [{species: 'Genesect', ability: 'frisk', item: id, moves: ['recover']}]);
+				battle.join('p2', 'Guest 2', 1, [
+					{species: 'Fennekin', ability: 'magician', moves: ['mysticalfire']},
+					{species: 'Abra', ability: 'synchronize', moves: ['thief', 'trick', 'knockoff']}
+				]);
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, id);
+				battle.choose('p2', 'switch 2');
+				battle.commitDecisions();
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, id);
+				battle.choose('p2', 'move 2');
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, id);
+				battle.choose('p2', 'move 3');
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, id);
+			});
+
+			it('should not be removed by Fling if held by a Genesect', function () {
+				battle = BattleEngine.Battle.construct();
+				battle.join('p1', 'Guest 1', 1, [{species: 'Mawile', ability: 'intimidate', moves: ['swordsdance']}]);
+				battle.join('p2', 'Guest 2', 1, [{species: 'Genesect', ability: 'frisk', item: id, moves: ['fling']}]);
+				battle.commitDecisions();
+				assert.strictEqual(battle.p2.active[0].item, id);
+			});
+
+			it('should not be given to a Genesect', function () {
+				battle = BattleEngine.Battle.construct();
+				battle.join('p1', 'Guest 1', 1, [{species: 'Genesect', ability: 'frisk', moves: ['thief']}]);
+				battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bestow']}]);
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, '');
+			});
+
+			it('should be removed if not held by a Genesect', function () {
+				battle = BattleEngine.Battle.construct();
+				battle.join('p1', 'Guest 1', 1, [{species: 'Genesect', ability: 'frisk', moves: ['knockoff']}]);
+				battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bulkup']}]);
+				battle.commitDecisions();
+				assert.strictEqual(battle.p2.active[0].item, '');
+			});
+		});
+	}
+});

--- a/test/simulator/items/mail.js
+++ b/test/simulator/items/mail.js
@@ -11,7 +11,7 @@ describe('Mail', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Blissey', ability: 'naturalcure', item: 'mail', moves: ['softboiled']}]);
 		battle.join('p2', 'Guest 2', 1, [
 			{species: 'Fennekin', ability: 'magician', moves: ['grassknot']},
-			{species: 'Abra', ability: 'synchronize', moves: ['thief']},
+			{species: 'Abra', ability: 'synchronize', moves: ['trick']},
 			{species: 'Lopunny', ability: 'klutz', moves: ['switcheroo']}
 		]);
 		battle.commitDecisions();
@@ -38,6 +38,14 @@ describe('Mail', function () {
 		battle = BattleEngine.Battle.construct();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Pangoro', ability: 'ironfist', item: 'mail', moves: ['swordsdance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['knockoff']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].item, 'mail');
+	});
+
+	it('should be stolen by Thief', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Pangoro', ability: 'ironfist', item: 'mail', moves: ['swordsdance']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['thief']}]);
 		battle.commitDecisions();
 		assert.notStrictEqual(battle.p1.active[0].item, 'mail');
 	});

--- a/test/simulator/items/plates.js
+++ b/test/simulator/items/plates.js
@@ -1,0 +1,62 @@
+var assert = require('assert');
+var battle;
+var plates = ['Draco Plate', 'Dread Plate', 'Earth Plate', 'Fist Plate', 'Flame Plate', 'Icicle Plate',
+				'Insect Plate', 'Iron Plate', 'Meadow Plate', 'Mind Plate', 'Pixie Plate', 'Sky Plate',
+				'Splash Plate', 'Spooky Plate', 'Stone Plate', 'Toxic Plate', 'Zap Plate'];
+
+describe('Plates', function () {
+	for (var i = 0; i < plates.length; i++) {
+		describe(plates[i], function () {
+			var id = plates[i].replace(/\W+/g, '').toLowerCase();
+
+			afterEach(function () {
+				battle.destroy();
+			});
+
+			it('should not be stolen or removed if held by an Arceus', function () {
+				battle = BattleEngine.Battle.construct();
+				battle.join('p1', 'Guest 1', 1, [{species: 'Arceus', ability: 'frisk', item: id, moves: ['recover']}]);
+				battle.join('p2', 'Guest 2', 1, [
+					{species: 'Fennekin', ability: 'magician', moves: ['mysticalfire']},
+					{species: 'Abra', ability: 'synchronize', moves: ['thief', 'trick', 'knockoff']}
+				]);
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, id);
+				battle.choose('p2', 'switch 2');
+				battle.commitDecisions();
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, id);
+				battle.choose('p2', 'move 2');
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, id);
+				battle.choose('p2', 'move 3');
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, id);
+			});
+
+			it('should not be removed by Fling if held by an Arceus', function () {
+				battle = BattleEngine.Battle.construct();
+				battle.join('p1', 'Guest 1', 1, [{species: 'Mawile', ability: 'intimidate', moves: ['swordsdance']}]);
+				battle.join('p2', 'Guest 2', 1, [{species: 'Arceus', ability: 'frisk', item: id, moves: ['fling']}]);
+				battle.commitDecisions();
+				assert.strictEqual(battle.p2.active[0].item, id);
+			});
+
+			it('should not be given to an Arceus', function () {
+				battle = BattleEngine.Battle.construct();
+				battle.join('p1', 'Guest 1', 1, [{species: 'Arceus', ability: 'multitype', moves: ['thief']}]);
+				battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bestow']}]);
+				battle.commitDecisions();
+				assert.strictEqual(battle.p1.active[0].item, '');
+			});
+
+			it('should be removed if not held by an Arceus', function () {
+				battle = BattleEngine.Battle.construct();
+				battle.join('p1', 'Guest 1', 1, [{species: 'Arceus', ability: 'multitype', moves: ['knockoff']}]);
+				battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bulkup']}]);
+				battle.commitDecisions();
+				assert.strictEqual(battle.p2.active[0].item, '');
+			});
+		});
+	}
+});


### PR DESCRIPTION
Knock Off no longer broadcasts the source so Arceus can knock off a Plate
from a non-Arceus, Genesect can knock off a Drive, etc. Updated Sticky
Hold to check for Knock Off specifically as a result.

TakeItem is no longer suppressed by Mold Breaker, fixing interaction with
Unburden. Updated Sticky Hold to check for Mold Breaker instead.

Items that prevent their own removal do not have that effect negated by
Klutz and other item-negating effects.

Thief and Covet can steal Mail.