### PR TITLE
Modify the stylings of polls

### DIFF
--- a/chat-plugins/poll.js
+++ b/chat-plugins/poll.js
@@ -42,7 +42,7 @@ var Poll = (function () {
 	Poll.prototype.generateVotes = function () {
 		var output = '<div class="infobox"><p style="margin: 2px 0 5px 0"><span style="border:1px solid #6A6;color:#484;border-radius:4px;padding:0 3px"><i class="fa fa-bar-chart"></i> Poll</span> <strong style="font-size:11pt">' + Tools.escapeHTML(this.question) + '</strong></p>';
 		this.options.forEach(function (option, number) {
-			output += '<div style="margin-top: 3px"><button value="/poll vote ' + number + '" name="send">' + number + '. <strong>' + Tools.escapeHTML(option.name) + '</strong></button></div>';
+			output += '<div style="margin-top: 3px"><button value="/poll vote ' + number + '" name="send" title="Vote for: ' + Tools.escapeHTML(option.name) + '">' + number + '. <strong>' + Tools.escapeHTML(option.name) + '</strong></button></div>';
 		});
 		output += '</div>';
 
@@ -59,7 +59,7 @@ var Poll = (function () {
 		var colors = ['#79A', '#8A8', '#88B'];
 		while (!i.done) {
 			var percentage = Math.round((i.value[1].votes * 100) / (this.totalVotes || 1));
-			output += '<div style="margin-top: 3px"><span>' + i.value[0] + '. <strong>' + Tools.escapeHTML(i.value[1].name) + '</strong></span><br /><span style="background:' + colors[c % 3] + ';padding-right:' + (percentage * 3) + 'px"></span><br /><small style="font-size:8pt;padding-left:6px">' + percentage + '% (' + i.value[1].votes + ' votes)</small></div>';
+			output += '<div style="margin-top: 3px"><span>' + i.value[0] + '. <strong>' + Tools.escapeHTML(i.value[1].name) + '</strong></span> <small style="font-size:8pt;padding-left:6px"> | ' + percentage + '% (' + i.value[1].votes + ' votes)</small><br /><span style="background:' + colors[c % 3] + ';padding-right:' + (percentage * 3) + 'px"></span></div>';
 			i = iter.next();
 			c++;
 		}


### PR DESCRIPTION
Polls currently leave a lot of potential blank space and/or unneeded extra lines, making them longer and less subtle.

This commit moves a few things around, such as:
- No longer leave a space for a bar if a poll option hasn't gotten any votes yet / doesn't get any votes
- Move the percent of votes line on the line with the options, separated by a "|" mark
- Make buttons in polls say "Vote for [option]" when they are hovered over, indicating more clearly to the user what the button does
- Create an overall more subtle styling of polls

Example of changes:
<img src="http://i.imgur.com/tk1YmKe.png">

After taking various surveys of random room staff on main, they appear to have the general thinking of "the more compact, the better."