### PR TITLE
Checkpunishments: Mark truly offline users only

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -174,7 +174,7 @@ exports.commands = {
 		if (!userid) return this.errorReply("Please enter a valid username.");
 		let targetUser = Users(userid);
 		let buf = Chat.html`<strong class="username">${target}</strong>`;
-		if (!targetUser) buf += ` <em style="color:gray">(offline)</em>`;
+		if (!targetUser || !targetUser.connected) buf += ` <em style="color:gray">(offline)</em>`;
 		buf += `<br /><br />`;
 		let atLeastOne = false;
 


### PR DESCRIPTION
The user object could of just not yet expired, but they also might not be online, which is why this is necessary