### PR TITLE
Use the correct target when bouncing back moves

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1441,7 +1441,7 @@ exports.BattleAbilities = {
 			}
 			let newMove = this.getMoveCopy(move.id);
 			newMove.hasBounced = true;
-			this.useMove(newMove, target, source);
+			this.useMove(newMove, this.effectData.target, source);
 			return null;
 		},
 		effect: {
@@ -3358,7 +3358,7 @@ exports.BattleAbilities = {
 			}
 			let newMove = this.getMoveCopy(move.id);
 			newMove.hasBounced = true;
-			this.useMove(newMove, target, source);
+			this.useMove(newMove, this.effectData.target, source);
 			return null;
 		},
 		effect: {

--- a/data/moves.js
+++ b/data/moves.js
@@ -8258,7 +8258,7 @@ exports.BattleMovedex = {
 				}
 				let newMove = this.getMoveCopy(move.id);
 				newMove.hasBounced = true;
-				this.useMove(newMove, target, source);
+				this.useMove(newMove, this.effectData.target, source);
 				return null;
 			},
 		},


### PR DESCRIPTION
Reference: http://www.smogon.com/forums/threads/3469932/page-265#post-6775149

It only mentioned Magic Bounce, but Magic Coat is doing the same thing.