### PR TITLE
Disallow private room scouting with /inv

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -196,22 +196,17 @@ exports.commands = {
 				if (!targetRoom || targetRoom === Rooms.global) return this.errorReply('The room "' + innerTarget + '" does not exist.');
 				if (targetRoom.staffRoom && !targetUser.isStaff) return this.errorReply('User "' + this.targetUsername + '" requires global auth to join room "' + targetRoom.id + '".');
 				if (targetRoom.modjoin) {
-					if (targetRoom.auth && (targetRoom.isPrivate === true || targetUser.group === ' ') && !(targetUser.userid in targetRoom.auth)) {
+					if (targetRoom.auth && (targetRoom.isPrivate === true || targetUser.group === ' ')) {
+						if (!(user.userid in targetRoom.auth)) {
+							return this.errorReply('The room "' + innerTarget + '" does not exist.');
+						}
 						this.parse('/roomvoice ' + targetUser.name, false, targetRoom);
-						if (!(targetUser.userid in targetRoom.auth)) {
-							return;
+						if (Config.groupsranking.indexOf(targetRoom.auth[targetUser.userid] || ' ') < Config.groupsranking.indexOf(targetRoom.modjoin) && !targetUser.can('bypassall')) {
+							return this.errorReply('The user "' + targetUser.name + '" does not have permission to join "' + innerTarget + '".');
 						}
 					}
 				}
-				if (targetRoom.isPrivate === true && targetRoom.modjoin && targetRoom.auth) {
-					if (!(user.userid in targetRoom.auth)) {
-						return this.errorReply('The room "' + innerTarget + '" does not exist.');
-					}
-					if (Config.groupsranking.indexOf(targetRoom.auth[targetUser.userid] || ' ') < Config.groupsranking.indexOf(targetRoom.modjoin) && !targetUser.can('bypassall')) {
-						return this.errorReply('The user "' + targetUser.name + '" does not have permission to join "' + innerTarget + '".');
-					}
-				}
-				if (targetRoom.isPrivate && !(user.userid in targetRoom.auth) && !user.can('makeroom')) {
+				if (targetRoom.isPrivate && targetRoom.auth && !(user.userid in targetRoom.auth) && !user.can('makeroom')) {
 					return this.errorReply('You do not have permission to invite people to this room.');
 				}
 


### PR DESCRIPTION
Right now regular users can find whether or not a modjoined private room exists by doing /invite [roomname], which is probably not optimal. 
The conditionals also seemed a little weird so I condensed them, if there's a case I missed please let me know.