### PR TITLE
Remove line of code that appears to be left over from Destiny Bond fix

### DIFF
--- a/data/statuses.js
+++ b/data/statuses.js
@@ -382,7 +382,6 @@ exports.BattleStatuses = {
 			this.effectData.counter = 3;
 		},
 		onStallMove: function () {
-			if (this.activeMove.id === 'destinybond') return true;
 			// this.effectData.counter should never be undefined here.
 			// However, just in case, use 1 if it is undefined.
 			let counter = this.effectData.counter || 1;


### PR DESCRIPTION
At least, it was added a09c011 in but not removed in 318ca6a (sadly this makes for some confusing diffs and the blame is now wrong).