### PR TITLE
Whois: Change order of parsing /checkpunishment

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -27,12 +27,12 @@ exports.commands = {
 		if (!room) room = Rooms.global;
 		let targetUser = this.targetUserOrSelf(target, user.group === ' ');
 		let showAll = (cmd === 'ip' || cmd === 'whoare' || cmd === 'alt' || cmd === 'alts');
+		if (showAll && !user.trusted && targetUser !== user) {
+			return this.errorReply(`/${cmd} - Access denied.`);
+		}
 		if (!targetUser) {
 			if (showAll) return this.parse('/checkpunishment ' + target);
 			return this.errorReply("User " + this.targetUsername + " not found.");
-		}
-		if (showAll && !user.trusted && targetUser !== user) {
-			return this.errorReply(`/${cmd} - Access denied.`);
 		}
 
 		let buf = Chat.html`<strong class="username"><small style="display:none">${targetUser.group}</small>${targetUser.name}</strong> `;


### PR DESCRIPTION
You have to be a "trusted" user to use /checkpunishment, so the commands that would parse /checkpunishment should be done after the check of if the user using it is a trusted user or not.