### PR TITLE
Add servertime command

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1037,6 +1037,13 @@ exports.commands = {
 		this.sendReplyBox("Uptime: <b>" + uptimeText + "</b>");
 	},
 
+	'!servertime': true,
+	servertime: function (target, room, user) {
+		if (!this.runBroadcast()) return;
+		let servertime = new Date();
+		this.sendReplyBox(`Server time: <b>${servertime.toLocaleString()}</b>`);
+	},
+
 	'!groups': true,
 	groups: function (target, room, user) {
 		if (!this.runBroadcast()) return;


### PR DESCRIPTION
I made a former pull request with the same name however during code alterartions I made a mistake while rebasing, so here's the code that was in my last commit. Which had the following description: Added servertime chat command that shows the current server time.