### PR TITLE
Tournaments: Allow ROs to allow % and up to run tours

### DIFF
--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -106,12 +106,14 @@ class RoomSettings {
 		return slowchatOutput.join(" ");
 	}
 	tourStatus() {
-		if (!this.user.can('tournamentsmanagement', null, this.room)) return "<button " + DISABLED + ">" + (this.room.toursEnabled ? '@' : '#') + "</button>";
+		if (!this.user.can('tournamentsmanagement', null, this.room)) return "<button " + DISABLED + ">" + (this.room.toursEnabled === true ? '@' : this.room.toursEnabled === '%' ? '%' : '#') + "</button>";
 
-		if (this.room.toursEnabled) {
-			return '<button class="button" name="send" value="/roomsetting tournament disable">#</button> <button ' + DISABLED + '>@</button>';
+		if (this.room.toursEnabled === true) {
+			return '<button class="button" name="send" value="/roomsetting tournament enable %">%</button> <button ' + DISABLED + '>@</button> <button class="button" name="send" value="/roomsetting tournament disable">#</button>';
+		} else if (this.room.toursEnabled === '%') {
+			return '<button ' + DISABLED + '>%</button> <button class="button" name="send" value="/roomsetting tournament enable @">@</button> <button class="button" name="send" value="/roomsetting tournament disable">#</button>';
 		} else {
-			return '<button ' + DISABLED + '>#</button> <button class="button" name="send" value="/roomsetting tournament enable">@</button> ';
+			return '<button class="button" name="send" value="/roomsetting tournament enable %">%</button> <button class="button" name="send" value="/roomsetting tournament enable @">@</button> <button ' + DISABLED + '>#</button>';
 		}
 	}
 	generateDisplay(user, room, connection) {

--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -1193,15 +1193,26 @@ Chat.commands.tournament = function (paramString, room, user) {
 		return this.parse('/help tournament');
 	} else if (cmd === 'on' || cmd === 'enable') {
 		if (!this.can('tournamentsmanagement', null, room)) return;
-		if (room.toursEnabled) {
-			return this.errorReply("Tournaments are already enabled.");
+		let rank = params[0];
+		if (rank && rank === '@') {
+			if (room.toursEnabled === true) return this.errorReply("Tournaments are already enabled for @ and above in this room.");
+			room.toursEnabled = true;
+			if (room.chatRoomData) {
+				room.chatRoomData.toursEnabled = true;
+				Rooms.global.writeChatRoomData();
+			}
+			return this.sendReply("Tournaments are now enabled for @ and up.");
+		} else if (rank && rank === '%') {
+			if (room.toursEnabled === rank) return this.errorReply("Tournaments are already enabled for % and above in this room.");
+			room.toursEnabled = rank;
+			if (room.chatRoomData) {
+				room.chatRoomData.toursEnabled = rank;
+				Rooms.global.writeChatRoomData();
+			}
+			return this.sendReply("Tournaments are now enabled for % and up.");
+		} else {
+			return this.errorReply("Tournament enable setting not recognized.  Valid options include [%|@].");
 		}
-		room.toursEnabled = true;
-		if (room.chatRoomData) {
-			room.chatRoomData.toursEnabled = true;
-			Rooms.global.writeChatRoomData();
-		}
-		return this.sendReply("Tournaments enabled.");
 	} else if (cmd === 'off' || cmd === 'disable') {
 		if (!this.can('tournamentsmanagement', null, room)) return;
 		if (!room.toursEnabled) {
@@ -1212,7 +1223,7 @@ Chat.commands.tournament = function (paramString, room, user) {
 			delete room.chatRoomData.toursEnabled;
 			Rooms.global.writeChatRoomData();
 		}
-		return this.sendReply("Tournaments disabled.");
+		return this.sendReply("Tournaments are now disabled.");
 	} else if (cmd === 'announce' || cmd === 'announcements') {
 		if (!this.can('tournamentsmanagement', null, room)) return;
 		if (!Config.tourannouncements.includes(room.id)) {
@@ -1244,8 +1255,10 @@ Chat.commands.tournament = function (paramString, room, user) {
 			Rooms.global.writeChatRoomData();
 		}
 	} else if (cmd === 'create' || cmd === 'new') {
-		if (room.toursEnabled) {
+		if (room.toursEnabled === true) {
 			if (!this.can('tournaments', null, room)) return;
+		} else if (room.toursEnabled === '%') {
+			if (!this.can('tournamentsmoderation', null, room)) return;
 		} else {
 			if (!user.can('tournamentsmanagement', null, room)) {
 				return this.errorReply("Tournaments are disabled in this room (" + room.id + ").");
@@ -1275,8 +1288,10 @@ Chat.commands.tournament = function (paramString, room, user) {
 		}
 
 		if (commands.creation[cmd]) {
-			if (room.toursEnabled) {
+			if (room.toursEnabled === true) {
 				if (!this.can('tournaments', null, room)) return;
+			} else if (room.toursEnabled === '%') {
+				if (!this.can('tournamentsmoderation', null, room)) return;
 			} else {
 				if (!user.can('tournamentsmanagement', null, room)) {
 					return this.errorReply("Tournaments are disabled in this room (" + room.id + ").");


### PR DESCRIPTION
This was requested several times, as a lot of rooms have bots to allow drivers to run tournaments for them.

Note: current room settings for tournaments will not change by default; if you had your room set to allow mods and up before, that will still be the case unless you change it; same for if you had tournaments disabled all together.

This changes the command syntax for `/tournament enable` to be: `/tournament enable [%/@]`.  The command syntax for `/tournament disable` has not changed. (disabling a tournament will make it so only # and up can run tournaments.)

This also re-arranges the roomsettings rank order UI for tournaments; it only makes sense that the ranks go in order of power least to greatest (left to right).