### PR TITLE
Seasonal: Fix Ascriptmaster's messages and signature move

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -930,7 +930,7 @@ exports.Formats = [
 				this.add('c|%Articuno|Abolish the patriarchy!');
 			}
 			if (name === 'ascriptmaster') {
-				this.add("c|@Ascriptmaster|Good luck, I'm behind 7 proxies");
+				this.add("c|@Ascriptmaster|It's time for a hero to take the stage!");
 			}
 			if (name === 'astara') {
 				this.add('c|%Ast☆arA|I\'d rather take a nap, I hope you won\'t be a petilil shit, Eat some rare candies and get on my level.');
@@ -1464,7 +1464,7 @@ exports.Formats = [
 				this.add('c|%Articuno|This is why you don\'t get any girls.');
 			}
 			if (name === 'ascriptmaster') {
-				this.add('c|@Ascriptmaster|Too overpowered. I\'m nerfing you next patch');
+				this.add('c|@Ascriptmaster|Farewell, my friends. May we meet another day...');
 			}
 			if (name === 'astara') {
 				sentences = ['/me twerks into oblivion', 'good night ♥', 'Astara Vista Baby'];

--- a/mods/seasonal/moves.js
+++ b/mods/seasonal/moves.js
@@ -3836,12 +3836,16 @@ exports.BattleMovedex = {
 			'Fire', 'Flying', 'Ghost', 'Grass', 'Ground', 'Ice',
 			'Normal', 'Poison', 'Psychic', 'Rock', 'Steel', 'Water',
 		],
-		onPrepareHit: function (target, source) {
-			this.attrLastMove('[still]');
-			this.add('-anim', source, 'Tri Attack', target);
+		onPrepareHit: function (target, source, move) {
+			this.attrLastMove('[anim] Tri Attack');
+			move.types = move.typechart.slice();
+			Tools.shuffle(move.types);
+			move.types.splice(3);
+			this.add("c|@Ascriptmaster|Go! " + move.types.join(', ') + "! Spectrum Triplet Beam!!!");
+			move.hitcount = 0;
 		},
 		onTryHit: function (target, source, move) {
-			move.type = move.typechart[this.random(18)];
+			move.type = move.types[move.hitcount++];
 		},
 		willCrit: true,
 		ignoreImmunity: true,


### PR DESCRIPTION
The switch-in and faint messages are last year's values, and Spectrum
Triplet Beam announces the three types used in the attack. (Also, the
three types used are now unique.)

http://www.smogon.com/forums/threads/super-staff-bros-melee-set-submissions.3566098/page-2#post-6690254 for the messages used. The signature move message was modified slightly.