### PR TITLE
Remove unused documented config-example perm

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -227,7 +227,6 @@ exports.replsocketmode = 0o600;
 //     - lock: locking (ipmute) and unlocking.
 //     - receivemutedpms: Receive PMs from muted users.
 //     - forcerename: /fr command.
-//     - redirect: /redir command.
 //     - ip: IP checking.
 //     - alts: Alt checking.
 //     - modlog: view the moderator logs.


### PR DESCRIPTION
The redirect command actually uses the 'warn' permission, and it seems as though this permission actually isn't a permission of any of the ranks currently.