### PR TITLE
Shrink needlessly long prototype chains for battles

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -1566,16 +1566,15 @@ Battle = (function () {
 					return battleProtoCache[formatarg];
 				}
 
-				// Scripts overrides Battle overrides Scripts overrides Tools
+				// Scripts overrides Battle overrides Tools
 				var tools = Tools.mod(formatarg);
 				var proto = Object.create(tools);
 				for (var i in Battle.prototype) {
 					proto[i] = Battle.prototype[i];
 				}
 				var battle = Object.create(proto);
-				var ret = Object.create(battle);
-				tools.install(ret);
-				return (battleProtoCache[formatarg] = ret);
+				tools.install(battle);
+				return (battleProtoCache[formatarg] = battle);
 			})());
 			Battle.prototype.init.call(battle, roomid, formatarg, rated);
 			return battle;

--- a/tools.js
+++ b/tools.js
@@ -986,7 +986,7 @@ module.exports = (function () {
 	};
 
 	/**
-	 * Install our Tools functions into the battle object
+	 * Install our Scripts functions into the battle object
 	 */
 	Tools.prototype.install = function (battle) {
 		for (var i in this.data.Scripts) {
@@ -996,18 +996,15 @@ module.exports = (function () {
 
 	Tools.construct = function (mod, parentMod) {
 		var tools = new Tools(mod, parentMod);
-		// Scripts override Tools.
-		var ret = Object.create(tools);
-		tools.install(ret);
-		if (ret.init) {
-			if (parentMod && ret.init === moddedTools[parentMod].data.Scripts.init) {
+		if (tools.init) {
+			if (parentMod && tools.init === moddedTools[parentMod].data.Scripts.init) {
 				// don't inherit init
-				delete ret.init;
+				delete tools.init;
 			} else {
-				ret.init();
+				tools.init();
 			}
 		}
-		return ret;
+		return tools;
 	};
 
 	moddedTools.base = Tools.construct();


### PR DESCRIPTION
Properties should now be searched in this order:
- Instance
- Scripts installed
- Battle.prototype properties
- <strike>Scripts installed (again)</strike>
- Tools properties
- Object properties