### PR TITLE
Don't modify the original template when compiling learnsets for dexsearch

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -586,6 +586,7 @@ exports.commands = {
 				dex[pokemon] = template;
 			}
 		}
+		dex = JSON.parse(JSON.stringify(dex)); // Don't modify the original template (when compiling learnsets)
 
 		let learnSetsCompiled = false;
 		//ensure searches with the least alternatives are run first


### PR DESCRIPTION
This broke the team validator on event pokemon if it was running in the
same process as the commands

For example, the synchronous validators or if my single process hack was in use