### PR TITLE
Allow non-broadcasted use of /roomhelp in lobby/battles

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1133,8 +1133,8 @@ exports.commands = {
 	},
 
 	roomhelp: function (target, room, user) {
-		if (room.id === 'lobby' || room.battle) return this.sendReply("This command is too spammy for lobby/battles.");
 		if (!this.runBroadcast()) return;
+		if (this.broadcasting && (room.id === 'lobby' || room.battle)) return this.sendReply("This command is too spammy for lobby/battles.");
 		this.sendReplyBox(
 			"Room drivers (%) can use:<br />" +
 			"- /warn OR /k <em>username</em>: warn a user and show the Pok&eacute;mon Showdown rules<br />" +


### PR DESCRIPTION
I was somewhat frustrated when I wanted to re-check room rank permissions while in lobby and was told I needed to go to a different room for that, despite not even trying to broadcast.
On the other hand, this will always let "+user123: !roomhelp" go through, instead of blocking the whole thing. As far as I can tell, this is not avoidable without non-trivially messing with the command parser. I think that is preferable to the way it is now, however.