### PR TITLE
Add support to randbats for mega stone banning

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1882,7 +1882,11 @@ exports.BattleScripts = {
 			// Holistic judgment
 			Ninetales: 79, Politoed: 79, Unown: 85, Wobbuffet: 79
 		};
-		var level = levelScale[template.tier] || 90;
+		var tier = template.tier;
+		if (tier.charAt(0) === '(') {
+			tier = tier.slice(1, -1);
+		}
+		var level = levelScale[tier] || 90;
 		if (customScale[template.name]) level = customScale[template.name];
 
 		if (template.name === 'Xerneas' && hasMove['geomancy']) level = 71;


### PR DESCRIPTION
This fixes a problem introduced by 77b6b666 causing certain Pokemon with mega stones (and base forme of Audino) to have level 90 in randbats.

This commit intentionally doesn't introduce any new levels for mons who have their tier in parenthesis. Looking over the list of mons who don't have hardcoded levels, most of them are barely improvement over their base forme, which is the issue in a standard tiers with its limit of one mega. However, because teams don't have to use a mega in randbats (because of how its generator works), getting just a slightly version of a Pokemon is not a big deal as it's still an improvement, even if minor.