### PR TITLE
Replace confusing variable name

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2090,7 +2090,6 @@ exports.BattleScripts = {
 		};
 	},
 	randomTeam: function (side) {
-		let pokemonLeft = 0;
 		let pokemon = [];
 
 		let excludedTiers = {'NFE':1, 'LC Uber':1, 'LC':1};
@@ -2127,7 +2126,7 @@ exports.BattleScripts = {
 		let puCount = 0;
 		let teamDetails = {};
 
-		while (pokemonPool.length && pokemonLeft < 6) {
+		while (pokemonPool.length && pokemon.length < 6) {
 			let template = this.getTemplate(this.sampleNoReplace(pokemonPool));
 			if (!template.exists) continue;
 
@@ -2224,7 +2223,7 @@ exports.BattleScripts = {
 			let set = this.randomSet(template, pokemon.length, teamDetails);
 
 			// Illusion shouldn't be the last Pokemon of the team
-			if (set.ability === 'Illusion' && pokemonLeft > 4) continue;
+			if (set.ability === 'Illusion' && pokemon.length > 4) continue;
 
 			// Limit 1 of any type combination, 2 in monotype
 			let typeCombo = types.sort().join();
@@ -2241,7 +2240,6 @@ exports.BattleScripts = {
 
 			// Now that our Pokemon has passed all checks, we can increment our counters
 			baseFormes[template.baseSpecies] = 1;
-			pokemonLeft++;
 
 			// Increment type counters
 			for (let t = 0; t < types.length; t++) {
@@ -2276,7 +2274,6 @@ exports.BattleScripts = {
 		return pokemon;
 	},
 	randomDoublesTeam: function (side) {
-		let pokemonLeft = 0;
 		let pokemon = [];
 
 		let excludedTiers = {'NFE':1, 'LC Uber':1, 'LC':1};
@@ -2303,7 +2300,7 @@ exports.BattleScripts = {
 		let puCount = 0;
 		let teamDetails = {megaCount: 0, stealthRock: 0, hazardClear: 0};
 
-		while (pokemonPool.length && pokemonLeft < 6) {
+		while (pokemonPool.length && pokemon.length < 6) {
 			let template = this.getTemplate(this.sampleNoReplace(pokemonPool));
 			if (!template.exists) continue;
 
@@ -2381,7 +2378,7 @@ exports.BattleScripts = {
 			let set = this.randomDoublesSet(template, pokemon.length, teamDetails);
 
 			// Illusion shouldn't be on the last pokemon of the team
-			if (set.ability === 'Illusion' && pokemonLeft > 4) continue;
+			if (set.ability === 'Illusion' && pokemon.length > 4) continue;
 
 			// Limit 1 of any type combination
 			let typeCombo = types.join();
@@ -2400,8 +2397,6 @@ exports.BattleScripts = {
 			pokemon.push(set);
 
 			// Now that our Pokemon has passed all checks, we can increment our counters
-			pokemonLeft++;
-
 			// Increment type counters
 			for (let t = 0; t < types.length; t++) {
 				if (types[t] in typeCount) {
@@ -3371,7 +3366,6 @@ exports.BattleScripts = {
 		const chosenTier = availableTiers[this.random(availableTiers.length)];
 		this.seed = prevSeed;
 
-		let pokemonLeft = 0;
 		let pokemon = [];
 
 		let pokemonPool = Object.keys(this.randomFactorySets[chosenTier]);
@@ -3389,7 +3383,7 @@ exports.BattleScripts = {
 			'levitate': ['Ground'],
 		};
 
-		while (pokemonPool.length && pokemonLeft < 6) {
+		while (pokemonPool.length && pokemon.length < 6) {
 			let template = this.getTemplate(this.sampleNoReplace(pokemonPool));
 			if (!template.exists) continue;
 
@@ -3425,7 +3419,6 @@ exports.BattleScripts = {
 
 			// Okay, the set passes, add it to our team
 			pokemon.push(set);
-			pokemonLeft++;
 
 			// Now that our Pokemon has passed all checks, we can update team data:
 			for (let t = 0; t < types.length; t++) {
@@ -3525,9 +3518,8 @@ exports.BattleScripts = {
 		let uberCount = 0;
 		let puCount = 0;
 		let teamDetails = {};
-		let pokemonLeft = 0;
 
-		while (pokemonLeft < 6) {
+		while (team.length < 6) {
 			let pokemon = this.sampleNoReplace(seasonalPokemonList);
 			let template = Object.assign({}, this.getTemplate(pokemon));
 
@@ -3576,7 +3568,7 @@ exports.BattleScripts = {
 				break;
 			}
 
-			let set = this.randomSet(template, pokemonLeft);
+			let set = this.randomSet(template, team.length);
 
 			let types = template.types;
 
@@ -3599,7 +3591,6 @@ exports.BattleScripts = {
 
 			// Now that our Pokemon has passed all checks, we can increment our counters
 			baseFormes[template.baseSpecies] = 1;
-			pokemonLeft++;
 
 			// Increment type counters
 			for (let t = 0; t < types.length; t++) {


### PR DESCRIPTION
A variable that is increasing from zero should probably not be called "pokemonLeft". Since it's effectively referring to the current size of the team, might as well use `Array.length` (which was already being used over pokemonLeft in a few places anyway).