### PR TITLE
Gen 1: Three minor bug fixes

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -764,7 +764,7 @@ exports.BattleMovedex = {
 		effect: {
 			onStart: function (target) {
 				this.add('-start', target, 'Substitute');
-				this.effectData.hp = Math.floor(target.maxhp / 4);
+				this.effectData.hp = Math.floor(target.maxhp / 4) + 1;
 				delete target.volatiles['partiallytrapped'];
 			},
 			onTryHitPriority: -1,

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -214,7 +214,7 @@ exports.BattleScripts = {
 		// Store 0 damage for last damage if move failed or dealt 0 damage.
 		// This only happens on moves that don't deal damage but call GetDamageVarsForPlayerAttack (disassembly).
 		if (!damage && (move.category !== 'Status' || (move.category === 'Status' && !(move.status in {'psn':1, 'tox':1, 'par':1}))) &&
-		!(move.id in {'conversion':1, 'haze':1, 'mist':1, 'focusenergy':1, 'confuseray':1, 'transform':1, 'lightscreen':1, 'reflect':1, 'substitute':1, 'mimic':1, 'leechseed':1, 'splash':1, 'softboiled':1, 'recover':1, 'rest':1})) {
+		!(move.id in {'conversion':1, 'haze':1, 'mist':1, 'focusenergy':1, 'confuseray':1, 'supersonic':1, 'transform':1, 'lightscreen':1, 'reflect':1, 'substitute':1, 'mimic':1, 'leechseed':1, 'splash':1, 'softboiled':1, 'recover':1, 'rest':1})) {
 			pokemon.battle.lastDamage = 0;
 		}
 

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -488,7 +488,14 @@ exports.BattleScripts = {
 			if (moveData.status) {
 				// Gen 1 bug: If the target has just used hyperbeam and must recharge, its status will be ignored and put to sleep.
 				// This does NOT revert the paralyse speed drop or the burn attack drop.
-				if (!target.status || moveData.status === 'slp' && target.volatiles['mustrecharge']) {
+				// Also, being put to sleep clears the recharge condition.
+				if (moveData.status == 'slp' && target.volatiles['mustrecharge']) {
+					// The sleep move is guaranteed to hit in this situation, unless Sleep Clause activates.
+					// Do not clear recharge in that case.
+					if (target.setStatus(moveData.status, pokemon, move)) {
+						target.removeVolatile('mustrecharge');
+					}
+				} else if (!target.status) {
 					if (target.setStatus(moveData.status, pokemon, move)) {
 						// Gen 1 mechanics: The burn attack drop and the paralyse speed drop are applied here directly on stat modifiers.
 						if (moveData.status === 'brn') target.modifyStat('atk', 0.5);

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -489,7 +489,7 @@ exports.BattleScripts = {
 				// Gen 1 bug: If the target has just used hyperbeam and must recharge, its status will be ignored and put to sleep.
 				// This does NOT revert the paralyse speed drop or the burn attack drop.
 				// Also, being put to sleep clears the recharge condition.
-				if (moveData.status == 'slp' && target.volatiles['mustrecharge']) {
+				if (moveData.status === 'slp' && target.volatiles['mustrecharge']) {
 					// The sleep move is guaranteed to hit in this situation, unless Sleep Clause activates.
 					// Do not clear recharge in that case.
 					if (target.setStatus(moveData.status, pokemon, move)) {


### PR DESCRIPTION
Another Gen 1 issue that I know of but I don't know how to fix right away is that Counter should be able to bounce back damage dealt to a Substitute. Right now, Counter is failing in these cases in PS.

A less important issue is the interaction between Substitute and partial-trapping moves. In particular, if the first of these moves breaks a Substitute, the damage of the following attacks should not be the damage dealt to knock out the Substitute, but the damage that the attack would've dealt had the target not had a Substitute up. This anomaly in the damage also applies to the interaction between Substitute and Counter.

Pointing those out in case someone wants to look into them.