### PR TITLE
Prevent global auth from being room deauthed by equal or lower rank

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -573,6 +573,9 @@ var commands = exports.commands = {
 		if (nextGroup !== ' ' && !user.can('room' + Config.groups[nextGroup].id, null, room)) {
 			return this.sendReply("/" + cmd + " - Access denied for promoting/demoting to " + Config.groups[nextGroup].name + ".");
 		}
+		if (nextGroup === ' ' && room.isPrivate !== true && targetUser.group && !user.can('room' + Config.groups[targetUser.group].id, null, room)) {
+			return this.sendReply("/" + cmd + " - Access denied for promoting/demoting to " + Config.groups[targetUser.group].name + ".");
+		}
 
 		if (nextGroup === ' ') {
 			delete room.auth[userid];


### PR DESCRIPTION
I dunno, it feels kind of strange that a room mod cannot room voice a global mod, but can still use de-room voice on room voices with global mod powers.