### PR TITLE
ProcessManager: subclass to extend ProcessManager, unit tests setup

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -15,10 +15,8 @@ const ProcessManager = require('./../process-manager');
 const MAX_PROCESSES = 1;
 const RESULTS_MAX_LENGTH = 10;
 
-const PM = exports.PM = new ProcessManager({
-	maxProcesses: MAX_PROCESSES,
-	execFile: __filename,
-	onMessageUpstream: function (message) {
+class DatasearchManager extends ProcessManager {
+	onMessageUpstream(message) {
 		// Protocol:
 		// "[id]|JSON"
 		let pipeIndex = message.indexOf('|');
@@ -30,8 +28,9 @@ const PM = exports.PM = new ProcessManager({
 			this.pendingTasks.delete(id);
 			this.release();
 		}
-	},
-	onMessageDownstream: function (message) {
+	}
+
+	onMessageDownstream(message) {
 		// protocol:
 		// "[id]|{data, sig}"
 		let pipeIndex = message.indexOf('|');
@@ -39,8 +38,9 @@ const PM = exports.PM = new ProcessManager({
 
 		let data = JSON.parse(message.slice(pipeIndex + 1));
 		process.send(id + '|' + JSON.stringify(this.receive(data)));
-	},
-	receive: function (data) {
+	}
+
+	receive(data) {
 		let result;
 		try {
 			switch (data.cmd) {
@@ -65,7 +65,14 @@ const PM = exports.PM = new ProcessManager({
 			result = {error: "Sorry! Our search engine crashed on your query. We've been automatically notified and will fix this crash."};
 		}
 		return result;
-	},
+	}
+}
+
+exports.DatasearchManager = DatasearchManager;
+
+const PM = exports.PM = new DatasearchManager({
+	execFile: __filename,
+	maxProcesses: MAX_PROCESSES,
 	isChatBased: true,
 });
 

--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1232,7 +1232,7 @@ exports.commands = {
 			buf += "<strong>" + (worker.pid || worker.process.pid) + "</strong> - Sockets " + i + "<br />";
 		}
 
-		const ProcessManager = require('./../process-manager');
+		const ProcessManager = require('../process-manager');
 		for (let managerData of ProcessManager.cache) {
 			let i = 0;
 			let processType = path.basename(managerData[1]);

--- a/process-manager.js
+++ b/process-manager.js
@@ -42,19 +42,30 @@ class ProcessWrapper extends EventEmitter {
 	}
 }
 
+// execFile - the path to the file to spawn the child process(es) from
+// maxProcesses - the maximum number of child processes to spawn
+// isChatBased - the process manager handles some chat functionality
 class ProcessManager {
 	constructor(options) {
-		if (!options) options = {};
+		if (!('execFile' in options)) {
+			Monitor.debug(
+				"No execFile property was missing form the options object to be " +
+				"given to the ProcessManager constructor!"
+			);
+		} else if (!('maxProcesses' in options) || !('isChatBased' in options)) {
+			Monitor.debug(
+				"An options object given to the ProcessManager constructor is " +
+				"missing required properties! The filename given is: " + (options.execFile || '""') + "."
+			);
+		}
 
 		this.processes = [];
 		this.taskId = 0;
+		this.execFile = options.execFile;
+		this.maxProcesses = (typeof options.maxProcesses === 'number') ? options.maxProcesses : 1;
+		this.isChatBased = !!options.isChatBased;
 
-		Object.assign(this, options);
-		if (typeof this.maxProcesses !== 'number') {
-			this.maxProcesses = 1;
-		}
-
-		processManagers.set(this, this.execFile);
+		processManagers.set(this, options.execFile);
 	}
 
 	spawn() {
@@ -88,6 +99,7 @@ class ProcessManager {
 	release(process) {
 		process.release();
 	}
+
 	send() {
 		if (!this.processes.length) {
 			return Promise.resolve(this.receive.apply(this, arguments));
@@ -120,6 +132,7 @@ class ProcessManager {
 			++this.taskId;
 		});
 	}
+
 	sendSync() {
 		// synchronously!
 		return this.receive.apply(this, arguments);
@@ -142,6 +155,7 @@ class ProcessManager {
 }
 
 ProcessManager.cache = processManagers;
+ProcessManager.ProcessWrapper = ProcessWrapper;
 module.exports = ProcessManager;
 
 function serialize(str) {

--- a/simulator.js
+++ b/simulator.js
@@ -18,19 +18,24 @@ global.Config = require('./config/config');
 const ProcessManager = require('./process-manager');
 const BattleEngine = require('./battle-engine').Battle;
 
-const SimulatorProcess = new ProcessManager({
-	maxProcesses: Config.simulatorprocesses,
-	execFile: 'simulator',
-	onMessageUpstream: function (message) {
+class SimulatorManager extends ProcessManager {
+	onMessageUpstream(message) {
 		let lines = message.split('\n');
 		let battle = this.pendingTasks.get(lines[0]);
 		if (battle) battle.receive(lines);
-	},
-	eval: function (code) {
+	}
+
+	eval(code) {
 		for (let process of this.processes) {
 			process.send('|eval|' + code);
 		}
-	},
+	}
+}
+
+const SimulatorProcess = new SimulatorManager({
+	execFile: __filename,
+	maxProcesses: global.Config ? Config.simulatorprocesses : 1,
+	isChatBased: false,
 });
 
 let slice = Array.prototype.slice;
@@ -441,6 +446,7 @@ class Battle {
 
 exports.BattlePlayer = BattlePlayer;
 exports.Battle = Battle;
+exports.SimulatorManager = SimulatorManager;
 exports.SimulatorProcess = SimulatorProcess;
 
 exports.create = function (id, format, rated, room) {

--- a/test/application/process-manager.js
+++ b/test/application/process-manager.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const ProcessManager = require('../../process-manager');
+const ProcessWrapper = ProcessManager.ProcessWrapper;
+
+// const DatasearchManager = require('../../chat-plugins/datasearch.js').DatasearchManager;
+// const SimulatorManager = require('../../simulator.js').SimulatorManager;
+// const TeamValidatorManager = require('../../team-validator.js').TeamValidatorManager;
+// const VerifierManager = require('../../verifier.js').VerifierManager;
+
+// DO NOT CLEAR PROCESSMANAGER'S CACHE DURING THESE TESTS
+// Delete the ProcessManager instances from it manually unless you want to break
+// other tests that rely on what's already there at the beginning of these tests
+// and watch the world burn.
+describe('ProcessManager', function () {
+	it('should construct', function () {
+		let pm;
+		let cacheSize = ProcessManager.cache.size;
+		assert.doesNotThrow(() => {
+			pm = new ProcessManager({
+				execFile: path.resolve('./process-manager'),
+				maxProcesses: 0,
+				isChatBased: false,
+			});
+		});
+		assert.strictEqual(ProcessManager.cache.size, cacheSize + 1);
+		assert.ok(ProcessManager.cache.delete(pm));
+	});
+
+	describe('ProcessWrapper', function () {
+		beforeEach(function () {
+			this.pm = new ProcessManager({
+				execFile: path.resolve('./process-manager'),
+				maxProcesses: 0,
+				isChatBased: false,
+			});
+		});
+
+		afterEach(function () {
+			// Temporary until final process-manager.js refactor
+			this.pm.processes.forEach(pw => {
+				pw.process.removeAllListeners('message');
+				pw.process.disconnect();
+				pw.process = null;
+				pw.removeAllListeners('message');
+				pw.pendingTasks.clear();
+				pw.PM.processes.splice(pw.PM.processes.indexOf(pw), 1);
+				pw.PM = null;
+			});
+
+			ProcessManager.cache.delete(this.pm);
+		});
+
+		it('should construct', function () {
+			assert.doesNotThrow(() => new ProcessWrapper(this.pm));
+		});
+	});
+});


### PR DESCRIPTION
Before, an options object containing properties and values to be used
was how decorated instances of the class would be created. This meant
the constructor could assign anything you feel like to `this`. Rather
than that, the constructor now assigns a strict set of values, and
methods are redefined in subclasses.

Basic unit tests were added to test if they could be written for after
the final refactor to fix the other memory leak here.