### PR TITLE
Fix incorrect wording in modjoin

### DIFF
--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -261,7 +261,7 @@ exports.commands = {
 			if (target === '+') {
 				this.add(`|raw|<div class="broadcast-red"><b>This room is now invite only!</b><br />Users must be rank + or invited with <code>/invite</code> to join</div>`);
 			} else {
-				this.add(`|raw|<div class="broadcast-red"><b>Moderated join was set to ${target}!</b><br />Only users of rank ${target} and higher can talk.</div>`);
+				this.add(`|raw|<div class="broadcast-red"><b>Moderated join was set to ${target}!</b><br />Only users of rank ${target} and higher can join.</div>`);
 			}
 			this.addModCommand(`${user.name} set modjoin to ${target}.`);
 		} else {


### PR DESCRIPTION
When setting modjoin to a setting higher than +, it says `Moderated join was set to ${target}! Only users of rank ${target} and higher can talk.`

I have changed this to `Moderated join was set to ${target}! Only users of rank ${target} and higher can join.`