### PR TITLE
Modify target sent when redirected

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -4607,6 +4607,11 @@ Battle = (() => {
 	Battle.prototype.attrLastMove = function () {
 		this.log[this.lastMoveLine] += '|' + Array.prototype.slice.call(arguments).join('|');
 	};
+	Battle.prototype.retargetLastMove = function (newTarget) {
+		let parts = this.log[this.lastMoveLine].split('|');
+		parts[4] = newTarget;
+		this.log[this.lastMoveLine] = parts.join('|');
+	};
 	Battle.prototype.debug = function (activity) {
 		if (this.getFormat().debug) {
 			this.add('debug', activity);

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1379,6 +1379,7 @@ exports.BattleAbilities = {
 			if (this.validTarget(this.effectData.target, source, move.target)) {
 				if (this.effectData.target !== target) {
 					this.add('-activate', this.effectData.target, 'ability: Lightning Rod');
+					this.retargetLastMove(this.effectData.target);
 				}
 				return this.effectData.target;
 			}
@@ -2717,6 +2718,7 @@ exports.BattleAbilities = {
 			if (this.validTarget(this.effectData.target, source, move.target)) {
 				if (this.effectData.target !== target) {
 					this.add('-activate', this.effectData.target, 'ability: Storm Drain');
+					this.retargetLastMove(this.effectData.target);
 				}
 				return this.effectData.target;
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -4665,6 +4665,7 @@ exports.BattleMovedex = {
 			onFoeRedirectTarget: function (target, source, source2, move) {
 				if (this.validTarget(this.effectData.target, source, move.target)) {
 					this.debug("Follow Me redirected target of move");
+					this.retargetLastMove(this.effectData.target);
 					return this.effectData.target;
 				}
 			},
@@ -10645,6 +10646,7 @@ exports.BattleMovedex = {
 			onFoeRedirectTarget: function (target, source, source2, move) {
 				if (source.runStatusImmunity('powder') && this.validTarget(this.effectData.target, source, move.target)) {
 					this.debug("Rage Powder redirected target of move");
+					this.retargetLastMove(this.effectData.target);
 					return this.effectData.target;
 				}
 			},


### PR DESCRIPTION
>The animation occurs on the user of Follow Me/Rage Powder, as if it was targeted. The user of redirection should not know which Pokemon was targeted initially, which is disclosed on PS due to the animation.

Not 100% sure if this is the best way to implement this, but it was the simplest idea I could think of. It's probably important enough for the doubles community to look at anyway.

Could possibly look to use this for https://github.com/Zarel/Pokemon-Showdown/pull/2438#issuecomment-192032470 too