### PR TITLE
Prevent the Confusion status using TryAddVolatile rather than a custom event

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -12014,17 +12014,9 @@ exports.BattleMovedex = {
 					return null;
 				}
 			},
-			onTryConfusion: function (target, source, effect) {
-				if (source && target !== source && effect && (!effect.infiltrates || target.side === source.side)) {
-					this.debug('interrupting addVolatile');
+			onTryAddVolatile: function (status, target, source, effect) {
+				if ((status.id === 'confusion' || status.id === 'yawn') && source && target !== source && effect && (!effect.infiltrates || target.side === source.side)) {
 					if (!effect.secondaries) this.add('-activate', target, 'move: Safeguard');
-					return null;
-				}
-			},
-			onTryAddVolatile: function (status, target, source, move) {
-				if (status.id === 'yawn' && target !== source && (!move.infiltrates || target.side === source.side)) {
-					this.debug('blocking yawn');
-					this.add('-activate', target, 'move: Safeguard');
 					return null;
 				}
 			},

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -150,8 +150,6 @@ exports.BattleStatuses = {
 	confusion: {
 		// this is a volatile status
 		onStart: function (target, source, sourceEffect) {
-			let result = this.runEvent('TryConfusion', target, source, sourceEffect);
-			if (!result) return result;
 			if (sourceEffect && sourceEffect.id === 'lockedmove') {
 				this.add('-start', target, 'confusion', '[fatigue]');
 			} else {

--- a/mods/gen1/statuses.js
+++ b/mods/gen1/statuses.js
@@ -136,8 +136,6 @@ exports.BattleStatuses = {
 	confusion: {
 		// this is a volatile status
 		onStart: function (target, source, sourceEffect) {
-			let result = this.runEvent('TryConfusion');
-			if (!result) return result;
 			if (sourceEffect && sourceEffect.id === 'lockedmove') {
 				this.add('-start', target, 'confusion', '[silent]');
 			} else {

--- a/mods/gen2/statuses.js
+++ b/mods/gen2/statuses.js
@@ -98,8 +98,6 @@ exports.BattleStatuses = {
 	confusion: {
 		inherit: true,
 		onStart: function (target, source, sourceEffect) {
-			let result = this.runEvent('TryConfusion', target, source, sourceEffect);
-			if (!result) return result;
 			if (sourceEffect && sourceEffect.id === 'lockedmove') {
 				this.add('-start', target, 'confusion', '[silent]');
 			} else {

--- a/mods/gennext/statuses.js
+++ b/mods/gennext/statuses.js
@@ -50,8 +50,6 @@ exports.BattleStatuses = {
 	confusion: {
 		// this is a volatile status
 		onStart: function (target, source, sourceEffect) {
-			let result = this.runEvent('TryConfusion', target, source, sourceEffect);
-			if (!result) return result;
 			if (sourceEffect && sourceEffect.id === 'lockedmove') {
 				this.add('-start', target, 'confusion', '[fatigue]');
 			} else {


### PR DESCRIPTION
Interestingly @Zarel added the `TryAddVolatile` event when he originally added Confusion blocking to Safeguard in cdd3af0.