### PR TITLE
Poison/burn/leech seed don't increment residualdmg in Gen1

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -453,9 +453,6 @@ exports.BattleMovedex = {
 		effect: {
 			onStart: function (target) {
 				this.add('-start', target, 'move: Leech Seed');
-				if (!target.volatiles['residualdmg']) target.addVolatile('residualdmg');
-				if (!target.volatiles['residualdmg'].counter) target.volatiles['residualdmg'].counter = 0;
-				target.volatiles['residualdmg'].counter++;
 			},
 			onAfterMoveSelfPriority: 1,
 			onAfterMoveSelf: function (pokemon) {
@@ -467,7 +464,7 @@ exports.BattleMovedex = {
 				// We check if leeched Pokémon has Toxic to increase leeched damage.
 				var toxicCounter = 1;
 				if (pokemon.volatiles['residualdmg']) {
-					if (pokemon.status === 'tox') pokemon.volatiles['residualdmg'].counter++;
+					pokemon.volatiles['residualdmg'].counter++;
 					toxicCounter = pokemon.volatiles['residualdmg'].counter;
 				}
 				var toLeech = this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1) * toxicCounter;

--- a/mods/gen1/statuses.js
+++ b/mods/gen1/statuses.js
@@ -13,18 +13,18 @@ exports.BattleStatuses = {
 		onStart: function (target) {
 			this.add('-status', target, 'brn');
 			target.addVolatile('brnattackdrop');
-			if (!target.volatiles['residualdmg']) target.addVolatile('residualdmg');
-			if (!target.volatiles['residualdmg'].counter) target.volatiles['residualdmg'].counter = 0;
-			target.volatiles['residualdmg'].counter++;
 		},
 		onAfterMoveSelfPriority: 2,
 		onAfterMoveSelf: function (pokemon) {
-			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1) * pokemon.volatiles['residualdmg'].counter, pokemon);
+			var toxicCounter = 1;
+			if (pokemon.volatiles['residualdmg']) {
+				pokemon.volatiles['residualdmg'].counter++;
+				toxicCounter = pokemon.volatiles['residualdmg'].counter;
+			}
+			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1) * toxicCounter, pokemon);
 		},
 		onSwitchIn: function (pokemon) {
 			pokemon.addVolatile('brnattackdrop');
-			pokemon.addVolatile('residualdmg');
-			pokemon.volatiles['residualdmg'].counter = 1;
 		},
 		onAfterSwitchInSelf: function (pokemon) {
 			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
@@ -96,17 +96,15 @@ exports.BattleStatuses = {
 		effectType: 'Status',
 		onStart: function (target) {
 			this.add('-status', target, 'psn');
-			if (!target.volatiles['residualdmg']) target.addVolatile('residualdmg');
-			if (!target.volatiles['residualdmg'].counter) target.volatiles['residualdmg'].counter = 0;
-			target.volatiles['residualdmg'].counter++;
 		},
 		onAfterMoveSelfPriority: 2,
 		onAfterMoveSelf: function (pokemon) {
-			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1) * pokemon.volatiles['residualdmg'].counter, pokemon);
-		},
-		onSwitchIn: function (pokemon) {
-			pokemon.addVolatile('residualdmg');
-			pokemon.volatiles['residualdmg'].counter = 1;
+			var toxicCounter = 1;
+			if (pokemon.volatiles['residualdmg']) {
+				pokemon.volatiles['residualdmg'].counter++;
+				toxicCounter = pokemon.volatiles['residualdmg'].counter;
+			}
+			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1) * toxicCounter, pokemon);
 		},
 		onAfterSwitchInSelf: function (pokemon) {
 			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
@@ -117,7 +115,7 @@ exports.BattleStatuses = {
 		onStart: function (target) {
 			this.add('-status', target, 'tox');
 			if (!target.volatiles['residualdmg']) target.addVolatile('residualdmg');
-			if (!target.volatiles['residualdmg'].counter) target.volatiles['residualdmg'].counter = 0;
+			target.volatiles['residualdmg'].counter = 0;
 		},
 		onAfterMoveSelfPriority: 2,
 		onAfterMoveSelf: function (pokemon) {
@@ -127,8 +125,6 @@ exports.BattleStatuses = {
 		onSwitchIn: function (pokemon) {
 			// Regular poison status and damage after a switchout -> switchin.
 			pokemon.setStatus('psn');
-			pokemon.addVolatile('residualdmg');
-			pokemon.volatiles['residualdmg'].counter = 1;
 		},
 		onAfterSwitchInSelf: function (pokemon) {
 			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));

--- a/test/simulator/misc/statuses.js
+++ b/test/simulator/misc/statuses.js
@@ -86,3 +86,22 @@ describe('Toxic Poison', function () {
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 16));
 	});
 });
+
+describe('Toxic Poison [Gen 1]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should affect Leech Seed damage counter', function () {
+		battle = BattleEngine.Battle.construct('battle-rby-toxic-leechseed', 'gen1customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Venusaur', moves: ['toxic', 'leechseed']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Chansey', moves: ['splash']}]);
+		battle.commitDecisions();
+		var pokemon = battle.p2.active[0];
+		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 16));
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		// (1/16) + (2/16) + (3/16) = (6/16)
+		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 16) * 6);
+	});
+});


### PR DESCRIPTION
Previously moves like Leech Seed incremented residualdmg when used by 1, but this doesn't actually happen in the game. Instead, an actual game uses a flag to store toxic poisoning flag, and when it's not specified, these statuses always dealt 1/16 of full HP.

This fixes the issue where the sequence of moves (Toxic followed by Leech Seed) was dealing 1/16, 3/16, and 4/16 of full HP in residual damage, instead of 1/16, 2/16, and 3/16.