### PR TITLE
Seasonal: Pass custom move sets into randomSet when generating teams

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -3488,26 +3488,29 @@ exports.BattleScripts = {
 
 		for (let i = 1; i < 6; i++) {
 			let pokemon = this.sampleNoReplace(seasonalPokemonList);
-			let template = this.getTemplate(pokemon);
-			let set = this.randomSet(template, i);
+			let template = Object.assign({}, this.getTemplate(pokemon));
+
 			if (template.id in {'vanilluxe':1, 'vanillite':1, 'vanillish':1}) {
-				set.moves = ['icebeam', 'weatherball', 'autotomize', 'flashcannon'];
+				template.randomBattleMoves = ['icebeam', 'weatherball', 'autotomize', 'flashcannon'];
 			}
 			if (template.id in {'pikachu':1, 'raichu':1}) {
-				set.moves = ['thunderbolt', 'surf', 'substitute', 'nastyplot'];
+				template.randomBattleMoves = ['thunderbolt', 'surf', 'substitute', 'nastyplot'];
 			}
 			if (template.id in {'rhydon':1, 'rhyperior':1}) {
-				set.moves = ['surf', 'megahorn', 'earthquake', 'rockblast'];
+				template.randomBattleMoves = ['surf', 'megahorn', 'earthquake', 'rockblast'];
 			}
 			if (template.id === 'reshiram') {
-				set.moves = ['tailwhip', 'dragontail', 'irontail', 'aquatail'];
+				template.randomBattleMoves = ['tailwhip', 'dragontail', 'irontail', 'aquatail'];
 			}
 			if (template.id === 'aggron') {
-				set.moves = ['surf', 'earthquake', 'bodyslam', 'rockslide'];
+				template.randomBattleMoves = ['surf', 'earthquake', 'bodyslam', 'rockslide'];
 			}
 			if (template.id === 'hariyama') {
-				set.moves = ['surf', 'closecombat', 'facade', 'fakeout'];
+				template.randomBattleMoves = ['surf', 'closecombat', 'facade', 'fakeout'];
 			}
+
+			let set = this.randomSet(template, i);
+
 			if (template.id === 'pelipper') {
 				set.ability = 'raindish';
 			}


### PR DESCRIPTION
This fixes issues like getting Choice items on Pokemon with setup moves.

Also, paging @Marty-D to confirm that the use of `Object.merge` is correct since he dealt with it for the November Seasonal in 0d37b7946d38ae81c3e0c47020ad2ab0b18d90ac