### PR TITLE
Enable announce command in PMs

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1971,6 +1971,7 @@ exports.commands = {
 	},
 	chatdeclarehelp: ["/cdeclare [message] - Anonymously announces a message to all chatrooms on the server. Requires: ~"],
 
+	'!announce': true,
 	wall: 'announce',
 	announce: function (target, room, user) {
 		if (!target) return this.parse('/help announce');


### PR DESCRIPTION
Before the semi-recent PM refactor, `/announce` /would/ work in private messages, this re-enables that functionality.