### PR TITLE
Reflected moves shouldnt be boosted by Prankster

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1759,6 +1759,7 @@ exports.BattleAbilities = {
 			}
 			let newMove = this.getMoveCopy(move.id);
 			newMove.hasBounced = true;
+			newMove.pranksterBoosted = false;
 			this.useMove(newMove, target, source);
 			return null;
 		},
@@ -1768,6 +1769,7 @@ exports.BattleAbilities = {
 			}
 			let newMove = this.getMoveCopy(move.id);
 			newMove.hasBounced = true;
+			newMove.pranksterBoosted = false;
 			this.useMove(newMove, this.effectData.target, source);
 			return null;
 		},

--- a/data/moves.js
+++ b/data/moves.js
@@ -9553,6 +9553,7 @@ exports.BattleMovedex = {
 				}
 				let newMove = this.getMoveCopy(move.id);
 				newMove.hasBounced = true;
+				newMove.pranksterBoosted = false;
 				this.useMove(newMove, target, source);
 				return null;
 			},
@@ -9562,6 +9563,7 @@ exports.BattleMovedex = {
 				}
 				let newMove = this.getMoveCopy(move.id);
 				newMove.hasBounced = true;
+				newMove.pranksterBoosted = false;
 				this.useMove(newMove, this.effectData.target, source);
 				return null;
 			},


### PR DESCRIPTION
Bug in action: [Replay - Turn 4](http://replay.pokemonshowdown.com/gen7pokebankou-523522946)

Proof that is really a bug: [Other Mechanics - Bullet point 15](http://www.smogon.com/forums/threads/pokemon-sun-moon-battle-mechanics-research.3586701/)

Dark-type Pokemon are now immune to moves affected by Prankster that target them. (yeah wtf?) (UltiMario) This immunity does not extend to ally Dark-type Pokemon. (OmegaDonut) Prankster Spikes, hazards, weather moves, and Trick Room are not blocked (raikoo)but Prankster Defog is. (UltiMario) **Dark-type Pokemon with Prankster will be affected by status moves bounced back with Magic Bounce/Coat. This is the case even if the Magic Bounce/Coat user is Dark-type.** (UltiMario) Prankster Assists is blocked by Dark-types even if it calls an attacking move. (raikoo) If a Dark-type uses a status move into a Pokemon with Prankster using Magic Coat, the Dark-type Pokemon will be unaffected by the reflected move. (UltiMario) Video evidence: (raikoo)

Edit: markdown fail