### PR TITLE
Monotype Random Battle: Enable Monotype-specific movesets

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -654,7 +654,7 @@ exports.Formats = [
 		name: "Monotype Random Battle",
 		section: "Randomized Metas",
 
-		team: 'random',
+		team: 'randomMonotype',
 		searchShow: false,
 		ruleset: ['Pokemon', 'Same Type Clause', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
 	},

--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1477,6 +1477,7 @@ exports.BattleFormatsData = {
 	zapdos: {
 		randomBattleMoves: ["thunderbolt", "heatwave", "hiddenpowerice", "roost", "toxic", "uturn", "defog"],
 		randomDoubleBattleMoves: ["thunderbolt", "heatwave", "hiddenpowergrass", "hiddenpowerice", "tailwind", "protect", "discharge"],
+		randomMonotypeBattleMoves: ["discharge", "voltswitch", "defog", "toxic", "heatwave", "substitute", "roar", "hiddenpowerice", "thunderbolt", "roost"],
 		eventPokemon: [
 			{"generation": 3, "level": 50, "shiny": 1, "moves":["thunderwave", "agility", "detect", "drillpeck"]},
 			{"generation": 3, "level": 70, "moves":["agility", "detect", "drillpeck", "charge"]},
@@ -1755,6 +1756,7 @@ exports.BattleFormatsData = {
 	ampharosmega: {
 		randomBattleMoves: ["voltswitch", "focusblast", "agility", "thunderbolt", "healbell", "dragonpulse"],
 		randomDoubleBattleMoves: ["focusblast", "hiddenpowerice", "hiddenpowergrass", "thunderbolt", "discharge", "dragonpulse", "protect"],
+		randomMonotypeBattleMoves: ["voltswitch", "thunderbolt", "rest", "sleeptalk", "healbell", "dragonpulse", "focusblast", "agility", "toxic"],
 		requiredItem: "Ampharosite",
 		tier: "UU",
 	},
@@ -1915,6 +1917,7 @@ exports.BattleFormatsData = {
 	gliscor: {
 		randomBattleMoves: ["roost", "substitute", "taunt", "earthquake", "protect", "toxic", "stealthrock", "knockoff"],
 		randomDoubleBattleMoves: ["tailwind", "substitute", "taunt", "earthquake", "protect", "stoneedge", "knockoff"],
+		randomMonotypeBattleMoves: ["toxic", "taunt", "earthquake", "swordsdance", "knockoff", "stoneedge", "roost", "stealthrock", "substitute", "protect"],
 		tier: "OU",
 	},
 	snubbull: {
@@ -2065,6 +2068,7 @@ exports.BattleFormatsData = {
 	skarmory: {
 		randomBattleMoves: ["whirlwind", "bravebird", "roost", "spikes", "stealthrock", "defog"],
 		randomDoubleBattleMoves: ["skydrop", "bravebird", "tailwind", "taunt", "feint", "protect", "ironhead"],
+		randomMonotypeBattleMoves: ["ironhead", "bravebird", "taunt", "roost", "stealthrock", "spikes", "whirlwind", "defog"],
 		tier: "OU",
 	},
 	houndour: {
@@ -2802,6 +2806,7 @@ exports.BattleFormatsData = {
 	torkoal: {
 		randomBattleMoves: ["shellsmash", "fireblast", "earthpower", "hiddenpowergrass", "stealthrock", "rapidspin", "yawn", "lavaplume"],
 		randomDoubleBattleMoves: ["protect", "heatwave", "earthpower", "willowisp", "shellsmash", "fireblast", "hiddenpowergrass"],
+		randomMonotypeBattleMoves: ["lavaplume", "rapidspin", "stealthrock", "yawn", "earthpower", "stoneedge", "toxic"],
 		tier: "PU",
 	},
 	spoink: {
@@ -4765,6 +4770,7 @@ exports.BattleFormatsData = {
 	eelektross: {
 		randomBattleMoves: ["thunderbolt", "flamethrower", "uturn", "voltswitch", "acidspray", "gigadrain", "knockoff", "superpower", "aquatail"],
 		randomDoubleBattleMoves: ["thunderbolt", "flamethrower", "uturn", "voltswitch", "knockoff", "gigadrain", "protect"],
+		randomMonotypeBattleMoves: ["rockslide", "u-turn", "gigadrain", "drainpunch", "knockoff", "flamethrower", "voltswitch", "acidspray"],
 		tier: "RU",
 	},
 	elgyem: {
@@ -5017,6 +5023,7 @@ exports.BattleFormatsData = {
 	thundurus: {
 		randomBattleMoves: ["thunderwave", "nastyplot", "thunderbolt", "hiddenpowerice", "hiddenpowerflying", "focusblast", "substitute", "knockoff", "taunt"],
 		randomDoubleBattleMoves: ["thunderwave", "nastyplot", "thunderbolt", "hiddenpowerice", "hiddenpowerflying", "focusblast", "substitute", "knockoff", "taunt", "protect"],
+		randomMonotypeBattleMoves: ["superpower", "voltswitch", "taunt", "knockoff", "thunderwave", "grassknot", "nastyplot", "hiddenpowerflying", "wildcharge", "uturn", "thunderbolt"],
 		eventPokemon: [
 			{"generation": 5, "level": 40, "shiny": 1, "isHidden": false, "moves":["revenge", "shockwave", "healblock", "agility"]},
 			{"generation": 5, "level": 5, "isHidden": true, "moves":["uproar", "astonish", "thundershock"], "pokeball": "dreamball"},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1149,7 +1149,7 @@ exports.BattleScripts = {
 
 		return counter;
 	},
-	randomSet: function (template, slot, teamDetails) {
+	randomSet: function (template, slot, teamDetails, alternateMovePool) {
 		if (slot === undefined) slot = 1;
 		let baseTemplate = (template = this.getTemplate(template));
 		let species = template.species;
@@ -1174,6 +1174,23 @@ exports.BattleScripts = {
 		}
 
 		let movePool = (template.randomBattleMoves ? template.randomBattleMoves.slice() : Object.keys(template.learnset));
+
+		// Check for alternate move pool.
+		if (template[alternateMovePool]) {
+			let newMovePool = template[alternateMovePool].slice();
+
+			// Confirm it is a valid list of moves.
+			let validMoveSet = true;
+			for (let i = 0; i < newMovePool.length; i++) {
+				let moveTemplate = this.getMove(newMovePool[i]);
+				if (!moveTemplate.exists) {
+					validMoveSet = false;
+					break;
+				}
+			}
+			if (validMoveSet) movePool = newMovePool;
+		}
+
 		let moves = [];
 		let ability = '';
 		let item = '';
@@ -3351,6 +3368,158 @@ exports.BattleScripts = {
 			}
 		}
 
+		return pokemon;
+	},
+	randomMonotypeTeam: function (side) {
+		let pokemon = [];
+
+		let excludedTiers = {'NFE':1, 'LC Uber':1, 'LC':1};
+		let allowedNFE = {'Chansey':1, 'Doublade':1, 'Gligar':1, 'Porygon2':1, 'Scyther':1, 'Piloswine':1, 'Golbat':1};
+
+		let typePool = Object.keys(this.data.TypeChart);
+		let type = typePool[this.random(typePool.length)];
+		let pokemonPool = [];
+		for (let id in this.data.FormatsData) {
+			let template = this.getTemplate(id);
+
+			let types = template.types;
+			if (template.battleOnly) types = this.getTemplate(template.baseSpecies).types;
+			if (types.indexOf(type) < 0) continue;
+
+			if (!excludedTiers[template.tier] && !template.isMega && !template.isPrimal && !template.isNonstandard && template.randomBattleMoves) {
+				pokemonPool.push(id);
+			}
+		}
+
+		let typeCount = {};
+		let typeComboCount = {};
+		let baseFormes = {};
+		let uberCount = 0;
+		let puCount = 0;
+		let teamDetails = {};
+
+		while (pokemonPool.length && pokemon.length < 6) {
+			let template = this.getTemplate(this.sampleNoReplace(pokemonPool));
+
+			if (!template.exists) continue;
+
+			// Limit to one of each species (Species Clause)
+			if (baseFormes[template.baseSpecies]) continue;
+
+			// Useless in Random Battle without greatly lowering the levels of everything else
+			if (template.species === 'Unown') continue;
+
+			// Only certain NFE Pokemon are allowed
+			if (template.evos.length && !allowedNFE[template.species]) continue;
+
+			let tier = template.tier;
+			switch (tier) {
+			case 'Uber':
+				// Ubers are limited to 2 but have a 20% chance of being added anyway.
+				if (uberCount > 1 && this.random(5) >= 1) continue;
+				break;
+			case 'PU':
+				// PUs are limited to 2 but have a 20% chance of being added anyway.
+				if (puCount > 1 && this.random(5) >= 1) continue;
+				break;
+			case 'Unreleased':
+				// Unreleased Pokémon have 20% the normal rate
+				if (this.random(5) >= 1) continue;
+				break;
+			case 'CAP':
+				// CAPs have 20% the normal rate
+				if (this.random(5) >= 1) continue;
+			}
+
+			// Adjust rate for species with multiple formes
+			switch (template.baseSpecies) {
+			// excluding Arceus, only 1 form for each type
+			// case 'Arceus':
+			// 	if (this.random(18) >= 1) continue;
+			// 	break;
+			case 'Basculin':
+				if (this.random(2) >= 1) continue;
+				break;
+			case 'Castform':
+				if (this.random(2) >= 1) continue;
+				break;
+			case 'Cherrim':
+				if (this.random(2) >= 1) continue;
+				break;
+			case 'Genesect':
+				if (this.random(5) >= 1) continue;
+				break;
+			case 'Gourgeist':
+				if (this.random(4) >= 1) continue;
+				break;
+			case 'Hoopa':
+				// Hoopa only has two forms for Psychic teams
+				if (type in {'Psychic':1} && this.random(2) >= 1) continue;
+				break;
+			case 'Meloetta':
+				// Meloetta only has two forms for Normal teams
+				if (type in {'Normal':1} && this.random(2) >= 1) continue;
+				break;
+			case 'Meowstic':
+				if (this.random(2) >= 1) continue;
+				break;
+			case 'Pikachu':
+				// Pikachu is not a viable NFE Pokemon
+				continue;
+			}
+
+			let set = this.randomSet(template, pokemon.length, teamDetails, 'randomMonotypeBattleMoves');
+
+			// Illusion shouldn't be the last Pokemon of the team
+			if (set.ability === 'Illusion' && pokemon.length > 4) continue;
+
+			// Limit 2 of any type combination
+			let types = template.types;
+			let typeCombo = types.slice().sort().join();
+			if (set.ability === 'Drought' || set.ability === 'Drizzle' || set.ability === 'Sand Stream') {
+				// Drought, Drizzle and Sand Stream don't count towards the type combo limit
+				typeCombo = set.ability;
+				if (typeCombo in typeComboCount) continue;
+			} else {
+				if (typeComboCount[typeCombo] >= 2) continue;
+			}
+
+			// Okay, the set passes, add it to our team
+			pokemon.push(set);
+
+			// Now that our Pokemon has passed all checks, we can increment our counters
+			baseFormes[template.baseSpecies] = 1;
+
+			// Increment type counters
+			for (let t = 0; t < types.length; t++) {
+				if (types[t] in typeCount) {
+					typeCount[types[t]]++;
+				} else {
+					typeCount[types[t]] = 1;
+				}
+			}
+			if (typeCombo in typeComboCount) {
+				typeComboCount[typeCombo]++;
+			} else {
+				typeComboCount[typeCombo] = 1;
+			}
+
+			// Increment Uber/NU counters
+			if (tier === 'Uber') {
+				uberCount++;
+			} else if (tier === 'PU') {
+				puCount++;
+			}
+
+			// Team has Mega/weather/hazards
+			if (this.getItem(set.item).megaStone) teamDetails['megaCount'] = 1;
+			if (set.ability === 'Snow Warning') teamDetails['hail'] = 1;
+			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails['rain'] = 1;
+			if (set.ability === 'Sand Stream') teamDetails['sand'] = 1;
+			if (set.moves.includes('stealthrock')) teamDetails['stealthRock'] = 1;
+			if (set.moves.includes('toxicspikes')) teamDetails['toxicSpikes'] = 1;
+			if (set.moves.includes('defog') || set.moves.includes('rapidspin')) teamDetails['hazardClear'] = 1;
+		}
 		return pokemon;
 	},
 	randomSeasonalFireworksTeam: function (side) {


### PR DESCRIPTION
I goobered up the last PR with merge conflicts. After a bit of googling and trying what others suggested in the dev room, I couldn't figure out how to fix it. I just made a new PR.

Contains: 
randomMonotypeTeam in scripts.js
ability to add custom movesets from format-data.js to randomSet in scripts.js
a couple sets for Monotype Random Battles in formats-data.js to serve as examples
