### PR TITLE
Update priority of switches when a player has no actives

### DIFF
--- a/test/simulator/abilities/intimidate.js
+++ b/test/simulator/abilities/intimidate.js
@@ -45,7 +45,7 @@ describe('Intimidate', function () {
 		assert.strictEqual(battle.p1.active[2].boosts['atk'], 0);
 	});
 
-	it('should wait until all simultaneous switch ins have completed before activating', function () {
+	it('should wait until all simultaneous switch ins at the beginning of a battle have completed before activating', function () {
 		battle = BattleEngine.Battle.construct('battle-intimidate-order1', 'customgame');
 		battle.join('p1', 'Guest 1', 1, [{species: "Arcanine", ability: 'intimidate', moves: ['morningsun']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'intimidate', moves: ['dragondance']}]);
@@ -71,6 +71,40 @@ describe('Intimidate', function () {
 		});
 		battle.commitDecisions(); // Finish Team Preview, switch both Pokemon in
 		assert.strictEqual(intimidateCount, 2);
+		assert.strictEqual(battle.p1.active[0].boosts['atk'], -1);
+		assert.strictEqual(battle.p2.active[0].boosts['atk'], -1);
+	});
+
+	it('should wait until all simultaneous switch ins after double-KOs have completed before activating', function () {
+		battle = BattleEngine.Battle.construct('battle-intimidate-ko1', 'customgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Blissey", ability: 'naturalcure', moves: ['healingwish']},
+			{species: "Arcanine", ability: 'intimidate', moves: ['healingwish']},
+			{species: "Gyarados", ability: 'intimidate', moves: ['healingwish']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Blissey", ability: 'naturalcure', moves: ['healingwish']},
+			{species: "Gyarados", ability: 'intimidate', moves: ['healingwish']},
+			{species: "Arcanine", ability: 'intimidate', moves: ['healingwish']}
+		]);
+		var intimidateCount = 0;
+		battle.on('Boost', battle.getFormat(), function (boost, target, source) {
+			assert.strictEqual(source.template.speciesid, intimidateCount % 2 === 0 ? 'arcanine' : 'gyarados');
+			intimidateCount++;
+		});
+		battle.commitDecisions(); // Team Preview
+		battle.commitDecisions();
+		battle.choose('p1', 'switch 2');
+		battle.choose('p2', 'switch 2');
+		// Both Pokemon switched in at the same time
+		assert.strictEqual(intimidateCount, 2);
+		assert.strictEqual(battle.p1.active[0].boosts['atk'], -1);
+		assert.strictEqual(battle.p2.active[0].boosts['atk'], -1);
+		// Do it again with the Pokemon in reverse order
+		battle.commitDecisions();
+		battle.choose('p1', 'switch 3');
+		battle.choose('p2', 'switch 3');
+		assert.strictEqual(intimidateCount, 4);
 		assert.strictEqual(battle.p1.active[0].boosts['atk'], -1);
 		assert.strictEqual(battle.p2.active[0].boosts['atk'], -1);
 	});


### PR DESCRIPTION
Switches and runSwitch were recently updated to priority 7 and 7.1, so
this part needs to be updated as well.