### PR TITLE
Fix recoil in Gen 3-4

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -346,7 +346,7 @@ exports.BattleScripts = {
 		}
 
 		if (move.recoil && totalDamage) {
-			this.damage(this.clampIntRange(Math.round(totalDamage * move.recoil[0] / move.recoil[1]), 1), pokemon, target, 'recoil');
+			this.damage(this.calcRecoilDamage(totalDamage, move), pokemon, target, 'recoil');
 		}
 
 		if (target && pokemon !== target) target.gotAttacked(move, damage, pokemon);
@@ -584,6 +584,10 @@ exports.BattleScripts = {
 			pokemon.switchFlag = move.selfSwitch;
 		}
 		return damage;
+	},
+
+	calcRecoilDamage: function (damageDealt, move) {
+		return this.clampIntRange(Math.round(damageDealt * move.recoil[0] / move.recoil[1]), 1);
 	},
 
 	canMegaEvo: function (pokemon) {

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -273,6 +273,10 @@ exports.BattleMovedex = {
 			return null;
 		},
 	},
+	doubleedge: {
+		inherit: true,
+		recoil: [1, 3],
+	},
 	dreameater: {
 		inherit: true,
 		desc: "Deals damage to one adjacent target, if it is asleep and does not have a Substitute. The user recovers half of the HP lost by the target, rounded up. If Big Root is held by the user, the HP recovered is 1.3x normal, rounded half down.",

--- a/mods/gen3/scripts.js
+++ b/mods/gen3/scripts.js
@@ -17,4 +17,8 @@ exports.BattleScripts = {
 			}
 		}
 	},
+
+	calcRecoilDamage: function (damageDealt, move) {
+		return this.clampIntRange(Math.floor(damageDealt * move.recoil[0] / move.recoil[1]), 1);
+	},
 };

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -148,6 +148,10 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: 80,
 	},
+	bravebird: {
+		inherit: true,
+		recoil: [1, 3],
+	},
 	brickbreak: {
 		inherit: true,
 		desc: "Reflect and Light Screen are removed from the target's field even if the attack misses or the target is a Ghost-type.",
@@ -339,6 +343,10 @@ exports.BattleMovedex = {
 			return null;
 		},
 	},
+	doubleedge: {
+		inherit: true,
+		recoil: [1, 3],
+	},
 	drainpunch: {
 		inherit: true,
 		basePower: 60,
@@ -471,6 +479,10 @@ exports.BattleMovedex = {
 			}
 			return 20;
 		},
+	},
+	flareblitz: {
+		inherit: true,
+		recoil: [1, 3],
 	},
 	focuspunch: {
 		inherit: true,
@@ -1214,6 +1226,10 @@ exports.BattleMovedex = {
 		inherit: true,
 		basePower: 50,
 	},
+	volttackle: {
+		inherit: true,
+		recoil: [1, 3],
+	},
 	whirlpool: {
 		inherit: true,
 		accuracy: 70,
@@ -1240,6 +1256,10 @@ exports.BattleMovedex = {
 				}
 			},
 		},
+	},
+	woodhammer: {
+		inherit: true,
+		recoil: [1, 3],
 	},
 	worryseed: {
 		inherit: true,

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -8,4 +8,8 @@ exports.BattleScripts = {
 			delete this.data.Pokedex[i].abilities['H'];
 		}
 	},
+
+	calcRecoilDamage: function (damageDealt, move) {
+		return this.clampIntRange(Math.floor(damageDealt * move.recoil[0] / move.recoil[1]), 1);
+	},
 };


### PR DESCRIPTION
The recoil of the 1/3 recoil moves in Gen 5-6 is 33% and rounded by ``Math.round``,
and the recoil in Gen 3-4 is 1/3 and rounded by ``Math.floor``.
(I don't know the recoil in Gen 1-2. Sorry.)

In Zarel/Pokemon-Showdown, the recoil was 1/3 long ago and changed into 33% about 3 years ago (See [this commit](https://github.com/Zarel/Pokemon-Showdown/commit/c195611628175c896076823a47a0b10accc00f72)), however the recoil in Gen 3-4 was changed into 33% at the same time.

So I changed ``moves.js`` and ``scripts.js`` to fix this bug.
Please check commits.