### PR TITLE
Ensure staffintros are seen

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -1644,6 +1644,7 @@ var ChatRoom = (function () {
 			} else {
 				entry = '|J|' + user.getIdentity(this.id);
 			}
+			if (this.staffMessage && user.can('mute', null, this)) this.sendUser(user, '|raw|<div class="infobox">(Staff intro:)<br /><div>' + this.staffMessage + '</div></div>');
 		} else if (!user.named) {
 			entry = '|L| ' + oldid;
 		} else {


### PR DESCRIPTION
With the current autojoin system, the user has already joined rooms
before the login process is completed, making the checks for staff in
ChatRoom.getIntroMessage fail. This ensures that staffintros are seen
when first joining the server by also sending them in ChatRoom.onRename.

This is the simplest solution I could find other than refactoring autojoin.