### PR TITLE
Roomsettings: Don't use 'true' in UI

### DIFF
--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -72,7 +72,7 @@ class RoomSettings {
 		return modjoinOutput.join(" ");
 	}
 	stretching() {
-		if (!this.user.can('editroom', null, this.room)) return "<button " + DISABLED + ">" + (this.room.filterStretching ? this.room.filterStretching : 'off') + "</button>";
+		if (!this.user.can('editroom', null, this.room)) return "<button " + DISABLED + ">" + (this.room.filterStretching ? 'filter stretching' : 'off') + "</button>";
 		if (this.room.filterStretching) {
 			return '<button class="button" name="send" value="/roomsetting stretchfilter off">off</button> <button ' + DISABLED + '>filter stretching</button>';
 		} else {
@@ -80,7 +80,7 @@ class RoomSettings {
 		}
 	}
 	capitals() {
-		if (!this.user.can('editroom', null, this.room)) return "<button " + DISABLED + ">" + (this.room.filterCaps ? this.room.filterCaps : 'off') + "</button>";
+		if (!this.user.can('editroom', null, this.room)) return "<button " + DISABLED + ">" + (this.room.filterCaps ? 'filter capitals' : 'off') + "</button>";
 		if (this.room.filterCaps) {
 			return '<button class="button" name="send" value="/roomsetting capsfilter off">off</button> <button ' + DISABLED + '>filter capitals</button>';
 		} else {


### PR DESCRIPTION
This makes it more consistent with the rest of the UI, specifically for the respected changes of filtering capitals / stretching.