### PR TITLE
Handle forced autojoin of lobby on side servers

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1308,10 +1308,10 @@ exports.commands = {
 
 	'!autojoin': true,
 	autojoin: function (target, room, user, connection) {
-		Rooms.global.autojoinRooms(user, connection);
 		let targets = target.split(',');
-		let autojoins = [];
 		if (targets.length > 11 || connection.inRooms.size > 1) return;
+		Rooms.global.autojoinRooms(user, connection);
+		let autojoins = [];
 		for (let i = 0; i < targets.length; i++) {
 			if (user.tryJoinRoom(targets[i], connection) === null) {
 				autojoins.push(targets[i]);


### PR DESCRIPTION
Autojoin for side servers is failing because the user is in 2 rooms when the server gets its autojoin request `global` and `lobby`. I tried resolving this client side but could not get it to send the autojoin before adding the room lobby (also not sure if having lobby at the end of the room list is desirable). This is probably not enough because it dosen't restrict it to just global when on main, but i'm not sure how to check if the server is main from the server side. I opened this as-is so Zarel could take a look considering hes usually in PS dev room after I leave at night during the week.