### PR TITLE
Accurate Oricorio's and Lycanroc's aliases.

### DIFF
--- a/data/aliases.js
+++ b/data/aliases.js
@@ -238,6 +238,12 @@ exports.BattleAliases = {
 	"lycanrocmidday": "Lycanroc",
 	"lycanrocday": "Lycanroc",
 	"lycanrocnight": "Lycanroc-Midnight",
+	"oricorioe": "Oricorio-Pom-Pom",
+	"oricoriog": "Oricorio-Sensu",
+	"oricoriof": "Oricorio",
+	"oricoriop": "Oricorio-Pa'u",
+	"lycanrocd": "Lycanroc",
+	"lycanrocn": "Lycanroc-Midnight",
 
 	// base formes
 	"nidoranfemale": "Nidoran-F",


### PR DESCRIPTION
Oricorio's formes are by their types - it's used like that at C&C on Smogon. There's precedent because "Wormadam-G = Wormadam-Sandy" and "Wormadam-S = Wormadam-Trash" (both being Ground-type and Steel-type, respectively). Lycanroc-D and Lycanroc-N also are the official aliases used there. (closed the older; this is probably OK.)