### PR TITLE
Random Battle: Fix Various Issues with Ubers

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2337,7 +2337,7 @@ exports.BattleScripts = {
 
 			let tier = template.tier;
 			switch (tier) {
-			case 'Uber':
+			case 'Uber': case 'Bank-Uber':
 				// Ubers are limited to 2 but have a 20% chance of being added anyway.
 				if (uberCount > 1 && this.random(5) >= 1) continue;
 				break;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2226,6 +2226,9 @@ exports.BattleScripts = {
 			Unown: 100,
 		};
 		let tier = template.tier;
+		if (tier.includes('Unreleased') && template.battleOnly) {
+			tier = baseTemplate.tier;
+		}
 		if (tier.charAt(0) === '(') {
 			tier = tier.slice(1, -1);
 		}


### PR DESCRIPTION
Fix Mega Mewtwo levels.

Fix limits on the number of Ubers per team.