### PR TITLE
Random Battle: Remove Rock Climb from Lycanroc-Midnight

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -5851,7 +5851,7 @@ exports.BattleFormatsData = {
 		tier: "New",
 	},
 	lycanrocmidnight: {
-		randomBattleMoves: ["bulkup", "stoneedge", "stealthrock", "suckerpunch", "swordsdance", "firefang", "rockclimb"],
+		randomBattleMoves: ["bulkup", "stoneedge", "stealthrock", "suckerpunch", "swordsdance", "firefang"],
 		tier: "New",
 	},
 	wishiwashi: {


### PR DESCRIPTION
It's a relatively weak move with no coverage and the measly 20% confusion isn't worth it at all.