### PR TITLE
Add Psycho Cut as Gallades signature attack

### DIFF
--- a/mods/gennext/README.md
+++ b/mods/gennext/README.md
@@ -204,6 +204,8 @@ New mechanic: Signature Pokémon:
   - Snorlax: Snore (100 base power)
 
   - Persian: Slash (60 base power 30% -1 Def)
+  
+  - Gallade: Psycho Cut
 
 - Again, note that while the Signature Pokémon will get the 1.5x damage boost,
   all Pokémon will get the other changes to the move listed above.


### PR DESCRIPTION
Adding Psycho Cut as Gallade`s signature move

Flavor-wise it makes a lot of sense for Gallade to get Psycho Cut. It`s one of  It would also give him a more accurate, powerful alternative to zen headbutt. Gallade is near the middle of RU, which is fine, but Mega Gallade is at the bottom of OU. Mega Gallade has no benefits at all from what NEXT has so far, and takes up a mega slot, so of all OU pokemon he is the one most needing of something little to help him.