### PR TITLE
Make duration strings use rounding

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -936,12 +936,19 @@ Chat.toDurationString = function (number, options) {
 	// https://github.com/tc39/ecma402/issues/47
 	const date = new Date(+number);
 	const parts = [date.getUTCFullYear() - 1970, date.getUTCMonth(), date.getUTCDate() - 1, date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds()];
+	const roundingBoundaries = [6, 15, 12, 30, 30];
 	const unitNames = ["second", "minute", "hour", "day", "month", "year"];
 	const positiveIndex = parts.findIndex(elem => elem > 0);
 	const precision = (options && options.precision ? options.precision : parts.length);
 	if (options && options.hhmmss) {
 		let string = parts.slice(positiveIndex).map(value => value < 10 ? "0" + value : "" + value).join(":");
 		return string.length === 2 ? "00:" + string : string;
+	}
+	// round least significant displayed unit
+	if (positiveIndex + precision < parts.length && precision > 0 && positiveIndex >= 0) {
+		if (parts[positiveIndex + precision] >= roundingBoundaries[positiveIndex + precision - 1]) {
+			parts[positiveIndex + precision - 1]++;
+		}
 	}
 	return parts.slice(positiveIndex).reverse().map((value, index) => value ? value + " " + unitNames[index] + (value > 1 ? "s" : "") : "").reverse().slice(0, precision).join(" ").trim();
 };


### PR DESCRIPTION
Currently, it floors everything, so 47 hours turn out as "1 day", which is confusing for everyone. It was also inconsistent with Punishments#checkLockExpiration(), which does regular rounding. Locks showed up as "2 days" and roombans as "1 day" despite roombans lasting longer.