### PR TITLE
Monotype Ruleset: Remove outdated Aegislash complex ban

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -652,15 +652,6 @@ exports.BattleFormats = {
 				typeTable = typeTable.filter(type => template.types.indexOf(type) >= 0);
 				if (!typeTable.length) return ["Your team must share a type."];
 			}
-			if (format.id === 'monotype') {
-				// Very complex bans
-				if (typeTable.length > 1) return;
-				switch (typeTable[0]) {
-				case 'Steel':
-					if (teamHas['aegislash']) return ["Aegislash is banned from Steel monotype teams."];
-					break;
-				}
-			}
 		},
 	},
 	megarayquazaclause: {


### PR DESCRIPTION
Previous code had Aegislash complex banned from Steel teams hard-coded into the Same Type Clause. This complex ban hasn't been a part of Monotype for half a year and was conflicting with attempts to use "/tour banlist !aegislash" to allow Aegislash in Monotype battles. (I forgot to mention this in the commit, but Aegislash is appropriately globally banned, so this will still reflect the current banlist.)