### PR TITLE
Ban Swagger from Doubles OU

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -190,7 +190,7 @@ exports.Formats = [
 		section: "ORAS Doubles",
 
 		gameType: 'doubles',
-		ruleset: ['Pokemon', 'Standard Doubles', 'Team Preview'],
+		ruleset: ['Pokemon', 'Standard Doubles', 'Swagger Clause', 'Team Preview'],
 		banlist: ['Arceus', 'Dialga', 'Giratina', 'Giratina-Origin', 'Groudon', 'Ho-Oh', 'Kyogre', 'Kyurem-White', 'Lugia',
 			'Mewtwo', 'Palkia', 'Rayquaza', 'Reshiram', 'Salamence-Mega', 'Salamencite', 'Shaymin-Sky', 'Xerneas', 'Yveltal', 'Zekrom',
 			'Soul Dew', 'Dark Void', 'Gravity ++ Grass Whistle', 'Gravity ++ Hypnosis', 'Gravity ++ Lovely Kiss', 'Gravity ++ Sing', 'Gravity ++ Sleep Powder', 'Gravity ++ Spore',


### PR DESCRIPTION
%kamikaze: http://www.smogon.com/forums/threads/np-doubles-ou-stage-4-infamous-jirachi-stays-in-dou-swagger-is-banned.3569913/page-10#post-6935868
%kamikaze: Swagger has been banned from Doubles OU
%kamikaze: so it would be great if someone can add Swagger Clause to it