### PR TITLE
ban evasion from Doubles Ubers

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -207,7 +207,7 @@ exports.Formats = [
 		section: "ORAS Doubles",
 
 		gameType: 'doubles',
-		ruleset: ['Pokemon', 'Species Clause', 'Moody Clause', 'OHKO Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview'],
+		ruleset: ['Pokemon', 'Species Clause', 'Moody Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Evasion Abilities Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview'],
 		banlist: ['Unreleased', 'Illegal', 'Dark Void']
 	},
 	{


### PR DESCRIPTION
#Arcticblast: do you definitely want evasion moves and abilities banned from DUbers?
@KyleCole: idc, but if you're running a tour with it and want it banned then im down

no longer allowed in singles Ubers iirc so why allow it here?