### PR TITLE
Mee: Filter out following text

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -89,6 +89,9 @@ exports.commands = {
 	'!me': true,
 	mee: 'me',
 	me: function (target, room, user) {
+		if (this.cmd === 'mee' && /[A-Z-a-z0-9/]/.test(target.charAt(0))) {
+			return this.errorReply(`/mee - must not start with a letter or number`);
+		}
 		target = this.canTalk(`/${this.cmd} ${target || ''}`);
 		if (!target) return;
 


### PR DESCRIPTION
Before, `/mee` didn't used to allow for a target, as this could lead to impersonation.

Ex: `/mee 2 tests` - if you're name is bobbyuser, then it would appear as "bobbyuser2 tests" in the chat.