### PR TITLE
Refactor Trick Room and fix interactions with speed-based moves

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -413,7 +413,7 @@ BattlePokemon = (function () {
 		}
 		this.battle.runEvent('ModifyPokemon', this);
 
-		this.speed = this.getStat('spe');
+		this.speed = this.getDecisionSpeed();
 	};
 	BattlePokemon.prototype.calculateStat = function (statName, boost, modifier) {
 		statName = toId(statName);
@@ -478,6 +478,14 @@ BattlePokemon = (function () {
 			stat = this.battle.getStatCallback(stat, statName, this, unboosted);
 		}
 		return stat;
+	};
+	BattlePokemon.prototype.getDecisionSpeed = function () {
+		let speed = this.getStat('spe');
+		if (speed > 10000) speed = 10000;
+		if (this.battle.getPseudoWeather('trickroom')) {
+			speed = 0x2710 - speed;
+		}
+		return speed & 0x1FFF;
 	};
 	BattlePokemon.prototype.getWeight = function () {
 		let weight = this.template.weightkg;

--- a/data/moves.js
+++ b/data/moves.js
@@ -14619,16 +14619,11 @@ exports.BattleMovedex = {
 			},
 			onStart: function (target, source) {
 				this.add('-fieldstart', 'move: Trick Room', '[of] ' + source);
-				this.getStatCallback = function (stat, statName) {
-					// If stat is speed and does not overflow (Trick Room Glitch) return negative speed.
-					if (statName === 'spe' && stat <= 1809) return -stat;
-					return stat;
-				};
 			},
+			// Speed modification is changed in BattlePokemon.getDecisionSpeed() in battle-engine.js
 			onResidualOrder: 23,
 			onEnd: function () {
 				this.add('-fieldend', 'move: Trick Room');
-				this.getStatCallback = null;
 			}
 		},
 		secondary: false,

--- a/test/simulator/moves/trickroom.js
+++ b/test/simulator/moves/trickroom.js
@@ -1,0 +1,103 @@
+'use strict';
+
+let assert = require('assert');
+let battle;
+
+describe('Trick Room', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should cause slower Pokemon to move before faster Pokemon in a priority bracket', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'spore']}]);
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, '');
+		assert.strictEqual(battle.p2.active[0].status, 'slp');
+	});
+
+	it('should not allow Pokemon using a lower priority move to act before other Pokemon', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'protect']}]);
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, '');
+		assert.strictEqual(battle.p2.active[0].status, '');
+	});
+
+	it('should also affect the activation order for abilities and other non-move actions', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Bronzong', ability: 'heatproof', moves: ['trickroom', 'explosion']},
+			{species: 'Hippowdon', ability: 'sandstream', moves: ['protect']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Ninjask', ability: 'speedboost', moves: ['shellsmash']},
+			{species: 'Ninetales', ability: 'drought', moves: ['protect']}
+		]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		battle.choose('p1', 'switch 2');
+		battle.choose('p2', 'switch 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].speciesid, 'hippowdon');
+		assert.strictEqual(battle.p2.active[0].speciesid, 'ninetales');
+		assert.strictEqual(battle.effectiveWeather(), 'sunnyday');
+	});
+
+	// The following two tests involve the Trick Room glitch, where turn order changes when a Pokemon goes to 1809 speed.
+
+	it('should roll over and cause Pokemon with 1809 or more speed to outspeed Pokemon with 1808 or less', function () {
+		battle = BattleEngine.Battle.construct('battle-trickroom-rollover', 'customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Ninjask', ability: 'swarm', evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 184}, moves: ['protect', 'spore']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Deoxys-Speed', ability: 'pressure', evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 224}, moves: ['spore', 'trickroom']}]);
+		battle.commitDecisions(); // Team Preview
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions(); // Trick Room is now up.
+
+		// This sets Ninjask to exactly 1809 Speed
+		battle.p1.active[0].boostBy({spe: 4});
+		battle.p1.active[0].setItem('choicescarf');
+		// This sets Deoxys to exactly 1808 Speed
+		battle.p2.active[0].boostBy({spe: 6});
+
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, '');
+		assert.strictEqual(battle.p2.active[0].status, 'slp');
+		battle.p2.active[0].clearStatus();
+		battle.p2.active[0].setItem('choicescarf'); // Deoxys is now much faster speed-wise than Ninjask, but should still be slower in Trick Room.
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].status, '');
+		assert.strictEqual(battle.p2.active[0].status, 'slp');
+	});
+
+	it('should not affect damage dealt by moves whose power is reliant on speed', function () {
+		battle = BattleEngine.Battle.construct('battle-trickroom-gyroball', 'customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Ninjask', ability: 'swarm', evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 184}, item: 'choicescarf', moves: ['earthquake']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Deoxys-Speed', ability: 'levitate', evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 224}, moves: ['gyroball', 'trickroom']}]);
+		battle.commitDecisions(); // Team Preview
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+
+		battle.p1.active[0].boostBy({spe: 4}); // 1809 Speed
+		battle.p2.active[0].boostBy({spe: 6}); // 1808 Speed
+
+		battle.on('BasePower', battle.getFormat(), function (bp, pokemon, target, move) {
+			if (move.id !== 'gyroball') return;
+			assert.strictEqual(bp, 25); // BP should theoretically be this based on speed values
+		});
+
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+});


### PR DESCRIPTION
Trick Room now uses a ModifyDecisionSpeed event to get its speed instead
of modifying the stat directly, since the Trick Room glitch would cause
calculations from Gyro Ball or Electro Ball to be inaccurate if the
Pokemon have speeds above and below the cutoff, respectively.