### PR TITLE
Z-Powered Focus Punch shouldn't have special Focus Punch behaviour

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -4150,7 +4150,7 @@ class Battle extends Tools.BattleDex {
 		}
 		if (!midTurn) {
 			if (decision.choice === 'move') {
-				if (this.getMove(decision.move).beforeTurnCallback) {
+				if (!decision.zmove && this.getMove(decision.move).beforeTurnCallback) {
 					this.addQueue({choice: 'beforeTurnMove', pokemon: decision.pokemon, move: decision.move, targetLoc: decision.targetLoc});
 				}
 			} else if (decision.choice === 'switch' || decision.choice === 'instaswitch') {


### PR DESCRIPTION
This was mentioned on the bug reports thread somewhere - Focus Punch's effects were applying even when it was actually All-Out Pummelling. Presumably Beak Blast has a similar problem.