### PR TITLE
Don't let Cloud Nine suppress Residual or End events from weathers

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2063,7 +2063,7 @@ Battle = (function () {
 			this.debug(eventid + ' handler suppressed by Gastro Acid');
 			return relayVar;
 		}
-		if (effect.effectType === 'Weather' && eventid !== 'TryWeather' && this.suppressingWeather()) {
+		if (effect.effectType === 'Weather' && eventid !== 'Residual' && eventid !== 'End' && this.suppressingWeather()) {
 			this.debug(eventid + ' handler suppressed by Air Lock');
 			return relayVar;
 		}
@@ -2276,7 +2276,7 @@ Battle = (function () {
 				}
 				continue;
 			}
-			if ((status.effectType === 'Weather' || eventid === 'Weather') && eventid !== 'TryWeather' && this.suppressingWeather()) {
+			if ((status.effectType === 'Weather' || eventid === 'Weather') && eventid !== 'Residual' && eventid !== 'End' && this.suppressingWeather()) {
 				this.debug(eventid + ' handler suppressed by Air Lock');
 				continue;
 			}


### PR DESCRIPTION
This allows the client to remove the weather when it expires, even if
there is a Cloud Nine Pokemon on the field.

-----

@Marty-D should confirm if `Residual` should be suppressed or not
because I'm unsure if messages that mention the weather is active
occur or not with Cloud Nine on the field.