### PR TITLE
Refactor to use .hasOwnProperty in favor of in

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -35,7 +35,7 @@ exports.commands = {
 		let buf = Tools.html`<strong class="username"><small style="display:none">${targetUser.group}</small>${targetUser.name}</strong> `;
 		if (!targetUser.connected) buf += ` <em style="color:gray">(offline)</em>`;
 		let roomauth = '';
-		if (room.auth && targetUser.userid in room.auth) roomauth = room.auth[targetUser.userid];
+		if (room.auth && room.auth.hasOwnProperty(targetUser.userid)) roomauth = room.auth[targetUser.userid];
 		if (Config.groups[roomauth] && Config.groups[roomauth].name) {
 			buf += `<br />${Config.groups[roomauth].name} (${roomauth})`;
 		}
@@ -138,7 +138,7 @@ exports.commands = {
 			buf += `<br />Private rooms: ${privaterooms}`;
 		}
 
-		if (user.can('alts', targetUser) || (room.isPrivate !== true && user.can('mute', targetUser, room) && targetUser.userid in room.users)) {
+		if (user.can('alts', targetUser) || (room.isPrivate !== true && user.can('mute', targetUser, room) && room.users.hasOwnProperty(targetUser.userid))) {
 			let bannedFrom = ``;
 			let mutedIn = ``;
 			for (let i = 0; i < Rooms.global.chatRooms.length; i++) {
@@ -494,7 +494,7 @@ exports.commands = {
 				if (foundData.exists) break;
 			}
 			if (!foundData.exists) return this.parse('/help effectiveness');
-			if (!source && method in sourceMethods) {
+			if (!source && sourceMethods.hasOwnProperty(method)) {
 				if (foundData.type) {
 					source = foundData;
 					atkName = foundData.name;
@@ -503,7 +503,7 @@ exports.commands = {
 					atkName = foundData.id;
 				}
 				searchMethods = targetMethods;
-			} else if (!defender && method in targetMethods) {
+			} else if (!defender && targetMethods.hasOwnProperty(method)) {
 				if (foundData.types) {
 					defender = foundData;
 					defName = foundData.species + " (not counting abilities)";
@@ -565,7 +565,7 @@ exports.commands = {
 			}
 
 			let eff;
-			if (move in Tools.data.TypeChart) {
+			if (Tools.data.TypeChart.hasOwnProperty(move)) {
 				sources.push(move);
 				for (let type in bestCoverage) {
 					if (!Tools.getImmunity(move, type) && !move.ignoreImmunity) continue;

--- a/chat-plugins/poll.js
+++ b/chat-plugins/poll.js
@@ -144,9 +144,9 @@ class Poll {
 
 		for (let i in this.room.users) {
 			let thisUser = this.room.users[i];
-			if (thisUser.userid in this.voters) {
+			if (this.voters.hasOwnProperty(thisUser.userid)) {
 				thisUser.sendTo(this.room, '|uhtml|poll' + this.room.pollNumber + '|' + results[this.voters[thisUser.userid]]);
-			} else if (thisUser.latestIp in this.voterIps) {
+			} else if (this.voterIps.hasOwnProperty(thisUser.latestIp)) {
 				thisUser.sendTo(this.room, '|uhtml|poll' + this.room.pollNumber + '|' + results[this.voterIps[thisUser.latestIp]]);
 			} else {
 				thisUser.sendTo(this.room, '|uhtml|poll' + this.room.pollNumber + '|' + votes);
@@ -156,9 +156,9 @@ class Poll {
 
 	displayTo(user, connection) {
 		if (!connection) connection = user;
-		if (user.userid in this.voters) {
+		if (this.voters.hasOwnProperty(user.userid)) {
 			connection.sendTo(this.room, '|uhtml|poll' + this.room.pollNumber + '|' + this.generateResults(false, this.voters[user.userid]));
-		} else if (user.latestIp in this.voterIps) {
+		} else if (this.voterIps.hasOwnProperty(user.latestIp)) {
 			connection.sendTo(this.room, '|uhtml|poll' + this.room.pollNumber + '|' + this.generateResults(false, this.voterIps[user.latestIp]));
 		} else {
 			connection.sendTo(this.room, '|uhtml|poll' + this.room.pollNumber + '|' + this.generateVotes());

--- a/commands.js
+++ b/commands.js
@@ -324,7 +324,7 @@ exports.commands = {
 			zinnia: '#zinnia',
 			clemont: '#clemont',
 		};
-		if (avatarid in avatarTable) {
+		if (avatarTable.hasOwnProperty(avatarid)) {
 			avatar = avatarTable[avatarid];
 		} else {
 			avatar = parseInt(avatarid);
@@ -434,22 +434,22 @@ exports.commands = {
 				if (!targetRoom || targetRoom === Rooms.global) return this.errorReply('The room "' + innerTarget + '" does not exist.');
 				if (targetRoom.staffRoom && !targetUser.isStaff) return this.errorReply('User "' + this.targetUsername + '" requires global auth to join room "' + targetRoom.id + '".');
 				if (targetRoom.modjoin) {
-					if (targetRoom.auth && (targetRoom.isPrivate === true || targetUser.group === ' ') && !(targetUser.userid in targetRoom.auth)) {
+					if (targetRoom.auth && (targetRoom.isPrivate === true || targetUser.group === ' ') && !targetRoom.auth.hasOwnProperty(targetUser.userid)) {
 						this.parse('/roomvoice ' + targetUser.name, false, targetRoom);
-						if (!(targetUser.userid in targetRoom.auth)) {
+						if (!targetRoom.auth.hasOwnProperty(targetUser.userid)) {
 							return;
 						}
 					}
 				}
 				if (targetRoom.isPrivate === true && targetRoom.modjoin && targetRoom.auth) {
-					if (!(user.userid in targetRoom.auth)) {
+					if (!targetRoom.auth.hasOwnProperty(user.userid)) {
 						return this.errorReply('The room "' + innerTarget + '" does not exist.');
 					}
 					if (Config.groupsranking.indexOf(targetRoom.auth[targetUser.userid] || ' ') < Config.groupsranking.indexOf(targetRoom.modjoin) && !targetUser.can('bypassall')) {
 						return this.errorReply('The user "' + targetUser.name + '" does not have permission to join "' + innerTarget + '".');
 					}
 				}
-				if (targetRoom.auth && targetRoom.isPrivate && !(user.userid in targetRoom.auth) && !user.can('makeroom')) {
+				if (targetRoom.auth && targetRoom.isPrivate && !targetRoom.auth.hasOwnProperty(user.userid) && !user.can('makeroom')) {
 					return this.errorReply('You do not have permission to invite people to this room.');
 				}
 
@@ -481,7 +481,7 @@ exports.commands = {
 		let targetUser = this.targetUser;
 
 		if (!targetUser || !targetUser.connected) return this.errorReply("User " + targetUser + " is not currently online.");
-		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
+		if (!room.users.hasOwnProperty(targetUser) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
 		if (targetUser.ignorePMs) return this.errorReply("This user is currently ignoring PMs.");
 		if (targetUser.locked) return this.errorReply("This user is currently locked, so you cannot send them a pminfobox.");
 
@@ -503,7 +503,7 @@ exports.commands = {
 		if (user.ignorePMs === (target || true)) return this.errorReply("You are already blocking private messages! To unblock, use /unblockpms");
 		if (user.can('lock') && !user.can('bypassall')) return this.errorReply("You are not allowed to block private messages.");
 		user.ignorePMs = true;
-		if (target in Config.groups) {
+		if (Config.groups.hasOwnProperty(target)) {
 			user.ignorePMs = target;
 			return this.sendReply("You are now blocking private messages, except from staff and " + target + ".");
 		}
@@ -1148,7 +1148,7 @@ exports.commands = {
 		// Only show popup if: user is online and in the room, the room is public, and not a groupchat or a battle.
 		let needsPopup = targetUser && room.users[targetUser.userid] && !room.isPrivate && !room.isPersonal && !room.battle;
 
-		if (nextGroup in Config.groups && currentGroup in Config.groups && Config.groups[nextGroup].rank < Config.groups[currentGroup].rank) {
+		if (Config.groups.hasOwnProperty(nextGroup) && Config.groups.hasOwnProperty(currentGroup) && Config.groups[nextGroup].rank < Config.groups[currentGroup].rank) {
 			if (targetUser && room.users[targetUser.userid] && !Config.groups[nextGroup].modlog) {
 				// if the user can't see the demotion message (i.e. rank < %), it is shown in the chat
 				targetUser.send(">" + room.id + "\n(You were demoted to Room " + groupName + " by " + user.name + ".)");
@@ -1191,7 +1191,7 @@ exports.commands = {
 			(Config.groups[b] || {rank:0}).rank - (Config.groups[a] || {rank:0}).rank
 		).map(r => {
 			let roomRankList = rankLists[r].sort();
-			roomRankList = roomRankList.map(s => s in targetRoom.users ? "**" + s + "**" : s);
+			roomRankList = roomRankList.map(s => targetRoom.users.hasOwnProperty(s) ? "**" + s + "**" : s);
 			return (Config.groups[r] ? Config.groups[r].name + "s (" + r + ")" : r) + ":\n" + roomRankList.join(", ");
 		});
 
@@ -1277,7 +1277,7 @@ exports.commands = {
 			return this.errorReply("Room bans are not meant to be used in room " + room.id + ".");
 		}
 		if (room.bannedUsers[userid] && room.bannedIps[targetUser.latestIp]) return this.sendReply("User " + targetUser.name + " is already banned from room " + room.id + ".");
-		if (targetUser in room.users || user.can('lock')) {
+		if (room.users.hasOwnProperty(targetUser) || user.can('lock')) {
 			targetUser.popup(
 				"|html|<p>" + Tools.escapeHTML(user.name) + " has banned you from the room " + room.id + ".</p>" + (target ? "<p>Reason: " + Tools.escapeHTML(target) + "</p>" : "") +
 				"<p>To appeal the ban, PM the staff member that banned you" + (room.auth ? " or a room owner. </p><p><button name=\"send\" value=\"/roomauth " + room.id + "\">List Room Staff</button></p>" : ".</p>")
@@ -1377,7 +1377,7 @@ exports.commands = {
 		target = this.splitTarget(target);
 		let targetUser = this.targetUser;
 		if (!targetUser || !targetUser.connected) return this.errorReply("User '" + this.targetUsername + "' not found.");
-		if (!(targetUser in room.users)) {
+		if (!room.users.hasOwnProperty(targetUser)) {
 			return this.errorReply("User " + this.targetUsername + " is not in the room " + room.id + ".");
 		}
 		if (target.length > MAX_REASON_LENGTH) {
@@ -1447,7 +1447,7 @@ exports.commands = {
 			return this.addModCommand("" + targetUser.name + " would be muted by " + user.name + problem + "." + (target ? " (" + target + ")" : ""));
 		}
 
-		if (targetUser in room.users) targetUser.popup("|modal|" + user.name + " has muted you in " + room.id + " for " + Tools.toDurationString(muteDuration) + ". " + target);
+		if (room.users.hasOwnProperty(targetUser)) targetUser.popup("|modal|" + user.name + " has muted you in " + room.id + " for " + Tools.toDurationString(muteDuration) + ". " + target);
 		this.addModCommand("" + targetUser.name + " was muted by " + user.name + " for " + Tools.toDurationString(muteDuration) + "." + (target ? " (" + target + ")" : ""));
 		if (targetUser.autoconfirmed && targetUser.autoconfirmed !== targetUser.userid) this.privateModCommand("(" + targetUser.name + "'s ac account: " + targetUser.autoconfirmed + ")");
 		let userid = targetUser.getLastId();
@@ -1747,7 +1747,7 @@ exports.commands = {
 		for (let userid in room.auth) {
 			if (room.auth[userid] === '+') {
 				delete room.auth[userid];
-				if (userid in room.users) room.users[userid].updateIdentity(room.id);
+				if (room.users.hasOwnProperty(userid)) room.users[userid].updateIdentity(room.id);
 				count++;
 			}
 		}
@@ -1995,7 +1995,7 @@ exports.commands = {
 				return this.errorReply("/modchat - Access denied for setting higher than " + Config.groupsranking[1] + ".");
 			}
 			let roomGroup = (room.auth && room.isPrivate === true ? ' ' : user.group);
-			if (room.auth && user.userid in room.auth) roomGroup = room.auth[user.userid];
+			if (room.auth && room.auth.hasOwnProperty(user.userid)) roomGroup = room.auth[user.userid];
 			if (Config.groupsranking.indexOf(target) > Math.max(1, Config.groupsranking.indexOf(roomGroup)) && !user.can('makeroom')) {
 				return this.errorReply("/modchat - Access denied for setting higher than " + roomGroup + ".");
 			}

--- a/config/formats.js
+++ b/config/formats.js
@@ -255,7 +255,7 @@ exports.Formats = [
 			let n = 0;
 			for (let i = 0; i < team.length; i++) {
 				let template = this.getTemplate(team[i].species).baseSpecies;
-				if (template in legends) n++;
+				if (legends.hasOwnProperty(template)) n++;
 				if (n > 2) return ["You can only use up to two legendary Pok\u00E9mon."];
 			}
 		},
@@ -394,7 +394,7 @@ exports.Formats = [
 			let template = this.tools.getTemplate(species);
 			if (!template.exists || template.isNonstandard) return ["" + set.species + " is not a real Pok\u00E9mon."];
 			if (template.battleOnly) template = this.tools.getTemplate(template.baseSpecies);
-			if (this.tools.getBanlistTable(this.format)[template.id] || template.tier in {'Uber': 1, 'Unreleased': 1} && template.species !== 'Aegislash') {
+			if (this.tools.getBanlistTable(this.format)[template.id] || {'Uber': 1, 'Unreleased': 1}.hasOwnProperty(template.tier) && template.species !== 'Aegislash') {
 				return ["" + template.species + " is banned by Follow The Leader."];
 			}
 
@@ -487,7 +487,7 @@ exports.Formats = [
 		],
 		onValidateSet: function (set) {
 			let bannedAbilities = {'Aerilate': 1, 'Arena Trap': 1, 'Contrary': 1, 'Fur Coat': 1, 'Huge Power': 1, 'Illusion': 1, 'Imposter': 1, 'Parental Bond': 1, 'Protean': 1, 'Pure Power': 1, 'Simple':1, 'Speed Boost': 1, 'Wonder Guard': 1};
-			if (set.ability in bannedAbilities) {
+			if (bannedAbilities.hasOwnProperty(set.ability)) {
 				let template = this.getTemplate(set.species || set.name);
 				let legalAbility = false;
 				for (let i in template.abilities) {

--- a/mods/tiershift/scripts.js
+++ b/mods/tiershift/scripts.js
@@ -31,8 +31,8 @@ exports.BattleScripts = {
 					if (item.megaEvolves === template.species) tier = this.battle.getTemplate(item.megaStone).tier;
 				}
 				if (tier.charAt(0) === '(') tier = tier.slice(1, -1);
-				let boost = (tier in boosts) ? boosts[tier] : 0;
-				if (this.set.ability in {'Drizzle': 1, 'Drought': 1}) {
+				let boost = boosts.hasOwnProperty(tier) ? boosts[tier] : 0;
+				if ({'Drizzle': 1, 'Drought': 1}.hasOwnProperty(this.set.ability)) {
 					boost = 0;
 				} else if (this.set.moves.indexOf('chatter') >= 0) {
 					boost = 15;

--- a/tournaments/generator-elimination.js
+++ b/tournaments/generator-elimination.js
@@ -285,7 +285,7 @@ module.exports = (() => {
 	Elimination.prototype.setMatchResult = function (match, result, score) {
 		if (!this.isBracketFrozen) return 'BracketNotFrozen';
 
-		if (!(result in {win:1, loss:1})) return 'InvalidMatchResult';
+		if (!{win:1, loss:1}.hasOwnProperty(result)) return 'InvalidMatchResult';
 
 		if (!this.users.has(match[0]) || !this.users.has(match[1])) return 'UserNotAdded';
 

--- a/tournaments/generator-round-robin.js
+++ b/tournaments/generator-round-robin.js
@@ -138,7 +138,7 @@ module.exports = (() => {
 	RoundRobin.prototype.setMatchResult = function (match, result, score) {
 		if (!this.isBracketFrozen) return 'BracketNotFrozen';
 
-		if (!(result in {win:1, loss:1, draw:1})) return 'InvalidMatchResult';
+		if (!{win:1, loss:1, draw:1}.hasOwnProperty(result)) return 'InvalidMatchResult';
 
 		let userA = match[0];
 		let userB = match[1];


### PR DESCRIPTION
#Zarel: hasOwnProperty is allowed now
#Zarel: since it's useful for a lot of the non-null-prototype objects we have to deal with
#Zarel: i.e. basically all of data/
#Zarel: in fact we should probably stop using in entirely
#Zarel: it should all be either hasOwnProperty or refactored to Map