### PR TITLE
Specifiy "poll" timeout in /poll timer

### DIFF
--- a/chat-plugins/poll.js
+++ b/chat-plugins/poll.js
@@ -161,7 +161,7 @@ exports.commands = {
 				room.poll.end();
 				delete room.poll;
 			}), (timeout * 60000));
-			return this.privateModCommand("(The timeout was set to " + timeout + " minutes by " + user.name + ".)");
+			return this.privateModCommand("(The poll timeout was set to " + timeout + " minutes by " + user.name + ".)");
 		},
 		timerhelp: ["/poll timer [minutes] - Sets the poll to automatically end after [minutes] minutes. Requires: % @ # & ~"],
 


### PR DESCRIPTION
Some room staff or people looking in the modlog may get confused by the message "The timeout was set to...," so this specifies that it's referring to "The poll" as it does when a poll is started / ended.