### PR TITLE
Allow formats to override inherited formats or rulesets

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -224,6 +224,24 @@ class Validator {
 				const reason = banReason`${banlistTable[check]}`;
 				return [`${template.baseSpecies} is ${reason}.`];
 			}
+			if (banlistTable['Unreleased'] && template.isUnreleased) {
+				if (!format.requirePentagon || (template.eggGroups[0] === 'Undiscovered' && !template.evos)) {
+					problems.push(`${name} (${template.species}) is unreleased.`);
+				}
+			}
+			let species = template.species;
+			let tier = template.tier;
+			if (item.megaEvolves === template.species) {
+				species = item.megaStone;
+				tier = tools.getTemplate(item.megaStone).tier;
+			}
+			if (tier) {
+				if (tier.charAt(0) === '(') tier = tier.slice(1, -1);
+				setHas[toId(tier)] = true;
+				if (banlistTable[tier] && banlistTable[toId(species)] !== false) {
+					problems.push(`${template.species} is in ${tier}, which is banned.`);
+				}
+			}
 		}
 
 		check = toId(set.ability);
@@ -240,11 +258,6 @@ class Validator {
 		}
 		if (banlistTable['Unreleased'] && item.isUnreleased) {
 			problems.push(`${name}'s item ${set.item} is unreleased.`);
-		}
-		if (banlistTable['Unreleased'] && template.isUnreleased) {
-			if (!format.requirePentagon || (template.eggGroups[0] === 'Undiscovered' && !template.evos)) {
-				problems.push(`${name} (${template.species}) is unreleased.`);
-			}
 		}
 		setHas[toId(set.ability)] = true;
 		if (banlistTable['illegal']) {
@@ -522,17 +535,6 @@ class Validator {
 				if (ability.name !== oldAbilities['0'] && ability.name !== oldAbilities['1'] && !oldAbilities['H']) {
 					problems.push(`${name} has moves incompatible with its ability.`);
 				}
-			}
-		}
-		if (item.megaEvolves === template.species) {
-			template = tools.getTemplate(item.megaStone);
-		}
-		if (template.tier) {
-			let tier = template.tier;
-			if (tier.charAt(0) === '(') tier = tier.slice(1, -1);
-			setHas[toId(tier)] = true;
-			if (banlistTable[tier]) {
-				problems.push(`${template.species} is in ${tier}, which is banned.`);
 			}
 		}
 

--- a/tools.js
+++ b/tools.js
@@ -596,10 +596,16 @@ module.exports = (() => {
 
 			banlistTable = format.banlistTable;
 			if (!subformat) subformat = format;
+			if (subformat.unbanlist) {
+				for (let i = 0; i < subformat.unbanlist.length; i++) {
+					banlistTable[subformat.banlist[i]] = false;
+					banlistTable[toId(subformat.banlist[i])] = false;
+				}
+			}
 			if (subformat.banlist) {
 				for (let i = 0; i < subformat.banlist.length; i++) {
 					// don't revalidate what we already validate
-					if (banlistTable[toId(subformat.banlist[i])]) continue;
+					if (banlistTable[toId(subformat.banlist[i])] !== undefined) continue;
 
 					banlistTable[subformat.banlist[i]] = subformat.name || true;
 					banlistTable[toId(subformat.banlist[i])] = subformat.name || true;
@@ -635,7 +641,7 @@ module.exports = (() => {
 			if (subformat.ruleset) {
 				for (let i = 0; i < subformat.ruleset.length; i++) {
 					// don't revalidate what we already validate
-					if (banlistTable['Rule:' + toId(subformat.ruleset[i])]) continue;
+					if (banlistTable['Rule:' + toId(subformat.ruleset[i])] !== undefined) continue;
 
 					banlistTable['Rule:' + toId(subformat.ruleset[i])] = subformat.ruleset[i];
 					if (!format.ruleset.includes(subformat.ruleset[i])) format.ruleset.push(subformat.ruleset[i]);


### PR DESCRIPTION
I'm probably using a sledgehammer to crack a nut here, but this allows formats to allow Pokémon, items, moves and abilities that have been banned or are unreleased. For instance, Itemize could add `overrides: ['Soul Dew'],` and otherwise remain an OU-based metagame, while Monotype could use the OU ruleset and override Deoxys-Defense, Deoxys-Speed and Landorus, as opposed to the complex banlist it currently enjoys.

I couldn't decide what to do about Genesect though; as written you need to override all five formes, as I didn't want to accidentally allow all Deoxys forms in Monotype for instance.