### PR TITLE
Fixed userlist ranks not appearing on join

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -750,6 +750,7 @@ var GlobalRoom = (function () {
 			if (this.chatRooms.length > 2) connection.send('|queryresponse|rooms|null'); // should display room list
 		}
 
+		user.updateIdentity();
 		return user;
 	};
 	GlobalRoom.prototype.onRename = function (user, oldid, joining) {


### PR DESCRIPTION
Sometimes, ranked users' ranks aren't shown on the userlist when they enter the room. This pull is to fix that.