### PR TITLE
Spectral Thief should set boosts to zero on target despite abilities

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -369,14 +369,15 @@ exports.BattleScripts = {
 			let boosts = {};
 			for (let statName in target.boosts) {
 				let stage = target.boosts[statName];
-				if (stage > 0) boosts[statName] = -stage;
-			}
-			this.boost(boosts, target);
-
-			for (let statName in boosts) {
-				boosts[statName] = -boosts[statName];
+				if (stage > 0) boosts[statName] = stage;
 			}
 			this.boost(boosts, pokemon);
+
+			for (let statName in boosts) {
+				boosts[statName] = 0;
+			}
+			target.setBoost(boosts);
+			this.add('-clearpositiveboost', target, pokemon, 'move: ' + move.name);
 		}
 
 		move.totalDamage = 0;

--- a/test/simulator/moves/spectralthief.js
+++ b/test/simulator/moves/spectralthief.js
@@ -79,4 +79,37 @@ describe(`Spectral Thief`, function () {
 		assert.statStage(thief, 'atk', 0);
 		assert.statStage(victim, 'atk', 2);
 	});
+
+	it(`should zero target's boosts if the target has Contrary`, function () {
+		battle = common.createBattle([
+			[{species: "Smeargle", ability: 'owntempo', item: 'focussash', moves: ['spectralthief']}],
+			[{species: "Serperior", ability: 'contrary', moves: ['leafstorm']}],
+		]);
+		const victim = battle.p2.active[0];
+		battle.commitDecisions();
+		assert.statStage(victim, 'spa', 0);
+		assert.false.fainted(victim);
+	});
+
+	it(`should zero target's boosts if the target has Clear Body`, function () {
+		battle = common.createBattle([
+			[{species: "Smeargle", ability: 'owntempo', moves: ['spectralthief']}],
+			[{species: "Tentacruel", ability: 'clearbody', moves: ['swordsdance']}],
+		]);
+		const victim = battle.p2.active[0];
+		battle.commitDecisions();
+		assert.statStage(victim, 'atk', 0);
+		assert.false.fainted(victim);
+	});
+
+	it(`should zero target's boosts if the target has Simple`, function () {
+		battle = common.createBattle([
+			[{species: "Smeargle", ability: 'owntempo', moves: ['spectralthief']}],
+			[{species: "Swoobat", ability: 'simple', moves: ['amnesia']}],
+		]);
+		const victim = battle.p2.active[0];
+		battle.commitDecisions();
+		assert.statStage(victim, 'spd', 0);
+		assert.false.fainted(victim);
+	});
 });


### PR DESCRIPTION
Merge only after https://github.com/Zarel/Pokemon-Showdown-Client/commit/c280c60671be767fe138a31026c3e0dbf13e4b78 is live