### PR TITLE
fix /modlog popup for empty search results

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1832,7 +1832,7 @@ exports.commands = {
 			} else {
 				if (!stdout) {
 					connection.popup("No moderator actions containing " + target + " were found on " + roomNames + "." +
-					                 strictMatch ? "" : " Add quotes to the search parameter to search for a phrase, rather than a user.");
+					                 (strictMatch ? "" : " Add quotes to the search parameter to search for a phrase, rather than a user."));
 				} else {
 					connection.popup("|wide||html|<p>The last " + grepLimit + " logged actions containing " + target + " on " + roomNames + "." +
 					                 (strictMatch ? "" : " Add quotes to the search parameter to search for a phrase, rather than a user.") + "</p>" + stdout);


### PR DESCRIPTION
Any search without results will currently give an empty popup.