### PR TITLE
Allow regular users to do /htmlbox

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1655,8 +1655,8 @@ exports.commands = {
 		if (!target) return this.parse('/help htmlbox');
 		target = this.canHTML(target);
 		if (!target) return;
-		if (!this.can('declare', null, room)) return;
 		if (!this.runBroadcast('!htmlbox')) return;
+		if (this.broadcasting && !this.can('declare', null, room)) return;
 
 		this.sendReplyBox(target);
 	},


### PR DESCRIPTION
This lets regular users, or users who don't have permission to use !htmlbox to first test and validate HTML by using the same validation system PS uses across the sim for things like roomintros, for example.