### PR TITLE
Fix broken permission with /htmlbox

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1705,8 +1705,11 @@ exports.commands = {
 		if (!target) return this.parse('/help htmlbox');
 		target = this.canHTML(target);
 		if (!target) return;
+
+		if (!this.canBroadcast('!htmlbox')) return;
+		if (this.broadcastMessage && !this.can('declare', null, room)) return false;
+
 		if (!this.runBroadcast('!htmlbox')) return;
-		if (this.broadcasting && !this.can('declare', null, room)) return;
 
 		this.sendReplyBox(target);
 	},


### PR DESCRIPTION
This now makes it so that if a user can broadcast but cannot declare in that room, and they attempt to broadcast it, it will now send them the error reply themselves instead of broadcasting the error reply to the room.

Credits to Slayer95 for this fix!