### PR TITLE
Move IPC from battle-engine.js to simulator.js

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -28,7 +28,6 @@ function init(callback) {
 	}
 
 	// Turn IPC methods into no-op
-	BattleEngine.Battle.prototype.send = noop;
 	BattleEngine.Battle.prototype.receive = noop;
 
 	let Simulator = global.Simulator;


### PR DESCRIPTION
This is my attempt at resolving #2655. Special thanks to Zarel for guiding me in the right direction.

This moves all the `process` stuff out of `battle-engine.js` and into `simulator.js`. It is worth pointing out that this includes `Battle.prototype.send` because it depends on `process`. I decided to make it an argument to construct. If there is a different preference, let me know.