### PR TITLE
Remove .js extension from requires

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ try {
  *********************************************************/
 
 try {
-	require.resolve('./config/config.js');
+	require.resolve('./config/config');
 } catch (err) {
 	if (err.code !== 'MODULE_NOT_FOUND') throw err; // should never happen
 
@@ -81,15 +81,16 @@ try {
 		fs.readFileSync(path.resolve(__dirname, 'config/config-example.js'))
 	);
 } finally {
-	global.Config = require('./config/config.js');
+	global.Config = require('./config/config');
 }
 
 if (Config.watchconfig) {
-	fs.watchFile(path.resolve(__dirname, 'config/config.js'), (curr, prev) => {
+	let configPath = require.resolve(__dirname, 'config/config');
+	fs.watchFile(configPath, (curr, prev) => {
 		if (curr.mtime <= prev.mtime) return;
 		try {
-			delete require.cache[require.resolve('./config/config.js')];
-			global.Config = require('./config/config.js');
+			delete require.cache[configPath];
+			global.Config = require('./config/config');
 			if (global.Users) Users.cacheGroupData();
 			console.log('Reloaded config/config.js');
 		} catch (e) {
@@ -102,38 +103,38 @@ if (Config.watchconfig) {
  * Set up most of our globals
  *********************************************************/
 
-global.Monitor = require('./monitor.js');
+global.Monitor = require('./monitor');
 
-global.Tools = require('./tools.js');
+global.Tools = require('./tools');
 global.toId = Tools.getId;
 
-global.LoginServer = require('./loginserver.js');
+global.LoginServer = require('./loginserver');
 
-global.Ladders = require(Config.remoteladder ? './ladders-remote.js' : './ladders.js');
+global.Ladders = require(Config.remoteladder ? './ladders-remote' : './ladders');
 
-global.Users = require('./users.js');
+global.Users = require('./users');
 
-global.Punishments = require('./punishments.js');
+global.Punishments = require('./punishments');
 
-global.Rooms = require('./rooms.js');
+global.Rooms = require('./rooms');
 
 delete process.send; // in case we're a child process
-global.Verifier = require('./verifier.js');
+global.Verifier = require('./verifier');
 Verifier.PM.spawn();
 
-global.CommandParser = require('./command-parser.js');
+global.CommandParser = require('./command-parser');
 
-global.Simulator = require('./simulator.js');
+global.Simulator = require('./simulator');
 
 global.Tournaments = require('./tournaments');
 
-global.Dnsbl = require('./dnsbl.js');
+global.Dnsbl = require('./dnsbl');
 Dnsbl.loadDatacenters();
 
 if (Config.crashguard) {
 	// graceful crash - allow current battles to finish before restarting
 	process.on('uncaughtException', err => {
-		let crashMessage = require('./crashlogger.js')(err, 'The main process');
+		let crashMessage = require('./crashlogger')(err, 'The main process');
 		if (crashMessage !== 'lockdown') return;
 		let stack = Tools.escapeHTML(err.stack).split("\n").slice(0, 2).join("<br />");
 		if (Rooms.lobby) {
@@ -152,7 +153,7 @@ if (Config.crashguard) {
  * Start networking processes to be connected to
  *********************************************************/
 
-global.Sockets = require('./sockets.js');
+global.Sockets = require('./sockets');
 
 exports.listen = function (port, bindAddress, workerCount) {
 	Sockets.listen(port, bindAddress, workerCount);
@@ -176,11 +177,11 @@ if (require.main === module) {
 Tools.includeFormats();
 Rooms.global.formatListText = Rooms.global.getFormatListText();
 
-global.TeamValidator = require('./team-validator.js');
+global.TeamValidator = require('./team-validator');
 TeamValidator.PM.spawn();
 
 /*********************************************************
  * Start up the REPL server
  *********************************************************/
 
-require('./repl.js').start('app', cmd => eval(cmd));
+require('./repl').start('app', cmd => eval(cmd));

--- a/battle-engine.js
+++ b/battle-engine.js
@@ -4938,7 +4938,7 @@ Battle = (() => {
 			let side = this[slot];
 			if (!side) {
 				console.log('**** ' + slot + ' tried to leave before it was possible in ' + this.id);
-				require('./crashlogger.js')(new Error('**** ' + slot + ' tried to leave before it was possible in ' + this.id), 'A simulator process');
+				require('./crashlogger')(new Error('**** ' + slot + ' tried to leave before it was possible in ' + this.id), 'A simulator process');
 				return;
 			}
 

--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -61,7 +61,7 @@ const PM = exports.PM = new ProcessManager({
 				result = null;
 			}
 		} catch (err) {
-			require('./../crashlogger.js')(err, 'A search query', data);
+			require('./../crashlogger')(err, 'A search query', data);
 			result = {error: "Sorry! Our search engine crashed on your query. We've been automatically notified and will fix this crash."};
 		}
 		return result;
@@ -242,24 +242,24 @@ exports.commands = {
 if (process.send && module === process.mainModule) {
 	// This is a child process!
 
-	global.Config = require('../config/config.js');
+	global.Config = require('../config/config');
 
 	if (Config.crashguard) {
 		process.on('uncaughtException', err => {
-			require('../crashlogger.js')(err, 'A dexsearch process', true);
+			require('../crashlogger')(err, 'A dexsearch process', true);
 		});
 	}
 
-	global.Tools = require('../tools.js');
+	global.Tools = require('../tools');
 	global.toId = Tools.getId;
 	Tools.includeData();
 	Tools.includeMods();
-	global.TeamValidator = require('../team-validator.js');
+	global.TeamValidator = require('../team-validator');
 
 	process.on('message', message => PM.onMessageDownstream(message));
 	process.on('disconnect', () => process.exit());
 
-	require('../repl.js').start('dexsearch', cmd => eval(cmd));
+	require('../repl').start('dexsearch', cmd => eval(cmd));
 } else if (!PM.maxProcesses) {
 	process.nextTick(() => Tools.includeMods());
 }

--- a/chat-plugins/mafia.js
+++ b/chat-plugins/mafia.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-let MafiaData = require('./mafia-data.js');
+let MafiaData = require('./mafia-data');
 
 const deadImage = '<img width="75" height="75" src="//play.pokemonshowdown.com/fx/mafia-dead.png" />';
 const meetingMsg = {town: 'The town has lynched a suspect!', mafia: 'The mafia strikes again!'};

--- a/command-parser.js
+++ b/command-parser.js
@@ -60,13 +60,13 @@ exports.multiLinePattern = {
  * Load command files
  *********************************************************/
 
-let baseCommands = exports.baseCommands = require('./commands.js').commands;
+let baseCommands = exports.baseCommands = require('./commands').commands;
 let commands = exports.commands = Object.assign({}, baseCommands);
 
 // Install plug-in commands
 
 // info always goes first so other plugins can shadow it
-Object.assign(commands, require('./chat-plugins/info.js').commands);
+Object.assign(commands, require('./chat-plugins/info').commands);
 
 for (let file of fs.readdirSync(path.resolve(__dirname, 'chat-plugins'))) {
 	if (file.substr(-3) !== '.js' || file === 'info.js') continue;
@@ -283,7 +283,7 @@ class CommandContext {
 		try {
 			result = commandHandler.call(this, this.target, this.room, this.user, this.connection, this.cmd, this.message);
 		} catch (err) {
-			if (require('./crashlogger.js')(err, 'A chat command', {
+			if (require('./crashlogger')(err, 'A chat command', {
 				user: this.user.name,
 				room: this.room.id,
 				message: this.message,

--- a/commands.js
+++ b/commands.js
@@ -2501,10 +2501,10 @@ exports.commands = {
 					}
 				}
 
-				CommandParser.uncacheTree('./command-parser.js');
-				delete require.cache[require.resolve('./commands.js')];
-				delete require.cache[require.resolve('./chat-plugins/info.js')];
-				global.CommandParser = require('./command-parser.js');
+				CommandParser.uncacheTree('./command-parser');
+				delete require.cache[require.resolve('./commands')];
+				delete require.cache[require.resolve('./chat-plugins/info')];
+				global.CommandParser = require('./command-parser');
 
 				let runningTournaments = Tournaments.tournaments;
 				CommandParser.uncacheTree('./tournaments');
@@ -2524,9 +2524,9 @@ exports.commands = {
 			} else if (target === 'formats') {
 				let toolsLoaded = !!Tools.isLoaded;
 				// uncache the tools.js dependency tree
-				CommandParser.uncacheTree('./tools.js');
+				CommandParser.uncacheTree('./tools');
 				// reload tools.js
-				global.Tools = require('./tools.js')[toolsLoaded ? 'includeData' : 'includeFormats'](); // note: this will lock up the server for a few seconds
+				global.Tools = require('./tools')[toolsLoaded ? 'includeData' : 'includeFormats'](); // note: this will lock up the server for a few seconds
 				// rebuild the formats list
 				Rooms.global.formatListText = Rooms.global.getFormatListText();
 				// respawn validator processes
@@ -2539,15 +2539,15 @@ exports.commands = {
 				return this.sendReply("Formats have been hotpatched.");
 			} else if (target === 'loginserver') {
 				fs.unwatchFile('./config/custom.css');
-				CommandParser.uncacheTree('./loginserver.js');
-				global.LoginServer = require('./loginserver.js');
+				CommandParser.uncacheTree('./loginserver');
+				global.LoginServer = require('./loginserver');
 				return this.sendReply("The login server has been hotpatched. New login server requests will use the new code.");
 			} else if (target === 'learnsets' || target === 'validator') {
 				TeamValidator.PM.respawn();
 				return this.sendReply("The team validator has been hotpatched. Any battles started after now will have teams be validated according to the new code.");
 			} else if (target === 'punishments') {
-				delete require.cache[require.resolve('./punishments.js')];
-				global.Punishments = require('./punishments.js');
+				delete require.cache[require.resolve('./punishments')];
+				global.Punishments = require('./punishments');
 				return this.sendReply("Punishments have been hotpatched.");
 			} else if (target === 'dnsbl') {
 				Dnsbl.loadDatacenters();

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1159,7 +1159,7 @@ exports.BattleScripts = {
 			template = this.getTemplate('unown');
 
 			let err = new Error('Template incompatible with random battles: ' + species);
-			require('../crashlogger.js')(err, 'The randbat set generator');
+			require('../crashlogger')(err, 'The randbat set generator');
 		}
 
 		if (typeof teamDetails !== 'object') teamDetails = {megaCount: teamDetails};
@@ -2433,7 +2433,7 @@ exports.BattleScripts = {
 			template = this.getTemplate('unown');
 
 			let err = new Error('Template incompatible with random battles: ' + species);
-			require('../crashlogger.js')(err, 'The doubles randbat set generator');
+			require('../crashlogger')(err, 'The doubles randbat set generator');
 		}
 
 		if (typeof teamDetails !== 'object') teamDetails = {megaCount: teamDetails};

--- a/mods/gen5/scripts.js
+++ b/mods/gen5/scripts.js
@@ -11,7 +11,7 @@ exports.BattleScripts = {
 			template = this.getTemplate('unown');
 
 			let err = new Error('Template incompatible with random battles: ' + name);
-			require('./../../crashlogger.js')(err, 'The randbat set generator');
+			require('./../../crashlogger')(err, 'The randbat set generator');
 		}
 
 		if (template.battleOnly) name = template.baseSpecies;

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -18,4 +18,4 @@ let port;
 if (process.argv[2]) {
 	port = parseInt(process.argv[2]); // eslint-disable-line radix
 }
-require('./app.js').listen(port);
+require('./app').listen(port);

--- a/repl.js
+++ b/repl.js
@@ -75,7 +75,7 @@ exports.start = function (prefix, suffix, evalFunction) {
 		if (e.code === "EADDRINUSE") {
 			fs.unlink(name, e => {
 				if (e && e.code !== "ENOENT") {
-					require('./crashlogger.js')(e, 'REPL: ' + name);
+					require('./crashlogger')(e, 'REPL: ' + name);
 					return;
 				}
 
@@ -84,6 +84,6 @@ exports.start = function (prefix, suffix, evalFunction) {
 			return;
 		}
 
-		require('./crashlogger.js')(e, 'REPL: ' + name);
+		require('./crashlogger')(e, 'REPL: ' + name);
 	});
 };

--- a/rooms.js
+++ b/rooms.js
@@ -586,7 +586,7 @@ let GlobalRoom = (() => {
 	};
 	GlobalRoom.prototype.matchmakingOK = function (search1, search2, user1, user2, formatid) {
 		// This should never happen.
-		if (!user1 || !user2) return void require('./crashlogger.js')(new Error("Matched user " + (user1 ? search2.userid : search1.userid) + " not found"), "The main process");
+		if (!user1 || !user2) return void require('./crashlogger')(new Error("Matched user " + (user1 ? search2.userid : search1.userid) + " not found"), "The main process");
 
 		// users must be different
 		if (user1 === user2) return false;
@@ -1699,8 +1699,8 @@ Rooms.GlobalRoom = GlobalRoom;
 Rooms.BattleRoom = BattleRoom;
 Rooms.ChatRoom = ChatRoom;
 
-Rooms.RoomGame = require('./room-game.js').RoomGame;
-Rooms.RoomGamePlayer = require('./room-game.js').RoomGamePlayer;
+Rooms.RoomGame = require('./room-game').RoomGame;
+Rooms.RoomGamePlayer = require('./room-game').RoomGamePlayer;
 
 // initialize
 

--- a/simulator.js
+++ b/simulator.js
@@ -13,14 +13,14 @@
 
 'use strict';
 
-global.Config = require('./config/config.js');
+global.Config = require('./config/config');
 
 const ProcessManager = require('./process-manager');
 const BattleEngine = require('./battle-engine').Battle;
 
 const SimulatorProcess = new ProcessManager({
 	maxProcesses: Config.simulatorprocesses,
-	execFile: 'simulator.js',
+	execFile: 'simulator',
 	onMessageUpstream: function (message) {
 		let lines = message.split('\n');
 		let battle = this.pendingTasks.get(lines[0]);
@@ -450,17 +450,17 @@ exports.create = function (id, format, rated, room) {
 if (process.send && module === process.mainModule) {
 	// This is a child process!
 
-	global.Tools = require('./tools.js').includeMods();
+	global.Tools = require('./tools').includeMods();
 	global.toId = Tools.getId;
 
 	if (Config.crashguard) {
 		// graceful crash - allow current battles to finish before restarting
 		process.on('uncaughtException', err => {
-			require('./crashlogger.js')(err, 'A simulator process');
+			require('./crashlogger')(err, 'A simulator process');
 		});
 	}
 
-	require('./repl.js').start('battle-engine-', process.pid, cmd => eval(cmd));
+	require('./repl').start('battle-engine-', process.pid, cmd => eval(cmd));
 
 	let Battles = new Map();
 
@@ -481,7 +481,7 @@ if (process.send && module === process.mainModule) {
 				try {
 					Battles.set(id, BattleEngine.construct(id, data[2], data[3], sendBattleMessage));
 				} catch (err) {
-					if (require('./crashlogger.js')(err, 'A battle', {
+					if (require('./crashlogger')(err, 'A battle', {
 						message: message,
 					}) === 'lockdown') {
 						let ministack = Tools.escapeHTML(err.stack).split("\n").slice(0, 2).join("<br />");
@@ -499,7 +499,7 @@ if (process.send && module === process.mainModule) {
 				// remove from battle list
 				Battles.delete(id);
 			} else {
-				require('./crashlogger.js')(new Error("Invalid dealloc"), 'A battle', {
+				require('./crashlogger')(new Error("Invalid dealloc"), 'A battle', {
 					message: message,
 				});
 			}
@@ -511,7 +511,7 @@ if (process.send && module === process.mainModule) {
 				try {
 					battle.receive(data, more);
 				} catch (err) {
-					require('./crashlogger.js')(err, 'A battle', {
+					require('./crashlogger')(err, 'A battle', {
 						message: message,
 						currentRequest: prevRequest,
 						log: '\n' + battle.log.join('\n').replace(/\n\|split\n[^\n]*\n[^\n]*\n[^\n]*\n/g, '\n'),

--- a/sockets.js
+++ b/sockets.js
@@ -18,7 +18,7 @@ global.Config = require('./config/config');
 
 if (cluster.isMaster) {
 	cluster.setupMaster({
-		exec: require('path').resolve(__dirname, 'sockets.js'),
+		exec: require('path').resolve(__dirname, 'sockets'),
 	});
 
 	let workers = exports.workers = {};
@@ -62,7 +62,7 @@ if (cluster.isMaster) {
 
 	cluster.on('disconnect', worker => {
 		// worker crashed, try our best to clean up
-		require('./crashlogger.js')(new Error("Worker " + worker.id + " abruptly died"), "The main process");
+		require('./crashlogger')(new Error("Worker " + worker.id + " abruptly died"), "The main process");
 
 		// this could get called during cleanup; prevent it from crashing
 		worker.send = () => {};
@@ -183,12 +183,12 @@ if (cluster.isMaster) {
 
 	// It's optional if you don't need these features.
 
-	global.Dnsbl = require('./dnsbl.js');
+	global.Dnsbl = require('./dnsbl');
 
 	if (Config.crashguard) {
 		// graceful crash
 		process.on('uncaughtException', err => {
-			require('./crashlogger.js')(err, 'Socket process ' + cluster.worker.id + ' (' + process.pid + ')', true);
+			require('./crashlogger')(err, 'Socket process ' + cluster.worker.id + ' (' + process.pid + ')', true);
 		});
 	}
 
@@ -496,5 +496,5 @@ if (cluster.isMaster) {
 
 	console.log('Test your server at http://' + (Config.bindaddress === '0.0.0.0' ? 'localhost' : Config.bindaddress) + ':' + Config.port);
 
-	require('./repl.js').start('sockets-', cluster.worker.id + '-' + process.pid, cmd => eval(cmd));
+	require('./repl').start('sockets-', cluster.worker.id + '-' + process.pid, cmd => eval(cmd));
 }

--- a/team-validator.js
+++ b/team-validator.js
@@ -865,7 +865,7 @@ const ProcessManager = require('./process-manager');
 
 PM = TeamValidator.PM = new ProcessManager({
 	maxProcesses: global.Config && Config.validatorprocesses,
-	execFile: 'team-validator.js',
+	execFile: 'team-validator',
 	onMessageUpstream: function (message) {
 		// Protocol:
 		// success: "[id]|1[details]"
@@ -902,7 +902,7 @@ PM = TeamValidator.PM = new ProcessManager({
 		try {
 			problems = TeamValidator(format).validateTeam(parsedTeam, removeNicknames);
 		} catch (err) {
-			require('./crashlogger.js')(err, 'A team validation', {
+			require('./crashlogger')(err, 'A team validation', {
 				format: format,
 				team: team,
 			});
@@ -923,18 +923,18 @@ PM = TeamValidator.PM = new ProcessManager({
 if (process.send && module === process.mainModule) {
 	// This is a child process!
 
-	global.Config = require('./config/config.js');
+	global.Config = require('./config/config');
 
 	if (Config.crashguard) {
 		process.on('uncaughtException', err => {
-			require('./crashlogger.js')(err, 'A team validator process', true);
+			require('./crashlogger')(err, 'A team validator process', true);
 		});
 	}
 
-	global.Tools = require('./tools.js').includeMods();
+	global.Tools = require('./tools').includeMods();
 	global.toId = Tools.getId;
 
-	require('./repl.js').start('team-validator-', process.pid, cmd => eval(cmd));
+	require('./repl').start('team-validator-', process.pid, cmd => eval(cmd));
 
 	process.on('message', message => PM.onMessageDownstream(message));
 	process.on('disconnect', () => process.exit());

--- a/test/application/rooms.js
+++ b/test/application/rooms.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-let userUtils = require('./../../dev-tools/users-utils.js');
+let userUtils = require('./../../dev-tools/users-utils');
 let User = userUtils.User;
 
 describe('Rooms features', function () {

--- a/test/application/simulator.js
+++ b/test/application/simulator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-let userUtils = require('./../../dev-tools/users-utils.js');
+let userUtils = require('./../../dev-tools/users-utils');
 let User = userUtils.User;
 
 describe('Simulator abstraction layer features', function () {

--- a/test/application/users.js
+++ b/test/application/users.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-let userUtils = require('./../../dev-tools/users-utils.js');
+let userUtils = require('./../../dev-tools/users-utils');
 let Connection = userUtils.Connection;
 let User = userUtils.User;
 

--- a/test/chat-plugins/datasearch.js
+++ b/test/chat-plugins/datasearch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const userUtils = require('./../../dev-tools/users-utils.js');
+const userUtils = require('./../../dev-tools/users-utils');
 const User = userUtils.User;
 
 describe('Learn', function () {

--- a/test/chat-plugins/trivia.js
+++ b/test/chat-plugins/trivia.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const Module = require('module');
 
-const userUtils = require('../../dev-tools/users-utils.js');
+const userUtils = require('../../dev-tools/users-utils');
 const User = userUtils.User;
 const Connection = userUtils.Connection;
 
@@ -12,7 +12,7 @@ const Connection = userUtils.Connection;
 // context. For now we'll just construct a skeleton module representing the
 // trivia module and wait...
 const triviaModule = (() => {
-	let pathname = require.resolve('../../chat-plugins/trivia.js');
+	let pathname = require.resolve('../../chat-plugins/trivia');
 	let ret = new Module(pathname, module);
 	Module._preloadModules(ret);
 

--- a/test/dev-tools/eslint/validate-conditionals.js
+++ b/test/dev-tools/eslint/validate-conditionals.js
@@ -1,7 +1,7 @@
 "use strict";
 
 describe("eslint-rules/validate-conditionals", function () {
-	const rule = require('./../../../dev-tools/eslint/validate-conditionals.js');
+	const rule = require('./../../../dev-tools/eslint/validate-conditionals');
 	const RuleTester = require('eslint/lib/testers/rule-tester');
 
 	const ruleTester = new RuleTester();

--- a/test/main.js
+++ b/test/main.js
@@ -19,10 +19,10 @@ function getDirTypedContentsSync(dir, forceType) {
 }
 
 function init(callback) {
-	require('./../app.js');
+	require('./../app');
 
 	// Run the battle engine in the main process to keep our sanity
-	let BattleEngine = global.BattleEngine = require('./../battle-engine.js');
+	let BattleEngine = global.BattleEngine = require('./../battle-engine');
 	for (let listener of process.listeners('message')) {
 		process.removeListener('message', listener);
 	}
@@ -59,7 +59,7 @@ before('initialization', function (done) {
 	// Load and override configuration before starting the server
 	let config;
 	try {
-		require.resolve('./../config/config.js');
+		require.resolve('./../config/config');
 	} catch (err) {
 		if (err.code !== 'MODULE_NOT_FOUND') throw err; // Should never happen
 
@@ -68,7 +68,7 @@ before('initialization', function (done) {
 			fs.readFileSync(path.resolve(__dirname, '../config/config-example.js'))
 		);
 	} finally {
-		config = require('./../config/config.js');
+		config = require('./../config/config');
 	}
 
 	try {
@@ -88,7 +88,7 @@ before('initialization', function (done) {
 	config.logchat = false;
 
 	// Don't create a REPL
-	require('./../repl.js').start = noop;
+	require('./../repl').start = noop;
 
 	// Sandbox file system: it's possible for a production server to be running in the same directory.
 	// And using a sandbox is safer anyway.

--- a/test/simulator/index.js
+++ b/test/simulator/index.js
@@ -7,7 +7,7 @@ function loadTests(desc, dir) {
 	let contents = fs.readdirSync(path.join(__dirname, dir));
 	describe(desc, function () {
 		for (let i = 0; i < contents.length; i++) {
-			if (contents[i].substr(-3) === '.js') require('./' + path.join(dir, contents[i]));
+			if (contents[i].substr(-3) === '.js') require('./' + path.join(dir, contents[i].substr(0, contents[i].length - 3)));
 		}
 	});
 }

--- a/tools.js
+++ b/tools.js
@@ -39,17 +39,17 @@ module.exports = (() => {
 
 	let dataTypes = ['Pokedex', 'FormatsData', 'Learnsets', 'Movedex', 'Statuses', 'TypeChart', 'Scripts', 'Items', 'Abilities', 'Natures', 'Formats', 'Aliases'];
 	let dataFiles = {
-		'Pokedex': 'pokedex.js',
-		'Movedex': 'moves.js',
-		'Statuses': 'statuses.js',
-		'TypeChart': 'typechart.js',
-		'Scripts': 'scripts.js',
-		'Items': 'items.js',
-		'Abilities': 'abilities.js',
-		'Formats': 'rulesets.js',
-		'FormatsData': 'formats-data.js',
-		'Learnsets': 'learnsets.js',
-		'Aliases': 'aliases.js',
+		'Pokedex': 'pokedex',
+		'Movedex': 'moves',
+		'Statuses': 'statuses',
+		'TypeChart': 'typechart',
+		'Scripts': 'scripts',
+		'Items': 'items',
+		'Abilities': 'abilities',
+		'Formats': 'rulesets',
+		'FormatsData': 'formats-data',
+		'Learnsets': 'learnsets',
+		'Aliases': 'aliases',
 	};
 
 	let BattleNatures = dataFiles.Natures = {
@@ -1158,7 +1158,7 @@ module.exports = (() => {
 		this.data.Aliases = BattleAliases;
 
 		// Load formats
-		let maybeFormats = tryRequire('./config/formats.js');
+		let maybeFormats = tryRequire('./config/formats');
 		if (maybeFormats instanceof Error) {
 			if (maybeFormats.code !== 'MODULE_NOT_FOUND') throw new Error("CRASH LOADING FORMATS:\n" + maybeFormats.stack);
 		}

--- a/tournaments/generator-elimination.js
+++ b/tournaments/generator-elimination.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let TreeNode = require('./lib/closure-goog.structs.TreeNode-c8e0b2dcd892.min.js').goog.structs.TreeNode;
+let TreeNode = require('./lib/closure-goog.structs.TreeNode-c8e0b2dcd892.min').goog.structs.TreeNode;
 
 const nameMap = {
 	'1': "Single",

--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -7,8 +7,8 @@ const MAX_REASON_LENGTH = 300;
 
 let TournamentGenerators = Object.create(null);
 let generatorFiles = {
-	'roundrobin': 'generator-round-robin.js',
-	'elimination': 'generator-elimination.js',
+	'roundrobin': 'generator-round-robin',
+	'elimination': 'generator-elimination',
 };
 for (let type in generatorFiles) {
 	TournamentGenerators[type] = require('./' + generatorFiles[type]);

--- a/verifier.js
+++ b/verifier.js
@@ -19,7 +19,7 @@ const ProcessManager = require('./process-manager');
 
 const PM = exports.PM = new ProcessManager({
 	maxProcesses: 1,
-	execFile: 'verifier.js',
+	execFile: 'verifier',
 	onMessageUpstream: function (message) {
 		// Protocol:
 		// success: "[id]|1"
@@ -58,9 +58,9 @@ const PM = exports.PM = new ProcessManager({
 if (process.send && module === process.mainModule) {
 	// This is a child process!
 
-	global.Config = require('./config/config.js');
+	global.Config = require('./config/config');
 
-	require('./repl.js').start('verifier', cmd => eval(cmd));
+	require('./repl').start('verifier', cmd => eval(cmd));
 
 	process.on('message', message => PM.onMessageDownstream(message));
 	process.on('disconnect', () => process.exit());


### PR DESCRIPTION
Resolves #2722

Motivation taken from #2722 

Suppose I want to use battle-engine.js in the browser and I have a webpack config that resolves es6 files with higher priority than js files. I can now override require('./crashlogger') in Battle.prototype.leave to my own implementation as I choose. I can use a similar method to create a tools.es6 that has all this.data built into it and define global.Tools for battle-engine.js to run in the browser.