### PR TITLE
Remove tic marks from "memusage" alias

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -2794,7 +2794,7 @@ exports.commands = {
 	},
 	crashfixedhelp: ["/crashfixed - Ends the active lockdown caused by a crash without the need of a restart. Requires: ~"],
 
-	'memusage': 'memoryusage',
+	memusage: 'memoryusage',
 	memoryusage: function (target) {
 		if (!this.can('hotpatch')) return false;
 		let memUsage = process.memoryUsage();


### PR DESCRIPTION
I'm not sure why these were here to begin with.