### PR TITLE
Random Battle: Add Rock Slide to Landorus-I

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -5036,8 +5036,8 @@ exports.BattleFormatsData = {
 		tier: "Uber",
 	},
 	landorus: {
-		randomBattleMoves: ["calmmind", "rockpolish", "earthpower", "focusblast", "psychic", "sludgewave", "stealthrock", "knockoff"],
-		randomDoubleBattleMoves: ["earthpower", "focusblast", "rockpolish", "hiddenpowerice", "psychic", "sludgebomb", "protect"],
+		randomBattleMoves: ["calmmind", "rockpolish", "earthpower", "focusblast", "psychic", "sludgewave", "stealthrock", "knockoff", "rockslide"],
+		randomDoubleBattleMoves: ["earthpower", "focusblast", "rockpolish", "hiddenpowerice", "psychic", "sludgebomb", "rockslide", "protect"],
 		eventPokemon: [
 			{"generation": 5, "level": 70, "shiny": 1, "isHidden": false, "moves":["rockslide", "earthquake", "sandstorm", "fissure"]},
 			{"generation": 5, "level": 5, "isHidden": true, "moves":["block", "mudshot", "rocktomb"], "pokeball": "dreamball"},


### PR DESCRIPTION
With balanced EVs, Landorus can still use its Physical movepool for
coverage thanks to its respectable base Attack, and Rock Slide is a
Rock-type move boosted by Sheer Force.