### PR TITLE
Allow Hackmons Cup for past gens

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1041,9 +1041,10 @@ exports.BattleScripts = {
 		// Unreleased are okay but no CAP
 
 		let num;
+		let last = [0, 151, 251, 386, 493, 649, 721, 802][this.gen];
 		for (let i = 0; i < 6; i++) {
 			do {
-				num = this.random(802) + 1;
+				num = this.random(last) + 1;
 			} while (num in hasDexNumber);
 			hasDexNumber[num] = i;
 		}


### PR DESCRIPTION
`randomHCTeam` works by picking six random dex numbers, then a random legitimate forme for each number (so for instance it will only pick a mega in gen >= 6). Naturally, for past gens, some dex numbers have no legitimate formes, so we have to limit the maximum dex number somehow.