### PR TITLE
Random Battle: Favor Poison Jab over Sludge Wave on Seviper

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1442,7 +1442,10 @@ exports.BattleScripts = {
 					if (hasMove['sludgebomb'] || counter.Special < 2) rejected = true;
 					break;
 				case 'poisonjab':
-					if (hasMove['gunkshot'] || hasMove['sludgewave'] && counter.setupType !== 'Physical') rejected = true;
+					if (hasMove['gunkshot']) rejected = true;
+					break;
+				case 'sludgewave':
+					if (hasMove['poisonjab']) rejected = true;
 					break;
 				case 'psychic':
 					if (hasMove['psyshock'] || hasMove['storedpower']) rejected = true;


### PR DESCRIPTION
Because of how moves are generated when a Pokemon has a setup move in its
move list, Seviper has a high chance of getting bad sets if Poison Jab is
rejected and Coil is added to its moves.