### PR TITLE
Allow usage of Z-move if base move was Encored

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -757,6 +757,8 @@ exports.BattleScripts = {
 		let zMoves = [];
 		for (let i = 0; i < pokemon.moves.length; i++) {
 			let move = this.getMove(pokemon.moves[i]);
+			let moveData = pokemon.getMoveData(move);
+			if (moveData.disabled && moveData.disabledSource === 'Encore') continue;
 			let zMove = this.getZMove(move, pokemon, true) || '';
 			zMoves.push(zMove);
 			if (zMove) atLeastOne = true;


### PR DESCRIPTION
This makes it so that even if the base move was encored the Pokemon still has the option to use its Z-move.