### PR TITLE
Detailed battle logs

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -1679,6 +1679,11 @@ Battle = (function () {
 		};
 	})();
 
+	Battle.logReplay = function (data, isReplay) {
+		if (isReplay === true) return data;
+		return '';
+	};
+
 	Battle.prototype = {};
 
 	Battle.prototype.init = function (roomid, formatarg, rated) {
@@ -3121,6 +3126,7 @@ Battle = (function () {
 		if (this.rated) {
 			this.add('rated');
 		}
+		this.add('seed', Battle.logReplay.bind(this, this.startingSeed.join(',')));
 		if (format && format.ruleset) {
 			for (var i = 0; i < format.ruleset.length; i++) {
 				this.addPseudoWeather(format.ruleset[i]);


### PR DESCRIPTION
<strike>- Crashlogger now reports more data of the last request. In particular, the moves available for active Pokémon will now be logged, so that meaningful knowledge can be gained from ``move 2`` etc choice logs.</strike>
- Replays will now log players decision, and starting battle seed. This should be extremely useful for handling bug reports. Requires https://github.com/Slayer95/Pokemon-Showdown-Client/blob/7cda6afcd2bc3dc991aa52bad36bf88ec7640ce7/js/battle.js