### PR TITLE
Clear user's message from all rooms they've talked in on ban/lock

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -415,6 +415,7 @@ class CommandContext {
 				}
 				user.lastMessage = message;
 				user.lastMessageTime = Date.now();
+				user.talkedIn.push(room.id);
 			}
 
 			if (Config.chatfilter) {

--- a/commands.js
+++ b/commands.js
@@ -1298,7 +1298,7 @@ exports.commands = {
 			Monitor.log("[CrisisMonitor] Confirmed user " + targetUser.name + (targetUser.confirmed !== targetUser.userid ? " (" + targetUser.confirmed + ")" : "") + " was roombanned from " + room.id + " by " + user.name + ", and should probably be demoted.");
 		}
 		let lastid = targetUser.getLastId();
-		this.add('|unlink|roomhide|' + lastid);
+		room.unlinkHide(targetUser, 'ROOMBAN');
 		if (lastid !== toId(this.inputUsername)) this.add('|unlink|roomhide|' + toId(this.inputUsername));
 	},
 	roombanhelp: ["/roomban [username] - Bans the user from the room you are in. Requires: @ # & ~"],
@@ -1533,7 +1533,7 @@ exports.commands = {
 		} else if (acAccount) {
 			this.privateModCommand("(" + name + "'s ac account: " + acAccount + ")");
 		}
-		this.add('|unlink|hide|' + userid);
+		room.unlinkHide(user, 'LOCK');
 		if (userid !== toId(this.inputUsername)) this.add('|unlink|hide|' + toId(this.inputUsername));
 
 		this.globalModlog("LOCK", targetUser, " by " + user.name + (target ? ": " + target : ""));
@@ -1592,7 +1592,7 @@ exports.commands = {
 		} else if (acAccount) {
 			this.privateModCommand("(" + name + "'s ac account: " + acAccount + ")");
 		}
-		this.add('|unlink|hide|' + userid);
+		room.unlinkHide(targetUser, 'LOCK');
 		if (userid !== toId(this.inputUsername)) this.add('|unlink|hide|' + toId(this.inputUsername));
 
 		this.globalModlog("WEEKLOCK", targetUser, " by " + user.name + (target ? ": " + target : ""));
@@ -1682,7 +1682,7 @@ exports.commands = {
 			this.privateModCommand("(" + name + "'s ac account: " + acAccount + ")");
 		}
 
-		this.add('|unlink|hide|' + userid);
+		room.unlinkHide(targetUser, 'BAN');
 		if (userid !== toId(this.inputUsername)) this.add('|unlink|hide|' + toId(this.inputUsername));
 		Punishments.ban(targetUser, null, null, target);
 		this.globalModlog("BAN", targetUser, " by " + user.name + (target ? ": " + target : ""));
@@ -2192,6 +2192,7 @@ exports.commands = {
 		if (!this.can('forcerename', targetUser)) return false;
 
 		this.addModCommand("" + targetUser.name + " was namelocked by " + user.name + "." + (reason ? " (" + reason + ")" : ""));
+		room.unlinkHide(targetUser, 'NAMELOCK');
 		this.globalModlog("NAMELOCK", targetUser, " by " + user.name + (reason ? ": " + reason : ""));
 		Rooms.global.cancelSearch(targetUser);
 		Punishments.namelock(targetUser, null, null, reason);

--- a/rooms.js
+++ b/rooms.js
@@ -84,6 +84,21 @@ let Room = (() => {
 		this.send(message);
 		return this;
 	};
+	Room.prototype.unlinkHide = function (user, punishment) {
+		let rooms = user.talkedIn;
+		if (rooms < 0) return false;
+		if (punishment === 'LOCK' || punishment === 'NAMELOCK' || punishment === 'BAN') {
+			rooms.forEach(curRoom => {
+				if (!Rooms(curRoom)) return;
+				Rooms(curRoom).add('|unlink|hide|' + user.userid).update();
+				return;
+			});
+		} else if (punishment === 'ROOMBAN') {
+			this.add('|unlink|roomhide|' + user.userid).update();
+		} else {
+			return false;
+		}
+	};
 	Room.prototype.logEntry = function () {};
 	Room.prototype.addRaw = function (message) {
 		return this.add('|raw|' + message);

--- a/users.js
+++ b/users.js
@@ -357,6 +357,7 @@ class User {
 		this.lastMessage = '';
 		this.lastMessageTime = 0;
 		this.lastReportTime = 0;
+		this.talkedIn = [];
 		this.s1 = '';
 		this.s2 = '';
 		this.s3 = '';


### PR DESCRIPTION
This makes it so that if a user is globally banned or locked, it hides their messages from all of the rooms that they've talked in up until that point.
