### PR TITLE
Random Battle: Don't count weak moves for Life Orb item checks

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1884,11 +1884,11 @@ exports.BattleScripts = {
 			item = 'Rocky Helmet';
 		} else if (counter.Physical + counter.Special >= 4 && (template.baseStats.def + template.baseStats.spd > 189 || hasMove['rapidspin'])) {
 			item = 'Assault Vest';
-		} else if (counter.Physical + counter.Special >= 4) {
+		} else if (counter.damagingMoves.length >= 4) {
 			item = (!!counter['ate'] || (hasMove['suckerpunch'] && !hasType['Dark'])) ? 'Life Orb' : 'Expert Belt';
-		} else if (counter.Physical + counter.Special >= 3 && !!counter['speedsetup'] && template.baseStats.hp + template.baseStats.def + template.baseStats.spd >= 300) {
+		} else if (counter.damagingMoves.length >= 3 && !!counter['speedsetup'] && template.baseStats.hp + template.baseStats.def + template.baseStats.spd >= 300) {
 			item = 'Weakness Policy';
-		} else if (counter.Physical + counter.Special >= 3 && ability !== 'Sturdy' && !hasMove['dragontail'] && !hasMove['rapidspin']) {
+		} else if (counter.damagingMoves.length >= 3 && ability !== 'Sturdy' && !hasMove['dragontail'] && !hasMove['superfang']) {
 			item = (template.baseStats.hp + template.baseStats.def + template.baseStats.spd < 285 || !!counter['speedsetup'] || hasMove['trickroom']) ? 'Life Orb' : 'Leftovers';
 		} else if (template.species === 'Palkia' && (hasMove['dracometeor'] || hasMove['spacialrend']) && hasMove['hydropump']) {
 			item = 'Lustrous Orb';


### PR DESCRIPTION
By checking the damagingMoves index length instead of the number of
Physical and Special moves, it not only ensures no Life Orb for Pokemon
with Rapid Spin, but also Nuzzle (such as Pachirisu) and any other
potential cases that have been missed.