### PR TITLE
Moves that hit the field should ignore Pokemon that have already fainted

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4475,7 +4475,7 @@ exports.BattleMovedex = {
 			for (let sideSlot = 0; sideSlot < this.sides.length; sideSlot++) {
 				let sideActive = this.sides[sideSlot].active;
 				for (let activeSlot = 0; activeSlot < sideActive.length; activeSlot++) {
-					if (sideActive[activeSlot] && sideActive[activeSlot].hasType('Grass')) {
+					if (sideActive[activeSlot] && sideActive[activeSlot].isActive && sideActive[activeSlot].hasType('Grass')) {
 						// This move affects every Grass-type Pokemon in play.
 						targets.push(sideActive[activeSlot]);
 					}
@@ -5759,7 +5759,7 @@ exports.BattleMovedex = {
 			this.add('-clearallboost');
 			for (let i = 0; i < this.sides.length; i++) {
 				for (let j = 0; j < this.sides[i].active.length; j++) {
-					if (this.sides[i].active[j]) this.sides[i].active[j].clearBoosts();
+					if (this.sides[i].active[j] && this.sides[i].active[j].isActive) this.sides[i].active[j].clearBoosts();
 				}
 			}
 		},
@@ -9577,7 +9577,7 @@ exports.BattleMovedex = {
 			let message = false;
 			for (let i = 0; i < this.sides.length; i++) {
 				for (let j = 0; j < this.sides[i].active.length; j++) {
-					if (this.sides[i].active[j]) {
+					if (this.sides[i].active[j] && this.sides[i].active[j].isActive) {
 						if (this.sides[i].active[j].hasAbility('soundproof')) {
 							this.add('-immune', this.sides[i].active[j], '[msg]', '[from] ability: Soundproof');
 							result = true;
@@ -11421,7 +11421,7 @@ exports.BattleMovedex = {
 			for (let sideSlot = 0; sideSlot < this.sides.length; sideSlot++) {
 				let sideActive = this.sides[sideSlot].active;
 				for (let activeSlot = 0; activeSlot < sideActive.length; activeSlot++) {
-					if (!sideActive[activeSlot]) continue;
+					if (!sideActive[activeSlot] || !sideActive[activeSlot].isActive) continue;
 					if (!sideActive[activeSlot].runImmunity('Ground')) {
 						this.add('-immune', sideActive[activeSlot], '[msg]');
 						anyAirborne = true;


### PR DESCRIPTION
Turn 3 of http://replay.pokemonshowdown.com/aqua-tripleshackmonscup-1290

Heliolisk OKHO's Roggenrola so Mawile's Rototiller shouldn't have attempted to affect it. (I assume that Roggenrola had Levitate in order for the immunity to trigger.)

I checked the other moves that try to hit the field too (excluding pseudo weather of course).