### PR TITLE
Wide Guard shouldn't block Status Spread Moves

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -18481,7 +18481,7 @@ exports.BattleMovedex = {
 			onTryHitPriority: 4,
 			onTryHit: function (target, source, effect) {
 				// Wide Guard blocks all spread moves
-				if (effect && effect.target !== 'allAdjacent' && effect.target !== 'allAdjacentFoes') {
+				if ((effect && effect.target !== 'allAdjacent' && effect.target !== 'allAdjacentFoes') || effect.category === "Status") {
 					return;
 				}
 				this.add('-activate', target, 'move: Wide Guard');


### PR DESCRIPTION
https://hastebin.com/raw/heceqemawe
According to this, Wide Guard isn't supposed to block Status Spread moves like String Shot, Dark Void etc. 