### PR TITLE
Report complex bans using the original text

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -64,7 +64,7 @@ class Validator {
 
 		for (let i = 0; i < format.teamBanTable.length; i++) {
 			let bannedCombo = true;
-			for (let j = 0; j < format.teamBanTable[i].length; j++) {
+			for (let j = 1; j < format.teamBanTable[i].length; j++) {
 				if (!teamHas[format.teamBanTable[i][j]]) {
 					bannedCombo = false;
 					break;
@@ -72,7 +72,7 @@ class Validator {
 			}
 			if (bannedCombo) {
 				let clause = format.name ? " by " + format.name : '';
-				problems.push("Your team has the combination of " + format.teamBanTable[i].join(' + ') + ", which is banned" + clause + ".");
+				problems.push("Your team has the combination of " + format.teamBanTable[i][0] + ", which is banned" + clause + ".");
 			}
 		}
 
@@ -500,7 +500,7 @@ class Validator {
 		}
 		for (let i = 0; i < format.setBanTable.length; i++) {
 			let bannedCombo = true;
-			for (let j = 0; j < format.setBanTable[i].length; j++) {
+			for (let j = 1; j < format.setBanTable[i].length; j++) {
 				if (!setHas[format.setBanTable[i][j]]) {
 					bannedCombo = false;
 					break;
@@ -508,7 +508,7 @@ class Validator {
 			}
 			if (bannedCombo) {
 				clause = format.name ? " by " + format.name : '';
-				problems.push(name + " has the combination of " + format.setBanTable[i].join(' + ') + ", which is banned" + clause + ".");
+				problems.push(name + " has the combination of " + format.setBanTable[i][0] + ", which is banned" + clause + ".");
 			}
 		}
 

--- a/tools.js
+++ b/tools.js
@@ -594,15 +594,18 @@ module.exports = (() => {
 					if (subformat.banlist[i].includes('+')) {
 						if (subformat.banlist[i].includes('++')) {
 							complexList = subformat.banlist[i].split('++');
+							let banlist = complexList.join('+');
 							for (let j = 0; j < complexList.length; j++) {
 								complexList[j] = toId(complexList[j]);
 							}
+							complexList.unshift(banlist);
 							format.teamBanTable.push(complexList);
 						} else {
 							complexList = subformat.banlist[i].split('+');
 							for (let j = 0; j < complexList.length; j++) {
 								complexList[j] = toId(complexList[j]);
 							}
+							complexList.unshift(subformat.banlist[i]);
 							format.setBanTable.push(complexList);
 						}
 					}


### PR DESCRIPTION
If your team fails to validate the Gravity + Lovely Kiss Doubles OU ban, the ban is actually reported as "Your team has the combination of gravity + lovelykiss, which is banned by Doubles OU."

I wrote this partly as a code simplification, but I suppose you might be worried by the potential run-time cost, in which case I have some ideas whereby I can implement a compromise approach.