### PR TITLE
Trivia: mitigate game end/question timeout race condition

### DIFF
--- a/test/chat-plugins/trivia.js
+++ b/test/chat-plugins/trivia.js
@@ -178,6 +178,11 @@ describe('Trivia', function () {
 		assert.strictEqual(this.game.verifyAnswer('not the right answer'), false);
 	});
 
+	it('should not throw when attempting to broadcast after the game has ended', function () {
+		this.game.destroy();
+		assert.doesNotThrow(() => this.game.broadcast('ayy', 'lmao'));
+	});
+
 	context('first mode', function () {
 		beforeEach(function () {
 			let questions = [{question: '', answers: ['answer'], category: 'ae'}];


### PR DESCRIPTION
This isn't very easy to reproduce, so I can't properly test any fixes yet.
Trivia#broadcast writes to debug monitor rather than throwing if called after
the game instance destroys itself.