### PR TITLE
teamHas should keep count of how many of each property the team has

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -498,7 +498,11 @@ class Validator {
 
 		if (teamHas) {
 			for (let i in setHas) {
-				teamHas[i] = true;
+				if (i in teamHas) {
+					teamHas[i]++;
+				} else {
+					teamHas[i] = 1;
+				}
 			}
 		}
 		for (let i = 0; i < format.setBanTable.length; i++) {


### PR DESCRIPTION
Several OMs (e.g. VoltTurn Mayhem) want to limit the count of a particular property (e.g. Fake Out). They are forced to recalculate this every time, when in fact we're almost tracking this already.

In theory some sort of banlist syntax could then be created to handle this directly e.g. `banlist: ["Fake Out > 1"],` although I wouldn't want to start to write that without some consensus on what the syntax should be.