### PR TITLE
Update embargo's short move description

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4315,7 +4315,7 @@ exports.BattleMovedex = {
 		basePower: 0,
 		category: "Status",
 		desc: "For 5 turns, the target's held item has no effect. An item's effect of causing forme changes is unaffected, but any other effects from such items are negated. During the effect, Fling and Natural Gift are prevented from being used by the target. Items thrown at the target with Fling will still activate for it. If the target uses Baton Pass, the replacement will remain unable to use items.",
-		shortDesc: "For 5 turns, the target can't use any items.",
+		shortDesc: "For 5 turns, the target's item has no effect.",
 		id: "embargo",
 		name: "Embargo",
 		pp: 15,


### PR DESCRIPTION
It was unclear what it meant by "the target cannot use items for 5 turns". I thought it meant items like berries had no effect for 5 turns. I felt the need to clarify, so I thought we should change it to: "For 5 turns, the target's item has no effect."