### PR TITLE
Fix PMs getting interfered by banned room words

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -330,8 +330,8 @@ class CommandContext {
 				return false;
 			}
 
-			if (!this.room.banwordRegex) this.updateBanwords();
-			if (this.room.banwordRegex !== true && this.room.banwordRegex.test(message) && !user.can('mute', null, this.room)) {
+			if (!room.banwordRegex) this.updateBanwords();
+			if (room.banwordRegex !== true && room.banwordRegex.test(message) && !user.can('mute', null, room)) {
 				this.errorReply("Your message contained banned words.");
 				return false;
 			}


### PR DESCRIPTION
If you go in a room and do /pm user, [message] and that message contains a banned word, it would filter it as if the message was getting sent to a room as a chat message.