### PR TITLE
Make 5 mon monotype randbats teams way less likely

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2092,13 +2092,14 @@ exports.BattleScripts = {
 		let allowedNFE = {'Chansey':1, 'Doublade':1, 'Gligar':1, 'Porygon2':1, 'Scyther':1};
 
 		// For Monotype
+		let isMonotype = this.format === 'monotyperandombattle';
 		let typePool = Object.keys(this.data.TypeChart);
 		let type = typePool[this.random(typePool.length)];
 
 		let pokemonPool = [];
 		for (let id in this.data.FormatsData) {
 			let template = this.getTemplate(id);
-			if (this.format === 'monotyperandombattle') {
+			if (isMonotype) {
 				let types = template.types;
 				if (template.battleOnly) types = this.getTemplate(template.baseSpecies).types;
 				if (types.indexOf(type) < 0) continue;
@@ -2203,7 +2204,7 @@ exports.BattleScripts = {
 
 			let types = template.types;
 
-			if (this.format !== 'monotyperandombattle') {
+			if (!isMonotype) {
 				// Limit 2 of any type
 				let skip = false;
 				for (let t = 0; t < types.length; t++) {
@@ -2220,13 +2221,15 @@ exports.BattleScripts = {
 			// Illusion shouldn't be the last Pokemon of the team
 			if (set.ability === 'Illusion' && pokemonLeft > 4) continue;
 
-			// Limit 1 of any type combination
-			let typeCombo = types.join();
+			// Limit 1 of any type combination, 2 in monotype
+			let typeCombo = types.sort().join();
 			if (set.ability === 'Drought' || set.ability === 'Drizzle' || set.ability === 'Sand Stream') {
 				// Drought, Drizzle and Sand Stream don't count towards the type combo limit
 				typeCombo = set.ability;
+				if (typeCombo in typeComboCount) continue;
+			} else {
+				if (typeComboCount[typeCombo] >= (isMonotype ? 2 : 1)) continue;
 			}
-			if (typeCombo in typeComboCount) continue;
 
 			// Okay, the set passes, add it to our team
 			pokemon.push(set);
@@ -2243,7 +2246,11 @@ exports.BattleScripts = {
 					typeCount[types[t]] = 1;
 				}
 			}
-			typeComboCount[typeCombo] = 1;
+			if (typeCombo in typeComboCount) {
+				typeComboCount[typeCombo]++;
+			} else {
+				typeComboCount[typeCombo] = 1;
+			}
 
 			// Increment Uber/NU counters
 			if (tier === 'Uber') {


### PR DESCRIPTION
Due to the "each type combination only once" restriction, Normal-type teams had a non-negligible chance of having less than 6 members, as most of its type combinations are only used by a single mon which could easily be skipped due to tier restrictions or bad luck. The types were also not sorted before filtering, so it was entirely possible to have Fighting/Psychic and Psychic/Fighting on the same team, which undermines the whole thing.
So, this sorts before filtering, but raises the limit to 2 of each combination per team, which hasn't yielded any 5 mon teams across 10000 generated teams. Drought/Drizzle/Sand Stream are still limited to one.

For comparison, here's a bunch of Normal type teams from before http://hastebin.com/raw/menenijebi and here's after http://hastebin.com/raw/wuwamakipa. The absurd amount of Pyroar/Heliolisk/Diggersby has gone down somewhat, so teams are more diverse (maybe at the cost of some viability/coverage, since the ubiquitous mono-Normals and Normal/Flyings are now way more common?)

Is this ok? Should this only affect Monotype, or regular randbats as well? Should it also be changed in the doubles team generator?