### PR TITLE
Implement pminfobox command (for bots)

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -252,6 +252,35 @@ exports.commands = {
 	},
 	msghelp: ["/msg OR /whisper OR /w [username], [message] - Send a private message."],
 
+	pminfobox: function (target, room, user, connection) {
+		if (!this.canTalk()) return this.errorReply("You cannot do this while unable to talk.");
+		if (!user.can('addhtml', null, room)) return false;
+		if (!target) return this.parse("/help pminfobox");
+
+		target = this.canHTML(target);
+		if (!target) return;
+
+		target = this.splitTarget(target);
+		let targetUser = this.targetUser;
+
+		if (!targetUser || !targetUser.connected) return this.errorReply("User " + targetUser + " is not currently online.");
+		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
+		if (targetUser.ignorePMs) return this.errorReply("This user is currently ignoring PMs.");
+		if (targetUser.locked) return this.errorReply("This user is currently locked, so you cannot send them a pminfobox.");
+
+		target = this.canTalk(target, null, targetUser);
+
+		// Apply the infobox to the message
+		target = '/raw <div class="infobox">' + target + '</div>';
+		let message = '|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + '|' + target;
+
+		user.send(message);
+		if (targetUser !== user) targetUser.send(message);
+		targetUser.lastPM = user.userid;
+		user.lastPM = targetUser.userid;
+	},
+	pminfoboxhelp: ["/pminfobox [user], [html]- PMs an [html] infobox to [user]. Requires * ~"],
+
 	blockpm: 'ignorepms',
 	blockpms: 'ignorepms',
 	ignorepm: 'ignorepms',


### PR DESCRIPTION
Adding this command isn't a far step from the current permission global bots and roombots already have - it basically does what it says, allows bots to PM users HTML infoboxes.

If it's a roombot, then it can only do this to users who are actually in the room that the bot has a roombot rank in for additional precaution.  It checks if the user is ignoring PMs as well as if they're locked or not.

Overall, this could be a game changer for bot developers and this gives them *much* more possibility.

(Shout-out to SolarisFox for giving me this idea!)