### PR TITLE
CONTRIBUTING.md: Make squashing optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Your commit summary should make it clear what part of the code you're talking ab
 - BAD: `Ban Genesect`
 - GOOD: `Monotype: Ban Genesect` (notice the uppercase "B")
 
-Do not make commits to fix commits in your pull request. Just squash/amend them into one commit.
+OPTIONAL: If you make commits to fix commits in your pull request, you can squash/amend them into one commit.
 
 - BAD: `Add /lock`, `Fix crash in /lock`, `Fix another crash in /lock` (if these are the same pullreq, they should be the same commit)
 - GOOD: `Add /lock`


### PR DESCRIPTION
Because squash-merge is a thing now, we probably don't have to enforce this as heavily as we used to.