### PR TITLE
Allow the banlist to specify a numeric limit of team properties

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -382,18 +382,9 @@ exports.BattleFormats = {
 	},
 	ateclause: {
 		effectType: 'Rule',
+		banlist: ['Aerilate + Pixilate + Refrigerate > 1'],
 		onStart: function () {
 			this.add('rule', '-ate Clause: Limit one of Aerilate/Refrigerate/Pixilate');
-		},
-		onValidateTeam: function (team, format) {
-			let ateAbility = false;
-			for (let i = 0; i < team.length; i++) {
-				let ability = toId(team[i].ability);
-				if (ability === 'refrigerate' || ability === 'pixilate' || ability === 'aerilate') {
-					if (ateAbility) return [team[i].name + " has more than one of Aerilate/Refrigerate/Pixilate, which is banned by -ate Clause."];
-					ateAbility = true;
-				}
-			}
 		},
 	},
 	ohkoclause: {
@@ -478,19 +469,9 @@ exports.BattleFormats = {
 	batonpassclause: {
 		effectType: 'Banlist',
 		name: 'Baton Pass Clause',
+		banlist: ["Baton Pass > 1"],
 		onStart: function () {
 			this.add('rule', 'Baton Pass Clause: Limit one Baton Passer, can\'t pass Spe and other stats simultaneously');
-		},
-		onValidateTeam: function (team, format) {
-			let BPcount = 0;
-			for (let i = 0; i < team.length; i++) {
-				if (team[i].moves.indexOf('Baton Pass') >= 0) {
-					BPcount++;
-				}
-				if (BPcount > 1) {
-					return [(team[i].name || team[i].species) + " has Baton Pass, but you are limited to one Baton Pass user by Baton Pass Clause."];
-				}
-			}
 		},
 		onValidateSet: function (set, format, setHas) {
 			if (!('batonpass' in setHas)) return;
@@ -539,19 +520,9 @@ exports.BattleFormats = {
 	batonpassspeedclause: {
 		effectType: 'Banlist',
 		name: 'Baton Pass Speed Clause',
+		banlist: ["Baton Pass > 1"],
 		onStart: function () {
 			this.add('rule', 'Baton Pass Clause: Limit one Baton Passer, can\'t pass Speed');
-		},
-		onValidateTeam: function (team, format) {
-			let BPcount = 0;
-			for (let i = 0; i < team.length; i++) {
-				if (team[i].moves.indexOf('Baton Pass') >= 0) {
-					BPcount++;
-				}
-				if (BPcount > 1) {
-					return [(team[i].name || team[i].species) + " has Baton Pass, but you are limited to one Baton Pass user by Baton Pass Clause."];
-				}
-			}
 		},
 		onValidateSet: function (set, format, setHas) {
 			if (!('batonpass' in setHas)) return;

--- a/team-validator.js
+++ b/team-validator.js
@@ -82,6 +82,19 @@ class Validator {
 			}
 		}
 
+		for (let i = 0; i < format.teamLimitTable.length; i++) {
+			let entry = format.teamLimitTable[i];
+			let count = 0;
+			for (let j = 3; j < entry.length; j++) {
+				if (teamHas[entry[j]] > 0) count += teamHas[entry[j]];
+			}
+			let limit = entry[2];
+			if (count > limit) {
+				let clause = entry[1] ? " by " + entry[1] : '';
+				problems.push("You are limited to " + limit + " of " + entry[0] + clause + ".");
+			}
+		}
+
 		if (format.ruleset) {
 			for (let i = 0; i < format.ruleset.length; i++) {
 				let subformat = tools.getFormat(format.ruleset[i]);

--- a/tools.js
+++ b/tools.js
@@ -601,6 +601,7 @@ module.exports = (() => {
 			if (!format.banlistTable) format.banlistTable = {};
 			if (!format.setBanTable) format.setBanTable = [];
 			if (!format.teamBanTable) format.teamBanTable = [];
+			if (!format.teamLimitTable) format.teamLimitTable = [];
 
 			banlistTable = format.banlistTable;
 			if (!subformat) subformat = format;
@@ -613,7 +614,14 @@ module.exports = (() => {
 					banlistTable[toId(subformat.banlist[i])] = subformat.name || true;
 
 					let complexList;
-					if (subformat.banlist[i].includes('+')) {
+					if (subformat.banlist[i].includes('>')) {
+						complexList = subformat.banlist[i].split('>');
+						let limit = parseInt(complexList[1]);
+						let banlist = complexList[0].trim();
+						complexList = banlist.split('+').map(toId);
+						complexList.unshift(banlist, subformat.name, limit);
+						format.teamLimitTable.push(complexList);
+					} else if (subformat.banlist[i].includes('+')) {
 						if (subformat.banlist[i].includes('++')) {
 							complexList = subformat.banlist[i].split('++');
 							let banlist = complexList.join('+');


### PR DESCRIPTION
As you can see, this can be used to simplify some of the rulesets, but OMs can also make use of this, for instance VoltTurn Mayhem could have `banlist: ['Fake Out > 1']`.