### PR TITLE
Copy auth from tournament room to tournament battle

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -824,7 +824,7 @@ exports.commands = {
 			return this.errorReply("User '" + name + "' is unregistered, and so can't be promoted.");
 		}
 
-		let currentGroup = ((room.auth && room.auth[userid]) || (room.isPrivate !== true && Users.usergroups[userid]) || ' ').charAt(0);
+		let currentGroup = room.getAuth({userid, group: (Users.usergroups[userid] || ' ').charAt(0)});
 		let nextGroup = target;
 		if (target === 'deauth') nextGroup = Config.groupsranking[0];
 		if (!nextGroup) {

--- a/rooms.js
+++ b/rooms.js
@@ -231,6 +231,9 @@ let Room = (() => {
 			if (user.userid in this.auth) {
 				return this.auth[user.userid];
 			}
+			if (this.tour && this.tour.room) {
+				return this.tour.room.getAuth(user);
+			}
 			if (this.isPrivate === true) {
 				return ' ';
 			}

--- a/test/application/rooms.js
+++ b/test/application/rooms.js
@@ -28,6 +28,8 @@ describe('Rooms features', function () {
 	});
 
 	describe('BattleRoom', function () {
+		const packedTeam = 'Weavile||lifeorb||swordsdance,knockoff,iceshard,iciclecrash|Jolly|,252,,,4,252|||||';
+
 		let room;
 		afterEach(function () {
 			if (room) room.expire();
@@ -36,11 +38,57 @@ describe('Rooms features', function () {
 		it('should allow two users to join the battle', function () {
 			let p1 = new User();
 			let p2 = new User();
-			let packedTeam = 'Weavile||lifeorb||swordsdance,knockoff,iceshard,iciclecrash|Jolly|,252,,,4,252|||||';
 			let options = [{rated: false, tour: false}, {rated: false, tour: {onBattleWin() {}}}, {rated: true, tour: false}, {rated: true, tour: {onBattleWin() {}}}];
 			for (let option of options) {
 				room = Rooms.global.startBattle(p1, p2, 'customgame', packedTeam, packedTeam, option);
 				assert.ok(room.battle.p1 && room.battle.p2); // Automatically joined
+			}
+		});
+
+		it('should copy auth from tournament', function () {
+			const p1 = new User();
+			const p2 = new User();
+			const options = {
+				rated: false,
+				auth: {},
+				tour: {
+					onBattleWin() {},
+					room: {getAuth() {
+						return '%';
+					}},
+				},
+			};
+			room = Rooms.global.startBattle(p1, p2, 'customgame', packedTeam, packedTeam, options);
+			assert.strictEqual(room.getAuth(new User()), '%');
+		});
+
+		it('should prevent overriding tournament room auth by a tournament player', function () {
+			const p1 = new User();
+			const p2 = new User();
+			const roomStaff = new User();
+			roomStaff.forceRename("Room auth", true);
+			const administrator = new User();
+			administrator.group = '~';
+			const options = {
+				rated: false,
+				auth: {},
+				tour: {
+					onBattleWin() {},
+					room: {getAuth(user) {
+						return '%';
+					}},
+				},
+			};
+			room = Rooms.global.startBattle(p1, p2, 'customgame', packedTeam, packedTeam, options);
+			assert.strictEqual(room.getAuth(roomStaff), '%', 'before promotion attempt');
+			CommandParser.parse("/roomvoice Room auth", room, p1, p1.connections[0]);
+			assert.strictEqual(room.getAuth(roomStaff), '%', 'after promotion attempt');
+			CommandParser.parse("/roomvoice Room auth", room, administrator, administrator.connections[0]);
+			assert.strictEqual(room.getAuth(roomStaff), '+', 'after being promoted by an administrator');
+
+			for (const user of [roomStaff, administrator]) {
+				user.disconnectAll();
+				user.destroy();
 			}
 		});
 	});

--- a/test/main.js
+++ b/test/main.js
@@ -48,6 +48,9 @@ function init(callback) {
 		this.seed = this.startingSeed = [0x09d56, 0x08642, 0x13656, 0x03653];
 	};
 
+	// Disable writing to modlog
+	require('./../command-parser.js').CommandContext.prototype.logModCommand = noop;
+
 	callback();
 }
 


### PR DESCRIPTION
This allows room staff to perform moderation in tournament battles.

Build is failing for unrelated reasons.