### PR TITLE
Extra AfterMove event seems unnecessary

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -57,7 +57,6 @@ exports.BattleScripts = {
 		}
 		pokemon.moveUsed(move);
 		this.useMove(move, pokemon, target, sourceEffect);
-		this.singleEvent('AfterMove', move, null, pokemon, target, move);
 		this.runEvent('AfterMove', pokemon, target, move);
 	},
 	useMove: function (move, pokemon, target, sourceEffect) {


### PR DESCRIPTION
Doesn't the `runEvent` call now make the `singleEvent` call redundant?