### PR TITLE
Fix Secret Power interactions with various abilities

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1893,9 +1893,16 @@ exports.BattleAbilities = {
 			onBasePowerPriority: 8,
 			onBasePower: function (basePower) {
 				if (this.effectData.hit) {
+					this.effectData.hit++;
 					return this.chainModify(0.5);
 				} else {
-					this.effectData.hit = true;
+					this.effectData.hit = 1;
+				}
+			},
+			onSourceModifySecondaries: function (secondaries, target, source, move) {
+				if (move.id === 'secretpower' && this.effectData.hit < 2) {
+					// hack to prevent accidentally suppressing King's Rock/Razor Fang
+					return secondaries.filter(effect => effect.volatileStatus === 'flinch');
 				}
 			},
 		},

--- a/data/moves.js
+++ b/data/moves.js
@@ -11727,23 +11727,31 @@ exports.BattleMovedex = {
 		pp: 20,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		onHit: function (target, pokemon) {
-			pokemon.addVolatile('secretpower');
+		onModifyMove: function (move, pokemon) {
+			if (this.isTerrain('')) return;
+			move.secondaries = [];
+			if (this.isTerrain('electricterrain')) {
+				move.secondaries.push({
+					chance: 30,
+					status: 'par',
+				});
+			} else if (this.isTerrain('grassyterrain')) {
+				move.secondaries.push({
+					chance: 30,
+					status: 'slp',
+				});
+			} else if (this.isTerrain('mistyterrain')) {
+				move.secondaries.push({
+					chance: 30,
+					boosts: {
+						spa: -1,
+					},
+				});
+			}
 		},
-		effect: {
-			duration: 1,
-			onAfterMoveSecondarySelf: function (source, target, move) {
-				if (this.random(10) < 3) {
-					if (this.isTerrain('') || this.isTerrain('electricterrain')) {
-						target.trySetStatus('par', source, move);
-					} else if (this.isTerrain('grassyterrain')) {
-						target.trySetStatus('slp', source, move);
-					} else if (this.isTerrain('mistyterrain')) {
-						this.boost({spa: -1}, target, source);
-					}
-				}
-				source.removeVolatile('secretpower');
-			},
+		secondary: {
+			chance: 30,
+			status: 'par',
 		},
 		target: "normal",
 		type: "Normal",


### PR DESCRIPTION
- Reverted 6603f97 (fixes interaction with Shield Dust)
- Moved Hit handler that changed the secondaries to ModifyMove for
  proper interaction with Serene Grace when terrains are present
- Added a volatile that ensures that the first hit of Secret Power
  under Parental Bond does not trigger its volatile

I need to verify that the secondaries that are set in certain terrains is indeed affected by Serene Grace, Is this true, @Marty-D?