### PR TITLE
Balanced Hackmons: Ban CFZs

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -311,12 +311,12 @@ exports.Formats = [
 			let problems = this.validateSet(set, teamHas) || [];
 			set.moves.forEach(move => {
 				if(this.tools.data.Movedex[toId(move)].isZ) {
-					problems.push(set.name + " has a Crystal Free Z-Move, which is banned by Balanced Hackmons.");
+					problems.push((set.name || set.species) + " has a Crystal Free Z-Move, which is banned by Balanced Hackmons.");
 				}
 			});
 			return problems;
 		},
-	},
+},
 	{
 		name: "[Gen 7] 1v1",
 		desc: [

--- a/config/formats.js
+++ b/config/formats.js
@@ -310,13 +310,13 @@ exports.Formats = [
 		validateSet: function (set, teamHas) {
 			let problems = this.validateSet(set, teamHas) || [];
 			set.moves.forEach(move => {
-				if(this.tools.data.Movedex[toId(move)].isZ) {
+				if (this.tools.data.Movedex[toId(move)].isZ) {
 					problems.push((set.name || set.species) + " has a Crystal Free Z-Move, which is banned by Balanced Hackmons.");
 				}
 			});
 			return problems;
 		},
-},
+	},
 	{
 		name: "[Gen 7] 1v1",
 		desc: [

--- a/config/formats.js
+++ b/config/formats.js
@@ -307,6 +307,15 @@ exports.Formats = [
 		mod: 'gen7',
 		ruleset: ['Pokemon', 'Ability Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'Team Preview', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Arena Trap', 'Huge Power', 'Moody', 'Parental Bond', 'Protean', 'Pure Power', 'Shadow Tag', 'Wonder Guard', 'Chatter', 'Extreme Evoboost'],
+		validateSet: function (set, teamHas) {
+			let problems = this.validateSet(set, teamHas) || [];
+			set.moves.forEach(move => {
+				if(this.tools.data.Movedex[toId(move)].isZ) {
+					problems.push(set.name + " has a Crystal Free Z-Move, which is banned by Balanced Hackmons.");
+				}
+			});
+			return problems;
+		},
 	},
 	{
 		name: "[Gen 7] 1v1",


### PR DESCRIPTION
Well, There are two alternatives to this:
- Modify the Team Validator so that CFZs can be conveniently added to the banlist table, even for other formats
- Add all the names of the Z-moves to the banlist table

I thought this would be the best, please correct me wherever I am wrong
@TheImmortal 