### PR TITLE
Fix minor information leak with Pursuit

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -10913,9 +10913,13 @@ exports.BattleMovedex = {
 			onBeforeSwitchOut: function (pokemon) {
 				this.debug('Pursuit start');
 				let sources = this.effectData.sources;
-				this.add('-activate', pokemon, 'move: Pursuit');
+				let alreadyAdded = false;
 				for (let i = 0; i < sources.length; i++) {
 					if (sources[i].moveThisTurn || sources[i].fainted) continue;
+					if (!alreadyAdded) {
+						this.add('-activate', pokemon, 'move: Pursuit');
+						alreadyAdded = true;
+					}
 					this.cancelMove(sources[i]);
 					// Run through each decision in queue to check if the Pursuit user is supposed to Mega Evolve this turn.
 					// If it is, then Mega Evolve before moving.


### PR DESCRIPTION
Currently, PS will notify both players if Pursuit has been used regardless if it actually succeeds or not (like if something U-Turn and kill the pursuiter, you still get a message that shows they planned to use Pursuit). It's a somewhat minor information leak, but it should still be fixed.