### PR TITLE
Seasonal: Fix Eevee General's faint messages

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1539,9 +1539,8 @@ exports.Formats = [
 				this.add('c|+sparkyboTTT|nice 1');
 			}
 			if (name === 'eeveegeneral') {
-				sentences = ["Electrolyte is in charge", "/me secretly cries", "inap!"];
-				this.add("c|~Eevee General|bye room");
-				this.add("c|!Eevee General|" + sentences[this.random(3)]);
+				sentences = ["bye room, Electrolyte is in charge", "/me secretly cries", "inap!"];
+				this.add("c|~Eevee General|" + sentences[this.random(3)]);
 			}
 			if (name === 'eyan') {
 				this.add("c|@Eyan|;-;7");


### PR DESCRIPTION
Upon his request:

[14:54] #Eevee General: I moved it
[14:55] #Eevee General: why does my mon get muted when it dies lol
[14:55] NotRhythms L0LOLL: idk joim coded it
[14:55] NotRhythms L0LOLL: lol
[14:59] #Eevee General: how do I edit that
[15:00] #Eevee General: aka make a pull request
[15:00] NotRhythms L0LOLL: i can do it
[15:00] NotRhythms L0LOLL: if u want
[15:00] #Eevee General: "bye room" is supposed to be paird with "electrolyte is in charge"
[15:00] #Eevee General: 2 separate lines
[15:00] #Eevee General: inap! is it's own line
[15:01] #Eevee General: and is a separate occurrence
[15:01] NotRhythms L0LOLL: k
[15:01] #Eevee General: ty
[15:01] NotRhythms L0LOLL: and is it supposed to be muted
[15:01] #Eevee General: n
[15:01] NotRhythms L0LOLL: and when is it supposed to accure
[15:01] NotRhythms L0LOLL: occur*
[15:01] #Eevee General: faint
[15:01] NotRhythms L0LOLL: o
[15:01] #Eevee General: these are faint messages
[15:01] NotRhythms L0LOLL: are they like randomly interchanging
[15:02] #Eevee General: yes
[15:02] #Eevee General: the other one is /me secretly cries