### PR TITLE
Shield Dust does not block self-boosting secondaries

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2323,11 +2323,11 @@ Battle = (function () {
 					ModifyAtk: 1, ModifyDef: 1, ModifySpA: 1, ModifySpD: 1, ModifySpe: 1,
 					ModifyBoost: 1,
 					ModifyDamage: 1,
+					ModifySecondaries: 1,
 					ModifyWeight: 1,
 					TryHit: 1,
 					TryHitSide: 1,
 					TryMove: 1,
-					TrySecondaryHit: 1,
 					Hit: 1,
 					Boost: 1,
 					DragOut: 1

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2350,9 +2350,11 @@ exports.BattleAbilities = {
 	},
 	"shielddust": {
 		shortDesc: "This Pokemon is not affected by the secondary effect of another Pokemon's attack.",
-		onTrySecondaryHit: function () {
+		onModifySecondaries: function (secondaries) {
 			this.debug('Shield Dust prevent secondary');
-			return null;
+			return secondaries.filter(function (effect) {
+				return !!effect.self;
+			});
 		},
 		id: "shielddust",
 		name: "Shield Dust",

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -551,12 +551,13 @@ exports.BattleScripts = {
 				this.moveHit(pokemon, pokemon, move, moveData.self, isSecondary, true);
 			}
 		}
-		if (moveData.secondaries && this.runEvent('TrySecondaryHit', target, pokemon, moveData)) {
+		if (moveData.secondaries) {
 			var secondaryRoll;
-			for (var i = 0; i < moveData.secondaries.length; i++) {
+			var secondaries = this.runEvent('ModifySecondaries', target, pokemon, moveData, moveData.secondaries.slice());
+			for (var i = 0; i < secondaries.length; i++) {
 				secondaryRoll = this.random(100);
-				if (typeof moveData.secondaries[i].chance === 'undefined' || secondaryRoll < moveData.secondaries[i].chance) {
-					this.moveHit(target, pokemon, move, moveData.secondaries[i], true, isSelf);
+				if (typeof secondaries[i].chance === 'undefined' || secondaryRoll < secondaries[i].chance) {
+					this.moveHit(target, pokemon, move, secondaries[i], true, isSelf);
 				}
 			}
 		}

--- a/test/simulator/abilities/shielddust.js
+++ b/test/simulator/abilities/shielddust.js
@@ -1,0 +1,77 @@
+var assert = require('assert');
+var battle;
+
+describe('Shield Dust', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should block secondary effects against the user', function () {
+		battle = BattleEngine.Battle.construct('battle-shielddust', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Latios', ability: 'noguard', moves: ['snarl']},
+			{species: 'Latias', ability: 'levitate', moves: ['roost']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Xerneas', ability: 'shielddust', moves: ['roost']},
+			{species: 'Yveltal', ability: 'pressure', moves: ['roost']}
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
+		assert.strictEqual(battle.p2.active[1].boosts['spa'], -1);
+	});
+
+	it('should not block secondary effects that affect the user of the move', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Ledian', ability: 'ironfist', moves: ['poweruppunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Dustox', ability: 'shielddust', moves: ['roost']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].boosts['atk'], 1);
+	});
+
+	it('should block added effects from items', function () {
+		battle = BattleEngine.Battle.construct('battle-kingsrock', 'customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Talonflame', ability: 'flamebody', item: 'kingsrock', moves: ['flamecharge']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Clefable', ability: 'shielddust', moves: ['cottonguard']}]);
+		battle.on('ModifyMove', battle.getFormat(), function (move) {
+			if (move.secondaries) {
+				for (var i = 0; i < move.secondaries.length; i++) {
+					move.secondaries[i].chance = 100;
+				}
+			}
+		});
+		battle.commitDecisions(); // Team Preview
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].boosts['spe'], 1);
+		assert.strictEqual(battle.p2.active[0].boosts['def'], 3); // Clefable did not flinch
+	});
+
+	it('should block added effects from Fling', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Ledian', ability: 'ironfist', item: 'petayaberry', moves: ['fling']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Dustox', ability: 'shielddust', moves: ['roost']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].boosts['spa'], 1);
+	});
+
+	it('should not block secondary effects on attacks used by the Pokemon with the ability', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Ledian', ability: 'shielddust', moves: ['poweruppunch', 'strugglebug']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Clefable', ability: 'unaware', moves: ['softboiled']}]);
+		battle.choose('p1', 'move 1');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].boosts['atk'], 1);
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].boosts['spa'], -1);
+	});
+
+	it('should be negated by Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Pinsir', ability: 'moldbreaker', moves: ['strugglebug']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Dustox', ability: 'shielddust', moves: ['roost']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].boosts['spa'], -1);
+	});
+});


### PR DESCRIPTION
Refactor TrySecondaryHit to become ModifySecondaries instead to allow for
proper behavior.