### PR TITLE
Escape HTML in room descriptions

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -395,9 +395,8 @@ var commands = exports.commands = {
 	roomdesc: function (target, room, user) {
 		if (!target) {
 			if (!this.canBroadcast()) return;
-			var re = /(https?:\/\/(([-\w\.]+)+(:\d+)?(\/([\w/_\.]*(\?\S+)?)?)?))/g;
 			if (!room.desc) return this.sendReply("This room does not have a description set.");
-			this.sendReplyBox("The room description is: " + room.desc.replace(re, '<a href="$1">$1</a>'));
+			this.sendReplyBox("The room description is: " + Tools.escapeHTML(room.desc));
 			return;
 		}
 		if (!this.can('declare')) return false;


### PR DESCRIPTION
Now, escape HTML in room descriptions to prevent things like this from being possible: http://prntscr.com/8g0mjy