### PR TITLE
Fix Burn Up's type test to work on the source, not the target

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -1991,8 +1991,8 @@ exports.BattleMovedex = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, defrost: 1},
-		onTryHit: function (pokemon) {
-			if (!pokemon.hasType("Fire")) return false;
+		onTryHit: function (target, source, move) {
+			if (!source.hasType("Fire")) return false;
 		},
 		self: {
 			onHit: function (pokemon) {


### PR DESCRIPTION
Oops. (I can never remember which way around these go, and the fact that some of these handlers just use `pokemon` is even more confusing.)