### PR TITLE
Random Battle: Improve Tyrantrum

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -5401,7 +5401,7 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	tyrantrum: {
-		randomBattleMoves: ["stealthrock", "dragondance", "stoneedge", "dragonclaw", "earthquake", "firefang", "outrage", "headsmash"],
+		randomBattleMoves: ["stealthrock", "dragondance", "dragonclaw", "earthquake", "superpower", "outrage", "headsmash"],
 		randomDoubleBattleMoves: ["rockslide", "dragondance", "headsmash", "dragonclaw", "earthquake", "icefang", "firefang", "protect"],
 		tier: "RU",
 	},


### PR DESCRIPTION
Reject Stone Edge with Rock Head + Head Smash

Reject Fire Fang with Head Smash

----

An alternate strategy for Fire Fang is to lock Tyrantrum to Rock Head if it has Head Smash, but I don't think that Fire Fang is useful enough without Strong Jaw. Maybe add Superpower (it's in its Scarfed set on Smogon) to its movepool as an option against Ferrothorn and maybe some other things the Fire coverage was dealing with.