### PR TITLE
Alter |move| target on every target change

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -458,12 +458,16 @@ BattlePokemon = (() => {
 			}
 			break;
 		default:
+			let selectedTarget = target;
 			if (!target || (target.fainted && target.side !== this.side)) {
 				// If a targeted foe faints, the move is retargeted
 				target = this.battle.resolveTarget(this, move);
 			}
 			if (target.side.active.length > 1) {
 				target = this.battle.priorityEvent('RedirectTarget', this, this, move, target);
+			}
+			if (selectedTarget !== target) {
+				this.battle.retargetLastMove(target);
 			}
 			targets = [target];
 

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1380,7 +1380,6 @@ exports.BattleAbilities = {
 			if (this.validTarget(this.effectData.target, source, move.target)) {
 				if (this.effectData.target !== target) {
 					this.add('-activate', this.effectData.target, 'ability: Lightning Rod');
-					this.retargetLastMove(this.effectData.target);
 				}
 				return this.effectData.target;
 			}
@@ -2722,7 +2721,6 @@ exports.BattleAbilities = {
 			if (this.validTarget(this.effectData.target, source, move.target)) {
 				if (this.effectData.target !== target) {
 					this.add('-activate', this.effectData.target, 'ability: Storm Drain');
-					this.retargetLastMove(this.effectData.target);
 				}
 				return this.effectData.target;
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -4861,7 +4861,6 @@ exports.BattleMovedex = {
 			onFoeRedirectTarget: function (target, source, source2, move) {
 				if (this.validTarget(this.effectData.target, source, move.target)) {
 					this.debug("Follow Me redirected target of move");
-					this.retargetLastMove(this.effectData.target);
 					return this.effectData.target;
 				}
 			},
@@ -11080,7 +11079,6 @@ exports.BattleMovedex = {
 			onFoeRedirectTarget: function (target, source, source2, move) {
 				if (source.runStatusImmunity('powder') && this.validTarget(this.effectData.target, source, move.target)) {
 					this.debug("Rage Powder redirected target of move");
-					this.retargetLastMove(this.effectData.target);
 					return this.effectData.target;
 				}
 			},


### PR DESCRIPTION
<s>I should have done this from the start when Ascriptmaster proposed it</s>

Fixes the issue with animations playing on fainted targets in doubles/triples. Has no impact on any other targeting behavior that I can tell, or have found.

Example on turn 3: http://replay.pokemonshowdown.com/vgc2016-363124841