### PR TITLE
Monotype: Extend Baton Pass and Evasion Clauses

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -453,6 +453,22 @@ exports.BattleFormats = {
 		onStart: function () {
 			this.add('rule', 'Evasion Moves Clause: Evasion moves are banned');
 		},
+		onValidateSet: function (set, format, setHas) {
+			let item = this.getItem(set.item);
+			if (!item.zMove) return;
+			let evasionBoosted = false;
+			for (let i = 0; i < set.moves.length; i++) {
+				let move = this.getMove(set.moves[i]);
+				if (move.type === item.zMoveType) {
+					if (move.zMoveBoost && move.zMoveBoost.evasion > 0) {
+						evasionBoosted = true;
+						break;
+					}
+				}
+			}
+			if (!evasionBoosted) return;
+			return [(set.name || set.species) + " can boost Evasion, which is banned by Evasion Clause."];
+		},
 	},
 	endlessbattleclause: {
 		effectType: 'Rule',
@@ -518,6 +534,7 @@ exports.BattleFormats = {
 				speedBoosted = true;
 				nonSpeedBoosted = true;
 			}
+			let item = this.getItem(set.item);
 			for (let i = 0; i < set.moves.length; i++) {
 				let move = this.getMove(set.moves[i]);
 				if (move.boosts && move.boosts.spe > 0) {
@@ -525,6 +542,14 @@ exports.BattleFormats = {
 				}
 				if (move.boosts && (move.boosts.atk > 0 || move.boosts.def > 0 || move.boosts.spa > 0 || move.boosts.spd > 0)) {
 					nonSpeedBoosted = true;
+				}
+				if (item.zMove && move.type === item.zMoveType) {
+					if (move.zMoveBoost && move.zMoveBoost.spe > 0) {
+						speedBoosted = true;
+					}
+					if (move.zMoveBoost && (move.zMoveBoost.atk > 0 || move.zMoveBoost.def > 0 || move.zMoveBoost.spa > 0 || move.zMoveBoost.spd > 0)) {
+						nonSpeedBoosted = true;
+					}
 				}
 			}
 
@@ -571,10 +596,16 @@ exports.BattleFormats = {
 			if (toId(set.item) === 'eeviumz') {
 				speedBoosted = true;
 			}
+			let item = this.getItem(set.item);
 			for (let i = 0; i < set.moves.length; i++) {
 				let move = this.getMove(set.moves[i]);
 				if (move.boosts && move.boosts.spe > 0) {
 					speedBoosted = true;
+				}
+				if (item.zMove && move.type === item.zMoveType) {
+					if (move.zMoveBoost && move.zMoveBoost.spe > 0) {
+						speedBoosted = true;
+					}
 				}
 			}
 


### PR DESCRIPTION
Monotype has extended the Baton Pass Clause and Evasion Clause to recognize and prohibit Z Moves that would violate them.

http://www.smogon.com/forums/threads/monotype.3587204/page-3#post-7105176

I'm assuming the name of the Monotype format will still be "Monotype" when the Gen 7 format is released.

Extended Baton Pass Clause Example: Disallow Z Celebrate + Baton Pass on Umbreon.
Extended Evasion Clause Example: Disallow Z Detect on Zapdos.