### PR TITLE
Polls: Fix not showing results on blank vote

### DIFF
--- a/chat-plugins/poll.js
+++ b/chat-plugins/poll.js
@@ -48,7 +48,7 @@ class Poll {
 		let userid = user.userid;
 
 		if (userid in this.voters || ip in this.voterIps) {
-			return user.sendTo(this.room, "You're already looking at the results.");
+			user.sendTo(this.room, "You're already looking at the results.");
 		} else {
 			this.voters[userid] = 0;
 			this.voterIps[ip] = 0;


### PR DESCRIPTION
I've experienced this problem before, and it's sometimes hard to replicate, but this should correct it.

The reason why this was a problem was that because of the ``return`` statement, the line ``this.updateTo(user);`` never actually happened, so it wasn't updating in one specific instance.

EXAMPLE OF BUG:
<img src="http://i.imgur.com/HoRmGvC.png">