### PR TITLE
Random Battle: Slightly modify HP EV adjustment strategies

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1957,14 +1957,38 @@ exports.BattleScripts = {
 				evs.hp -= 4;
 				evs.atk += 4;
 			}
+		} else if (hasMove['substitute'] && ability === 'Unburden' && item === 'Sitrus Berry') {
+			// Prepare HP for Unburden Substitute.
+			let hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+			while (hp % 4 > 0) {
+				evs.hp -= 4;
+				if (evs.atk > evs.spa) {
+					evs.spa += 4;
+				} else if (evs.spa > evs.atk) {
+					evs.spa += 4;
+				} else if (counter.Physical > counter.Special) {
+					evs.atk += 4;
+				} else {
+					evs.spa += 4;
+				}
+
+				hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+			}
 		} else {
-			// Prepare HP for double Stealth Rock weaknesses. Those are mutually exclusive with Belly Drum HP check.
+			// Prepare HP for double Stealth Rock weaknesses. Those are mutually exclusive with Belly Drum and Substitute HP checks.
 			// First, 25% damage.
 			if (this.getEffectiveness('Rock', template) === 1) {
 				let hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 				if (hp % 4 === 0) {
 					evs.hp -= 4;
-					if (counter.Physical > counter.Special) {
+
+					// Check again just in case
+					hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+					if (hp % 4 === 0) { // the HP hasn't gone down yet
+						evs.hp -= 4;
+						evs.atk += 4;
+						evs.spa += 4;
+					} else if (counter.Physical > counter.Special) {
 						evs.atk += 4;
 					} else {
 						evs.spa += 4;
@@ -1977,7 +2001,14 @@ exports.BattleScripts = {
 				let hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 				if (hp % 2 === 0) {
 					evs.hp -= 4;
-					if (counter.Physical > counter.Special) {
+
+					// Check again just in case
+					hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+					if (hp % 4 === 0) { // the HP hasn't gone down yet
+						evs.hp -= 4;
+						evs.atk += 4;
+						evs.spa += 4;
+					} else if (counter.Physical > counter.Special) {
 						evs.atk += 4;
 					} else {
 						evs.spa += 4;


### PR DESCRIPTION
Fixes HP values with Unburden/Substitute/Sitrus Berry combo.

Fixes HP values for Stealth Rock-weak Pokemon with Hidden Power.

=====

The idea with the second change is the fact that HP Flying Thundurus won't lose an HP point if we only drop its HP EVs by 4 (because of the drop in the HP IV)