### PR TITLE
Fix Unnerve Activation Timing

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -4047,6 +4047,7 @@ Battle = (() => {
 			this.switchIn(decision.target, decision.pokemon.position);
 			break;
 		case 'runSwitch':
+			this.runEvent('TrySwitchIn', decision.pokemon);
 			this.runEvent('SwitchIn', decision.pokemon);
 			if (this.gen <= 2 && !decision.pokemon.side.faintedThisTurn && decision.pokemon.draggedIn !== this.turn) this.runEvent('AfterSwitchInSelf', decision.pokemon);
 			if (!decision.pokemon.hp) break;
@@ -4093,6 +4094,7 @@ Battle = (() => {
 			let pokemon = this.p1.active[i];
 			if (pokemon.forceSwitchFlag) {
 				if (pokemon.hp) this.dragIn(pokemon.side, pokemon.position);
+				runEvent('TrySwitchIn', pokemon);
 				pokemon.forceSwitchFlag = false;
 			}
 		}

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -3122,7 +3122,7 @@ exports.BattleAbilities = {
 	},
 	"unnerve": {
 		shortDesc: "While this Pokemon is active, it prevents opposing Pokemon from using their Berries.",
-		onStart: function (pokemon) {
+		onTrySwitchIn: function (pokemon) {
 			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
 		},
 		onFoeTryEatItem: false,


### PR DESCRIPTION
Added event "TrySwitchIn" for unnerve timing to allow it to activate
before hazards. Tested with normal switch ins and drag outs.