### PR TITLE
Properly animate Spectral Thief

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -375,6 +375,7 @@ exports.BattleScripts = {
 				}
 			}
 			if (stolen) {
+				this.attrLastMove('[still]');
 				this.add('-clearpositiveboost', target, pokemon, 'move: ' + move.name);
 				this.boost(boosts, pokemon);
 
@@ -382,6 +383,7 @@ exports.BattleScripts = {
 					boosts[statName] = 0;
 				}
 				target.setBoost(boosts);
+				this.add('-anim', pokemon, "Spectral Thief", target);
 			}
 		}
 


### PR DESCRIPTION
In case of boosts, the attacking animation would play 1st, stealing the
boosts last, instead of the other way around.
This approach was chosen since Spectral Thief is the only move that
steals boosts this way, for now