### PR TITLE
Fix OHKO moves' interaction with accuracy-changing abilities/effects

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -367,7 +367,7 @@ exports.BattleAbilities = {
 	},
 	"compoundeyes": {
 		shortDesc: "This Pokemon's moves have their accuracy multiplied by 1.3.",
-		onSourceAccuracy: function (accuracy) {
+		onSourceModifyAccuracy: function (accuracy) {
 			if (typeof accuracy !== 'number') return;
 			this.debug('compoundeyes - enhancing accuracy');
 			return accuracy * 1.3;
@@ -2214,7 +2214,7 @@ exports.BattleAbilities = {
 		onImmunity: function (type, pokemon) {
 			if (type === 'sandstorm') return false;
 		},
-		onAccuracy: function (accuracy) {
+		onModifyAccuracy: function (accuracy) {
 			if (typeof accuracy !== 'number') return;
 			if (this.isWeather('sandstorm')) {
 				this.debug('Sand Veil - decreasing accuracy');
@@ -2428,7 +2428,7 @@ exports.BattleAbilities = {
 		onImmunity: function (type, pokemon) {
 			if (type === 'hail') return false;
 		},
-		onAccuracy: function (accuracy) {
+		onModifyAccuracy: function (accuracy) {
 			if (typeof accuracy !== 'number') return;
 			if (this.isWeather('hail')) {
 				this.debug('Snow Cloak - decreasing accuracy');
@@ -2767,7 +2767,7 @@ exports.BattleAbilities = {
 	},
 	"tangledfeet": {
 		shortDesc: "This Pokemon's evasiveness is doubled as long as it is confused.",
-		onAccuracy: function (accuracy, target) {
+		onModifyAccuracy: function (accuracy, target) {
 			if (typeof accuracy !== 'number') return;
 			if (target && target.volatiles['confusion']) {
 				this.debug('Tangled Feet - decreasing accuracy');
@@ -3140,8 +3140,8 @@ exports.BattleAbilities = {
 	"wonderskin": {
 		desc: "All non-damaging moves that check accuracy have their accuracy changed to 50% when used on this Pokemon. This change is done before any other accuracy modifying effects.",
 		shortDesc: "Status moves with accuracy checks are 50% accurate when used on this Pokemon.",
-		onAccuracyPriority: 10,
-		onAccuracy: function (accuracy, target, source, move) {
+		onModifyAccuracyPriority: 10,
+		onModifyAccuracy: function (accuracy, target, source, move) {
 			if (move.category === 'Status' && typeof move.accuracy === 'number') {
 				this.debug('Wonder Skin - setting accuracy to 50');
 				return 50;

--- a/data/items.js
+++ b/data/items.js
@@ -522,7 +522,7 @@ exports.BattleItems = {
 		fling: {
 			basePower: 10
 		},
-		onAccuracy: function (accuracy) {
+		onModifyAccuracy: function (accuracy) {
 			if (typeof accuracy !== 'number') return;
 			this.debug('brightpowder - decreasing accuracy');
 			return accuracy * 0.9;
@@ -2268,7 +2268,7 @@ exports.BattleItems = {
 		fling: {
 			basePower: 10
 		},
-		onAccuracy: function (accuracy) {
+		onModifyAccuracy: function (accuracy) {
 			if (typeof accuracy !== 'number') return;
 			this.debug('lax incense - decreasing accuracy');
 			return accuracy * 0.9;
@@ -2886,11 +2886,11 @@ exports.BattleItems = {
 		},
 		effect: {
 			duration: 2,
-			onModifyMove: function (move, pokemon) {
-				this.add('-enditem', pokemon, 'Micle Berry');
-				pokemon.removeVolatile('micleberry');
-				if (typeof move.accuracy === 'number') {
-					move.accuracy *= 1.2;
+			onSourceModifyAccuracy: function (accuracy, target, source) {
+				this.add('-enditem', source, 'Micle Berry');
+				source.removeVolatile('micleberry');
+				if (typeof accuracy === 'number') {
+					return accuracy * 1.2;
 				}
 			}
 		},
@@ -4722,9 +4722,9 @@ exports.BattleItems = {
 		fling: {
 			basePower: 10
 		},
-		onModifyMove: function (move) {
-			if (typeof move.accuracy === 'number') {
-				move.accuracy *= 1.1;
+		onSourceModifyAccuracy: function (accuracy) {
+			if (typeof accuracy === 'number') {
+				return accuracy * 1.1;
 			}
 		},
 		num: 265,
@@ -4825,10 +4825,10 @@ exports.BattleItems = {
 		fling: {
 			basePower: 10
 		},
-		onModifyMove: function (move, user, target) {
-			if (typeof move.accuracy === 'number' && !this.willMove(target)) {
+		onSourceModifyAccuracy: function (accuracy, target) {
+			if (typeof accuracy === 'number' && !this.willMove(target)) {
 				this.debug('Zoom Lens boosting accuracy');
-				move.accuracy *= 1.2;
+				return accuracy * 1.2;
 			}
 		},
 		num: 276,

--- a/data/moves.js
+++ b/data/moves.js
@@ -5386,7 +5386,7 @@ exports.BattleMovedex = {
 			onStart: function () {
 				this.add('-fieldstart', 'move: Gravity');
 			},
-			onAccuracy: function (accuracy) {
+			onModifyAccuracy: function (accuracy) {
 				if (typeof accuracy !== 'number') return;
 				return accuracy * 5 / 3;
 			},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -263,6 +263,8 @@ exports.BattleScripts = {
 					return false;
 				}
 			}
+		} else {
+			accuracy = this.runEvent('ModifyAccuracy', target, pokemon, move, accuracy);
 		}
 		if (move.alwaysHit) {
 			accuracy = true; // bypasses ohko accuracy modifiers

--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -96,7 +96,7 @@ exports.BattleAbilities = {
 			}
 			return basePower * 7 / 8;
 		},
-		onAccuracy: function () {}
+		onModifyAccuracy: function () {}
 	},
 	"sandveil": {
 		inherit: true,
@@ -108,7 +108,7 @@ exports.BattleAbilities = {
 				return basePower * 4 / 5;
 			}
 		},
-		onAccuracy: function () {}
+		onModifyAccuracy: function () {}
 	},
 	"waterveil": {
 		inherit: true,
@@ -231,7 +231,7 @@ exports.BattleAbilities = {
 	"compoundeyes": {
 		desc: "The accuracy of this Pokemon's moves receives a 60% increase; for example, a 50% accurate move becomes 80% accurate.",
 		shortDesc: "This Pokemon's moves have their Accuracy boosted to 1.6x.",
-		onSourceAccuracy: function (accuracy) {
+		onSourceModifyAccuracy: function (accuracy) {
 			if (typeof accuracy !== 'number') return;
 			this.debug('compoundeyes - enhancing accuracy');
 			return accuracy * 1.6;

--- a/mods/gennext/items.js
+++ b/mods/gennext/items.js
@@ -49,18 +49,18 @@ exports.BattleItems = {
 	},
 	"widelens": {
 		inherit: true,
-		onModifyMove: function (move, user, target) {
-			if (typeof move.accuracy === 'number') {
-				move.accuracy *= 1.3;
+		onSourceModifyAccuracy: function (accuracy) {
+			if (typeof accuracy === 'number') {
+				return accuracy * 1.3;
 			}
 		}
 	},
 	"zoomlens": {
 		inherit: true,
-		onModifyMove: function (move, user, target) {
-			if (typeof move.accuracy === 'number' && !this.willMove(target)) {
+		onSourceModifyAccuracy: function (accuracy, target) {
+			if (typeof accuracy === 'number' && !this.willMove(target)) {
 				this.debug('Zoom Lens boosting accuracy');
-				move.accuracy *= 1.6;
+				return accuracy * 1.6;
 			}
 		}
 	},


### PR DESCRIPTION
Add a new event ModifyAccuracy that affects all moves other than OHKO
moves and switched many event handlers that originally used the Accuracy
event to ModifyAccuracy instead.

---

Based on a conversation with @Marty-D a few days back. I think I caught
all the relevant event cases after grepping `/on\w*Accuracy/`.

Will change the new event name if it doesn't fit.

@Zarel, about Gen-NEXT Substitute, is it supposed to give OHKO moves
the 100% accuracy as well, or no?