### PR TITLE
Only switch to Ash Greninja if we're not already using a custom template

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -196,6 +196,9 @@ class Validator {
 
 		if (!template) {
 			template = tools.getTemplate(set.species);
+			if (ability.id === 'battlebond' && template.id === 'greninja') {
+				template = tools.getTemplate('greninjaash');
+			}
 		}
 		if (!template.exists) {
 			return [`The Pokemon "${set.species}" does not exist.`];
@@ -292,9 +295,6 @@ class Validator {
 		}
 		if (set.moves && Array.isArray(set.moves)) {
 			set.moves = set.moves.filter(val => val);
-		}
-		if (ability.id === 'battlebond' && template.id === 'greninja') {
-			template = tools.getTemplate('greninjaash');
 		}
 		if (!set.moves || !set.moves.length) {
 			problems.push(`${name} has no moves.`);


### PR DESCRIPTION
When validating against a custom template based on Ash Greninja with added moves, the code was switching back to a stock Ash Greninja. (Note that the OMs with custom validation will still need work to get this right, but this at least makes it possible.)