### PR TITLE
Change to /scavengerhelp

### DIFF
--- a/chat-plugins/scavengers.js
+++ b/chat-plugins/scavengers.js
@@ -159,7 +159,7 @@ exports.commands = {
 			'<strong>Player commands:</strong><br />' +
 			'- /scavengers - Join the scavengers room<br />' +
 			'- /joinhunt - Join the current scavenger hunt<br />' +
-			'- /scavenge <em>guess</em> - Attempt to answer the hint<br />' +
+			'- /scavenge _______ - Attempt to answer the hint<br />' +
 			'- /scavengerstatus - Get your current game status<br />' +
 			'<br />' +
 			'<strong>Staff commands:</strong><br />' +


### PR DESCRIPTION
Changed "/scavenge <em>guess</em>" to "/scavenge _______" in the /scavengerhelp command. Especially considering UGM is beginning effective today-ish, helps make the command more clear to new users and get them acclimatized to the room. There has been recurring issue for a long time of new users believing that they need to type "/scavenge guess [their answer]" instead of "/scavenge [their answer]," the latter of which is correct.