### PR TITLE
Fix issues with pminfobox & addhtmlbox commands

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1649,6 +1649,7 @@ exports.commands = {
 	},
 	addhtmlbox: function (target, room, user, connection, cmd, message) {
 		if (!target) return this.parse('/help htmlbox');
+		if (!this.canTalk()) return this.errorReply("You cannot do this while unable to talk.");
 		target = this.canHTML(target);
 		if (!target) return;
 		if (!this.can('addhtml', null, room)) return;

--- a/commands.js
+++ b/commands.js
@@ -489,8 +489,6 @@ exports.commands = {
 		if (targetUser.ignorePMs) return this.errorReply("This user is currently ignoring PMs.");
 		if (targetUser.locked) return this.errorReply("This user is currently locked, so you cannot send them a pminfobox.");
 
-		target = this.canTalk(target, null, targetUser);
-
 		// Apply the infobox to the message
 		target = '/raw <div class="infobox">' + target + '</div>';
 		let message = '|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + '|' + target;


### PR DESCRIPTION
- The line that we're removing from pminfobox was checking a character limit, which isn't ideal when we're using HTML.
- The fact that bots can always use /addhtmlbox even when they aren't able to talk is a potential security issue, so we're adding a check to prevent that.