### PR TITLE
Allow formats to unban inherited formats or rulesets

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -231,24 +231,6 @@ class Validator {
 				const reason = banReason`${banlistTable[check]}`;
 				return [`${template.baseSpecies} is ${reason}.`];
 			}
-			if (banlistTable['Unreleased'] && template.isUnreleased) {
-				if (!format.requirePentagon || (template.eggGroups[0] === 'Undiscovered' && !template.evos)) {
-					problems.push(`${name} (${template.species}) is unreleased.`);
-				}
-			}
-			let species = template.species;
-			let tier = template.tier;
-			if (item.megaEvolves === template.species) {
-				species = item.megaStone;
-				tier = tools.getTemplate(item.megaStone).tier;
-			}
-			if (tier) {
-				if (tier.charAt(0) === '(') tier = tier.slice(1, -1);
-				setHas[toId(tier)] = true;
-				if (banlistTable[tier] && banlistTable[toId(species)] !== false) {
-					problems.push(`${template.species} is in ${tier}, which is banned.`);
-				}
-			}
 		}
 
 		check = toId(set.ability);
@@ -265,6 +247,11 @@ class Validator {
 		}
 		if (banlistTable['Unreleased'] && item.isUnreleased) {
 			problems.push(`${name}'s item ${set.item} is unreleased.`);
+		}
+		if (banlistTable['Unreleased'] && template.isUnreleased) {
+			if (!format.requirePentagon || (template.eggGroups[0] === 'Undiscovered' && !template.evos)) {
+				problems.push(`${name} (${template.species}) is unreleased.`);
+			}
 		}
 		setHas[toId(set.ability)] = true;
 		if (banlistTable['illegal']) {
@@ -543,6 +530,17 @@ class Validator {
 				if (ability.name !== oldAbilities['0'] && ability.name !== oldAbilities['1'] && !oldAbilities['H']) {
 					problems.push(`${name} has moves incompatible with its ability.`);
 				}
+			}
+		}
+		if (item.megaEvolves === template.species) {
+			template = tools.getTemplate(item.megaStone);
+		}
+		if (template.tier) {
+			let tier = template.tier;
+			if (tier.charAt(0) === '(') tier = tier.slice(1, -1);
+			setHas[toId(tier)] = true;
+			if (banlistTable[tier]) {
+				problems.push(`${template.species} is in ${tier}, which is banned.`);
 			}
 		}
 

