### PR TITLE
Fix client-side activation of Aromatherapy and Heal Bell for all gens

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -858,11 +858,11 @@ BattlePokemon = (() => {
 	BattlePokemon.prototype.trySetStatus = function (status, source, sourceEffect) {
 		return this.setStatus(this.status || status, source, sourceEffect);
 	};
-	BattlePokemon.prototype.cureStatus = function () {
+	BattlePokemon.prototype.cureStatus = function (silent) {
 		if (!this.hp) return false;
 		// unlike clearStatus, gives cure message
 		if (this.status) {
-			this.battle.add('-curestatus', this, this.status);
+			this.battle.add('-curestatus', this, this.status, silent ? '[silent]' : '[msg]');
 			this.setStatus('');
 		}
 	};

--- a/data/moves.js
+++ b/data/moves.js
@@ -464,17 +464,14 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, distance: 1},
 		onHit: function (pokemon, source, move) {
-			this.add('-cureteam', source, '[from] move: Aromatherapy');
+			this.add('-activate', source, 'move: Aromatherapy');
 			let side = pokemon.side;
 			for (let i = 0; i < side.pokemon.length; i++) {
 				if (side.pokemon[i] !== source && ((side.pokemon[i].hasAbility('sapsipper')) ||
 						(side.pokemon[i].volatiles['substitute'] && !move.infiltrates))) {
 					continue;
 				}
-				if (side.pokemon[i].status && side.pokemon[i].hp) {
-					this.add('-curestatus', side.pokemon[i], side.pokemon[i].status);
-					side.pokemon[i].status = '';
-				}
+				side.pokemon[i].cureStatus();
 			}
 		},
 		target: "allyTeam",
@@ -6124,14 +6121,11 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, sound: 1, distance: 1, authentic: 1},
 		onHit: function (pokemon, source) {
-			this.add('-cureteam', source, '[from] move: Heal Bell');
+			this.add('-activate', source, 'move: Heal Bell');
 			let side = pokemon.side;
 			for (let i = 0; i < side.pokemon.length; i++) {
 				if (side.pokemon[i].hasAbility('soundproof')) continue;
-				if (side.pokemon[i].status && side.pokemon[i].hp) {
-					this.add('-curestatus', side.pokemon[i], side.pokemon[i].status);
-					side.pokemon[i].status = '';
-				}
+				side.pokemon[i].cureStatus();
 			}
 		},
 		target: "allyTeam",

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -167,6 +167,13 @@ exports.BattleMovedex = {
 			},
 		},
 	},
+	healbell: {
+		inherit: true,
+		onHit: function (target, source) {
+			this.add('-cureteam', source, '[from] move: Heal Bell');
+			source.side.pokemon.forEach(pokemon => pokemon.clearStatus());
+		},
+	},
 	highjumpkick: {
 		inherit: true,
 		onMoveFail: function (target, source, move) {

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -22,6 +22,13 @@ exports.BattleMovedex = {
 		inherit: true,
 		flags: {contact: 1, protect: 1, mirror: 1},
 	},
+	aromatherapy: {
+		inherit: true,
+		onHit: function (target, source) {
+			this.add('-cureteam', source, '[from] move: Aromatherapy');
+			source.side.pokemon.forEach(pokemon => pokemon.clearStatus());
+		},
+	},
 	assist: {
 		inherit: true,
 		desc: "The user performs a random move from any of the Pokemon on its team. Assist cannot generate itself, Chatter, Copycat, Counter, Covet, Destiny Bond, Detect, Endure, Feint, Focus Punch, Follow Me, Helping Hand, Me First, Metronome, Mimic, Mirror Coat, Mirror Move, Protect, Sketch, Sleep Talk, Snatch, Struggle, Switcheroo, Thief or Trick.",
@@ -468,6 +475,15 @@ exports.BattleMovedex = {
 		onModifyMove: function () { },
 		boosts: {
 			spa: 1,
+		},
+	},
+	healbell: {
+		inherit: true,
+		onHit: function (target, source) {
+			this.add('-activate', source, 'move: Heal Bell');
+			source.side.pokemon.forEach(pokemon => {
+				if (!pokemon.hasAbility('soundproof')) pokemon.cureStatus(true);
+			});
 		},
 	},
 	hiddenpower: {

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -27,14 +27,9 @@ exports.BattleMovedex = {
 	},
 	aromatherapy: {
 		inherit: true,
-		onHit: function (pokemon, source) {
+		onHit: function (target, source) {
 			this.add('-cureteam', source, '[from] move: Aromatherapy');
-			let side = pokemon.side;
-			for (let i = 0; i < side.pokemon.length; i++) {
-				if (side.pokemon[i].status && side.pokemon[i].hp) {
-					side.pokemon[i].status = '';
-				}
-			}
+			source.side.pokemon.forEach(pokemon => pokemon.clearStatus());
 		},
 	},
 	assist: {
@@ -573,14 +568,11 @@ exports.BattleMovedex = {
 	},
 	healbell: {
 		inherit: true,
-		onHit: function (pokemon, source) {
-			this.add('-cureteam', source, '[from] move: Heal Bell');
-			let side = pokemon.side;
-			for (let i = 0; i < side.pokemon.length; i++) {
-				if (side.pokemon[i].status && side.pokemon[i].hp) {
-					side.pokemon[i].status = '';
-				}
-			}
+		onHit: function (target, source) {
+			this.add('-activate', source, 'move: Heal Bell');
+			source.side.pokemon.forEach(pokemon => {
+				if (!pokemon.hasAbility('soundproof')) pokemon.cureStatus(true);
+			});
 		},
 	},
 	healblock: {

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -19,15 +19,9 @@ exports.BattleMovedex = {
 	},
 	aromatherapy: {
 		inherit: true,
-		onHit: function (pokemon, source) {
-			this.add('-cureteam', source, '[from] move: Aromatherapy');
-			let side = pokemon.side;
-			for (let i = 0; i < side.pokemon.length; i++) {
-				if (side.pokemon[i].status && side.pokemon[i].hp) {
-					this.add('-curestatus', side.pokemon[i], side.pokemon[i].status);
-					side.pokemon[i].status = '';
-				}
-			}
+		onHit: function (target, source) {
+			this.add('-activate', source, 'move: Aromatherapy');
+			source.side.pokemon.forEach(pokemon => pokemon.cureStatus());
 		},
 	},
 	assist: {
@@ -340,15 +334,9 @@ exports.BattleMovedex = {
 	healbell: {
 		inherit: true,
 		flags: {snatch: 1, sound: 1},
-		onHit: function (pokemon, source) {
-			this.add('-cureteam', source, '[from] move: Heal Bell');
-			let side = pokemon.side;
-			for (let i = 0; i < side.pokemon.length; i++) {
-				if (side.pokemon[i].status && side.pokemon[i].hp) {
-					this.add('-curestatus', side.pokemon[i], side.pokemon[i].status);
-					side.pokemon[i].status = '';
-				}
-			}
+		onHit: function (target, source) {
+			this.add('-activate', source, 'move: Heal Bell');
+			source.side.pokemon.forEach(pokemon => pokemon.cureStatus());
 		},
 	},
 	healpulse: {


### PR DESCRIPTION
Requires the client-side patches for `-activate` and `[silent]`.
* Gen5/6: Sends `-activate` instead of `-cureteam` so that the client only cures the individual advertised statuses.
* Gen3/4 Heal Bell: Sends `-activate`, and uses silent `-curestatus` because Soundproof Pokémon don't get cured, and cures aren't advertised.
* Gen3/4 Aromatherapy and Gen2 Heal Bell: Continues to use `-cureteam`.