### PR TITLE
ipsearch: Make "No results found." a sendReply

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -204,7 +204,7 @@ exports.commands = {
 		}
 		if (!results.length) {
 			if (!target.includes('.')) return this.errorReply("'" + target + "' is not a valid IP or host.");
-			return this.errorReply("No results found.");
+			return this.sendReply("No results found.");
 		}
 		return this.sendReply(results.join('; '));
 	},


### PR DESCRIPTION
#Zarel: >No results found.
#Zarel: why is that red???
%panpawn: I don't know
%panpawn: it was red before that commit
#Zarel: Should probably be sendReply for "No results found"