### PR TITLE
Fix Defeatist's interaction with HP

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -462,13 +462,13 @@ exports.BattleAbilities = {
 		shortDesc: "While this Pokemon has 1/2 or less of its max HP, its Attack and Sp. Atk are halved.",
 		onModifyAtkPriority: 5,
 		onModifyAtk: function (atk, pokemon) {
-			if (pokemon.hp < pokemon.maxhp / 2) {
+			if (pokemon.hp <= pokemon.maxhp / 2) {
 				return this.chainModify(0.5);
 			}
 		},
 		onModifySpAPriority: 5,
 		onModifySpA: function (atk, pokemon) {
-			if (pokemon.hp < pokemon.maxhp / 2) {
+			if (pokemon.hp <= pokemon.maxhp / 2) {
 				return this.chainModify(0.5);
 			}
 		},


### PR DESCRIPTION
@Marty-D: please stop believing websites that aren't this one or UPC :/
The description for Defeatist is literally "While this Pokemon has 1/2
or less of its maximum HP, its Attack and Special Attack are halved."
I even looked in-game and it said it was half of lower, and even sites
we shouldn't trust say it's 1/2 or less of max HP.