### PR TITLE
Simplify Mold Breaker clones by getting the move to ignore abilities

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2311,7 +2311,7 @@ class Battle extends Tools.BattleDex {
 		return true;
 	}
 	suppressingAttackEvents() {
-		return (this.activePokemon && this.activePokemon.isActive && (!this.activePokemon.ignoringAbility() && this.activePokemon.getAbility().stopAttackEvents) || (this.activeMove && this.activeMove.ignoreAbility));
+		return this.activePokemon && this.activePokemon.isActive && this.activeMove && this.activeMove.ignoreAbility;
 	}
 	suppressingWeather() {
 		let pokemon;

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1916,7 +1916,9 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Mold Breaker');
 		},
-		stopAttackEvents: true,
+		onModifyMove: function (move) {
+			move.ignoreAbility = true;
+		},
 		id: "moldbreaker",
 		name: "Mold Breaker",
 		rating: 3.5,
@@ -3580,7 +3582,9 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Teravolt');
 		},
-		stopAttackEvents: true,
+		onModifyMove: function (move) {
+			move.ignoreAbility = true;
+		},
 		id: "teravolt",
 		name: "Teravolt",
 		rating: 3.5,
@@ -3731,7 +3735,9 @@ exports.BattleAbilities = {
 		onStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Turboblaze');
 		},
-		stopAttackEvents: true,
+		onModifyMove: function (move) {
+			move.ignoreAbility = true;
+		},
 		id: "turboblaze",
 		name: "Turboblaze",
 		rating: 3.5,


### PR DESCRIPTION
We have a shiny new `ignoreAbility` flag on a move. We can use this to simplify the code that tests for an active Mold Breaker clone, by getting the Ability to add the flag to the move, since then all we have to do is to check the flag. (Some moves already have the flag of course.)

As a bonus, this also simplifies the coding for several OMs, in particular Multibility, Partners in Crime and Pokébilities, as they no longer have to special case the Mold Breaker effect.