### PR TITLE
Fix sorting in /roomauth

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -797,7 +797,9 @@ exports.commands = {
 		Object.keys(rankLists).sort(function (a, b) {
 			return (Config.groups[b] || {rank:0}).rank - (Config.groups[a] || {rank:0}).rank;
 		}).forEach(function (r) {
-			buffer.push((Config.groups[r] ? Config.groups[r] .name + "s (" + r + ")" : r) + ":\n" + rankLists[r].sort().join(", "));
+			buffer.push((Config.groups[r] ? Config.groups[r].name + "s (" + r + ")" : r) + ":\n" + rankLists[r].sort(function (a, b) {
+				return toId(a) > toId(b);
+			}).join(", "));
 		});
 
 		if (!buffer.length) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1442,7 +1442,10 @@ exports.BattleScripts = {
 					if (hasMove['sludgebomb'] || counter.Special < 2) rejected = true;
 					break;
 				case 'poisonjab':
-					if (hasMove['gunkshot'] || hasMove['sludgewave'] && counter.setupType !== 'Physical') rejected = true;
+					if (hasMove['gunkshot']) rejected = true;
+					break;
+				case 'sludgewave':
+					if (hasMove['poisonjab']) rejected = true;
 					break;
 				case 'psychic':
 					if (hasMove['psyshock'] || hasMove['storedpower']) rejected = true;


### PR DESCRIPTION
Following up on TI's comment about how this breaks the sorting order. Made it sort by the name's id instead (ignoring the **'s).   Sorry I overlooked that last time.

**praise TI**
This is how it looks like: http://prntscr.com/9h239z