### PR TITLE
Showblacklist: Check size of room's blacklist

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2223,7 +2223,7 @@ exports.commands = {
 		if (!room.chatRoomData) return this.errorReply("This room does not support blacklists.");
 
 		const subMap = Punishments.roomUserids.get(room.id);
-		if (!subMap) {
+		if (!subMap || subMap.size === 0) {
 			return this.sendReply("This room has no blacklisted users.");
 		}
 		let blMap = new Map();


### PR DESCRIPTION
This fixes a bug where it would show a blacklist infobox reply as if there were users blacklisted, even if there aren't.

Example screencap:
<img src="http://image.prntscr.com/image/d7a74a434b024460a1897ca686fcdce5.png">