### PR TITLE
Gen 1: Reduce occurrence of extremely weak team

### DIFF
--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -1069,6 +1069,8 @@ exports.BattleScripts = {
 
 			// Bias the tiers so you get less shitmons and only one of the two Ubers.
 			// If you have a shitmon, you're covered in OUs and Ubers if possible
+			if ((template.speciesid in handicapMons) && nuCount > 1) continue;
+
 			let tier = template.tier;
 			switch (tier) {
 			case 'LC':


### PR DESCRIPTION
You won't get more UU if you already have handicapMons, however if you get a lot UU first, you could still get handicapMons.
This fix make sure you wont get handicapMons once you have at least 2 NU/worse (which is already bad enough)