### PR TITLE
Fix terrain seed activation

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2254,6 +2254,7 @@ class Battle extends Tools.BattleDex {
 			this.terrainData = prevTerrainData;
 			return false;
 		}
+		this.runEvent('SetTerrain', source);
 		return true;
 	}
 	clearTerrain() {

--- a/data/items.js
+++ b/data/items.js
@@ -1467,6 +1467,12 @@ exports.BattleItems = {
 		fling: {
 			basePower: 10,
 		},
+		onAnySetTerrain: function () {
+			let pokemon = this.effectData.target;
+			if (this.isTerrain('electricterrain') && pokemon.useItem()) {
+				this.boost({def: 1}, pokemon);
+			}
+		},
 		onUpdate: function (pokemon) {
 			if (this.isTerrain('electricterrain') && pokemon.useItem()) {
 				this.boost({def: 1});
@@ -2118,6 +2124,12 @@ exports.BattleItems = {
 		spritenum: 667,
 		fling: {
 			basePower: 10,
+		},
+		onAnySetTerrain: function () {
+			let pokemon = this.effectData.target;
+			if (this.isTerrain('grassyterrain') && pokemon.useItem()) {
+				this.boost({def: 1}, pokemon);
+			}
 		},
 		onUpdate: function (pokemon) {
 			if (this.isTerrain('grassyterrain') && pokemon.useItem()) {
@@ -3494,6 +3506,12 @@ exports.BattleItems = {
 		fling: {
 			basePower: 10,
 		},
+		onAnySetTerrain: function () {
+			let pokemon = this.effectData.target;
+			if (this.isTerrain('mistyterrain') && pokemon.useItem()) {
+				this.boost({spd: 1}, pokemon);
+			}
+		},
 		onUpdate: function (pokemon) {
 			if (this.isTerrain('mistyterrain') && pokemon.useItem()) {
 				this.boost({spd: 1});
@@ -4217,6 +4235,12 @@ exports.BattleItems = {
 		spritenum: 665,
 		fling: {
 			basePower: 10,
+		},
+		onAnySetTerrain: function () {
+			let pokemon = this.effectData.target;
+			if (this.isTerrain('psychicterrain') && pokemon.useItem()) {
+				this.boost({spd: 1}, pokemon);
+			}
 		},
 		onUpdate: function (pokemon) {
 			if (this.isTerrain('psychicterrain') && pokemon.useItem()) {


### PR DESCRIPTION
Terrain seeds (such as electric seed, psychic seed) should active as soon as the appropriate terrain is activated, or when the pokemon holding the seed switches into the terrain. When two tapu's get on the field in the same turn only the slower terrain activates its seeds. This adds the event `SetTerrain` which is run whenever a terrain is set.

**Proof that the current setup is a bug:** Sun & Moon Replay code: ZCLW-WWWW-WWW5-CJF5

---
- Thanks to @Lionyx for helping me test this (it took a few hours)

- Thanks to @urkerab for answering my questions on `runEvent` and the bug in general.