### PR TITLE
Fix incorrect Water Pulse chance in description.

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -15097,7 +15097,7 @@ exports.BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		category: "Special",
-		desc: "Has a 10% chance to confuse the target.",
+		desc: "Has a 20% chance to confuse the target.",
 		shortDesc: "20% chance to confuse the target.",
 		id: "waterpulse",
 		name: "Water Pulse",


### PR DESCRIPTION
Chance to confuse was incorrectly displayed as 10% in the in-battle description.