### PR TITLE
Enable build only for Node 4.0 and above and latest iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
+  - "4.1"
+  - "4.0"
+  - "iojs"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
As the code will now use the new ES6 syntax if #2251 gets merged, we need to run builds only on NodeJS 4.0 and above and on a recent stable release of io.js