### PR TITLE
Run Spore immunities in the correct order

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1863,7 +1863,7 @@ exports.BattleAbilities = {
 		},
 		onTryHitPriority: 1,
 		onTryHit: function (target, source, move) {
-			if (move.flags['powder'] && target !== source) {
+			if (move.flags['powder'] && target !== source && this.getImmunity('powder', target)) {
 				this.add('-immune', target, '[msg]', '[from] ability: Overcoat');
 				return null;
 			}
@@ -2375,6 +2375,7 @@ exports.BattleAbilities = {
 	"sapsipper": {
 		desc: "This Pokemon is immune to Grass-type moves and raises its Attack by 1 stage when hit by a Grass-type move.",
 		shortDesc: "This Pokemon's Attack is raised 1 stage if hit by a Grass move; Grass immunity.",
+		onTryHitPriority: 1,
 		onTryHit: function (target, source, move) {
 			if (target !== source && move.type === 'Grass') {
 				if (!this.boost({atk:1})) {

--- a/data/items.js
+++ b/data/items.js
@@ -3894,7 +3894,7 @@ exports.BattleItems = {
 			if (type === 'sandstorm' || type === 'hail' || type === 'powder') return false;
 		},
 		onTryHit: function (pokemon, source, move) {
-			if (move.flags['powder'] && pokemon !== source) {
+			if (move.flags['powder'] && pokemon !== source && this.getImmunity('powder', pokemon)) {
 				this.add('-activate', pokemon, 'item: Safety Goggles', move.name);
 				return null;
 			}

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -233,15 +233,15 @@ exports.BattleScripts = {
 			return false;
 		}
 
-		if (move.flags['powder'] && target !== pokemon && !this.getImmunity('powder', target)) {
-			this.debug('natural powder immunity');
-			this.add('-immune', target, '[msg]');
-			return false;
-		}
-
 		hitResult = this.runEvent('TryHit', target, pokemon, move);
 		if (!hitResult) {
 			if (hitResult === false) this.add('-fail', target);
+			return false;
+		}
+
+		if (move.flags['powder'] && target !== pokemon && !this.getImmunity('powder', target)) {
+			this.debug('natural powder immunity');
+			this.add('-immune', target, '[msg]');
 			return false;
 		}
 


### PR DESCRIPTION
- Ensure Sap Sipper runs before Safety Goggles (for non-Grass types)
- Overcoat and Safety Goggles should not trigger for Powder moves on Grass types
- Grass immunity to powder moves should run after Sap Sipper