### PR TITLE
Don't burn attackers that hit after Beak Blast aborts

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -1120,6 +1120,9 @@ exports.BattleMovedex = {
 				}
 			},
 		},
+		onMoveAborted: function (pokemon) {
+			pokemon.removeVolatile('beakblast');
+		},
 		onAfterMove: function (pokemon) {
 			pokemon.removeVolatile('beakblast');
 		},


### PR DESCRIPTION
I checked and something using a slower contact move (e.g. Revenge) will not normally get burned, but if the move is Disabled earlier that turn then they will get burned, and shouldn't be, according to @Marty-D's comment on PR #2977, which sadly I don't seem to be able to reopen.