### PR TITLE
Fix behavior with Ability activation in double-KO scenarios

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2704,7 +2704,7 @@ Battle = (function () {
 		}
 		this.add('switch', pokemon, pokemon.getDetails);
 		pokemon.update();
-		this.prioritizeQueue({pokemon: pokemon, choice: 'runSwitch'});
+		this.insertQueue({pokemon: pokemon, choice: 'runSwitch'});
 	};
 	Battle.prototype.canSwitch = function (side) {
 		var canSwitchIn = [];
@@ -2773,7 +2773,7 @@ Battle = (function () {
 				this.singleEvent('Start', pokemon.getItem(), pokemon.itemData, pokemon);
 			}
 		} else {
-			this.prioritizeQueue({pokemon: pokemon, choice: 'runSwitch'});
+			this.insertQueue({pokemon: pokemon, choice: 'runSwitch'});
 		}
 		return true;
 	};
@@ -3463,14 +3463,8 @@ Battle = (function () {
 		}
 		return false;
 	};
-	Battle.prototype.addQueue = function (decision, noSort, side) {
+	Battle.prototype.resolvePriority = function (decision, side) {
 		if (decision) {
-			if (Array.isArray(decision)) {
-				for (var i = 0; i < decision.length; i++) {
-					this.addQueue(decision[i], noSort);
-				}
-				return;
-			}
 			if (!decision.side && side) decision.side = side;
 			if (!decision.side && decision.pokemon) decision.side = decision.pokemon.side;
 			if (!decision.choice && decision.move) decision.choice = 'move';
@@ -3526,11 +3520,44 @@ Battle = (function () {
 				// if there's no actives, switches happen before activations
 				decision.priority = 6.2;
 			}
+		}
+	};
+	Battle.prototype.addQueue = function (decision, noSort, side) {
+		if (decision) {
+			if (Array.isArray(decision)) {
+				for (var i = 0; i < decision.length; i++) {
+					this.addQueue(decision[i], noSort);
+				}
+				return;
+			}
+			this.resolvePriority(decision, side);
 
 			this.queue.push(decision);
 		}
 		if (!noSort) {
 			this.queue.sort(Battle.comparePriority);
+		}
+	};
+	Battle.prototype.insertQueue = function (decision, side) {
+		// WARNING: Do not use this function if the queue is not already sorted!
+		if (decision) {
+			if (Array.isArray(decision)) {
+				for (var i = 0; i < decision.length; i++) {
+					this.insertQueue(decision[i], side);
+				}
+				return;
+			}
+			this.resolvePriority(decision, side);
+
+			for (var i = 0; i <= this.queue.length; i++) {
+				if (i === this.queue.length) {
+					this.queue.push(decision);
+					break;
+				} else if (Battle.comparePriority(decision, this.queue[i]) < 0) {
+					this.queue.splice(i, 0, decision);
+					break;
+				}
+			}
 		}
 	};
 	Battle.prototype.prioritizeQueue = function (decision, source, sourceEffect) {

--- a/test/simulator/abilities/desolateland.js
+++ b/test/simulator/abilities/desolateland.js
@@ -69,6 +69,7 @@ describe('Desolate Land', function () {
 			{species: "Venusaur", ability: 'chlorophyll', moves: ['growth']},
 			{species: "Toxicroak", ability: 'dryskin', moves: ['bulkup']}
 		]);
+		battle.test = true;
 		battle.p1.active[0].damage = function () {
 			if (battle.activeMove.id === 'weatherball') {
 				assert.strictEqual(battle.activeMove.type, 'Fire');

--- a/test/simulator/abilities/intimidate.js
+++ b/test/simulator/abilities/intimidate.js
@@ -44,4 +44,12 @@ describe('Intimidate', function () {
 		assert.strictEqual(battle.p1.active[1].boosts['atk'], -1);
 		assert.strictEqual(battle.p1.active[2].boosts['atk'], 0);
 	});
+
+	it('should wait until all simultaneous switch ins have completed before activating', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Arcanine", ability: 'intimidate', moves: ['morningsun']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'intimidate', moves: ['dragondance']}]);
+		assert.strictEqual(battle.p1.active[0].boosts['atk'], -1);
+		assert.strictEqual(battle.p2.active[0].boosts['atk'], -1);
+	});
 });


### PR DESCRIPTION
Added a new check behavior in addQueue to insert a decision in the correct
position as needed. The 'insert' flag tells addQueue to put the decision
in the correct place, but not re-sort the queue.

----

It's a very temporary and quick fix for the bugs that I introduced in the earlier
Quash PR but it's the best I can do without getting a headache from refactoring
the entire queueing system.

@Zarel @Slayer95 @DanUgore 