### PR TITLE
When Users#setGroup is called, use Config ranks

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1902,7 +1902,7 @@ exports.commands = {
 
 		if (targetUser.confirmed) return this.errorReply("User '" + name + "' is already confirmed.");
 
-		targetUser.setGroup(' ', true);
+		targetUser.setGroup(Config.groupsranking[0], true);
 		this.sendReply("User '" + name + "' is now confirmed.");
 	},
 	confirmuserhelp: ["/confirmuser [username] - Confirms the user (makes them immune to locks). Requires: & ~"],

--- a/users.js
+++ b/users.js
@@ -964,7 +964,7 @@ class User {
 			}
 		}
 		this.confirmed = '';
-		this.setGroup(' ');
+		this.setGroup(Config.groupsranking[0]);
 		return removed;
 	}
 	markInactive() {


### PR DESCRIPTION
This makes it so that when Users#setGroup is called, it looks slightly less hard-coded to be a whatever symbol a regular user is (should that symbol ever change)