### PR TITLE
Fix negation of boolean conditions in /ds

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -532,7 +532,7 @@ var commands = exports.commands = {
 
 		for (var cat = 0; cat < categories.length; cat++) {
 			var search = categories[cat];
-			if (!searches[search]) continue;
+			if (!(search in searches)) continue;
 			switch (search) {
 			case 'types':
 				for (var mon in dex) {


### PR DESCRIPTION
Previously, something like !ds !recovery didn't work, because the existence search check assumed that the search cannot be called with parameter false. However, boolean searches like recovery and priority do simply use booleans.