### PR TITLE
Add One-Click Deploy to Heroku Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Navigation: [Website][1] | **Server repository** | [Client repository][2]
 [![Build Status](https://travis-ci.org/Zarel/Pokemon-Showdown.svg)](https://travis-ci.org/Zarel/Pokemon-Showdown)
 [![Dependency Status](https://david-dm.org/zarel/Pokemon-Showdown.svg)](https://david-dm.org/zarel/Pokemon-Showdown)
 [![devDependency Status](https://david-dm.org/zarel/Pokemon-Showdown/dev-status.svg)](https://david-dm.org/zarel/Pokemon-Showdown#info=devDependencies)
-
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 Introduction
 ------------------------------------------------------------------------
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "Pokémon Showdown",
+  "description": "A Pokémon Battle Simulator"
+}


### PR DESCRIPTION
This PR introduces a 'Deploy to Heroku' button in the README to make it simpler for users to deploy this application to heroku. The file app.json was also added to the project as it is necessary for the heroku button.

I had previously created a PR for these changes, but I closed it as the commits were not squashed properly. This PR fixed that.

Thanks!