### PR TITLE
Refactor move redirection

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -538,7 +538,7 @@ BattlePokemon = (function () {
 				target = this.battle.resolveTarget(this, move);
 			}
 			if (target.side.active.length > 1) {
-				target = this.battle.runEvent('RedirectTarget', this, this, move, target);
+				target = this.battle.priorityEvent('RedirectTarget', this, this, move, target);
 			}
 			targets = [target];
 
@@ -2271,7 +2271,7 @@ Battle = (function () {
 	 *   variables that are passed as arguments to the event handler, but
 	 *   they're useful for functions called by the event handler.
 	 */
-	Battle.prototype.runEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+	Battle.prototype.runEvent = function (eventid, target, source, effect, relayVar, onEffect, fastExit) {
 		if (this.eventDepth >= 8) {
 			// oh fuck
 			this.add('message', 'STACK LIMIT EXCEEDED');
@@ -2375,7 +2375,7 @@ Battle = (function () {
 
 			if (returnVal !== undefined) {
 				relayVar = returnVal;
-				if (!relayVar) break;
+				if (!relayVar || fastExit) break;
 				if (hasRelayVar) {
 					args[0] = relayVar;
 				}
@@ -2390,6 +2390,13 @@ Battle = (function () {
 		this.event = parentEvent;
 
 		return relayVar;
+	};
+	/**
+	 * priorityEvent works just like runEvent, except it exits and returns
+	 * on the first non-undefined value instead of only on null/false.
+	 */
+	Battle.prototype.priorityEvent = function (eventid, target, source, effect, relayVar, onEffect) {
+		return this.runEvent(eventid, target, source, effect, relayVar, onEffect, true);
 	};
 	Battle.prototype.resolveLastPriority = function (statuses, callbackType) {
 		var order = false;

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1359,7 +1359,6 @@ exports.BattleAbilities = {
 				return null;
 			}
 		},
-		onAnyRedirectTargetPriority: 1,
 		onAnyRedirectTarget: function (target, source, source2, move) {
 			if (move.type !== 'Electric' || move.id in {firepledge:1, grasspledge:1, waterpledge:1}) return;
 			if (this.validTarget(this.effectData.target, source, move.target)) {
@@ -2610,7 +2609,6 @@ exports.BattleAbilities = {
 				return null;
 			}
 		},
-		onAnyRedirectTargetPriority: 1,
 		onAnyRedirectTarget: function (target, source, source2, move) {
 			if (move.type !== 'Water' || move.id in {firepledge:1, grasspledge:1, waterpledge:1}) return;
 			if (this.validTarget(this.effectData.target, source, move.target)) {

--- a/data/moves.js
+++ b/data/moves.js
@@ -2118,6 +2118,7 @@ exports.BattleMovedex = {
 				this.effectData.position = null;
 				this.effectData.damage = 0;
 			},
+			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
 				return source.side.foe.active[this.effectData.position];
@@ -4643,6 +4644,7 @@ exports.BattleMovedex = {
 		volatileStatus: 'followme',
 		effect: {
 			duration: 1,
+			onFoeRedirectTargetPriority: 1,
 			onFoeRedirectTarget: function (target, source, source2, move) {
 				if (this.validTarget(this.effectData.target, source, move.target)) {
 					this.debug("Follow Me redirected target of move");
@@ -8339,6 +8341,7 @@ exports.BattleMovedex = {
 				this.effectData.position = null;
 				this.effectData.damage = 0;
 			},
+			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
 				return source.side.foe.active[this.effectData.position];
@@ -8633,6 +8636,7 @@ exports.BattleMovedex = {
 				this.effectData.position = null;
 				this.effectData.damage = 0;
 			},
+			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
 				return source.side.foe.active[this.effectData.position];
@@ -10606,6 +10610,7 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-start', pokemon, 'move: Rage Powder');
 			},
+			onFoeRedirectTargetPriority: 1,
 			onFoeRedirectTarget: function (target, source, source2, move) {
 				if (source.runImmunity('powder') && this.validTarget(this.effectData.target, source, move.target)) {
 					this.debug("Rage Powder redirected target of move");
@@ -12311,7 +12316,7 @@ exports.BattleMovedex = {
 					return null;
 				}
 			},
-			onRedirectTargetPriority: -99,
+			onRedirectTargetPriority: 99,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
 				if (this.effectData.source.fainted) return;

--- a/mods/gen3/abilities.js
+++ b/mods/gen3/abilities.js
@@ -51,7 +51,6 @@ exports.BattleAbilities = {
 	"lightningrod": {
 		desc: "During double battles, this Pokemon draws any single-target Electric-type attack to itself. If an opponent uses an Electric-type attack that affects multiple Pokemon, those targets will be hit. This ability does not affect Electric Hidden Power or Judgment.",
 		shortDesc: "This Pokemon draws opposing Electric moves to itself.",
-		onFoeRedirectTargetPriority: 1,
 		onFoeRedirectTarget: function (target, source, source2, move) {
 			if (move.type !== 'Electric') return;
 			if (this.validTarget(this.effectData.target, source, move.target)) {

--- a/test/simulator/abilities/lightningrod.js
+++ b/test/simulator/abilities/lightningrod.js
@@ -43,6 +43,42 @@ describe('Lightning Rod', function () {
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
+	it('should redirect to the fastest Pokemon with the ability', function () {
+		battle = BattleEngine.Battle.construct('battle-lightningrod-speed', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Manectric', ability: 'lightningrod', moves: ['sleeptalk']},
+			{species: 'Manectric', ability: 'lightningrod', moves: ['sleeptalk']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
+			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.p1.active[0].boostBy({spe: 6});
+		battle.choose('p1', 'move 1, move 1');
+		battle.choose('p2', 'move 1 1, move 1 2');
+		assert.strictEqual(battle.p1.active[0].boosts['spa'], 2);
+		assert.strictEqual(battle.p1.active[1].boosts['spa'], 0);
+	});
+
+	it('should not redirect if another Pokemon has used Follow Me', function () {
+		battle = BattleEngine.Battle.construct('battle-lightningrod-followme', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Manectric', ability: 'lightningrod', moves: ['sleeptalk']},
+			{species: 'Manectric', ability: 'static', moves: ['followme']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
+			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.p1.active[0].boostBy({spe: 6});
+		battle.choose('p1', 'move 1, move 1');
+		battle.choose('p2', 'move 1 2, move 1 1');
+		assert.strictEqual(battle.p1.active[0].boosts['spa'], 0);
+		assert.notStrictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+	});
+
 	it('should have its Electric-type immunity and its ability to redirect moves suppressed by Mold Breaker', function () {
 		battle = BattleEngine.Battle.construct('battle-moldbreaker-lightningrod', 'doublescustomgame');
 		battle.join('p1', 'Guest 1', 1, [

--- a/test/simulator/abilities/stormdrain.js
+++ b/test/simulator/abilities/stormdrain.js
@@ -35,6 +35,42 @@ describe('Storm Drain', function () {
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
+	it('should redirect to the fastest Pokemon with the ability', function () {
+		battle = BattleEngine.Battle.construct('battle-doubles-stormdrain-speed', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk']},
+			{species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Azumarill', ability: 'thickfat', moves: ['waterfall']},
+			{species: 'Azumarill', ability: 'thickfat', moves: ['waterfall']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.p1.active[0].boostBy({spe: 6});
+		battle.choose('p1', 'move 1, move 1');
+		battle.choose('p2', 'move 1 1, move 1 2');
+		assert.strictEqual(battle.p1.active[0].boosts['spa'], 2);
+		assert.strictEqual(battle.p1.active[1].boosts['spa'], 0);
+	});
+
+	it('should not redirect if another Pokemon has used Follow Me', function () {
+		battle = BattleEngine.Battle.construct('battle-stormdrain-followme', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk']},
+			{species: 'Azumarill', ability: 'thickfat', moves: ['followme']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']},
+			{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.p1.active[0].boostBy({spe: 6});
+		battle.choose('p1', 'move 1, move 1');
+		battle.choose('p2', 'move 1 2, move 1 1');
+		assert.strictEqual(battle.p1.active[0].boosts['spa'], 0);
+		assert.notStrictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+	});
+
 	it('should have its Water-type immunity and its ability to redirect moves suppressed by Mold Breaker', function () {
 		battle = BattleEngine.Battle.construct('battle-moldbreaker-stormdrain', 'doublescustomgame');
 		battle.join('p1', 'Guest 1', 1, [


### PR DESCRIPTION
Implemented a new priorityEvent function that is set to abort when any
event handler returns a non-undefined result, unlike runEvent which waits
until all event handlers have run. Set RedirectTarget to use this event.

Changed ability/move priorities for RedirectTarget handlers to fit under
this new paradigm.

Added new Lightning Rod and Storm Drain tests to ensure proper behavior.