### PR TITLE
Fix ghost users bug in room#getUserList

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -1478,7 +1478,7 @@ class ChatRoom extends Room {
 		let buffer = '';
 		let counter = 0;
 		for (let i in this.users) {
-			if (!this.users[i].named) {
+			if (!Users(this.users[i]) || !this.users[i].named) {
 				continue;
 			}
 			counter++;


### PR DESCRIPTION
I have found several incidents where room#users will store a guest number, even after that guest is offline.  Then, when a user joins the room, this check never happens so their user name would get displayed on the room list.