### PR TITLE
checkpunishment: Fix checking for offline users

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -199,7 +199,7 @@ exports.commands = {
 
 		let punishments = Punishments.getRoomPunishments(targetUser);
 
-		if (punishments.length) {
+		if (punishments && punishments.length) {
 			buf += `<br />Room punishments: `;
 
 			buf += punishments.map(([room, punishment]) => {


### PR DESCRIPTION
- It returns nothing in the case the user does not exist in the map, hence ``punishments.length`` crashes