### PR TITLE
Some roomnames shouldn't be allowed

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -661,6 +661,7 @@ let GlobalRoom = (function () {
 	};
 	GlobalRoom.prototype.addChatRoom = function (title) {
 		let id = toId(title);
+		if (id === 'battles' || id === 'rooms' || id === 'ladder' || id === 'teambuilder') return false;
 		if (rooms[id]) return false;
 
 		let chatRoomData = {


### PR DESCRIPTION
This prevents the server from being able to make rooms with ids of: battles, teambuilder, rooms, ladder