### PR TITLE
Replace some uses of forEach with map

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -47,11 +47,10 @@ exports.commands = {
 			}
 		}
 
-		let buffer = [];
-		Object.keys(rankLists).sort(function (a, b) {
+		let buffer = Object.keys(rankLists).sort(function (a, b) {
 			return (Config.groups[b] || {rank: 0}).rank - (Config.groups[a] || {rank: 0}).rank;
-		}).forEach(function (r) {
-			buffer.push((Config.groups[r] ? Config.groups[r].name + "s (" + r + ")" : r) + ":\n" + rankLists[r].sortBy(toId).join(", "));
+		}).map(function (r) {
+			return (Config.groups[r] ? Config.groups[r].name + "s (" + r + ")" : r) + ":\n" + rankLists[r].sortBy(toId).join(", ");
 		});
 
 		if (!buffer.length) buffer = "This server has no global authority.";
@@ -793,15 +792,13 @@ exports.commands = {
 			rankLists[targetRoom.auth[u]].push(u);
 		}
 
-		let buffer = [];
-		Object.keys(rankLists).sort(function (a, b) {
+		let buffer = Object.keys(rankLists).sort(function (a, b) {
 			return (Config.groups[b] || {rank:0}).rank - (Config.groups[a] || {rank:0}).rank;
-		}).forEach(function (r) {
-			let roomRankList = [];
-			rankLists[r].sort().forEach(function (s) {
-				roomRankList.push(s in targetRoom.users ? "**" + s + "**" : s);
+		}).map(function (r) {
+			let roomRankList = rankLists[r].sort().map(function (s) {
+				return s in targetRoom.users ? "**" + s + "**" : s;
 			});
-			buffer.push((Config.groups[r] ? Config.groups[r].name + "s (" + r + ")" : r) + ":\n" + roomRankList.join(", "));
+			return (Config.groups[r] ? Config.groups[r].name + "s (" + r + ")" : r) + ":\n" + roomRankList.join(", ");
 		});
 
 		if (!buffer.length) {


### PR DESCRIPTION
I noticed the `.forEach`/`.push` usage in PR #2342 and it seems to me that `.map` would be a better fit. I spotted another case in `commands.js` so I updated that too, and I also found a similar case in `chat-plugins/trivia.js` where I can just use `Array.from` directly.