### PR TITLE
Allow validateSet to run twice on the same Pokemon set

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -189,7 +189,7 @@ exports.BattleFormats = {
 					let moveid = move.id;
 					if (hasMove[moveid]) continue;
 					hasMove[moveid] = true;
-					moves.push(set.moves[i]);
+					moves.push(move.id);
 				}
 			}
 			set.moves = moves;

--- a/team-validator.js
+++ b/team-validator.js
@@ -253,16 +253,15 @@ class Validator {
 				if (!set.moves[i]) continue;
 				let move = tools.getMove(Tools.getString(set.moves[i]));
 				if (!move.exists) return ['"' + move.name + '" is an invalid move.'];
-				set.moves[i] = move.name;
 				check = move.id;
 				setHas[check] = true;
 				if (banlistTable[check]) {
 					clause = typeof banlistTable[check] === 'string' ? " by " + banlistTable[check] : '';
-					problems.push(name + "'s move " + set.moves[i] + " is banned" + clause + ".");
+					problems.push(name + "'s move " + move.name + " is banned" + clause + ".");
 				}
 
 				if (banlistTable['Unreleased']) {
-					if (move.isUnreleased) problems.push(name + "'s move " + set.moves[i] + " is unreleased.");
+					if (move.isUnreleased) problems.push(name + "'s move " + move.name + " is unreleased.");
 				}
 
 				if (banlistTable['illegal']) {


### PR DESCRIPTION
`validateSet` converts `set.moves` to use move names, however the `Pokemon` ruleset expects `set.moves` to use move ids. Since it already uses `move.name` for two of its error messages I just used that for the other two messages too.
