### PR TITLE
Fix Red Card's interaction with spread moves

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -3629,10 +3629,10 @@ exports.BattleItems = {
 		},
 		onAfterMoveSecondary: function (target, source, move) {
 			if (source && source !== target && source.hp && target.hp && move && move.category !== 'Status') {
-				if (!source.isActive || !this.canSwitch(source.side) || target.forceSwitchFlag) return;
+				if (!source.isActive || !this.canSwitch(source.side) || source.forceSwitchFlag || target.forceSwitchFlag) return;
 				if (target.useItem(null, source)) { // This order is correct - the item is used up even against a pokemon with Ingrain or that otherwise can't be forced out
 					if (this.runEvent('DragOut', source, target, move)) {
-						this.dragIn(source.side, source.position);
+						source.forceSwitchFlag = true;
 					}
 				}
 			}


### PR DESCRIPTION
By setting `forceSwitchFlag` the switch doesn't happen until after all the damage is calculated, ensuring that all applicable boosts apply. There's an extra test in the case of two Red Cards (not that this would happen in VGC without some sort of Trick shenanigans).