### PR TITLE
Add Type: Null to pokebank lc banlist

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -60,7 +60,7 @@ exports.Formats = [
 		mod: 'gen7',
 		maxLevel: 5,
 		ruleset: ['Pokemon', 'Standard', 'Swagger Clause', 'Team Preview', 'Little Cup'],
-		banlist: ['LC Uber', 'Gligar', 'Misdreavus', 'Scyther', 'Sneasel', 'Tangela', 'Eevium Z', 'Dragon Rage', 'Sonic Boom'],
+		banlist: ['LC Uber', 'Gligar', 'Misdreavus', 'Scyther', 'Sneasel', 'Tangela', 'Type: Null', 'Eevium Z', 'Dragon Rage', 'Sonic Boom'],
 	},
 	{
 		name: "[Gen 7] Pokebank Anything Goes",


### PR DESCRIPTION
Type: Null is nfe and should not be legal in little cup. However the validator is allowing it, possibly on account of it having an evolution family despite it being unavailable at level 5. There may be a better implementation to fix this, however this resolves the issue of it being available on the ladder for the time being.