### PR TITLE
Tournaments: show users who have joined

### DIFF
--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -304,7 +304,11 @@ Tournament = (function () {
 
 	Tournament.prototype.getBracketData = function () {
 		var data = this.generator.getBracketData();
-		if (data.type === 'tree' && data.rootNode) {
+		if (data.type === 'tree') {
+			if (!data.rootNode) {
+				data.users = usersToNames(this.generator.getUsers()).sort();
+				return data;
+			}
 			var queue = [data.rootNode];
 			while (queue.length > 0) {
 				var node = queue.shift();


### PR DESCRIPTION
During signups in elimination tournaments, show users who have joined in
place of the empty bracket.

Please merge after the next client update.