### PR TITLE
Disallow being able to be promoted to room rank while locked

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -745,6 +745,12 @@ exports.commands = {
 				return this.errorReply("/" + cmd + " - Access denied for promoting/demoting to " + Config.groups[nextGroup].name + ".");
 			}
 		}
+		if ((!room.isPrivate && !room.battle && !room.isPersonal) && targetUser.locked && (nextGroup === '%' || nextGroup === '@')) {
+			Monitor.log("[CrisisMonitor] " + user.name + " was automatically demoted in " + room.id + " for trying to promote locked user: " + targetUser.name + ".");
+			room.auth[user.userid] = '@';
+			user.updateIdentity(room.id);
+			return this.errorReply("You have been automatically deauthed for trying to promote locked user: '" + name + "'.");
+		}
 
 		if (nextGroup === ' ') {
 			delete room.auth[userid];


### PR DESCRIPTION
this fixes a bypassal where users who are locked,and then become promoted cannot refresh and be able to talk in the room where they have roomrank