### PR TITLE
Add 3 second delay from clicking "Battle!" button

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -3112,7 +3112,9 @@ exports.commands = {
 					return false;
 				}
 			}
-			Rooms.global.searchBattle(user, target);
+			setTimeout(function () {
+				Rooms.global.searchBattle(user, target);
+			}, 3000);
 		} else {
 			Rooms.global.cancelSearch(user);
 		}


### PR DESCRIPTION
This makes it so that once you click the "Battle!" button, it will wait a good 3 seconds before it actually starts searching for a battle. This gives users more time to be able to click the cancel button for the tiers that nearly instantly get them a battle.