### PR TITLE
Fix typo in roomunban message

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1210,7 +1210,7 @@ exports.commands = {
 		let name = Punishments.roomUnban(room, target);
 
 		if (name) {
-			this.addModCommand("" + name + " was unbanned by " + user.name + ".");
+			this.addModCommand("" + name + " was unbanned from " + room.title + " by " + user.name + ".");
 			if (!room.isPrivate && room.chatRoomData) {
 				this.globalModlog("UNROOMBAN", name, " by " + user.name);
 			}


### PR DESCRIPTION
It had the same message as a global unban; there was no way to tell the difference...