### PR TITLE
Disallow modchat wars in battles

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1448,6 +1448,10 @@ exports.commands = {
 		if (room.modchat && room.modchat.length <= 1 && Config.groupsranking.indexOf(room.modchat) > 1 && !user.can('modchatall', null, room)) {
 			return this.errorReply("/modchat - Access denied for removing a setting higher than " + Config.groupsranking[1] + ".");
 		}
+		if (room.requestModchat) {
+			let error = room.requestModchat(user);
+			if (error) return this.errorReply(error);
+		}
 
 		target = target.toLowerCase();
 		let currentModchat = room.modchat;
@@ -1485,6 +1489,7 @@ exports.commands = {
 			let modchat = Tools.escapeHTML(room.modchat);
 			this.add("|raw|<div class=\"broadcast-red\"><b>Moderated chat was set to " + modchat + "!</b><br />Only users of rank " + modchat + " and higher can talk.</div>");
 		}
+		if (room.battle && !room.modchat && !user.can('modchat')) room.requestModchat(null);
 		this.logModCommand(user.name + " set modchat to " + room.modchat);
 
 		if (room.chatRoomData) {

--- a/rooms.js
+++ b/rooms.js
@@ -898,6 +898,7 @@ let BattleRoom = (function () {
 
 	BattleRoom.prototype.resetTimer = null;
 	BattleRoom.prototype.resetUser = '';
+	BattleRoom.prototype.modchatUser = '';
 	BattleRoom.prototype.expireTimer = null;
 	BattleRoom.prototype.active = false;
 
@@ -1245,6 +1246,17 @@ let BattleRoom = (function () {
 		}
 
 		return false;
+	};
+	BattleRoom.prototype.requestModchat = function (user) {
+		if (user === null) {
+			this.modchatUser = '';
+			return;
+		} else if (user.can('modchat') || !this.modchatUser || this.modchatUser === user.userid) {
+			this.modchatUser = user.userid;
+			return;
+		} else {
+			return "Only the user who set modchat and global staff can change modchat levels in battle rooms";
+		}
 	};
 	BattleRoom.prototype.decision = function (user, choice, data) {
 		this.battle.sendFor(user, choice, data);


### PR DESCRIPTION
The second check in commands isn't optimal, but I wanted players to be able to set modchat if their opponent turns it off, and I couldn't see a way of doing that without a whole other function.