### PR TITLE
Implement Triple Kick multiple accuracy checks

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2476,6 +2476,9 @@ exports.BattleAbilities = {
 			if (move.multihit && move.multihit.length) {
 				move.multihit = move.multihit[1];
 			}
+			if (move.multiaccuracy) {
+				delete move.multiaccuracy;
+			}
 		},
 		id: "skilllink",
 		name: "Skill Link",

--- a/data/moves.js
+++ b/data/moves.js
@@ -14637,6 +14637,7 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		multihit: [3, 3],
+		multiaccuracy: true,
 		effect: {
 			duration: 1,
 			onStart: function () {

--- a/data/moves.js
+++ b/data/moves.js
@@ -14636,7 +14636,7 @@ exports.BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		multihit: [3, 3],
+		multihit: 3,
 		multiaccuracy: true,
 		effect: {
 			duration: 1,

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -327,6 +327,11 @@ exports.BattleScripts = {
 			for (i = 0; i < hits && target.hp && pokemon.hp; i++) {
 				if (pokemon.status === 'slp' && !isSleepUsable) break;
 
+				if (move.multiaccuracy && i > 0 && accuracy !== true && this.random(100) >= accuracy) {
+					// TODO: Investigate whether Triple Kick only uses initial accuracy for each accuracy check as assumed here.
+					break;
+				}
+
 				moveDamage = this.moveHit(target, pokemon, move);
 				if (moveDamage === false) break;
 				if (nullDamage && (moveDamage || moveDamage === 0 || moveDamage === undefined)) nullDamage = false;


### PR DESCRIPTION
Any multi-strike move with the `multiaccuracy` property set to `true` will now check for accuracy before each hit.


I have no knowledge, however, of whether Triple Kick actually uses its accuracy for hits 2 & 3 (instead of hard-coded 90% chance of connecting the hit), and if it does, whether it uses the same accuracy for each hit instead of adjusting to current accuracy/evasion modifiers which may change between hits.

The latter concern also extends to other multi-strike moves. If the user of a contact-making multi-strike move was damaged by Rocky Helmet or other similar sources to the point where it ate its Lansat Berry, the critical bonus, which is applied in `onModifyMove`, will not apply to the remaining hits. I suspect that this is not the case on cartridge. There may be also other similar cases. If these concerns turn out to be real, it might be necessary to look into whether more events need to be placed inside the multi-strike loop.