### PR TITLE
Add Config option for dnsbl

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -22,6 +22,11 @@ exports.potd = '';
 //   crash, so this option is provided
 exports.crashguard = true;
 
+// dnsbl - a very basic way that detects proxies, and will attempt to block
+//  It should be noted that this isn't overly reliable, and can possibly give
+//  false positives
+exports.dnsbl = false;
+
 // login server data - don't forget the http:// and the trailing slash
 //   This is the URL of the user database and ladder mentioned earlier.
 //   Don't change this setting - there aren't any other login servers right now


### PR DESCRIPTION
It appears that https://github.com/Zarel/Pokemon-Showdown/commit/be5741bd7e88647e33a0de1c6c170606a34d49f0 introduced a new Config option that wasn't documented in ``config/config-example.js``