### PR TITLE
Trivia: version trivia data

### DIFF
--- a/chat-plugins/trivia.js
+++ b/chat-plugins/trivia.js
@@ -41,6 +41,7 @@ if (!triviaData || typeof triviaData.leaderboard !== 'object') triviaData.leader
 if (!Array.isArray(triviaData.ladder)) triviaData.ladder = [];
 if (!Array.isArray(triviaData.questions)) triviaData.questions = [];
 if (!Array.isArray(triviaData.submissions)) triviaData.submissions = [];
+if (typeof triviaData.version !== 'number') triviaData.version = 0;
 
 let writeTriviaData = (() => {
 	let writing = false;


### PR DESCRIPTION
Versioning trivia data is entirely irrelevant now, but it's necessary for the rewrite to upgrade old trivia data automatically after making changes to it that would break the plugin.