### PR TITLE
Hotpatch: Inform development room on hotpatch use

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -2476,8 +2476,10 @@ exports.commands = {
 		if (!this.can('hotpatch')) return false;
 		if (Monitor.hotpatchLock) return this.errorReply("Hotpatch is currently been disabled. (" + Monitor.hotpatchLock + ")");
 
-		let staff = Rooms('staff');
-		if (staff) staff.add("(" + user.name + " used /hotpatch " + target + ")").update();
+		for (let roomid of ['development', 'staff', 'upperstaff']) {
+			let curRoom = Rooms(roomid);
+			if (curRoom) curRoom.add("|c|~|(" + user.name + " used /hotpatch " + target + ")").update();
+		}
 
 		try {
 			if (target === 'chat' || target === 'commands') {


### PR DESCRIPTION
If there isn't a "development" room, then it will instead default to the "staff" room, if it exists.