### PR TITLE
Bold online users in Roomauth

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -790,7 +790,7 @@ exports.commands = {
 		let rankLists = {};
 		for (let u in targetRoom.auth) {
 			if (!rankLists[targetRoom.auth[u]]) rankLists[targetRoom.auth[u]] = [];
-			rankLists[targetRoom.auth[u]].push(u);
+			rankLists[targetRoom.auth[u]].push(u in targetRoom.users ? "**" + u + "**" : u);
 		}
 
 		let buffer = [];


### PR DESCRIPTION
This allows people who want to appeal their roomban to be able to identify the users that are online in that room.   I hope this is the most efficient way of doing it.