### PR TITLE
Team Validator: Validate Happiness when set

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -148,7 +148,6 @@ class Validator {
 		}
 
 		set.species = Tools.getSpecies(set.species);
-
 		set.name = tools.getName(set.name);
 		let item = tools.getItem(Tools.getString(set.item));
 		set.item = item.name;
@@ -214,6 +213,9 @@ class Validator {
 			} else {
 				return [`"${set.ability}" is an invalid ability.`];
 			}
+		}
+		if (set.happiness !== undefined && isNaN(set.happiness)) {
+			problems.push(`${set.species} has an invalid happiness.`);
 		}
 
 		let banlistTable = tools.getBanlistTable(format);


### PR DESCRIPTION
Addresses https://github.com/Zarel/Pokemon-Showdown/issues/2815#issuecomment-251421263

Happiness didn't exist in gen 1 as far as I know, so I assumed a set with happiness set would also be wrong for that generation as well.