### PR TITLE
Fix Snatch and Imprison's interaction with Pressure

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -541,6 +541,18 @@ BattlePokemon = (function () {
 				target = this.battle.runEvent('RedirectTarget', this, this, move, target);
 			}
 			targets = [target];
+
+			// Resolve apparent targets for Pressure.
+			if (move.pressureTarget) {
+				// At the moment, this is the only supported target.
+				if (move.pressureTarget === 'foeSide') {
+					for (var i = 0; i < this.side.foe.active.length; i++) {
+						if (this.side.foe.active[i] && !this.side.foe.active[i].fainted) {
+							targets.push(this.side.foe.active[i]);
+						}
+					}
+				}
+			}
 		}
 		return targets;
 	};

--- a/data/moves.js
+++ b/data/moves.js
@@ -7010,6 +7010,7 @@ exports.BattleMovedex = {
 			}
 		},
 		secondary: false,
+		pressureTarget: "foeSide",
 		target: "self",
 		type: "Psychic"
 	},
@@ -12699,6 +12700,7 @@ exports.BattleMovedex = {
 			}
 		},
 		secondary: false,
+		pressureTarget: "foeSide",
 		target: "self",
 		type: "Dark"
 	},

--- a/test/simulator/abilities/pressure.js
+++ b/test/simulator/abilities/pressure.js
@@ -77,6 +77,24 @@ describe('Pressure', function () {
 		assert.strictEqual(battle.p2.active[1].getMoveData(Tools.getMove('spikes')).pp, 28);
 		assert.strictEqual(battle.p2.active[2].getMoveData(Tools.getMove('rockslide')).pp, 13);
 	});
+
+	it('should deduct PP for each opposing Pressure Pokemon when Snatch of Imprison are used', function () {
+		battle = BattleEngine.Battle.construct('battle-pressure-snatch', 'triplescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Giratina", ability: 'pressure', moves: ['rest']},
+			{species: "Palkia", ability: 'pressure', moves: ['rest']},
+			{species: "Dialga", ability: 'pressure', moves: ['rest']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Kyurem", ability: 'pressure', moves: ['snatch']},
+			{species: "Zekrom", ability: 'teravolt', moves: ['imprison']},
+			{species: "Reshiram", ability: 'turboblaze', moves: ['rest']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].getMoveData(Tools.getMove('snatch')).pp, 12);
+		assert.strictEqual(battle.p2.active[1].getMoveData(Tools.getMove('imprison')).pp, 12);
+	});
 });
 
 describe('Pressure [Gen 4]', function () {


### PR DESCRIPTION
They're treated as foeSide moves for Pressure, but officially target
themselves.