### PR TITLE
Fix Queenly Majesty and Dazzling

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -587,7 +587,7 @@ exports.BattleAbilities = {
 		desc: "While this Pokemon is active, priority moves from opposing Pokemon targeted at allies are prevented from having an effect.",
 		shortDesc: "While this Pokemon is active, allies are protected from opposing priority moves.",
 		onFoeTryMove: function (target, source, effect) {
-			if (source.side === this.effectData.target.side && effect.priority > 0.1 && effect.target !== 'self') {
+			if (source.side === this.effectData.target.side && effect.priority > 0.1 && effect.target !== 'self' && effect.target !== 'foeSide') {
 				this.attrLastMove('[still]');
 				this.add('cant', this.effectData.target, 'ability: Dazzling', effect, '[of] ' + target);
 				return false;
@@ -2563,7 +2563,7 @@ exports.BattleAbilities = {
 		desc: "While this Pokemon is active, priority moves from opposing Pokemon targeted at allies are prevented from having an effect.",
 		shortDesc: "While this Pokemon is active, allies are protected from opposing priority moves.",
 		onFoeTryMove: function (target, source, effect) {
-			if (source.side === this.effectData.target.side && effect.priority > 0.1 && effect.target !== 'self') {
+			if (source.side === this.effectData.target.side && effect.priority > 0.1 && effect.target !== 'self' && effect.target !== 'foeSide') {
 				this.attrLastMove('[still]');
 				this.add('cant', this.effectData.target, 'ability: Queenly Majesty', effect, '[of] ' + target);
 				return false;


### PR DESCRIPTION
According to ih8ih8sn0w, who is a badged researcher on Smogon, Queenly Majesty and Dazzling are not supposed to block priority moves whose targets are `'foeSide'`.