### PR TITLE
Normalize overwrites moves that change type

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1782,7 +1782,7 @@ exports.BattleAbilities = {
 		shortDesc: "This Pokemon's moves are changed to be Normal type.",
 		onModifyMovePriority: 1,
 		onModifyMove: function (move) {
-			if (move.id !== 'struggle') {
+			if (move.id !== 'struggle' && this.getMove(move.id).type !== 'Normal') {
 				move.type = 'Normal';
 			}
 		},

--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -122,7 +122,6 @@ exports.BattleAbilities = {
 	},
 	"normalize": {
 		inherit: true,
-		onModifyMovePriority: -1,
 		onModifyMove: function (move) {
 			if (move.id !== 'struggle') {
 				move.type = 'Normal';

--- a/test/simulator/abilities/normalize.js
+++ b/test/simulator/abilities/normalize.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const assert = require('assert');
+let battle;
+
+describe('Normalize', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should change most of the user\'s moves to Normal-type', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', moves: ['grassknot']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Normal'));
+	});
+
+	it('should not change Hidden Power to Normal-type', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfighting']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Fighting'));
+	});
+
+	it('should not change Techno Blast to Normal-type if the user is holding a Drive', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'dousedrive', moves: ['technoblast']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Water'));
+	});
+
+	it('should not change Judgment to Normal-type if the user is holding a Plate', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'zapplate', moves: ['judgment']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Electric'));
+	});
+
+	it('should not change Weather Ball to Normal-type if sun, rain, or hail is an active weather', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['sunnyday']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Fire'));
+	});
+
+	it('should not change Natural Gift to Normal-type if the user is holding a Berry', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'chopleberry', moves: ['naturalgift']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Fighting'));
+	});
+});
+
+describe('Normalize [Gen 4]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should change most of the user\'s moves to Normal-type', function () {
+		battle = BattleEngine.Battle.construct('battle-normalize-dp', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', moves: ['grassknot']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Normal'));
+	});
+
+	it('should change Hidden Power to Normal-type', function () {
+		battle = BattleEngine.Battle.construct('battle-normalize-dp-hp', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfire']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Normal'));
+	});
+
+	it('should change Judgment to Normal-type even if the user is holding a Plate', function () {
+		battle = BattleEngine.Battle.construct('battle-normalize-dp-judgment', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'pixieplate', moves: ['judgment']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Normal'));
+	});
+
+	it('should change Weather Ball to Normal-type even if sun, rain, or hail is an active weather', function () {
+		battle = BattleEngine.Battle.construct('battle-normalize-dp-weather', 'gen4customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['sunnyday']}]);
+		battle.commitDecisions();
+		assert.ok(battle.p2.active[0].hasType('Normal'));
+	});
+});


### PR DESCRIPTION
Set all the moves that change type, such as Hidden Power,
Natural Gift, Judgment, and Technoblast, to change their
types within a volatile to guarantee proper interaction
with Normalize and all other effects.