### PR TITLE
Make Bulletproof's description (more) accurate

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -266,7 +266,7 @@ exports.BattleAbilities = {
 		num: 66,
 	},
 	"bulletproof": {
-		shortDesc: "This Pokemon is immune to bullet moves.",
+		shortDesc: "This Pokemon is immune to ball, bomb, and bullet moves.",
 		onTryHit: function (pokemon, target, move) {
 			if (move.flags['bullet']) {
 				this.add('-immune', pokemon, '[msg]', '[from] ability: Bulletproof');


### PR DESCRIPTION
The description currently lists that Pokemon with Bulletproof are immune to "bullet" moves. However, while this is true, it also makes Bulletproof users immune to ball and bomb moves, which isn't listed at the moment.