### PR TITLE
Fix Own Tempo's interaction with Confuse Ray again

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1887,8 +1887,8 @@ exports.BattleAbilities = {
 				pokemon.removeVolatile('confusion');
 			}
 		},
-		onImmunity: function (type, pokemon) {
-			if (type === 'confusion') return false;
+		onTryAddVolatile: function (status, pokemon) {
+			if (status.id === 'confusion') return null;
 		},
 		onHit: function (target, source, move) {
 			if (move && move.volatileStatus === 'confusion') {


### PR DESCRIPTION
After 39ec460 Confuse Ray against Own Tempo started saying "But it failed!" again. By using `onTryAddVolatileStatus` the `null` return gets propagated back to `moveHit`; the `onHit` is still needed for the ability activation of course. Swagger (and presumably Flatter) still boosts and activates Own Tempo if it hits, assuming this is the desired result.