### PR TITLE
Entrainment and Role Play should send the Ability name

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -3690,7 +3690,7 @@ exports.BattleMovedex = {
 		onHit: function (target, source) {
 			let oldAbility = target.setAbility(source.ability);
 			if (oldAbility) {
-				this.add('-ability', target, target.ability, '[from] move: Entrainment');
+				this.add('-ability', target, this.getAbility(target.ability), '[from] move: Entrainment');
 				return;
 			}
 			return false;
@@ -11284,7 +11284,7 @@ exports.BattleMovedex = {
 		onHit: function (target, source) {
 			let oldAbility = source.setAbility(target.ability);
 			if (oldAbility) {
-				this.add('-ability', source, source.ability, '[from] move: Role Play', '[of] ' + target);
+				this.add('-ability', source, this.getAbility(source.ability), '[from] move: Role Play', '[of] ' + target);
 				return;
 			}
 			return false;


### PR DESCRIPTION
This doesn't affect a live battle because the battle engine has access to `abilities.js` to look up the name but the replay viewer doesn't have that luxury.