### PR TITLE
Add One-Click Heroku Deploy Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Navigation: [Website][1] | **Server repository** | [Client repository][2]
 [![Build Status](https://travis-ci.org/Zarel/Pokemon-Showdown.svg)](https://travis-ci.org/Zarel/Pokemon-Showdown)
 [![Dependency Status](https://david-dm.org/zarel/Pokemon-Showdown.svg)](https://david-dm.org/zarel/Pokemon-Showdown)
 [![devDependency Status](https://david-dm.org/zarel/Pokemon-Showdown/dev-status.svg)](https://david-dm.org/zarel/Pokemon-Showdown#info=devDependencies)
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)]
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 Introduction
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Navigation: [Website][1] | **Server repository** | [Client repository][2]
 [![Build Status](https://travis-ci.org/Zarel/Pokemon-Showdown.svg)](https://travis-ci.org/Zarel/Pokemon-Showdown)
 [![Dependency Status](https://david-dm.org/zarel/Pokemon-Showdown.svg)](https://david-dm.org/zarel/Pokemon-Showdown)
 [![devDependency Status](https://david-dm.org/zarel/Pokemon-Showdown/dev-status.svg)](https://david-dm.org/zarel/Pokemon-Showdown#info=devDependencies)
-
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)]
 Introduction
 ------------------------------------------------------------------------
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "Pokémon Showdown",
+  "description": "A Pokémon Battle Simulator"
+}


### PR DESCRIPTION
This PR introduces a 'Deploy to Heroku' button in the README to make it simpler for users to deploy this application to heroku. The file `app.json` was also added to the project as it is necessary for the heroku button.

Thanks!

EDIT: I tried to squash the other commits as specified in the contributing guidelines, but I suppose it did not work. Will try to fix this.