### PR TITLE
Refactor fainting from sacrificial moves

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4584,7 +4584,7 @@ exports.BattleMovedex = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		selfdestruct: true,
+		selfdestruct: "always",
 		secondary: false,
 		target: "allAdjacent",
 		type: "Normal",
@@ -4916,9 +4916,7 @@ exports.BattleMovedex = {
 		accuracy: 100,
 		basePower: 0,
 		damageCallback: function (pokemon) {
-			let damage = pokemon.hp;
-			pokemon.faint();
-			return damage;
+			return pokemon.hp;
 		},
 		category: "Special",
 		desc: "Deals damage to the target equal to the user's current HP. If this move is successful, the user faints.",
@@ -4929,7 +4927,7 @@ exports.BattleMovedex = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1},
-		selfdestruct: true,
+		selfdestruct: "ifHit",
 		secondary: false,
 		target: "normal",
 		type: "Fighting",
@@ -7224,7 +7222,7 @@ exports.BattleMovedex = {
 				return false;
 			}
 		},
-		selfdestruct: true,
+		selfdestruct: "ifHit",
 		sideCondition: 'healingwish',
 		effect: {
 			duration: 2,
@@ -9422,7 +9420,7 @@ exports.BattleMovedex = {
 				return false;
 			}
 		},
-		selfdestruct: true,
+		selfdestruct: "ifHit",
 		sideCondition: 'lunardance',
 		effect: {
 			duration: 2,
@@ -10021,7 +10019,7 @@ exports.BattleMovedex = {
 			atk: -2,
 			spa: -2,
 		},
-		selfdestruct: true,
+		selfdestruct: "ifHit",
 		secondary: false,
 		target: "normal",
 		type: "Dark",
@@ -14130,7 +14128,7 @@ exports.BattleMovedex = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		selfdestruct: true,
+		selfdestruct: "always",
 		secondary: false,
 		target: "allAdjacent",
 		type: "Normal",


### PR DESCRIPTION
Sacrificial moves behave differently in terms of whether the user faints when the move fails, further complicated by the requirement that the user always faint first in case of damage-dealing moves. The current implementation of these behavior is confusing and prone to errors. 
- Moves that always cause the user to faint once the move is initiated (Explosion, Selfdestruct) are determined by checking targets, because they happen to be both spread moves. Therefore, spread sacrificial moves always behave this way, while single-target ones always behave like all other existing sacrificial moves. Move data has no control over this behavior. Furthermore, when a sacrificial, single-target damaging move fails due to lack of target, the battle crashes.
- Final Gambit fainting is hard-coded in `DamageCallback`, avoiding crashes, but it is very poor practice and does not make use of the `selfdestruct` flag at all.
- There are multiple redundant checks for the `selfdestruct` flag, or the user fainting in general, in `useMove()` and `tryMoveHit()`.

By specifying the different fainting behavior in the `selfdestruct` flag (`always` or `ifHit`), the three problems outlined above could be remedied. This should increase performance somewhat, and enable the battle engine to accommodate sacrificial moves with different behavior, e.g. in an OM or a future generation.