### PR TITLE
Adds .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /config/*
+!/config/formats.js
 /logs/*
 /node_modules
 /eslint-cache


### PR DESCRIPTION
I doubt this adds much value to anyone but myself but the omission of certain files (such as config/) is a pain to deal with if using showdown as an NPM dependency.

https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package