### PR TITLE
ModifyPriority should run on the Z move if relevant

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -4174,15 +4174,15 @@ class Battle extends Tools.BattleDex {
 
 			decision.move = this.getMoveCopy(decision.move);
 			if (!decision.priority && !deferPriority) {
-				let priority = decision.move.priority;
+				let move = decision.move;
 				if (decision.zmove) {
 					let zMoveName = this.getZMove(decision.move, decision.pokemon, true);
 					let zMove = this.getMove(zMoveName);
 					if (zMove.exists) {
-						priority = zMove.priority;
+						move = zMove;
 					}
 				}
-				priority = this.runEvent('ModifyPriority', decision.pokemon, target, decision.move, priority);
+				let priority = this.runEvent('ModifyPriority', decision.pokemon, target, move, move.priority);
 				decision.priority = priority;
 				// In Gen 6, Quick Guard blocks moves with artificially enhanced priority.
 				if (this.gen > 5) decision.move.priority = priority;


### PR DESCRIPTION
As reported here: http://www.smogon.com/forums/posts/7219391

Gale Wings Supersonic Skystrike still works of course, but this stops Z-moves from being affected by Triage if they were based on a draining move.