### PR TITLE
Support switching to own custom avatar in any server if confirmed

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -326,6 +326,8 @@ exports.commands = {
 		};
 		if (avatarid in avatarTable) {
 			avatar = avatarTable[avatarid];
+		} else if (avatarid === user.userid && user.confirmed === user.userid) {
+			avatar = '#' + avatarid;
 		} else {
 			avatar = parseInt(avatarid);
 		}


### PR DESCRIPTION
This allows users with globally registered custom avatars to use them in any server, as long as they are confirmed.
