### PR TITLE
Gramatical correction in /roomauth and /authlist

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -613,7 +613,7 @@ var commands = exports.commands = {
 		Object.keys(rankLists).sort(function (a, b) {
 			return (Config.groups[b] || {rank:0}).rank - (Config.groups[a] || {rank:0}).rank;
 		}).forEach(function (r) {
-			buffer.push((Config.groups[r] ? Config.groups[r] .name + "s (" + r + ")" : r) + ":\n" + rankLists[r].sort().join(", "));
+			buffer.push((Config.groups[r] ? Config.groups[r].name + (rankLists[r].sort().length > 1 ? "s" : "") + " (" + r + ")" : r) + ":\n" + rankLists[r].sort().join(", "));
 		});
 
 		if (!buffer.length) {

--- a/commands.js
+++ b/commands.js
@@ -49,10 +49,10 @@ var commands = exports.commands = {
 		Object.keys(rankLists).sort(function (a, b) {
 			return (Config.groups[b] || {rank: 0}).rank - (Config.groups[a] || {rank: 0}).rank;
 		}).forEach(function (r) {
-			buffer.push((Config.groups[r] ? Config.groups[r].name + "s (" + r + ")" : r) + ":\n" + rankLists[r].sortBy(toId).join(", "));
+			buffer.push((Config.groups[r] ? Config.groups[r].name + (rankLists[r].sort().length > 1 ? "s" : "") + " (" + r + ")" : r) + ":\n" + rankLists[r].sortBy(toId).join(", "));
 		});
 
-		if (!buffer.length) buffer = "This server has no auth.";
+		if (!buffer.length) buffer = "This server has no global authority.";
 		connection.popup(buffer.join("\n\n"));
 	},
 


### PR DESCRIPTION
Before, /roomauth (and /authlist) would display that there would be plural of a rank even if there was only one user of that rank.  (Example: http://i.imgur.com/zxfJWSV.png) Now, roomauth and /authlist will look for if there is more than one of each rank and to mark if it is in fact plural or not accordingly.

(Also, slight grammatical change in the return message of /authlist if the server has no global authority.)