### PR TITLE
Don't let Cursed Body activate for Doom Desire or Future Sight

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -409,7 +409,7 @@ exports.BattleAbilities = {
 		shortDesc: "If this Pokemon is hit by an attack, there is a 30% chance that move gets disabled.",
 		onAfterDamage: function (damage, target, source, move) {
 			if (!source || source.volatiles['disable']) return;
-			if (source !== target && move && move.effectType === 'Move') {
+			if (source !== target && move && move.effectType === 'Move' && !move.isFutureMove) {
 				if (this.random(10) < 3) {
 					source.addVolatile('disable', this.effectData.target);
 				}


### PR DESCRIPTION
See http://replay.pokemonshowdown.com/rom-tripleshackmonscup-40052 (yeah I know it's not main but the code isn't *that* different...)

Turn 2, Emolga used Doom Desire on Klefki. Klefki fainted on move 4, so I brought in Volcarona. Emolga used Mega Kick on Volcarona because it knew it resisted Doom Desire, but it took the Doom Desire attack anyway. However Cursed Body then tried to disable Doom Desire, but ended up disabling Mega Kick instead.

I don't know what the cart mechanics are, so I'm assuming they're likely to be the same as Grudge and Destiny Bond which don't activate for future moves.