### PR TITLE
Add Minior and Magearna form aliases

### DIFF
--- a/data/aliases.js
+++ b/data/aliases.js
@@ -304,6 +304,13 @@ exports.BattleAliases = {
 	"florgesorange": "Florges",
 	"florgeswhite": "Florges",
 	"florgesyellow": "Florges",
+	"miniororange": "Minior",
+	"minioryellow": "Minior",
+	"miniorgreen": "Minior",
+	"miniorblue": "Minior",
+	"miniorindigo": "Minior",
+	"miniorviolet": "Minior",
+	"magearnaoriginal": "Magearna",
 
 	// items
 	"assvest": "Assault Vest",


### PR DESCRIPTION
Un-breaks the teambuilder if someone decided to pick another version of either of these right now. Should maybe disable the option while there's no sprite for them, but if it's ever meant to work then this needs to be added either way.