### PR TITLE
Tournaments: Update help command with new enable

### DIFF
--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -1331,7 +1331,8 @@ Chat.commands.tournamenthelp = function (target, room, user) {
 		"- scouting &lt;allow|disallow>: Specifies whether joining tournament matches while in a tournament is allowed.<br />" +
 		"- modjoin &lt;allow|disallow>: Specifies whether players can modjoin their battles.<br />" +
 		"- getusers: Lists the users in the current tournament.<br />" +
-		"- on/off: Enables/disables allowing mods to start tournaments in the current room.<br />" +
+		"- on/enable &lt;%|@>: Enables allowing drivers or mods to start tournaments in the current room.<br />" +
+		"- off/disable: Disables allowing drivers and mods to start tournaments in the current room.<br />" +
 		"- announce/announcements &lt;on|off>: Enables/disables tournament announcements for the current room.<br />" +
 		"More detailed help can be found <a href=\"https://www.smogon.com/forums/threads/3570628/#post-6777489\">here</a>"
 	);


### PR DESCRIPTION
The command syntax for the enable command has changed as of https://github.com/Zarel/Pokemon-Showdown/commit/8744e94a2d31c3947f7e053683b7c843c25a57e7 - this updates the help command to reflect those changes.