### PR TITLE
Random Battle: Update Mamoswine

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1931,7 +1931,7 @@ exports.BattleFormatsData = {
 		tier: "NU"
 	},
 	mamoswine: {
-		randomBattleMoves: ["iceshard","earthquake","endeavor","iciclecrash","stealthrock","superpower","knockoff"],
+		randomBattleMoves: ["iceshard","earthquake","iciclecrash","stealthrock","superpower","knockoff"],
 		randomDoubleBattleMoves: ["iceshard","earthquake","rockslide","iciclecrash","protect","superpower","knockoff"],
 		eventPokemon: [
 			{"generation":5,"level":34,"gender":"M","isHidden":true,"moves":["hail","icefang","takedown","doublehit"]},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -976,7 +976,7 @@ exports.BattleScripts = {
 		};
 		// Moves that shouldn't be the only STAB moves:
 		let NoStab = {
-			aquajet:1, bounce:1, chargebeam:1, clearsmog:1, eruption:1, fakeout:1, flamecharge:1, pursuit:1, quickattack:1, skyattack:1, waterspout:1
+			aquajet:1, bounce:1, chargebeam:1, clearsmog:1, eruption:1, fakeout:1, flamecharge:1, iceshard:1, pursuit:1, quickattack:1, skyattack:1, waterspout:1
 		};
 
 		// Iterate through all moves we've chosen so far and keep track of what they do:


### PR DESCRIPTION
Ice Shard can no longer be the only STAB on any Pokemon.

Remove Endeavor from Mamoswine. (less than 10% usage)