### PR TITLE
Random Battle: Modify move rejection with 2 non-STAB attacks

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2748,10 +2748,10 @@ exports.BattleScripts = {
 					if (typeCombo !== 'Electric/Ice' && typeCombo !== 'Fighting/Ghost') {
 						var rejectableMoves = [];
 						var baseDiff = movePool.length - availableHP;
-						if (baseDiff || availableHP && (!hasMove['hiddenpower'] || counter.damagingMoves[0].id === 'hiddenpower')) {
+						if (baseDiff && counter.damagingMoves[0].id !== 'seismictoss' || availableHP && (!hasMove['hiddenpower'] || counter.damagingMoves[0].id === 'hiddenpower')) {
 							rejectableMoves.push(counter.damagingMoveIndex[counter.damagingMoves[0].id]);
 						}
-						if (baseDiff || availableHP && (!hasMove['hiddenpower'] || counter.damagingMoves[1].id === 'hiddenpower')) {
+						if (baseDiff && counter.damagingMoves[1].id !== 'seismictoss' || availableHP && (!hasMove['hiddenpower'] || counter.damagingMoves[1].id === 'hiddenpower')) {
 							rejectableMoves.push(counter.damagingMoveIndex[counter.damagingMoves[1].id]);
 						}
 						if (rejectableMoves.length) {


### PR DESCRIPTION
Seismic Toss is not rejected in these cases. Primarily affects Chansey,
Blissey, and Deoxys-Defense to ensure that they have an attacking move.