--- a/team-validator.js
+++ b/team-validator.js
@@ -539,7 +539,7 @@ class Validator {
 			let tier = template.tier;
 			if (tier.charAt(0) === '(') tier = tier.slice(1, -1);
 			setHas[toId(tier)] = true;
-			if (banlistTable[tier]) {
+			if (banlistTable[tier] && banlistTable[template.id] !== false) {
 				problems.push(`${template.species} is in ${tier}, which is banned.`);
 			}
 		}

--- a/team-validator.js
+++ b/team-validator.js
@@ -231,23 +231,23 @@ class Validator {
 				const reason = banReason`${banlistTable[check]}`;
 				return [`${template.baseSpecies} is ${reason}.`];
 			}
-		}
-		if (banlistTable['Unreleased'] && template.isUnreleased) {
-			if (!format.requirePentagon || (template.eggGroups[0] === 'Undiscovered' && !template.evos)) {
-				problems.push(`${name} (${template.species}) is unreleased.`);
+			if (banlistTable['Unreleased'] && template.isUnreleased) {
+				if (!format.requirePentagon || (template.eggGroups[0] === 'Undiscovered' && !template.evos)) {
+					problems.push(`${name} (${template.species}) is unreleased.`);
+				}
 			}
-		}
-		let species = template.species;
-		let tier = template.tier;
-		if (item.megaEvolves === template.species) {
-			species = item.megaStone;
-			tier = tools.getTemplate(item.megaStone).tier;
-		}
-		if (tier) {
-			if (tier.charAt(0) === '(') tier = tier.slice(1, -1);
-			setHas[toId(tier)] = true;
-			if (banlistTable[tier] && banlistTable[toId(species)] !== false) {
-				problems.push(`${template.species} is in ${tier}, which is banned.`);
+			let species = template.species;
+			let tier = template.tier;
+			if (item.megaEvolves === template.species) {
+				species = item.megaStone;
+				tier = tools.getTemplate(item.megaStone).tier;
+			}
+			if (tier) {
+				if (tier.charAt(0) === '(') tier = tier.slice(1, -1);
+				setHas[toId(tier)] = true;
+				if (banlistTable[tier] && banlistTable[toId(species)] !== false) {
+					problems.push(`${template.species} is in ${tier}, which is banned.`);
+				}
 			}
 		}
 

--- a/tools.js
+++ b/tools.js
@@ -625,10 +625,16 @@ module.exports = (() => {
 
 			banlistTable = format.banlistTable;
 			if (!subformat) subformat = format;
+			if (subformat.unbanlist) {
+				for (let i = 0; i < subformat.unbanlist.length; i++) {
+					banlistTable[subformat.unbanlist[i]] = false;
+					banlistTable[toId(subformat.unbanlist[i])] = false;
+				}
+			}
 			if (subformat.banlist) {
 				for (let i = 0; i < subformat.banlist.length; i++) {
 					// don't revalidate what we already validate
-					if (banlistTable[toId(subformat.banlist[i])]) continue;
+					if (banlistTable[toId(subformat.banlist[i])] !== undefined) continue;
 
 					banlistTable[subformat.banlist[i]] = subformat.name || true;
 					banlistTable[toId(subformat.banlist[i])] = subformat.name || true;
@@ -664,7 +670,7 @@ module.exports = (() => {
 			if (subformat.ruleset) {
 				for (let i = 0; i < subformat.ruleset.length; i++) {
 					// don't revalidate what we already validate
-					if (banlistTable['Rule:' + toId(subformat.ruleset[i])]) continue;
+					if (banlistTable['Rule:' + toId(subformat.ruleset[i])] !== undefined) continue;
 
 					banlistTable['Rule:' + toId(subformat.ruleset[i])] = subformat.ruleset[i];
 					if (!format.ruleset.includes(subformat.ruleset[i])) format.ruleset.push(subformat.ruleset[i]);

--- a/tools.js
+++ b/tools.js
@@ -627,8 +627,8 @@ module.exports = (() => {
 			if (!subformat) subformat = format;
 			if (subformat.unbanlist) {
 				for (let i = 0; i < subformat.unbanlist.length; i++) {
-					banlistTable[subformat.unbanlist[i]] = false;
-					banlistTable[toId(subformat.unbanlist[i])] = false;
+					banlistTable[subformat.banlist[i]] = false;
+					banlistTable[toId(subformat.banlist[i])] = false;
 				}
 			}
 			if (subformat.banlist) {

--- a/tools.js
+++ b/tools.js
@@ -625,16 +625,10 @@ module.exports = (() => {
 
 			banlistTable = format.banlistTable;
 			if (!subformat) subformat = format;
-			if (subformat.unbanlist) {
-				for (let i = 0; i < subformat.unbanlist.length; i++) {
-					banlistTable[subformat.banlist[i]] = false;
-					banlistTable[toId(subformat.banlist[i])] = false;
-				}
-			}
 			if (subformat.banlist) {
 				for (let i = 0; i < subformat.banlist.length; i++) {
 					// don't revalidate what we already validate
-					if (banlistTable[toId(subformat.banlist[i])] !== undefined) continue;
+					if (banlistTable[toId(subformat.banlist[i])]) continue;
 
 					banlistTable[subformat.banlist[i]] = subformat.name || true;
 					banlistTable[toId(subformat.banlist[i])] = subformat.name || true;
@@ -670,7 +664,7 @@ module.exports = (() => {
 			if (subformat.ruleset) {
 				for (let i = 0; i < subformat.ruleset.length; i++) {
 					// don't revalidate what we already validate
-					if (banlistTable['Rule:' + toId(subformat.ruleset[i])] !== undefined) continue;
+					if (banlistTable['Rule:' + toId(subformat.ruleset[i])]) continue;
 
 					banlistTable['Rule:' + toId(subformat.ruleset[i])] = subformat.ruleset[i];
 					if (!format.ruleset.includes(subformat.ruleset[i])) format.ruleset.push(subformat.ruleset[i]);


### PR DESCRIPTION
As fb4066d showed, I made a right mess of extracting the unban code from my original override patch. Indeed, it misreports the error when you try to use a Mega forme which is in too high a tier. So, I thought I'd start over, in effect, via the following three commits:

1. Backout of fb4066d
2. Backout of 056e1a0
3. What I should have done in the first place, instead of trying to extricate the unban code from the override code.

Naturally the `tools.js` changes will disappear when the PR gets squashed together, as I did at least manage to get that bit right, but for the `team-validator.js` changes, the easiest way is just to look at 814f780.