### PR TITLE
LC: Ban Eevium Z

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -63,7 +63,7 @@ exports.Formats = [
 		mod: 'gen7',
 		maxLevel: 5,
 		ruleset: ['Pokemon', 'Standard', 'Team Preview', 'Little Cup'],
-		banlist: ['LC Uber', 'Gligar', 'Misdreavus', 'Scyther', 'Sneasel', 'Tangela', 'Dragon Rage', 'Sonic Boom', 'Swagger'],
+		banlist: ['LC Uber', 'Gligar', 'Misdreavus', 'Scyther', 'Sneasel', 'Tangela', 'Dragon Rage', 'Sonic Boom', 'Swagger', 'Eevium Z'],
 	},
 	{
 		name: "[Gen 7] Anything Goes",


### PR DESCRIPTION
Eeevium Z was quietly banned from Little Cup the other day: http://www.smogon.com/forums/threads/plans-for-sumo-and-beyond.3586679/page-2#post-7089293

I think this is the first Z-move ban, but I'm assuming this is the optimal way to do it...