### PR TITLE
Make Flower Gift work in battles

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -782,15 +782,13 @@ exports.BattleAbilities = {
 		},
 		onModifyAtkPriority: 3,
 		onAllyModifyAtk: function (atk) {
-			if (this.effectData.target.template.speciesid !== 'cherrim') return;
-			if (this.isWeather(['sunnyday', 'desolateland'])) {
+			if (this.effectData.target.template.speciesid === 'cherrimsunshine') {
 				return this.chainModify(1.5);
 			}
 		},
 		onModifySpDPriority: 4,
 		onAllyModifySpD: function (spd) {
-			if (this.effectData.target.template.speciesid !== 'cherrim') return;
-			if (this.isWeather(['sunnyday', 'desolateland'])) {
+			if (this.effectData.target.template.speciesid === 'cherrimsunshine') {
 				return this.chainModify(1.5);
 			}
 		},

--- a/test/simulator/abilities/flowergift.js
+++ b/test/simulator/abilities/flowergift.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var battle;
+
+describe('Flower Gift', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should boost allies\' physical attacks', function () {
+		battle = BattleEngine.Battle.construct('battle-flowergift-boost', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Cherrim", ability: 'flowergift', moves: ['aromatherapy']},
+			{species: "Snorlax", ability: 'immunity', moves: ['tackle']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Blissey", ability: 'serenegrace', moves: ['aromatherapy']},
+			{species: "Blissey", ability: 'serenegrace', moves: ['aromatherapy']}
+		]);
+		battle.commitDecisions();
+
+		var blissey = battle.p2.active[0];
+
+		battle.choose('p1', 'move 1, move 1 1');
+		battle.choose('p2', 'move 1, move 1');
+
+		var damage = blissey.maxhp - blissey.hp;
+
+		// Restart the battle but with sun
+		blissey.heal(blissey.maxhp);
+		battle.setWeather('sunnyday');
+		battle.seed = battle.startingSeed.slice();
+		battle.choose('p1', 'move 1, move 1 1');
+		battle.choose('p2', 'move 1, move 1');
+
+		var sunDamage = blissey.maxhp - blissey.hp;
+		assert.strictEqual(sunDamage, battle.modify(damage, 1.5));
+	});
+});


### PR DESCRIPTION
Previously, Flower Gift didn't work at all because Cherrim wasn't Cherrim-Sunshine. Now a forme is properly checked to make sure it's Cherrim-Sunshine. Weather test can be skipped, because Cherrim-Sunshine with Flower Gift cannot be used outside of sun (even in Hackmons).