### PR TITLE
Fix /ds with 2+ moves as argument not working for gen 7 mons

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -653,7 +653,7 @@ function runDexsearch(target, cmd, canAll, message) {
 			let lsetData = {fastCheck: true, set: {}};
 			for (let group = 0; group < moveGroups.length; group++) {
 				for (let i = 0; i < moveGroups[group].length; i++) {
-					let problem = TeamValidator('anythinggoes').checkLearnset(moveGroups[group][i], mon, lsetData);
+					let problem = TeamValidator('gen7ou').checkLearnset(moveGroups[group][i], mon, lsetData);
 					if (!problem) break;
 					if (i === moveGroups[group].length - 1) return false;
 				}


### PR DESCRIPTION
This also seems to be the way /learn validates moves. 
Now I assume that "gen7ou" will just turn into "ou" at some point, would that break this? Or will we also switch to gen 7 as the base then, making this work just like /oraslearn works currently despite "gen6ou" not being a thing?