### PR TITLE
Chat: Tell locked users their lock duration

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -96,9 +96,8 @@ exports.commands = {
 				buf += `<br />NAMELOCKED: ${targetUser.namelocked}`;
 				let punishment = Punishments.userids.get(targetUser.locked);
 				if (punishment) {
-					let expiresIn = new Date(punishment[2]).getTime() - Date.now();
-					let expiresDays = Math.round(expiresIn / 1000 / 60 / 60 / 24);
-					if (expiresIn > 1) buf += ` (expires in around ${expiresDays} day${Chat.plural(expiresDays)})`;
+					let expiresIn = Punishments.checkLockExpiration(targetUser.locked);
+					if (expiresIn) buf += expiresIn;
 					if (punishment[3]) buf += ` (reason: ${punishment[3]})`;
 				}
 			} else if (targetUser.locked) {
@@ -116,9 +115,8 @@ exports.commands = {
 				}
 				let punishment = Punishments.userids.get(targetUser.locked);
 				if (punishment) {
-					let expiresIn = new Date(punishment[2]).getTime() - Date.now();
-					let expiresDays = Math.round(expiresIn / 1000 / 60 / 60 / 24);
-					if (expiresIn > 1) buf += ` (expires in around ${expiresDays} day${Chat.plural(expiresDays)})`;
+					let expiresIn = Punishments.checkLockExpiration(targetUser.locked);
+					if (expiresIn) buf += expiresIn;
 					if (punishment[3]) buf += ` (reason: ${punishment[3]})`;
 				}
 			}

--- a/chat.js
+++ b/chat.js
@@ -531,9 +531,10 @@ class CommandContext {
 		}
 		if (!user.can('bypassall')) {
 			let lockType = (user.namelocked ? `namelocked` : user.locked ? `locked` : ``);
+			let lockExpiration = Punishments.checkLockExpiration(user.namelocked || user.locked);
 			if (room) {
 				if (lockType) {
-					this.errorReply(`You are ${lockType} and can't talk in chat.`);
+					this.errorReply(`You are ${lockType} and can't talk in chat. ${lockExpiration}`);
 					return false;
 				}
 				if (room.isMuted(user)) {
@@ -556,7 +557,7 @@ class CommandContext {
 			}
 			if (targetUser) {
 				if (lockType && !targetUser.can('lock')) {
-					return this.errorReply(`You are ${lockType} and can only private message members of the global moderation team (users marked by @ or above in the Help room).`);
+					return this.errorReply(`You are ${lockType} and can only private message members of the global moderation team (users marked by @ or above in the Help room). ${lockExpiration}`);
 				}
 				if (targetUser.locked && !user.can('lock')) {
 					return this.errorReply(`The user "${targetUser.name}" is locked and cannot be PMed.`);

--- a/punishments.js
+++ b/punishments.js
@@ -956,6 +956,18 @@ Punishments.checkNewNameInRoom = function (user, userid, roomid) {
 	}
 };
 
+Punishments.checkLockExpiration = function (userid) {
+	const punishment = Punishments.userids.get(userid);
+
+	if (punishment) {
+		let expiresIn = new Date(punishment[2]).getTime() - Date.now();
+		let expiresDays = Math.round(expiresIn / 1000 / 60 / 60 / 24);
+		if (expiresIn > 1) return ` (expires in around ${expiresDays} day${Chat.plural(expiresDays)})`;
+	}
+
+	return ``;
+};
+
 Punishments.isRoomBanned = function (user, roomid) {
 	if (!user) return;
 


### PR DESCRIPTION
This also adds `Punishments#checkLockExpiration` - mostly for this, but also to remove some repetitive code in the whois command as well.