### PR TITLE
WiFi Room Giveaway: Fix Alolan Form GIF Display

### DIFF
--- a/chat-plugins/wifi.js
+++ b/chat-plugins/wifi.js
@@ -119,8 +119,8 @@ class Giveaway {
 				}
 				if (value.otherFormes) {
 					for (let i = 0; i < value.otherFormes.length; i++) {
-						// Hardcore alola formes.
-						if (value.otherFormes[i].endsWith('alola')) {
+						// Hardcore Alolan formes.
+						if (value.otherFormes[i].endsWith('alolan')) {
 							if (/alolan?/.test(text)) {
 								spriteid += '-alolan';
 								break;


### PR DESCRIPTION
Changes made to cause proper parsing for Alolan forms, allowing for the
giveaway to render the gif for the target form by using 'Pokemon-Alolan'
as well as 'Pokemon Alolan'

Without the change use of '/lg User, Pokemon-Alolan' and '/lg User, Pokemon Alolan' show:
![prechange](https://cloud.githubusercontent.com/assets/24725521/21446208/234da44e-c891-11e6-99dd-01af9e005808.PNG)

With the change added, gif properly displays.
![postchange](https://cloud.githubusercontent.com/assets/24725521/21446214/41c7ffd2-c891-11e6-8e66-8a2a9a278c5f.PNG)

