### PR TITLE
Whois: Don't display negative expire times

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -96,7 +96,7 @@ exports.commands = {
 				if (punishment) {
 					let expiresIn = new Date(punishment[2]).getTime() - Date.now();
 					let expiresDays = Math.round(expiresIn / 1000 / 60 / 60 / 24);
-					buf += ` (expires in around ${expiresDays} day${Tools.plural(expiresDays)})`;
+					if (expiresIn > 1) buf += ` (expires in around ${expiresDays} day${Tools.plural(expiresDays)})`;
 					if (punishment[3]) buf += ` (reason: ${punishment[3]})`;
 				}
 			} else if (targetUser.locked) {
@@ -116,7 +116,7 @@ exports.commands = {
 				if (punishment) {
 					let expiresIn = new Date(punishment[2]).getTime() - Date.now();
 					let expiresDays = Math.round(expiresIn / 1000 / 60 / 60 / 24);
-					buf += ` (expires in around ${expiresDays} day${Tools.plural(expiresDays)})`;
+					if (expiresIn > 1) buf += ` (expires in around ${expiresDays} day${Tools.plural(expiresDays)})`;
 					if (punishment[3]) buf += ` (reason: ${punishment[3]})`;
 				}
 			}


### PR DESCRIPTION
Before, if a user was perma locked or perma banned, it would show that their lock would expire in a negative time - this fixes that.

For consistency, I also added the check to the namelock check as well.