### PR TITLE
Add unlogtext command

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1892,6 +1892,24 @@ exports.commands = {
 	},
 	hidetexthelp: ["/hidetext [username] - Removes a locked or banned user's messages from chat (includes users banned from the room). Requires: % (global only), @ * # & ~"],
 
+	unlogtext: function (target, room, user) {
+		if (!target) return this.parse('/help unlogtext');
+		this.splitTarget(target);
+		let targetUser = this.targetUser;
+		let name = this.targetUserName;
+		let userid = targetUser.getLastId();
+		if (!user.can("rangeban")) {
+			this.errorReply("/unlogtext - Access denied.");
+			return false;
+		}
+		if (!targetUser) return this.errorReply("User '" + name + "' not found.");
+		if (!(targetUser.locked || (room.bannedUsers[toId(name)] && room.bannedIps[targetUser.latestIp]) || user.can('rangeban'))) return this.errorReply("User '" + name + "' is not banned from this room or locked.");
+		this.add('|unlink|perma|' + userid);
+		if (userid !== toId(this.inputUsername)) this.add('|unlink|perma|' + toId(this.inputUsername));
+		this.addModCommand("" + targetUser.name + "'s messages were deleted from the log in room " + room.id + " by " + user.name + ".");
+	},
+	unlogtexthelp: ["/unlogtext [username] - Removes a locked or banned user's messages from chat and clears them from the room's log. Requires: & ~"],
+
 	banwords: 'banword',
 	banword: {
 		add: function (target, room, user) {


### PR DESCRIPTION
The unlogtext command clears a banned user's messages from the room such that regular users can no longer see them (staff still can), which is useful if they leaked something sensitive/private. This was partially suggested in the issues file under "Fixes to text hiding." https://github.com/Zarel/Pokemon-Showdown/issues/2444
