### PR TITLE
Refactor Anger Point to the Hit event handler

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2327,7 +2327,6 @@ Battle = (() => {
 					TryHit: 1,
 					TryHitSide: 1,
 					TryMove: 1,
-					Hit: 1,
 					Boost: 1,
 					DragOut: 1,
 				};

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -115,7 +115,7 @@ exports.BattleAbilities = {
 	"angerpoint": {
 		desc: "If this Pokemon, but not its substitute, is struck by a critical hit, its Attack is raised by 12 stages.",
 		shortDesc: "If this Pokemon (not its substitute) takes a critical hit, its Attack is raised 12 stages.",
-		onAfterDamage: function (damage, target, source, move) {
+		onHit: function (target, source, move) {
 			if (!target.hp) return;
 			if (move && move.effectType === 'Move' && move.crit) {
 				target.setBoost({atk: 6});

--- a/test/simulator/abilities/angerpoint.js
+++ b/test/simulator/abilities/angerpoint.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('assert');
+let battle;
+
+describe('Anger Point', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should maximize Attack when hit by a critical hit', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Cryogonal", ability: 'noguard', moves: ['frostbreath']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['endure']}]);
+
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.pokemon[0].boosts['atk'], 6);
+	});
+
+	it('should maximize Attack when hit by a critical hit even if the foe has Mold Breaker', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Haxorus", ability: 'moldbreaker', item: 'scopelens', moves: ['focusenergy', 'falseswipe']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['defensecurl']}]);
+
+		battle.commitDecisions();
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.pokemon[0].boosts['atk'], 6);
+	});
+
+	it('should not maximize Attack when dealing a critical hit', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Cryogonal", ability: 'noguard', moves: ['endure']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['stormthrow']}]);
+
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.pokemon[0].boosts['atk'], 0);
+		assert.strictEqual(battle.p2.pokemon[0].boosts['atk'], 0);
+	});
+
+	it('should not maximize Attack when behind a substitute', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Cryogonal", ability: 'noguard', item: 'laggingtail', moves: ['frostbreath']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['substitute']}]);
+
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.pokemon[0].boosts['atk'], 0);
+	});
+});

--- a/test/simulator/moves/clearsmog.js
+++ b/test/simulator/moves/clearsmog.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const assert = require('assert');
+let battle;
+
+describe('Clear Smog', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should remove all stat boosts from the target', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['calmmind']}]);
+
+		battle.commitDecisions();
+
+		assert.strictEqual(battle.p2.pokemon[0].boosts['spa'], 0);
+		assert.strictEqual(battle.p2.pokemon[0].boosts['spd'], 0);
+	});
+
+	it('should not remove stat boosts from a target behind a substitute', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog', 'toxic']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['substitute', 'calmmind']}]);
+
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		battle.choose('p2', 'move 2');
+		battle.commitDecisions();
+
+		assert.strictEqual(battle.p2.pokemon[0].boosts['spa'], 1);
+		assert.strictEqual(battle.p2.pokemon[0].boosts['spd'], 1);
+	});
+
+	it('should not remove stat boosts if the target is immune to its attack type', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', item: 'laggingtail', moves: ['clearsmog']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Steelix", ability: 'prankster', moves: ['irondefense']}]);
+
+		battle.commitDecisions();
+
+		assert.strictEqual(battle.p2.pokemon[0].boosts['def'], 2);
+	});
+
+	it('should not remove stat boosts from the user', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Arcanine", ability: 'intimidate', moves: ['morningsun']}]);
+
+		battle.commitDecisions();
+
+		assert.strictEqual(battle.p1.pokemon[0].boosts['atk'], -1);
+	});
+
+	it('should trigger before Anger Point activates during critical hits', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', item: 'scopelens', moves: ['focusenergy', 'clearsmog']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['bulkup']}]);
+
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.pokemon[0].boosts['atk'], 1);
+		assert.strictEqual(battle.p2.pokemon[0].boosts['def'], 1);
+
+		battle.choose('p1', 'move 2');
+		battle.commitDecisions();
+		assert.strictEqual(battle.p2.pokemon[0].boosts['atk'], 6);
+		assert.strictEqual(battle.p2.pokemon[0].boosts['def'], 0);
+	});
+});


### PR DESCRIPTION
This fixes its interaction with Clear Smog because Hit handlers for
moves always activate before all other global event handlers.

Removed the Hit event from the list of events stopped by Mold Breaker
variants as there are no abilities that would be negated by it that
use that handler.