### PR TITLE
Make the move Mono Flying restore types correctly

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -1239,11 +1239,11 @@ BattlePokemon = (() => {
 		if (this.status) hpstring += ' ' + this.status;
 		return hpstring;
 	};
-	BattlePokemon.prototype.setType = function (newType, enforce) {
+	BattlePokemon.prototype.setType = function (newTypes, enforce) {
 		// Arceus first type cannot be normally changed
 		if (!enforce && this.template.num === 493) return false;
 
-		this.types = [newType];
+		this.types = newTypes.split('/');
 		this.addedType = '';
 
 		return true;

--- a/mods/seasonal/moves.js
+++ b/mods/seasonal/moves.js
@@ -2575,7 +2575,7 @@ exports.BattleMovedex = {
 					for (let p in thisSide.active) {
 						const pokemon = thisSide.active[p];
 						if ((pokemon.types[0] === 'Flying' && !pokemon.types[1]) || !pokemon.hp) continue;
-						pokemon.setType(pokemon.template.types, true);
+						pokemon.setType(pokemon.template.types.join('/'), true);
 						this.add('-end', pokemon, 'typechange');
 					}
 				}


### PR DESCRIPTION
`setType` only works for a single type as a string, but the move Mono Flying passes it an array of types.