### PR TITLE
Don't allow locked users to roompromote

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1061,6 +1061,7 @@ exports.commands = {
 			this.sendReply("/roompromote - This room isn't designed for per-room moderation");
 			return this.sendReply("Before setting room staff, you need to set a room owner with /roomowner");
 		}
+		if (!this.canTalk()) return;
 		if (!target) return this.parse('/help roompromote');
 
 		target = this.splitTarget(target, true);

--- a/test/application/rooms.js
+++ b/test/application/rooms.js
@@ -64,6 +64,7 @@ describe('Rooms features', function () {
 			const roomStaff = new User();
 			roomStaff.forceRename("Room auth", true);
 			const administrator = new User();
+			administrator.forceRename("Admin", true);
 			administrator.group = '~';
 			const options = {
 				rated: false,


### PR DESCRIPTION
As per #2927. The test failed because the administrator was not named, which canTalk() checks for regardless of permissions.