### PR TITLE
Gen-NEXT: Update README.md

### DIFF
--- a/mods/gennext/README.md
+++ b/mods/gennext/README.md
@@ -52,8 +52,8 @@ Major changes:
   everything else.
 
 - Drives will change Genesect's typing immediately after switch-in, to Bug/Ice,
-  Bug/Fire, Bug/Electric, or Bug/Water. However, Download will not activate
-  unless Genesect holds a Drive.
+  Bug/Fire, Bug/Electric, or Bug/Water. However, Download will not activate for
+  Genesect unless it holds a Drive.
 
 - Unown gets an item named Strange Orb (select "Stick" in the teambuilder)
   It doubles its SpA, SpD, and Spe, and changes its type to the type of its
@@ -67,7 +67,7 @@ Major changes:
   Hail last forever. Probopass will make Sandstorm last forever.
 
 - Hail is improved:
-  - Silver Wind, Ominous Wind, and Avalanche deal 1.5x as much damage in Hail
+  - Silver Wind, Ominous Wind, and Avalanche deal 1.5x damage in Hail
   - Snow Cloak no longer modifies evasion, but instead decreases damage by 25%
     in Hail (and 12.5% out of Hail)
   - Ice Body has 30% chance of freezing a contact move (and grants passive
@@ -139,7 +139,7 @@ Major changes:
 
 - Twister is now a 80 base power Flying move with a 30% confusion chance
 
-- - Hoopa (both forms), Floette-Eternal-Flower, and Volcanion are released.
+- - Floette-Eternal-Flower and Volcanion are released.
 
 New mechanic: Signature Pokémon:
 
@@ -210,31 +210,31 @@ New mechanic: Intrinsics:
 - Pokémon that previously get Levitate are now immune to Ground intrinsically.
   Instead, they get new abilities in addition to their Ground immunity:
 
-  - Unown: Shadow Tag
+  - Azelf: Steadfast
 
   - Bronzong: Heatproof
-
-  - Flygon: Compoundeyes, Sand Rush
-
-  - Weezing: Aftermath
-
-  - Eelektross: Poison Heal
 
   - Claydol: Filter
 
   - Cryogonal: Ice Body
 
+  - Eelektross: Poison Heal
+
+  - Flygon: Compoundeyes, Sand Rush
+
   - Gengar: Cursed Body
 
-  - Mismagius: Cursed Body
+  - Hydreigon: Sheer Force
 
   - Mesprit: Serene Grace
 
+  - Mismagius: Cursed Body
+
+  - Unown: Shadow Tag
+
   - Uxie: Synchronize
 
-  - Azelf: Steadfast
-
-  - Hydreigon: Sheer Force
+  - Weezing: Aftermath
 
 New: Type-specific items:
 
@@ -242,8 +242,8 @@ New: Type-specific items:
 
 - Black Sludge: heals 1/8 per turn for pure Poison types
 
-- Focus Band: always works, but breaks after getting hit once for
-  pure Fighting types (so basically it'd be a Sash that stays intact
+- Focus Band: breaks on first hit, but allows pure Fighting types to survive
+  that hit with 1 HP (so basically it'd be a Focus sash that stays intact
   after residual damage); does nothing for other Pokémon
 
 - Wise Glasses: 1.2x Special damage for pure Psychic types
@@ -288,8 +288,6 @@ Minor move changes:
 
 - Multi-hit moves are now all perfect-accuracy
 
-- Whirlwind and Roar have perfect accuracy
-
 - Silver Wind, Ominous Wind, and AncientPower have a 100% chance of raising
   one of Def/SpA/SpD/Spe at random, rather than a 10% chance of raising every
   stat
@@ -331,10 +329,10 @@ Minor move changes:
 
 - Autotomize now gives +3 Speed
 
-- Zoroark gets a significantly wider movepool: It now learns: Ice Beam, Giga
+- Zoroark gets a significantly wider movepool. It now learns: Ice Beam, Giga
   Drain, Earthquake, Stone Edge, Superpower, X-Scissor
 
-- if Illusion is active, Night Daze now displays as a random non-Status move
+- If Illusion is active, Night Daze now displays as a random non-Status move
   in the copied Pokémon's moveset
 
 - Selfdestruct and Explosion are now 200 and 250 base power autocrit moves,
@@ -358,7 +356,7 @@ Minor move changes:
 
 Minor learnset changes:
 
-- Azumarill now gets Belly Drum with no incompatibilities
+- Azumarill gets Belly Drum with no incompatibilities
 
 - Mantine gets many new moves: Recover, Whirlwind, Baton Pass, Wish, Soak,
   Lock-On, Acid Spray, Octazooka, Stockpile
@@ -406,6 +404,9 @@ Minor learnset changes:
   - Delphox: Magic Guard
   - Greninja: Pickpocket
 
+- Crawdaunt's Hidden Ability is now Tough Claws (this is because of a
+  nerf to Adaptability which is discussed below)
+
 Minor ability changes:
 
 - Justified now caps base power to 100 against non-Dark foes:
@@ -429,9 +430,7 @@ Minor ability changes:
   provides immunity to Hail and freeze, and provides a one-time immunity
   to Water and Ice, after which it turns into Shell Armor
 
-- Adaptability is now 1.33x to non-STAB moves instead of to STAB moves.
-
-- Crawdaunt is given Tough Claws instead of Adaptability to compensate.
+- Adaptability is now 1.33x to non-STAB moves instead of to STAB moves
 
 - Shadow Tag now lasts only one turn
 
@@ -447,9 +446,9 @@ Minor ability changes:
 
 - Victory Star grants 1.5x accuracy (but only for the user)
 
-- Solid Rock and Filter now reduce 1/2 damage of SE moves, not 1/4
+- Solid Rock and Filter now reduce damage of SE moves by 1/2, not 1/4
 
-- Iron Fist now grants a 1.33x boost
+- Iron Fist now grants a 1.33x boost to punching moves
 
 - Outrage, Thrash, and Petal Dance don't lock if the user has Own Tempo
 
@@ -466,13 +465,13 @@ Minor ability changes:
 
 - Thick Fat grants half damage from Fighting
 
-- Aftermath no longer requires contact, and its damage is buffed to 1/3 of the
+- Aftermath no longer requires contact, and is buffed to deal 1/3 of the
   foe's max HP
 
 - Cursed Body works like Aftermath now, but instead of dealing damage, it
   causes the foe to be Cursed (like Ghost-type Curse)
 
-- Gluttony allows a Pokémon to use a Berry twice.
+- Gluttony allows a Pokémon to use a Berry twice
 
 - Guts, Quick Feet, and Toxic Boost take half damage from poisoning
 
@@ -485,7 +484,8 @@ Minor ability changes:
   reduction in rain, in addition to its usual effect
 
 - Multiscale decreases damage by 1/3 rather than 1/2 (Sorry, Dragonite,
-  this is in return for a usable physical Flying STAB in Aerial Ace)
+  this is in exchange for a usable physical Flying STAB from a buffed
+  Aerial Ace)
 
 Minor item changes:
 
