### PR TITLE
canBroadcast: check canTalk only when broadcasting

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -171,14 +171,11 @@ class CommandContext {
 		return true;
 	}
 	canBroadcast(checkOnly, suppressMessage) {
-		let message = this.canTalk(this.message);
-		if (!message) return false;
-		let normalized = message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
-
+		let message, normalized = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
 		if (!this.broadcasting && this.cmdToken === BROADCAST_TOKEN) {
 			if (!this.user.can('broadcast', null, this.room)) {
 				this.errorReply("You need to be voiced to broadcast this command's information.");
-				this.errorReply("To see it for yourself, use: /" + message.substr(1));
+				this.errorReply("To see it for yourself, use: /" + this.message.substr(1));
 				return false;
 			}
 
@@ -188,6 +185,8 @@ class CommandContext {
 				this.errorReply("You can't broadcast this because it was just broadcast.");
 				return false;
 			}
+			message = this.canTalk(this.message);
+			if (!message) return false;
 			this.broadcasting = true;
 		}
 		if (this.broadcasting && !checkOnly) {


### PR DESCRIPTION
- eliminate the issue of disabling /dt [mon] twice and making it impossible to use /dt during modchat
- make /ds actually not return false on the second time canBroadcast() is called.