### PR TITLE
Add /staffintro to /roomhelp

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -2180,6 +2180,7 @@ var commands = exports.commands = {
 			"- /roomvoice <em>username</em>: appoint a room voice<br />" +
 			"- /roomdevoice <em>username</em>: remove a room voice<br />" +
 			"- /modchat <em>[off/autoconfirmed/+]</em>: set modchat level<br />" +
+			"- /staffintro <em>intro</em>: sets the staff introduction that will be displayed for all staff joining the room<br />" +
 			"<br />" +
 			"Room owners (#) can also use:<br />" +
 			"- /roomintro <em>intro</em>: sets the room introduction that will be displayed for all users joining the room<br />" +


### PR DESCRIPTION
Room moderators now gain a new command (/staffintro), so we can list it in /roomhelp along with the others.