### PR TITLE
Tests: clear all users created during rooms.js tests

### DIFF
--- a/test/application/rooms.js
+++ b/test/application/rooms.js
@@ -29,6 +29,10 @@ describe('Rooms features', function () {
 		let room;
 		afterEach(function () {
 			if (room) room.expire();
+			Users.users.forEach(user => {
+				user.disconnectAll();
+				user.destroy();
+			});
 		});
 
 		it('should allow two users to join the battle', function () {
@@ -83,11 +87,6 @@ describe('Rooms features', function () {
 			assert.strictEqual(room.getAuth(roomStaff), '%', 'after promotion attempt');
 			Chat.parse("/roomvoice Room auth", room, administrator, administrator.connections[0]);
 			assert.strictEqual(room.getAuth(roomStaff), '+', 'after being promoted by an administrator');
-
-			for (const user of [roomStaff, administrator]) {
-				user.disconnectAll();
-				user.destroy();
-			}
 		});
 	});
 });


### PR DESCRIPTION
This left behind 7 users in Users.users before.