### PR TITLE
Added room banned name phrases

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -315,6 +315,9 @@ class CommandContext {
 		if (room.filterCaps && user.name.match(/[A-Z\s]{6,}/)) {
 			return this.errorReply(`Your username contains too many capital letters, which this room doesn't allow.`);
 		}
+		if (this.checkBanwords(room, user.name)) {
+			return this.errorReply(`Your username contains a phrase banned by this room.`);
+		}
 		// Removes extra spaces and null characters
 		message = message.trim().replace(/[ \u0000\u200B-\u200F]+/g, ' ');
 


### PR DESCRIPTION
Added /addbannameword and /deletebannameword commands, which allow ROs to add phrases (e..g 'harambe') to the rooms list of banned name phrases. Users that have that phrase in their name (e.g. HarambeTheGreat, hiharambe, etc.) will not be able to join the room. Also prevents users from changing their nickname in a room, if their new name would contain such a phrase (e.g. changing from CheeseMuffin to harambeeeee).