@@ -508,8 +508,9 @@ Bans:
 
 Specifically, differences from regular OU:
 
-- unbanned: Gengarite, Kangaskhanite, Lucarionite, Aegislash, Blaziken, Genesect, Mawilite, Salamencite
+- unbanned: Aegislash, Blaziken, Genesect, Landorus, Gengarite, Kangaskhanite,
+  Lucarionite, Mawilite, Salamencite
 
-- banned: Kyurem, Kyurem-Black
+- banned: Hoopa-Unbound, Kyurem, Kyurem-Black
 
 - There is no Moody Clause or Evasion Clause

--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -1,10 +1,4 @@
 exports.BattleAbilities = {
-	"drizzle": {
-		inherit: true,
-		onStart: function (source) {
-			this.setWeather('raindance', source, null);
-		}
-	},
 	"swiftswim": {
 		inherit: true,
 		onModifySpe: function (spe, pokemon) {
@@ -13,30 +7,12 @@ exports.BattleAbilities = {
 			}
 		}
 	},
-	"drought": {
-		inherit: true,
-		onStart: function (source) {
-			this.setWeather('sunnyday', source, null);
-		}
-	},
 	"chlorophyll": {
 		inherit: true,
 		onModifySpe: function (spe) {
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
 				return this.chainModify(1.5);
 			}
-		}
-	},
-	"snowwarning": {
-		inherit: true,
-		onStart: function (source) {
-			this.setWeather('hail', source, null);
-		}
-	},
-	"sandstream": {
-		inherit: true,
-		onStart: function (source) {
-			this.setWeather('sandstorm', source, null);
 		}
 	},
 	"sandrush": {

--- a/mods/gennext/formats-data.js
+++ b/mods/gennext/formats-data.js
@@ -11,11 +11,19 @@ exports.BattleFormatsData = {
 		inherit: true,
 		tier: 'OU'
 	},
+	landorus: {
+		inherit: true,
+		tier: 'OU'
+	},
 	deoxysdefense: {
 		inherit: true,
 		tier: 'Uber'
 	},
 	deoxysspeed: {
+		inherit: true,
+		tier: 'Uber'
+	},
+	hoopaunbound: {
 		inherit: true,
 		tier: 'Uber'
 	},


### PR DESCRIPTION
Improved the grammar on many parts of the README. Also, sorted the Pokemon
in the Intrinsic Levitate section and removed mention of released Hoopa.

Staying true to the Gen-NEXT OU banning philosophy, Hoopa-Unbound is now
banned. Landorus-I is now unbanned.

Removed ability modification in weather-setting abilities as they are no
longer needed.

----

I want to discuss unbanning Aegislash. I think if we changed Stance Change to activate at the beginning of the turn instead of right before attacking, it would be balanced.