### PR TITLE
Critical Hit Ratio refactor: Use an event to modify crit ratios

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -3448,18 +3448,19 @@ Battle = (() => {
 		basePower = this.clampIntRange(basePower, 1);
 
 		let critMult;
+		let critRatio = this.runEvent('ModifyCritRatio', pokemon, target, move, move.critRatio || 0);
 		if (this.gen <= 5) {
-			move.critRatio = this.clampIntRange(move.critRatio, 0, 5);
+			critRatio = this.clampIntRange(critRatio, 0, 5);
 			critMult = [0, 16, 8, 4, 3, 2];
 		} else {
-			move.critRatio = this.clampIntRange(move.critRatio, 0, 4);
+			critRatio = this.clampIntRange(critRatio, 0, 4);
 			critMult = [0, 16, 8, 2, 1];
 		}
 
 		move.crit = move.willCrit || false;
 		if (move.willCrit === undefined) {
-			if (move.critRatio) {
-				move.crit = (this.random(critMult[move.critRatio]) === 0);
+			if (critRatio) {
+				move.crit = (this.random(critMult[critRatio]) === 0);
 			}
 		}
 

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2781,8 +2781,8 @@ exports.BattleAbilities = {
 	},
 	"superluck": {
 		shortDesc: "This Pokemon's critical hit ratio is raised by 1 stage.",
-		onModifyMove: function (move) {
-			move.critRatio++;
+		onModifyCritRatio: function (critRatio) {
+			return critRatio + 1;
 		},
 		id: "superluck",
 		name: "Super Luck",

--- a/data/items.js
+++ b/data/items.js
@@ -2477,9 +2477,9 @@ exports.BattleItems = {
 		fling: {
 			basePower: 40,
 		},
-		onModifyMove: function (move, user) {
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.baseTemplate.species === 'Chansey') {
-				move.critRatio += 2;
+				return critRatio + 2;
 			}
 		},
 		num: 256,
@@ -3563,8 +3563,8 @@ exports.BattleItems = {
 		fling: {
 			basePower: 80,
 		},
-		onModifyMove: function (move) {
-			move.critRatio++;
+		onModifyCritRatio: function (critRatio) {
+			return critRatio + 1;
 		},
 		num: 326,
 		gen: 4,
@@ -3934,8 +3934,8 @@ exports.BattleItems = {
 		fling: {
 			basePower: 30,
 		},
-		onModifyMove: function (move) {
-			move.critRatio++;
+		onModifyCritRatio: function (critRatio) {
+			return critRatio + 1;
 		},
 		num: 232,
 		gen: 2,
@@ -4385,9 +4385,9 @@ exports.BattleItems = {
 			basePower: 60,
 		},
 		spritenum: 475,
-		onModifyMove: function (move, user) {
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.baseTemplate.species === 'Farfetch\'d') {
-				move.critRatio += 2;
+				return critRatio + 2;
 			}
 		},
 		num: 259,

--- a/data/moves.js
+++ b/data/moves.js
@@ -4604,8 +4604,8 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-start', pokemon, 'move: Focus Energy');
 			},
-			onModifyMove: function (move) {
-				move.critRatio += 2;
+			onModifyCritRatio: function (critRatio) {
+				return critRatio + 2;
 			},
 		},
 		secondary: false,

--- a/mods/gen2/items.js
+++ b/mods/gen2/items.js
@@ -20,17 +20,19 @@ exports.BattleItems = {
 	},
 	luckypunch: {
 		inherit: true,
-		onModifyMove: function (move, user) {
+		onModifyCritRatioPriority: -1,
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.template.species === 'Chansey') {
-				move.critRatio = 3;
+				return 3;
 			}
 		},
 	},
 	stick: {
 		inherit: true,
-		onModifyMove: function (move, user) {
+		onModifyCritRatioPriority: -1,
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.template.species === 'Farfetch\'d') {
-				move.critRatio = 3;
+				return 3;
 			}
 		},
 	},

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -151,9 +151,8 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-start', pokemon, 'move: Focus Energy');
 			},
-			onModifyMovePriority: 1,
-			onModifyMove: function (move) {
-				move.critRatio += 1;
+			onModifyCritRatio: function (critRatio) {
+				return critRatio + 1;
 			},
 		},
 	},

--- a/mods/gen3/items.js
+++ b/mods/gen3/items.js
@@ -85,9 +85,9 @@ exports.BattleItems = {
 	},
 	"luckypunch": {
 		inherit: true,
-		onModifyMove: function (move, user) {
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.template.species === 'Chansey') {
-				move.critRatio += 2;
+				return critRatio + 2;
 			}
 		},
 	},
@@ -223,9 +223,9 @@ exports.BattleItems = {
 	},
 	"stick": {
 		inherit: true,
-		onModifyMove: function (move, user) {
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.template.species === 'Farfetch\'d') {
-				move.critRatio += 2;
+				return critRatio + 2;
 			}
 		},
 	},

--- a/mods/gen4/items.js
+++ b/mods/gen4/items.js
@@ -160,9 +160,9 @@ exports.BattleItems = {
 	},
 	"luckypunch": {
 		inherit: true,
-		onModifyMove: function (move, user) {
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.template.species === 'Chansey') {
-				move.critRatio += 2;
+				return critRatio + 2;
 			}
 		},
 	},
