### PR TITLE
Users: don't add userids to user.prevNames on rename if it never changed

### DIFF
--- a/users.js
+++ b/users.js
@@ -745,7 +745,7 @@ class User {
 			return false;
 		}
 
-		if (this.named) this.prevNames[this.userid] = this.name;
+		if (this.named && this.userid !== userid) this.prevNames[this.userid] = this.name;
 		this.name = name;
 
 		let oldid = this.userid;


### PR DESCRIPTION
Renaming from, say, Morfent❤ to Morfent used to add morfent to the user object's prevNames.