### PR TITLE
Don't burn attackers that hit after Beak Blast

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -1109,6 +1109,12 @@ exports.BattleMovedex = {
 		beforeTurnCallback: function (pokemon) {
 			pokemon.addVolatile('beakblast');
 		},
+		beforeMoveCallback: function (pokemon) {
+			pokemon.removeVolatile('beakblast');
+		},
+		onMoveAborted: function (pokemon) {
+			pokemon.removeVolatile('beakblast');
+		},
 		effect: {
 			duration: 1,
 			onStart: function (pokemon) {


### PR DESCRIPTION
The move description says that it only burns while its beak is heating up, so lower priority moves should be able to hit without getting burned. https://www.smogon.com/forums/posts/7110878