### PR TITLE
Fix Encore's interaction with Z-Moves

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4380,7 +4380,7 @@ exports.BattleMovedex = {
 			onStart: function (target) {
 				let noEncore = {encore:1, mimic:1, mirrormove:1, sketch:1, struggle:1, transform:1};
 				let moveIndex = target.moves.indexOf(target.lastMove);
-				if (!target.lastMove || noEncore[target.lastMove] || (target.moveset[moveIndex] && target.moveset[moveIndex].pp <= 0)) {
+				if (!target.lastMove || this.getMove(target.lastMove).isZ || noEncore[target.lastMove] || (target.moveset[moveIndex] && target.moveset[moveIndex].pp <= 0)) {
 					// it failed
 					delete target.volatiles['encore'];
 					return false;


### PR DESCRIPTION
Encore should fail against Z-moves:
Encore will fail against a Pokemon that previously used a Z-move (LegoFigure11)