### PR TITLE
Banwords: Don't allow banning spaces

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -2254,7 +2254,7 @@ exports.commands = {
 	banwords: 'banword',
 	banword: {
 		add: function (target, room, user) {
-			if (!target) return this.parse('/help banword');
+			if (!target || target === ' ') return this.parse('/help banword');
 			if (!user.can('declare', null, room)) return;
 
 			if (!room.banwords) room.banwords = [];


### PR DESCRIPTION
A user might do ``/banword add  `` when trying to pull up the help command and accidentally end up banning spaces, this prevents that.