### PR TITLE
Accurate Oricorio's and Lycanroc's aliases

### DIFF
--- a/data/aliases.js
+++ b/data/aliases.js
@@ -238,7 +238,13 @@ exports.BattleAliases = {
 	"lycanrocmidday": "Lycanroc",
 	"lycanrocday": "Lycanroc",
 	"lycanrocnight": "Lycanroc-Midnight",
-
+        "oricoriog": "Oricorio-Sensu",
+        "oricorioe": "Oricorio-Pom-Pom",
+        "oricoriop": "Oricorio-Pa'u",
+        "oricoriof": "Oricorio",
+        "lycanrocd": "Lycanroc",
+        "lycanrocn": "Lycanroc-Midnight",
+  
 	// base formes
 	"nidoranfemale": "Nidoran-F",
 	"nidoranmale": "Nidoran-M",


### PR DESCRIPTION
Oricorio's formes are by their types - it's used like that at C&C on Smogon. There's precedent because "Wormadam-G = Wormadam-Sandy" and "Wormadam-S = Wormadam-Trash" (both being Ground-type and Steel-type, respectively). Lycanroc-D and Lycanroc-N also are the official aliases used there.