### PR TITLE
Random Battle: Remove Fire Fang from Garchomp

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1340,11 +1340,14 @@ exports.BattleScripts = {
 				case 'superpower':
 					if (counter.setupType && (hasMove['drainpunch'] || hasMove['focusblast'])) rejected = true;
 					break;
-				case 'fierydance': case 'firefang': case 'flamethrower':
-					if ((hasMove['fireblast'] && counter.setupType !== 'Physical') || hasMove['overheat']) rejected = true;
+				case 'fierydance': case 'flamethrower':
+					if (hasMove['fireblast'] || hasMove['overheat']) rejected = true;
 					break;
 				case 'fireblast':
 					if ((hasMove['flareblitz'] || hasMove['lavaplume']) && !counter.setupType && !counter['speedsetup']) rejected = true;
+					break;
+				case 'firefang':
+					if (counter.setupType !== 'Physical' && (hasMove['fireblast'] || movePool.indexOf('fireblast') >= 0)) rejected = true;
 					break;
 				case 'firepunch': case 'sacredfire':
 					if (hasMove['fireblast'] || hasMove['flareblitz']) rejected = true;


### PR DESCRIPTION
5.3% usage on TIBot, 12% on sweepercalc. At the end of the day, though, it only really helps against Pokemon that are double weak to Fire or are named Bronzong, otherwise the EdgeQuake combo is better for everything else.