### PR TITLE
Fix Focus Punch bugs

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4623,10 +4623,7 @@ exports.BattleMovedex = {
 			pokemon.addVolatile('focuspunch');
 		},
 		beforeMoveCallback: function (pokemon) {
-			if (!pokemon.removeVolatile('focuspunch')) {
-				return false;
-			}
-			if (pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.damage > 0 && this.getMove(pokemon.lastAttackedBy.move).category !== 'Status') {
+			if (pokemon.volatiles['focuspunch'] && pokemon.volatiles['focuspunch'].lostFocus) {
 				this.add('cant', pokemon, 'Focus Punch', 'Focus Punch');
 				return true;
 			}
@@ -4635,6 +4632,11 @@ exports.BattleMovedex = {
 			duration: 1,
 			onStart: function (pokemon) {
 				this.add('-singleturn', pokemon, 'move: Focus Punch');
+			},
+			onHit: function (pokemon, source, move) {
+				if (move.category !== 'Status') {
+					pokemon.volatiles['focuspunch'].lostFocus = true;
+				}
 			},
 		},
 		secondary: false,

--- a/test/simulator/moves/focuspunch.js
+++ b/test/simulator/moves/focuspunch.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('assert');
+let battle;
+
+describe('Focus Punch', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should cause the user to lose focus if hit by an attacking move', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not cause the user to lose focus if hit by a status move', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['toxic']}]);
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not cause the user to lose focus if hit while behind a substitute', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['substitute', 'focuspunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}]);
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should cause the user to lose focus if hit by a move called by Nature Power', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['naturepower']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should not cause the user to lose focus on later uses of Focus Punch if hit', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+
+	it('should cause the user to lose focus if hit by an attacking move followed by a status move in one turn', function () {
+		battle = BattleEngine.Battle.construct('battle-focuspunch', 'doublescustomgame');
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']},
+			{species: 'Blissey', ability: 'naturalcure', moves: ['softboiled']},
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']},
+			{species: 'Ivysaur', ability: 'overgrow', moves: ['toxic']},
+		]);
+		battle.commitDecisions(); // Team Preview
+		battle.choose('p1', 'move 1 1, move 1');
+		battle.choose('p2', 'move 1 1, move 1 1');
+		assert.strictEqual(battle.p1.active[0].status, 'tox');
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	});
+});


### PR DESCRIPTION
By setting a handler to listen for the Hit event, Pokemon will now lose
focus properly when attacked by multiple Pokemon or by Nature Power.

---

I'm still working on the Revenge etc. fixes and will submit that later, probably