### PR TITLE
Victory Star shouldn't increase accuracy to more than 100%

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -3168,6 +3168,9 @@ exports.BattleAbilities = {
 		onAllyModifyMove: function (move) {
 			if (typeof move.accuracy === 'number') {
 				move.accuracy *= 1.1;
+				if (move.accuracy > 100) {
+					move.accuracy = 100;
+				}
 			}
 		},
 		id: "victorystar",


### PR DESCRIPTION
Since accuracies are in percentages, they should not exceed 100.