### PR TITLE
Implement /shadowjoin

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -114,7 +114,7 @@ function canTalk(user, room, connection, message, targetUser) {
 			}
 		}
 	}
-	if (room && !(user.userid in room.users)) {
+	if (room && !(user.userid in room.users) && !(user.userid in room.hiddenUsers)) {
 		connection.popup("You can't send a message to this room without being in it.");
 		return false;
 	}

--- a/commands.js
+++ b/commands.js
@@ -739,9 +739,15 @@ var commands = exports.commands = {
 
 	joim: 'join',
 	j: 'join',
-	join: function (target, room, user, connection) {
+	shadowjoin: 'join',
+	join: function (target, room, user, connection, cmd) {
 		if (!target) return false;
-		if (user.tryJoinRoom(target, connection) === null) {
+		var hidden = false;
+		if (cmd === "shadowjoin") {
+			if (!user.can('lock')) return this.sendReply("/" + cmd + " - Access denied.");
+			hidden = true;
+		}
+		if (user.tryJoinRoom(target, connection, hidden) === null) {
 			connection.sendTo(target, "|noinit|namerequired|The room '" + target + "' does not exist or requires a login to join.");
 		}
 	},

--- a/users.js
+++ b/users.js
@@ -1329,7 +1329,7 @@ User = (function () {
 		this.autoconfirmed = '';
 		this.updateIdentity();
 	};
-	User.prototype.tryJoinRoom = function (room, connection) {
+	User.prototype.tryJoinRoom = function (room, connection, shadowjoin) {
 		var roomid = (room && room.id ? room.id : room);
 		room = Rooms.search(room);
 		if (!room) {
@@ -1367,7 +1367,7 @@ User = (function () {
 			connection.send(">" + toId(roomid) + "\n|deinit");
 		}
 
-		var joinResult = this.joinRoom(room, connection);
+		var joinResult = this.joinRoom(room, connection, shadowjoin);
 		if (!joinResult) {
 			if (joinResult === null) {
 				connection.sendTo(roomid, "|noinit|joinfailed|You are banned from the room '" + roomid + "'.");
@@ -1378,7 +1378,7 @@ User = (function () {
 		}
 		return true;
 	};
-	User.prototype.joinRoom = function (room, connection) {
+	User.prototype.joinRoom = function (room, connection, shadowjoin) {
 		room = Rooms.get(room);
 		if (!room) return false;
 		if (!this.can('bypassall')) {
@@ -1393,7 +1393,7 @@ User = (function () {
 				// only join full clients, not pop-out single-room
 				// clients
 				if (this.connections[i].rooms['global']) {
-					this.joinRoom(room, this.connections[i]);
+					this.joinRoom(room, this.connections[i], false, shadowjoin);
 				}
 			}
 			return true;
@@ -1402,7 +1402,7 @@ User = (function () {
 			connection.joinRoom(room);
 			if (!this.roomCount[room.id]) {
 				this.roomCount[room.id] = 1;
-				room.onJoin(this, connection);
+				room.onJoin(this, connection, false, shadowjoin);
 			} else {
 				this.roomCount[room.id]++;
 				room.onJoinConnection(this, connection);


### PR DESCRIPTION
This allows staff to join rooms without anyone being able to see them join. This is especially useful for checking on battle games that are suspected to contain problematic users without influencing their behavior by staff presence. 

While shadowjoined to a chat room the user will not appear in the userlist, but is still able to talk / user commands. I still need to make it so that if you join a room you are currently shadowjoined in you properly join the room, however I wanted to make sure this was a desired feature before working on it too much.