### PR TITLE
Random Battle: Prevent generating teams with too many Uber Pokemon

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2455,8 +2455,8 @@ exports.BattleScripts = {
 				typeComboCount[typeCombo] = 1;
 			}
 
-			// Increment Uber/NU counters
-			if (tier === 'Uber') {
+			// Increment Uber/Bank-Uber/PU counters
+			if (tier === 'Uber' || tier === 'Bank-Uber') {
 				uberCount++;
 			} else if (tier === 'PU') {
 				puCount++;


### PR DESCRIPTION
At the moment, it doesn't properly account for Bank-Uber tiered Pokemon, resulting in matches like this : http://replay.pokemonshowdown.com/gen7randombattle-515699799
Also updated the comments to match the changes.