### PR TITLE
On failed takeItem, re-set item id instead of item object

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -974,7 +974,7 @@ exports.BattleMovedex = {
 				return false;
 			}
 			if (!target.setItem(yourItem)) {
-				source.item = yourItem;
+				source.item = yourItem.id;
 				return false;
 			}
 			this.add('-item', target, yourItem.name, '[from] move: Bestow', '[of] ' + source);
@@ -14317,8 +14317,8 @@ exports.BattleMovedex = {
 			let myItem = source.takeItem();
 			if (target.item || source.item || (!yourItem && !myItem) ||
 					(myItem.onTakeItem && myItem.onTakeItem(myItem, target) === false)) {
-				if (yourItem) target.item = yourItem;
-				if (myItem) source.item = myItem;
+				if (yourItem) target.item = yourItem.id;
+				if (myItem) source.item = myItem.id;
 				return false;
 			}
 			this.add('-activate', source, 'move: Trick', '[of] ' + target);
@@ -15138,8 +15138,8 @@ exports.BattleMovedex = {
 			let myItem = source.takeItem();
 			if (target.item || source.item || (!yourItem && !myItem) ||
 					(myItem.onTakeItem && myItem.onTakeItem(myItem, target) === false)) {
-				if (yourItem) target.item = yourItem;
-				if (myItem) source.item = myItem;
+				if (yourItem) target.item = yourItem.id;
+				if (myItem) source.item = myItem.id;
 				return false;
 			}
 			this.add('-activate', source, 'move: Trick', '[of] ' + target);


### PR DESCRIPTION
When trick, switcheroo, and bestow fail, their items are put back on the pokemon
they came from. However, the item object itself was being set, rather than its
id (as is done in thief).

This is causing request messages to be sent from server to client containing an extra object in the item field, instead of a string as expected.
For example (note Furret's item):
```
>battle-randombattle-47
|request|{"active":[{"moves":[{"move":"Trick","id":"trick","pp":15,"maxpp":16,"target":"normal","disabled":false},{"move":"Aqua Tail","id":"aquatail","pp":16,"maxpp":16,"target":"normal","disabled":true},{"move":"Knock Off","id":"knockoff","pp":32,"maxpp":32,"target":"normal","disabled":true},{"move":"Double-Edge","id":"doubleedge","pp":24,"maxpp":24,"target":"normal","disabled":true}]}],"side":{"name":"0raichu","id":"p1","pokemon":[{"ident":"p1: Furret","details":"Furret, L83, F","condition":"199/277","active":true,"stats":{"atk":174,"def":154,"spa":122,"spd":139,"spe":197},"moves":["trick","aquatail","knockoff","doubleedge"],"baseAbility":"frisk","item":{"id":"choicescarf","name":"Choice Scarf","spritenum":69,"fling":{"basePower":10},"isChoice":true,"num":287,"gen":4,"desc":"Holder's Speed is 1.5x, but it can only select the first move it executes.","cached":true,"exists":true,"fullname":"item: Choice Scarf","category":"Effect","effectType":"Item"},"pokeball":"pokeball"},{"ident":"p1: Azelf","details":"Azelf, L77","condition":"242/242","active":false,"stats":{"atk":197,"def":152,"spa":237,"spd":152,"spe":222},"moves":["nastyplot","dazzlinggleam","taunt","psyshock"],"baseAbility":"levitate","item":"leftovers","pokeball":"pokeball"},{"ident":"p1: Tyrantrum","details":"Tyrantrum, L79, M","condition":"0 fnt","active":false,"stats":{"atk":237,"def":234,"spa":155,"spd":139,"spe":158},"moves":["earthquake","outrage","stealthrock","superpower"],"baseAbility":"strongjaw","item":"lifeorb","pokeball":"pokeball"},{"ident":"p1: Gligar","details":"Gligar, L77, M","condition":"182/227","active":false,"stats":{"atk":160,"def":206,"spa":98,"spd":145,"spe":175},"moves":["uturn","toxic","defog","earthquake"],"baseAbility":"immunity","item":"eviolite","pokeball":"pokeball"},{"ident":"p1: Machamp","details":"Machamp, L77, F","condition":"265/265","active":false,"stats":{"atk":245,"def":168,"spa":145,"spd":175,"spe":129},"moves":["icepunch","stoneedge","knockoff","dynamicpunch"],"baseAbility":"noguard","item":"choiceband","pokeball":"pokeball"},{"ident":"p1: Pidgeot","details":"Pidgeot, L76, F","condition":"251/251","active":false,"stats":{"atk":166,"def":158,"spa":150,"spd":150,"spe":198},"moves":["uturn","heatwave","roost","hurricane"],"baseAbility":"tangledfeet","item":"pidgeotite","pokeball":"pokeball"}]},"rqid":15}
```