### PR TITLE
Modchat: Fix access denied reply

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1741,7 +1741,7 @@ exports.commands = {
 			let roomGroup = (room.auth && room.isPrivate === true ? ' ' : user.group);
 			if (room.auth && user.userid in room.auth) roomGroup = room.auth[user.userid];
 			if (Config.groupsranking.indexOf(target) > Math.max(1, Config.groupsranking.indexOf(roomGroup)) && !user.can('makeroom')) {
-				return this.errorReply("/modchat - Access denied for setting higher than " + Config.groupsranking[1] + ".");
+				return this.errorReply("/modchat - Access denied for setting higher than " + roomGroup + ".");
 			}
 			room.modchat = target;
 			break;


### PR DESCRIPTION
Before, if a RO (not a global leader or up) tried setting modchat, it would say: "/modchat - Access denied for setting higher than +."

Now, this fixes that by checking what permission that user actually has in the room, as in if they're a roommod (up to +) or roomowner (up to #).