### PR TITLE
Random Battle: Improve Archeops'  sets

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -4559,8 +4559,8 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	archeops: {
-		randomBattleMoves: ["stoneedge", "rockslide", "earthquake", "uturn", "pluck", "headsmash"],
-		randomDoubleBattleMoves: ["stoneedge", "rockslide", "earthquake", "uturn", "pluck", "tailwind", "taunt", "protect"],
+		randomBattleMoves: ["stoneedge", "earthquake", "uturn", "pluck", "acrobatics", "headsmash"],
+		randomDoubleBattleMoves: ["stoneedge", "rockslide", "earthquake", "uturn", "pluck", "acrobatics", "tailwind", "taunt", "protect"],
 		tier: "NU",
 	},
 	trubbish: {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1444,7 +1444,7 @@ exports.BattleScripts = {
 				case 'acrobatics':
 					if (hasMove['hurricane'] && counter.setupType !== 'Physical') rejected = true;
 					break;
-				case 'airslash': case 'oblivionwing':
+				case 'airslash': case 'oblivionwing': case 'pluck':
 					if (hasMove['acrobatics'] || hasMove['bravebird'] || hasMove['hurricane']) rejected = true;
 					break;
 				case 'shadowclaw':


### PR DESCRIPTION
Archeops gets Acrobatics as a more reliable Flying STAB.

Landorus gets Rock Slide as a Sheer Force-boosted Rock move for coverage. (Now split to #2604)

-----

@TheImmortal 

Acrobatics has > 50% usage on Archeops. Even if it denies it the strength of Banded Head Smash, there isn't really any reason Pluck should be on its list.

Rock Slide has around 30% usage on Landorus. Coverage is nice, especially with the randbats flat-EV policy and it coming off of Lando's stronger 125 base Attack.