### PR TITLE
Random Doubles: Fix Level Scaling for Parental Bond and Protean

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -3259,10 +3259,10 @@ exports.BattleScripts = {
 		if (templateAbility === 'Huge Power' || templateAbility === 'Pure Power') {
 			bst += template.baseStats.atk;
 		} else if (templateAbility === 'Parental Bond') {
-			bst += 0.5 * (evs.atk > evs.spa ? template.baseStats.atk : template.baseStats.spa);
+			bst += 0.5 * (counter.Physical > counter.Special ? template.baseStats.atk : template.baseStats.spa);
 		} else if (templateAbility === 'Protean') {
 			// Holistic judgment. Don't boost Protean as much as Parental Bond
-			bst += 0.3 * (evs.atk > evs.spa ? template.baseStats.atk : template.baseStats.spa);
+			bst += 0.3 * (counter.Physical > counter.Special ? template.baseStats.atk : template.baseStats.spa);
 		} else if (templateAbility === 'Fur Coat') {
 			bst += template.baseStats.def;
 		}


### PR DESCRIPTION
EV values are balanced now, so it's better to base it on the number of
attacks.