### PR TITLE
Do not send rename messages when nicking to the user's current username

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -3212,6 +3212,8 @@ exports.commands = {
 	},
 
 	trn: function (target, room, user, connection) {
+		if (target === user.name) return false;
+
 		let commaIndex = target.indexOf(',');
 		let targetName = target;
 		let targetRegistered = false;


### PR DESCRIPTION
This presents ghost guest nicks from appearing when logging out and renaming to
the user's guest nick and prevents being able to spam rename messages when
renaming to the user's current username.