### PR TITLE
Implement slowchat system

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -233,6 +233,7 @@ exports.replsocketmode = 0o600;
 //     - declare: /declare command.
 //     - announce: /announce command.
 //     - modchat: Set modchat.
+//     - slowchat: Set slowchat.
 //     - potd: Set PotD.
 //     - forcewin: /forcewin command.
 //     - battlemessage: /a command.
@@ -317,6 +318,7 @@ exports.grouplist = [
 		jurisdiction: 'u',
 		ban: true,
 		modchat: true,
+		slowchat: true,
 		roomvoice: true,
 		forcerename: true,
 		ip: true,

--- a/rooms.js
+++ b/rooms.js
@@ -866,6 +866,7 @@ let BattleRoom = (() => {
 		Room.call(this, roomid, "" + p1.name + " vs. " + p2.name);
 		this.modchat = (Config.battlemodchat || false);
 		this.modjoin = false;
+		this.slowchat = false;
 		this.reportJoins = Config.reportbattlejoins;
 
 		format = '' + (format || '');


### PR DESCRIPTION
This is basically a system that allows for room moderators or higher to set a minimum time between a user's messages sent to the room.
This is especially helpful for times the server might be lagging or the chat is just moving much too fast.
Alternatively, this could also help to stop spammers in their tracks and give staff more time to handle them as well.

I got this idea from the suggestions thread:
<img src="http://image.prntscr.com/image/8dfcc571d9fe4a6195ee557aa4ea29ff.png">