### PR TITLE
Changed Vullaby, Pawniard, and Ferroseed tiers

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -4807,7 +4807,7 @@ exports.BattleFormatsData = {
 	},
 	ferroseed: {
 		randomBattleMoves: ["spikes", "stealthrock", "leechseed", "seedbomb", "protect", "thunderwave", "gyroball"],
-		tier: "New",
+		tier: "LC",
 	},
 	ferrothorn: {
 		randomBattleMoves: ["spikes", "stealthrock", "leechseed", "powerwhip", "thunderwave", "protect", "knockoff", "gyroball"],
@@ -4952,7 +4952,7 @@ exports.BattleFormatsData = {
 	},
 	pawniard: {
 		randomBattleMoves: ["swordsdance", "substitute", "suckerpunch", "ironhead", "brickbreak", "knockoff"],
-		tier: "New",
+		tier: "LC",
 	},
 	bisharp: {
 		randomBattleMoves: ["swordsdance", "substitute", "suckerpunch", "ironhead", "brickbreak", "knockoff"],
@@ -4981,7 +4981,7 @@ exports.BattleFormatsData = {
 	},
 	vullaby: {
 		randomBattleMoves: ["knockoff", "roost", "taunt", "whirlwind", "toxic", "defog", "uturn", "bravebird"],
-		tier: "New",
+		tier: "LC",
 	},
 	mandibuzz: {
 		randomBattleMoves: ["foulplay", "knockoff", "roost", "taunt", "whirlwind", "toxic", "uturn", "bravebird", "defog"],


### PR DESCRIPTION
Vullaby, Pawniard, and Ferroseed were listed as "new" which made them show up as Banned in the teambuilder for LC. If you want to add the "new" tag back in addition to LC that's fine, but this at least is a good fix atm that won't confuse people.