### PR TITLE
Random Battle: Add minimum SpD threshold for Assault Vest

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1897,7 +1897,7 @@ exports.BattleScripts = {
 			item = 'Light Clay';
 		} else if (ability === 'Iron Barbs' || ability === 'Rough Skin') {
 			item = 'Rocky Helmet';
-		} else if (counter.Physical + counter.Special >= 4 && (template.baseStats.def + template.baseStats.spd > 189 || hasMove['rapidspin'])) {
+		} else if (counter.Physical + counter.Special >= 4 && template.baseStats.spd > 55 && (template.baseStats.def + template.baseStats.spd > 189 || hasMove['rapidspin'])) {
 			item = 'Assault Vest';
 		} else if (counter.damagingMoves.length >= 4) {
 			item = (!!counter['Normal'] || (hasMove['suckerpunch'] && !hasType['Dark'])) ? 'Life Orb' : 'Expert Belt';


### PR DESCRIPTION
Cutoff is set to 56 Special Defense. Mostly affects Cloysters, Delibirds,
and Sandslash if they have Rapid Spin.