### PR TITLE
Fix crash in /hotpatch with compiled .node modules

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -656,7 +656,9 @@ exports.uncacheTree = function (root) {
 		for (let i = 0; i < uncache.length; ++i) {
 			if (require.cache[uncache[i]]) {
 				newuncache.push.apply(newuncache,
-					require.cache[uncache[i]].children.map(cachedModule => cachedModule.id)
+					require.cache[uncache[i]].children
+						.filter(cachedModule => !cachedModule.id.endsWith('.node'))
+						.map(cachedModule => cachedModule.id)
 				);
 				delete require.cache[uncache[i]];
 			}


### PR DESCRIPTION
Modules compiled using node.js' addons API do not get added to
require.cache and will make /hotpatch crash if any of them happen to
have been required when it is called.