### PR TITLE
Gen 1: Fix auto-Struggle on 0 PP for locked moves (Wrap)

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -92,17 +92,7 @@ exports.BattleMovedex = {
 				this.add('-activate', pokemon, 'Bide');
 				return false;
 			},
-			onDisableMove: function (pokemon) {
-				if (!pokemon.hasMove('bide')) {
-					return;
-				}
-				let moves = pokemon.moveset;
-				for (let i = 0; i < moves.length; i++) {
-					if (moves[i].id !== 'bide') {
-						pokemon.disableMove(moves[i].id);
-					}
-				}
-			},
+			onLockMove: 'bide',
 		},
 		type: "???", // Will look as Normal but it's STAB-less
 	},

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -96,7 +96,7 @@ exports.BattleScripts = {
 		pokemon.lastDamage = 0;
 		let lockedMove = this.runEvent('LockMove', pokemon);
 		if (lockedMove === true) lockedMove = false;
-		if (!lockedMove && (!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].locked !== target)) {
+		if (!lockedMove) {
 			pokemon.deductPP(move, null, target);
 			// On gen 1 moves are stored when they are chosen and a PP is deducted.
 			pokemon.side.lastMove = move.id;

--- a/mods/gen1/statuses.js
+++ b/mods/gen1/statuses.js
@@ -221,16 +221,9 @@ exports.BattleStatuses = {
 		onStart: function (target, source, effect) {
 			this.effectData.move = effect.id;
 		},
-		onDisableMove: function (pokemon) {
-			if (!pokemon.hasMove(this.effectData.move)) {
-				return;
-			}
-			let moves = pokemon.moveset;
-			for (let i = 0; i < moves.length; i++) {
-				if (moves[i].id !== this.effectData.move) {
-					pokemon.disableMove(moves[i].id);
-				}
-			}
+		onLockMove: function () {
+			if (!this.effectData.target.hasMove(this.effectData.move)) return false;
+			return this.effectData.move;
 		},
 	},
 	lockedmove: {


### PR DESCRIPTION
- Moves Bide and Wrap move-lock implementation to `LockMove`.
Initially, they used the legacy `ModifyPokemon` event, and they were
only moved to `DisableMove` in the mass-refactor that removed said event.

Refs #2598