### PR TITLE
Prevent IV values that represent half of a DV

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -243,6 +243,12 @@ BattlePokemon = (function () {
 		for (let i in this.set.ivs) {
 			this.set.ivs[i] = this.battle.clampIntRange(this.set.ivs[i], 0, 31);
 		}
+		if (this.battle.gen && this.battle.gen <= 2) {
+			// We represent DVs using even IVs. Ensure they are in fact even.
+			for (let i in this.set.ivs) {
+				this.set.ivs[i] &= 30;
+			}
+		}
 
 		let hpTypes = ['Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark'];
 		if (this.battle.gen && this.battle.gen === 2) {

--- a/test/simulator/items/leftovers.js
+++ b/test/simulator/items/leftovers.js
@@ -18,12 +18,12 @@ describe('Leftovers [Gen 2]', function () {
 			{species: "Miltank", moves: ['seismictoss']}
 		]);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].hp, 591);
+		assert.strictEqual(battle.p1.active[0].hp, 590);
 
 		battle.choose('p1', 'switch 2');
 		battle.commitDecisions();
 
 		battle.choose('p1', 'switch 2');
-		assert.strictEqual(battle.p1.active[0].hp, 631);
+		assert.strictEqual(battle.p1.active[0].hp, 630);
 	});
 });


### PR DESCRIPTION
The client's tooltip (but not the teambuilder) correctly calculates a Gen1/2 Pokémon's speed using a (DV range of 0-15 equivalent) IV range of 0-30, however the battle engine allows odd IVs in Gen1/2 thus gaining an extra half DV. For example, a level 100 Zapdos can have a speed of 205 to 298 but in actual battle you will get 31 IVs for a speed of 299.