### PR TITLE
Roomfaqs: Remove trailing whitespace in help cmd

### DIFF
--- a/chat-plugins/room-faqs.js
+++ b/chat-plugins/room-faqs.js
@@ -67,8 +67,10 @@ exports.commands = {
 		this.sendReplyBox(roomFaqs[room.id][topic]);
 		if (!this.broadcasting && user.can('declare', null, room)) this.sendReplyBox('<code>/addfaq ' + topic + ', ' + Chat.escapeHTML(roomFaqs[room.id][topic]) + '</code>');
 	},
-	roomfaqhelp: ["/roomfaq - Shows the list of all available FAQ topics",
-			  "/roomfaq <topic> - Shows the FAQ for <topic>.",
-			  "/addfaq <topic>, <text> - Adds an entry for <topic> in this room or updates it. Requires: # & ~",
-			  "/removefaq <topic> - Removes the entry for <topic> in this room. Requires: # & ~"],
+	roomfaqhelp: [
+		"/roomfaq - Shows the list of all available FAQ topics",
+		"/roomfaq <topic> - Shows the FAQ for <topic>.",
+		"/addfaq <topic>, <text> - Adds an entry for <topic> in this room or updates it. Requires: # & ~",
+		"/removefaq <topic> - Removes the entry for <topic> in this room. Requires: # & ~",
+	],
 };


### PR DESCRIPTION
And also indent them like the rest of the multi-line help commands across the repo