### PR TITLE
Check if a room exists as an alias before creating it

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -261,6 +261,7 @@ var commands = exports.commands = {
 		var id = toId(target);
 		if (!id) return this.parse('/help makechatroom');
 		if (Rooms.rooms[id]) return this.sendReply("The room '" + target + "' already exists.");
+		if (Rooms.get(id) || Rooms.aliases[id]) return this.sendReply("The room you are trying to make is currently set as an alias for an existing room. (" + Rooms.aliases[id].title + ")");
 		if (Rooms.global.addChatRoom(target)) {
 			if (cmd === 'makeprivatechatroom') {
 				var targetRoom = Rooms.search(target);


### PR DESCRIPTION
It is possible that an Administrator could attempt to make a room that an already existing room has as an alias.  This check will prevent this moving forward.