### PR TITLE
Add -ability tag to Imposter activation

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1175,6 +1175,7 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			var target = pokemon.side.foe.active[pokemon.side.foe.active.length - 1 - pokemon.position];
 			if (target) {
+				this.add('-ability', pokemon, 'Imposter');
 				pokemon.transformInto(target, pokemon);
 			}
 		},


### PR DESCRIPTION
The other option is to modify `transformInto` in such a way that it broadcasts `-transform` messages to use the correct `[from]` parameter, then add a client change to check for it.

Either way will allow Imposter to be properly tracked by the client.