@@ -225,9 +225,9 @@ exports.BattleItems = {
 	},
 	"stick": {
 		inherit: true,
-		onModifyMove: function (move, user) {
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.template.species === 'Farfetch\'d') {
-				move.critRatio += 2;
+				return critRatio + 2;
 			}
 		},
 	},

--- a/mods/gennext/items.js
+++ b/mods/gennext/items.js
@@ -150,9 +150,9 @@ exports.BattleItems = {
 		spritenum: 475,
 		// The Stick is a stand-in for a number of pokemon-exclusive items
 		// introduced with Gen Next
-		onModifyMove: function (move, user) {
+		onModifyCritRatio: function (critRatio, user) {
 			if (user.template.species === 'Farfetch\'d') {
-				move.critRatio += 2;
+				return critRatio + 2;
 			}
 		},
 		onModifyDef: function (def, pokemon) {

--- a/test/simulator/items/lansatberry.js
+++ b/test/simulator/items/lansatberry.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('assert');
+let battle;
+
+describe('Lansat Berry', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should apply a Focus Energy effect when consumed', function () {
+		battle = BattleEngine.Battle.construct();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Aggron', ability: 'sturdy', item: 'lansatberry', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Lucario', ability: 'adaptability', moves: ['aurasphere']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].item, '');
+		assert.ok('focusenergy' in battle.p1.active[0].volatiles);
+	});
+
+	it('should start to apply the effect even in middle of an attack', function () {
+		battle = BattleEngine.Battle.construct('battle-lansat', 'customgame');
+		battle.join('p1', 'Guest 1', 1, [{species: 'Makuhita', ability: 'guts', item: 'lansatberry', moves: ['triplekick']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Muk', ability: 'noguard', item: 'rockyhelmet', moves: ['acidarmor']}]);
+		battle.commitDecisions(); // Team Preview
+
+		let i = 0;
+		let expectedRatio = [1, 1, 1, 1, 1, 3];
+		battle.on('ModifyCritRatio', battle.getFormat(), -99, function (critRatio, pokemon) {
+			assert.strictEqual(critRatio, expectedRatio[i++]);
+		});
+
+		battle.commitDecisions();
+		battle.commitDecisions();
+
+		assert.strictEqual(battle.p1.active[0].item, '');
+		assert.strictEqual(battle.p1.active[0].hp, 3);
+		assert.strictEqual(i, 6);
+	});
+});


### PR DESCRIPTION
This allows for proper crit ratios when a Pokemon loses/gains an ability,
item, or other effect in the middle of a multi-hit attack.