### PR TITLE
Fix /statcalc to round between applying modifiers

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1932,7 +1932,7 @@ exports.commands = {
 		if (calcHP) {
 			output = (((iv + (2 * statValue) + (ev / 4) + 100) * level) / 100) + 10;
 		} else {
-			output = Math.floor((((iv + (2 * statValue) + (ev / 4)) * level) / 100) + 5) * nature;
+			output = Math.floor(nature * Math.floor((((iv + (2 * statValue) + (ev / 4)) * level) / 100) + 5));
 			if (positiveMod) {
 				output *= (2 + modifier) / 2;
 			} else {


### PR DESCRIPTION
!statcalc gardevoir, spe 252+ scarf
Base 80 at level 100 with 31 IVs, 252+ EVs at +1: 427. (should be 426)
!statcalc gardevoir 252+ spe
Base 80 at level 100 with 31 IVs, 252+ EVs: 284.