### PR TITLE
Declare version and support sending config to client

### DIFF
--- a/app.js
+++ b/app.js
@@ -309,8 +309,6 @@ global.toId = function (text) {
 
 global.Tools = require('./tools.js').includeFormats();
 
-global.LoginServer = require('./loginserver.js');
-
 global.Users = require('./users.js');
 
 global.Rooms = require('./rooms.js');
@@ -318,6 +316,7 @@ global.Rooms = require('./rooms.js');
 // Generate and cache the format list.
 Rooms.global.formatListText = Rooms.global.getFormatListText();
 
+global.LoginServer = require('./loginserver.js');
 
 delete process.send; // in case we're a child process
 global.Verifier = require('./verifier.js');

--- a/command-parser.js
+++ b/command-parser.js
@@ -529,12 +529,6 @@ var parse = exports.parse = function (message, room, user, connection, levelsDee
 	return message || false;
 };
 
-exports.package = {};
-fs.readFile(path.resolve(__dirname, 'package.json'), function (err, data) {
-	if (err) return;
-	exports.package = JSON.parse(data);
-});
-
 exports.uncacheTree = function (root) {
 	var uncache = [require.resolve(root)];
 	do {

--- a/commands.js
+++ b/commands.js
@@ -24,7 +24,7 @@ var commands = exports.commands = {
 
 	version: function (target, room, user) {
 		if (!this.canBroadcast()) return;
-		this.sendReplyBox("Server version: <b>" + CommandParser.package.version + "</b>");
+		this.sendReplyBox("Server version: <b>" + Rooms.global.version + "</b>");
 	},
 
 	auth: 'authority',

--- a/loginserver.js
+++ b/loginserver.js
@@ -244,3 +244,5 @@ require('fs').watchFile('./config/custom.css', function (curr, prev) {
 	LoginServer.request('invalidatecss', {}, function () {});
 });
 LoginServer.request('invalidatecss', {}, function () {});
+
+LoginServer.request('updateversion', {version: Rooms.global.version}, function () {});

--- a/rooms.js
+++ b/rooms.js
@@ -282,6 +282,7 @@ var Room = (function () {
 var GlobalRoom = (function () {
 	function GlobalRoom(roomid) {
 		this.id = roomid;
+		this.version = require('./package.json').version;
 
 		// init battle rooms
 		this.battleCount = 0;
@@ -418,6 +419,8 @@ var GlobalRoom = (function () {
 	GlobalRoom.prototype.type = 'global';
 
 	GlobalRoom.prototype.formatListText = '|formats';
+
+	GlobalRoom.prototype.configText = '|config|{}';
 
 	GlobalRoom.prototype.reportUserStats = function () {
 		if (this.maxUsersDate) {
@@ -731,7 +734,7 @@ var GlobalRoom = (function () {
 	};
 	GlobalRoom.prototype.onJoinConnection = function (user, connection) {
 		var initdata = '|updateuser|' + user.name + '|' + (user.named ? '1' : '0') + '|' + user.avatar + '\n';
-		connection.send(initdata + this.formatListText);
+		connection.send(initdata + this.formatListText + '\n|version|' + this.version + '\n' + this.configText);
 		if (this.chatRooms.length > 2) connection.send('|queryresponse|rooms|null'); // should display room list
 	};
 	GlobalRoom.prototype.onJoin = function (user, connection, merging) {
@@ -746,7 +749,7 @@ var GlobalRoom = (function () {
 
 		if (!merging) {
 			var initdata = '|updateuser|' + user.name + '|' + (user.named ? '1' : '0') + '|' + user.avatar + '\n';
-			connection.send(initdata + this.formatListText);
+			connection.send(initdata + this.formatListText + '\n|version|' + this.version + '\n' + this.configText);
 			if (this.chatRooms.length > 2) connection.send('|queryresponse|rooms|null'); // should display room list
 		}
 
@@ -877,6 +880,7 @@ var BattleRoom = (function () {
 
 		this.rated = rated;
 		this.battle = Simulator.create(this.id, format, rated, this);
+		this.add('|version|' + rooms.global.version);
 
 		this.sideTicksLeft = [21, 21];
 		if (!rated && !this.tour) this.sideTicksLeft = [28, 28];


### PR DESCRIPTION
Requires https://github.com/Zarel/Pokemon-Showdown-Client/pull/441

Client will be aware of version and config.
Login server will be aware of version as well, which will allow replay server to server specific battle data/scripts files according to the version stored with the replay.