### PR TITLE
Normalize ModifySpe calculations with the other Modify-Stat events

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -472,9 +472,7 @@ BattlePokemon = (function () {
 		// stat modifier effects
 		if (!unmodified) {
 			var statTable = {atk:'Atk', def:'Def', spa:'SpA', spd:'SpD', spe:'Spe'};
-			var statMod = 1;
-			statMod = this.battle.runEvent('Modify' + statTable[statName], this, null, null, statMod);
-			stat = this.battle.modify(stat, statMod);
+			stat = this.battle.runEvent('Modify' + statTable[statName], this, null, null, stat);
 		}
 		if (this.battle.getStatCallback) {
 			stat = this.battle.getStatCallback(stat, statName, this, unboosted);

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -288,9 +288,9 @@ exports.BattleAbilities = {
 	},
 	"chlorophyll": {
 		shortDesc: "If Sunny Day is active, this Pokemon's Speed is doubled.",
-		onModifySpe: function (speMod) {
+		onModifySpe: function (spe) {
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
-				return this.chain(speMod, 2);
+				return this.chainModify(2);
 			}
 		},
 		id: "chlorophyll",
@@ -2030,9 +2030,9 @@ exports.BattleAbilities = {
 	"quickfeet": {
 		desc: "If this Pokemon has a major status condition, its Speed is multiplied by 1.5; the Speed drop from paralysis is ignored.",
 		shortDesc: "If this Pokemon is statused, its Speed is 1.5x; ignores Speed drop from paralysis.",
-		onModifySpe: function (speMod, pokemon) {
+		onModifySpe: function (spe, pokemon) {
 			if (pokemon.status) {
-				return this.chain(speMod, 1.5);
+				return this.chainModify(1.5);
 			}
 		},
 		id: "quickfeet",
@@ -2188,9 +2188,9 @@ exports.BattleAbilities = {
 	"sandrush": {
 		desc: "If Sandstorm is active, this Pokemon's Speed is doubled. This Pokemon takes no damage from Sandstorm.",
 		shortDesc: "If Sandstorm is active, this Pokemon's Speed is doubled; immunity to Sandstorm.",
-		onModifySpe: function (speMod, pokemon) {
+		onModifySpe: function (spe, pokemon) {
 			if (this.isWeather('sandstorm')) {
-				return this.chain(speMod, 2);
+				return this.chainModify(2);
 			}
 		},
 		onImmunity: function (type, pokemon) {
@@ -2400,8 +2400,8 @@ exports.BattleAbilities = {
 			onModifyAtk: function (atk, pokemon) {
 				return this.chainModify(0.5);
 			},
-			onModifySpe: function (speMod, pokemon) {
-				return this.chain(speMod, 0.5);
+			onModifySpe: function (spe, pokemon) {
+				return this.chainModify(0.5);
 			},
 			onEnd: function (target) {
 				this.add('-end', target, 'Slow Start');
@@ -2722,9 +2722,9 @@ exports.BattleAbilities = {
 	},
 	"swiftswim": {
 		shortDesc: "If Rain Dance is active, this Pokemon's Speed is doubled.",
-		onModifySpe: function (speMod, pokemon) {
+		onModifySpe: function (spe, pokemon) {
 			if (this.isWeather(['raindance', 'primordialsea'])) {
-				return this.chain(speMod, 2);
+				return this.chainModify(2);
 			}
 		},
 		id: "swiftswim",
@@ -2998,9 +2998,9 @@ exports.BattleAbilities = {
 			pokemon.removeVolatile('unburden');
 		},
 		effect: {
-			onModifySpe: function (speMod, pokemon) {
+			onModifySpe: function (spe, pokemon) {
 				if (!pokemon.item) {
-					return this.chain(speMod, 2);
+					return this.chainModify(2);
 				}
 			}
 		},

--- a/data/items.js
+++ b/data/items.js
@@ -794,8 +794,8 @@ exports.BattleItems = {
 		onModifyMove: function (move, pokemon) {
 			pokemon.addVolatile('choicelock');
 		},
-		onModifySpe: function (speMod) {
-			return this.chain(speMod, 1.5);
+		onModifySpe: function (spe) {
+			return this.chainModify(1.5);
 		},
 		isChoice: true,
 		num: 287,
@@ -2031,8 +2031,8 @@ exports.BattleItems = {
 		onNegateImmunity: function (pokemon, type) {
 			if (type === 'Ground') return false;
 		},
-		onModifySpe: function (speMod) {
-			return this.chain(speMod, 0.5);
+		onModifySpe: function (spe) {
+			return this.chainModify(0.5);
 		},
 		num: 278,
 		gen: 4,
@@ -2550,8 +2550,8 @@ exports.BattleItems = {
 		fling: {
 			basePower: 60
 		},
-		onModifySpe: function (speMod) {
-			return this.chain(speMod, 0.5);
+		onModifySpe: function (spe) {
+			return this.chainModify(0.5);
 		},
 		num: 215,
 		gen: 3,
@@ -3483,9 +3483,9 @@ exports.BattleItems = {
 		fling: {
 			basePower: 10
 		},
-		onModifySpe: function (speMod, pokemon) {
+		onModifySpe: function (spe, pokemon) {
 			if (pokemon.template.species === 'Ditto' && !pokemon.transformed) {
-				return this.chain(speMod, 2);
+				return this.chainModify(2);
 			}
 		},
 		num: 274,

--- a/data/moves.js
+++ b/data/moves.js
@@ -5290,8 +5290,8 @@ exports.BattleMovedex = {
 			onEnd: function (targetSide) {
 				this.add('-sideend', targetSide, 'Grass Pledge');
 			},
-			onModifySpe: function (speMod, pokemon) {
-				return this.chain(speMod, 0.25);
+			onModifySpe: function (spe, pokemon) {
+				return this.chainModify(0.25);
 			}
 		},
 		secondary: false,
@@ -13944,8 +13944,8 @@ exports.BattleMovedex = {
 			onStart: function (side) {
 				this.add('-sidestart', side, 'move: Tailwind');
 			},
-			onModifySpe: function (speMod, pokemon) {
-				return this.chain(speMod, 2);
+			onModifySpe: function (spe, pokemon) {
+				return this.chainModify(2);
 			},
 			onResidualOrder: 21,
 			onResidualSubOrder: 4,

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -19,9 +19,9 @@ exports.BattleStatuses = {
 		onStart: function (target) {
 			this.add('-status', target, 'par');
 		},
-		onModifySpe: function (speMod, pokemon) {
+		onModifySpe: function (spe, pokemon) {
 			if (!pokemon.hasAbility('quickfeet')) {
-				return this.chain(speMod, 0.25);
+				return this.chainModify(0.25);
 			}
 		},
 		onBeforeMovePriority: 1,

--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -7,9 +7,9 @@ exports.BattleAbilities = {
 	},
 	"swiftswim": {
 		inherit: true,
-		onModifySpe: function (speMod, pokemon) {
+		onModifySpe: function (spe, pokemon) {
 			if (this.isWeather(['raindance', 'primordialsea'])) {
-				return this.chain(speMod, 1.5);
+				return this.chainModify(1.5);
 			}
 		}
 	},
@@ -21,9 +21,9 @@ exports.BattleAbilities = {
 	},
 	"chlorophyll": {
 		inherit: true,
-		onModifySpe: function (speMod) {
+		onModifySpe: function (spe) {
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
-				return this.chain(speMod, 1.5);
+				return this.chainModify(1.5);
 			}
 		}
 	},
@@ -41,9 +41,9 @@ exports.BattleAbilities = {
 	},
 	"sandrush": {
 		inherit: true,
-		onModifySpe: function (speMod, pokemon) {
+		onModifySpe: function (spe, pokemon) {
 			if (this.isWeather('sandstorm')) {
-				return this.chain(speMod, 1.5);
+				return this.chainModify(1.5);
 			}
 		}
 	},


### PR DESCRIPTION
The Modify(STAT) events can no longer get a floating-point modifier
because battle.runEvent already calls battle.modify, which rounds it.