### PR TITLE
Update items.js

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -4038,7 +4038,6 @@ exports.BattleItems = {
 	"poweranklet": {
 		id: "poweranklet",
 		name: "Power Anklet",
-		isUnreleased: false,
 		spritenum: 354,
 		fling: {
 			basePower: 70,
@@ -4053,7 +4052,6 @@ exports.BattleItems = {
 	"powerband": {
 		id: "powerband",
 		name: "Power Band",
-		isUnreleased: false,
 		spritenum: 355,
 		fling: {
 			basePower: 70,
@@ -4068,7 +4066,6 @@ exports.BattleItems = {
 	"powerbelt": {
 		id: "powerbelt",
 		name: "Power Belt",
-		isUnreleased: false,
 		spritenum: 356,
 		fling: {
 			basePower: 70,
@@ -4083,7 +4080,6 @@ exports.BattleItems = {
 	"powerbracer": {
 		id: "powerbracer",
 		name: "Power Bracer",
-		isUnreleased: false,
 		spritenum: 357,
 		fling: {
 			basePower: 70,
@@ -4115,7 +4111,6 @@ exports.BattleItems = {
 	"powerlens": {
 		id: "powerlens",
 		name: "Power Lens",
-		isUnreleased: false,
 		spritenum: 359,
 		fling: {
 			basePower: 70,
@@ -4130,7 +4125,6 @@ exports.BattleItems = {
 	"powerweight": {
 		id: "powerweight",
 		name: "Power Weight",
-		isUnreleased: false,
 		spritenum: 360,
 		fling: {
 			basePower: 70,

--- a/data/items.js
+++ b/data/items.js
@@ -4035,6 +4035,66 @@ exports.BattleItems = {
 		gen: 3,
 		desc: "Cannot be eaten by the holder. No effect when eaten with Bug Bite or Pluck.",
 	},
+	"poweranklet": {
+		id: "poweranklet",
+		name: "Power Anklet",
+		isUnreleased: false,
+		spritenum: 354,
+		fling: {
+			basePower: 70,
+		},
+		onModifySpe: function (spe) {
+			return this.chainModify(0.5);
+		},
+		num: 293,
+		gen: 4,
+		desc: "Holder's Speed is halved.",
+	},
+	"powerband": {
+		id: "powerband",
+		name: "Power Band",
+		isUnreleased: false,
+		spritenum: 355,
+		fling: {
+			basePower: 70,
+		},
+		onModifySpe: function (spe) {
+			return this.chainModify(0.5);
+		},
+		num: 292,
+		gen: 4,
+		desc: "Holder's Speed is halved.",
+	},
+	"powerbelt": {
+		id: "powerbelt",
+		name: "Power Belt",
+		isUnreleased: false,
+		spritenum: 356,
+		fling: {
+			basePower: 70,
+		},
+		onModifySpe: function (spe) {
+			return this.chainModify(0.5);
+		},
+		num: 290,
+		gen: 4,
+		desc: "Holder's Speed is halved.",
+	},
+	"powerbracer": {
+		id: "powerbracer",
+		name: "Power Bracer",
+		isUnreleased: false,
+		spritenum: 357,
+		fling: {
+			basePower: 70,
+		},
+		onModifySpe: function (spe) {
+			return this.chainModify(0.5);
+		},
+		num: 289,
+		gen: 4,
+		desc: "Holder's Speed is halved.",
+	},
 	"powerherb": {
 		id: "powerherb",
 		onChargeMove: function (pokemon, target, move) {
@@ -4051,6 +4111,36 @@ exports.BattleItems = {
 		num: 271,
 		gen: 4,
 		desc: "Holder's two-turn moves complete in one turn (except Sky Drop). Single use.",
+	},
+	"powerlens": {
+		id: "powerlens",
+		name: "Power Lens",
+		isUnreleased: false,
+		spritenum: 359,
+		fling: {
+			basePower: 70,
+		},
+		onModifySpe: function (spe) {
+			return this.chainModify(0.5);
+		},
+		num: 291,
+		gen: 4,
+		desc: "Holder's Speed is halved.",
+	},
+	"powerweight": {
+		id: "powerweight",
+		name: "Power Weight",
+		isUnreleased: false,
+		spritenum: 360,
+		fling: {
+			basePower: 70,
+		},
+		onModifySpe: function (spe) {
+			return this.chainModify(0.5);
+		},
+		num: 294,
+		gen: 4,
+		desc: "Holder's Speed is halved.",
 	},
 	"premierball": {
 		id: "premierball",

--- a/data/items.js
+++ b/data/items.js
@@ -3058,6 +3058,7 @@ exports.BattleItems = {
 		name: "Macho Brace",
 		isUnreleased: true,
 		spritenum: 269,
+		ignoreKlutz: true,
 		fling: {
 			basePower: 60,
 		},
@@ -3066,7 +3067,7 @@ exports.BattleItems = {
 		},
 		num: 215,
 		gen: 3,
-		desc: "Holder's Speed is halved.",
+		desc: "Holder's Speed is halved. The Ability Klutz does not ignore this effect.",
 	},
 	"magnet": {
 		id: "magnet",
@@ -4039,6 +4040,7 @@ exports.BattleItems = {
 		id: "poweranklet",
 		name: "Power Anklet",
 		spritenum: 354,
+		ignoreKlutz: true,
 		fling: {
 			basePower: 70,
 		},
@@ -4047,12 +4049,13 @@ exports.BattleItems = {
 		},
 		num: 293,
 		gen: 4,
-		desc: "Holder's Speed is halved.",
+		desc: "Holder's Speed is halved. The Ability Klutz does not ignore this effect.",
 	},
 	"powerband": {
 		id: "powerband",
 		name: "Power Band",
 		spritenum: 355,
+		ignoreKlutz: true,
 		fling: {
 			basePower: 70,
 		},
@@ -4061,12 +4064,13 @@ exports.BattleItems = {
 		},
 		num: 292,
 		gen: 4,
-		desc: "Holder's Speed is halved.",
+		desc: "Holder's Speed is halved. The Ability Klutz does not ignore this effect.",
 	},
 	"powerbelt": {
 		id: "powerbelt",
 		name: "Power Belt",
 		spritenum: 356,
+		ignoreKlutz: true,
 		fling: {
 			basePower: 70,
 		},
@@ -4075,12 +4079,13 @@ exports.BattleItems = {
 		},
 		num: 290,
 		gen: 4,
-		desc: "Holder's Speed is halved.",
+		desc: "Holder's Speed is halved. The Ability Klutz does not ignore this effect.",
 	},
 	"powerbracer": {
 		id: "powerbracer",
 		name: "Power Bracer",
 		spritenum: 357,
+		ignoreKlutz: true,
 		fling: {
 			basePower: 70,
 		},
@@ -4089,7 +4094,7 @@ exports.BattleItems = {
 		},
 		num: 289,
 		gen: 4,
-		desc: "Holder's Speed is halved.",
+		desc: "Holder's Speed is halved. The Ability Klutz does not ignore this effect.",
 	},
 	"powerherb": {
 		id: "powerherb",
@@ -4112,6 +4117,7 @@ exports.BattleItems = {
 		id: "powerlens",
 		name: "Power Lens",
 		spritenum: 359,
+		ignoreKlutz: true,
 		fling: {
 			basePower: 70,
 		},
@@ -4120,12 +4126,13 @@ exports.BattleItems = {
 		},
 		num: 291,
 		gen: 4,
-		desc: "Holder's Speed is halved.",
+		desc: "Holder's Speed is halved. The Ability Klutz does not ignore this effect.",
 	},
 	"powerweight": {
 		id: "powerweight",
 		name: "Power Weight",
 		spritenum: 360,
+		ignoreKlutz: true,
 		fling: {
 			basePower: 70,
 		},
@@ -4134,7 +4141,7 @@ exports.BattleItems = {
 		},
 		num: 294,
 		gen: 4,
-		desc: "Holder's Speed is halved.",
+		desc: "Holder's Speed is halved. The Ability Klutz does not ignore this effect.",
 	},
 	"premierball": {
 		id: "premierball",


### PR DESCRIPTION
Added speed-lowering items for use in VGC Trick Room. Power Anklet, Power Band, Power Belt, Power Bracer, Power Lens, and Power Weight are all clone items of Macho Brace, but have competitive use on Trick Room teams in metagames with Item Clause, like VGC.