### PR TITLE
Fix interaction between Burn Up, Powder and Primordial Sea

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -1997,8 +1997,10 @@ exports.BattleMovedex = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, defrost: 1},
-		onTryHit: function (target, source, move) {
-			if (!source.hasType("Fire")) return false;
+		onTryMove: function (pokemon, target, move) {
+			if (pokemon.hasType('Fire')) return;
+			this.add('-fail', pokemon, 'move: Burn Up');
+			return null;
 		},
 		self: {
 			onHit: function (pokemon) {
@@ -3055,7 +3057,7 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
 		status: 'slp',
-		onTry: function (pokemon, target, move) {
+		onTryMove: function (pokemon, target, move) {
 			if (pokemon.template.species === 'Darkrai' || move.hasBounced) {
 				return;
 			}
@@ -11889,6 +11891,7 @@ exports.BattleMovedex = {
 			onStart: function (target) {
 				this.add('-singleturn', target, 'Powder');
 			},
+			onTryMovePriority: -1,
 			onTryMove: function (pokemon, target, move) {
 				if (move.type === 'Fire') {
 					this.add('-activate', pokemon, 'move: Powder');

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -171,6 +171,10 @@ exports.BattleScripts = {
 			}
 		}
 
+		if (!this.singleEvent('TryMove', move, null, pokemon, target, move)) {
+			return true;
+		}
+
 		if (!this.runEvent('TryMove', pokemon, target, move)) {
 			return true;
 		}

--- a/mods/gen6/moves.js
+++ b/mods/gen6/moves.js
@@ -14,7 +14,7 @@ exports.BattleMovedex = {
 	darkvoid: {
 		inherit: true,
 		accuracy: 80,
-		onTry: function () {},
+		onTryMove: function () {},
 	},
 	destinybond: {
 		inherit: true,
@@ -154,6 +154,23 @@ exports.BattleMovedex = {
 	rockblast: {
 		inherit: true,
 		flags: {protect: 1, mirror: 1},
+	},
+	powder: {
+		inherit: true,
+		effect: {
+			duration: 1,
+			onStart: function (target) {
+				this.add('-singleturn', target, 'Powder');
+			},
+			onTryMovePriority: 1,
+			onTryMove: function (pokemon, target, move) {
+				if (move.type === 'Fire') {
+					this.add('-activate', pokemon, 'move: Powder');
+					this.damage(this.clampIntRange(Math.round(pokemon.maxhp / 4), 1));
+					return false;
+				}
+			},
+		},
 	},
 	sheercold: {
 		inherit: true,


### PR DESCRIPTION
- Powder should not activate if Burn Up fails due to being the wrong type
- Powder should activate before Primordial Sea (according to a forum post I read somewhere)

While I was there I made Dark Void only fail once instead of once per hit (affects Doubles battles).