### PR TITLE
Make learnset searching check for event levels

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -871,6 +871,7 @@ class Validator {
 								continue;
 							}
 						}
+						if (level < template.eventPokemon[learned.substr(2)].level) continue;
 						sources.push(learned + ' ' + template.id);
 					} else if (learned.charAt(1) === 'D') {
 						// DW moves:


### PR DESCRIPTION
This is so that /learn5 rejects event moves that are only available from events with level >5.

Also, this would crash if template.eventPokemon[learned.substr(2)] doesn't actually exist, which I assume can only happen through inconsistent or malformed data. Is it worth calling the crashlogger in that case? I'm asking because the same is true for line 868 and there's no check there either.