### PR TITLE
Implement stretching/caps checks

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1768,6 +1768,52 @@ exports.commands = {
 	slowchathelp: ["/slowchat [number] - Sets slowchat in the room for [number] seconds. Must be between 2-60 seconds. Requires @ * # & ~",
 		"/slowchat [off/disable] - Disables slowchat in the room. Requires @ * # & ~"],
 
+	stretching: function (target, room, user) {
+		if (!target) return this.sendReply("Stretching in this room is currently set to: " + (room.stretching ? room.stretching : false));
+		if (!this.canTalk()) return this.errorReply("You cannot do this while unable to talk.");
+		if (!this.can('editroom', null, room)) return false;
+
+		if (target === 'enable' || target === 'on') {
+			if (room.filterStretching) return this.errorReply("Stretching is already enabled in this room.");
+			room.filterStretching = true;
+		} else if (target === 'disable' || target === 'off') {
+			if (!room.filterStretching) return this.errorReply("Stretching is already disabled in this room.");
+			room.filterStretching = false;
+		} else {
+			return this.parse("/help stretching");
+		}
+		this.privateModCommand("(" + user.name + " set stretching to " + room.stretching + ")");
+
+		if (room.chatRoomData) {
+			room.chatRoomData.filterStretching = room.filterStretching;
+			Rooms.global.writeChatRoomData();
+		}
+	},
+	stretchinghelp: ["/stretching [enable/disable] - Toggles having the server check messages containing too much stretching. Requires "],
+
+	capitals: function (target, room, user) {
+		if (!target) return this.sendReply("Capitals in this room is currently set to: " + (room.capitals ? room.capitals : false));
+		if (!this.canTalk()) return this.errorReply("You cannot do this while unable to talk.");
+		if (!this.can('editroom', null, room)) return false;
+
+		if (target === 'enable' || target === 'on') {
+			if (room.filterCaps) return this.errorReply("Capitals is already enabled in this room.");
+			room.filterCaps = true;
+		} else if (target === 'disable' || target === 'off') {
+			if (!room.filterCaps) return this.errorReply("Capitals is already disabled in this room.");
+			room.filterCaps = false;
+		} else {
+			return this.parse("/help capitals");
+		}
+		this.privateModCommand("(" + user.name + " set capitals to " + room.capitals + ")");
+
+		if (room.chatRoomData) {
+			room.chatRoomData.filterCaps = room.filterCaps;
+			Rooms.global.writeChatRoomData();
+		}
+	},
+	capitalshelp: ["/capitals [enable/disable] - Toggles having the server check messages containing too many capitals. Requires "],
+
 	declare: function (target, room, user) {
 		if (!target) return this.parse('/help declare');
 		if (!this.can('declare', null, room)) return false;

--- a/rooms.js
+++ b/rooms.js
@@ -867,6 +867,8 @@ let BattleRoom = (() => {
 		this.modchat = (Config.battlemodchat || false);
 		this.modjoin = false;
 		this.slowchat = false;
+		this.filterStretching = false;
+		this.filterCaps = false;
 		this.reportJoins = Config.reportbattlejoins;
 
 		format = '' + (format || '');
@@ -1354,6 +1356,8 @@ let ChatRoom = (() => {
 		this.destroyingLog = false;
 		if (!this.modchat) this.modchat = (Config.chatmodchat || false);
 		if (!this.modjoin) this.modjoin = false;
+		if (!this.filterStretching) this.filterStretching = false;
+		if (!this.filterCaps) this.filterCaps = false;
 
 		if (Config.logchat) {
 			this.rollLogFile(true);


### PR DESCRIPTION
Before, PS often relied on bots to handle moderating users who send messages that contained too many capitals or stretching.

This should be something that's preventative, not reactive, which is what this does.

Now, bots are no longer needed for these purposes as this allows stretching/caps punishments to be prevented, server-side.

edit; ALSO, I have implemented a roomsettings command in this PR.
editedit; jk that was a prank

(Special thanks to sparkychild for helping me come up with the stretching/caps checks!)