### PR TITLE
Use 'gamemanagement' permission in mafia.js

### DIFF
--- a/chat-plugins/mafia.js
+++ b/chat-plugins/mafia.js
@@ -894,7 +894,7 @@ exports.commands = {
 		},
 
 		disable: function (target, room, user) {
-			if (!this.can('mafiamanagement', null, room)) return;
+			if (!this.can('gamemanagement', null, room)) return;
 			if (!room.mafiaEnabled) {
 				return this.errorReply("Mafia is already disabled.");
 			}
@@ -907,7 +907,7 @@ exports.commands = {
 		},
 
 		enable: function (target, room, user) {
-			if (!this.can('mafiamanagement', null, room)) return;
+			if (!this.can('gamemanagement', null, room)) return;
 			if (room.mafiaEnabled) {
 				return this.errorReply("Mafia is already enabled.");
 			}


### PR DESCRIPTION
The 'mafiamanagement' permission isn't a default permission defined in config/config-example.js and therefore the commands can only be used by groups having the 'root' permission (usually only administrators).