### PR TITLE
ipsearch: Specify no results found due to invalid search

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -202,7 +202,10 @@ exports.commands = {
 				}
 			});
 		}
-		if (!results.length) return this.errorReply("No results found.");
+		if (!results.length) {
+			if (!target.includes('.')) return this.errorReply("'" + target + "' is not a valid IP or host.");
+			return this.errorReply("No results found.");
+		}
 		return this.sendReply(results.join('; '));
 	},
 	ipsearchhelp: ["/ipsearch [ip|range|host] - Find all users with specified IP, IP range, or host. Requires: & ~"],


### PR DESCRIPTION
In order to use ``/ipsearch``, the target must either be: a. A host, or b. An IP, or c. An IP range - all of which must include a period of some sorts... So, if the user doesn't use one, they're using the command wrong and should be displayed the help command instead of it searching anyways.