### PR TITLE
Tournaments: Use gen 7 when no gen is specified

### DIFF
--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -920,7 +920,15 @@ function createTournament(room, format, generator, playerCap, isRated, args, out
 	format = Tools.getFormat(format);
 	if (format.effectType !== 'Format' || !format.tournamentShow) {
 		output.errorReply(format.id + " is not a valid tournament format.");
-		output.errorReply("Valid formats: " + Object.values(Tools.data.Formats).filter(f => f.effectType === 'Format' && f.tournamentShow).map(format => format.name).join(", "));
+		output.errorReply("Valid formats: " + Object.values(Tools.data.Formats).filter(f => f.effectType === 'Format' && f.tournamentShow).map(format => {
+			if (!toId(format.name).startsWith('gen')) {
+				return '[Gen 6] ' + format.name;
+			} else if (format.name.startsWith('[Gen 7] ')) {
+				return format.name.substr(8);
+			} else {
+				return format.name;
+			}
+		}).join(", "));
 		return;
 	}
 	if (!TournamentGenerators[toId(generator)]) {
@@ -1335,7 +1343,14 @@ Chat.commands.tournament = function (paramString, room, user) {
 			return this.sendReply("Usage: " + cmd + " <format>, <type> [, <comma-separated arguments>]");
 		}
 
-		let tour = createTournament(room, params.shift(), params.shift(), params.shift(), Config.ratedtours, params, this);
+		let format = toId(params.shift());
+		if (format.startsWith('gen6')) {
+			format = format.substr(4);
+		} else if (!format.startsWith('gen')) {
+			format = 'gen7' + format;
+		}
+
+		let tour = createTournament(room, format, params.shift(), params.shift(), Config.ratedtours, params, this);
 		if (tour) {
 			this.privateModCommand("(" + user.name + " created a tournament in " + tour.format + " format.)");
 			if (room.tourAnnouncements) {


### PR DESCRIPTION
Simply an update to the tournaments system so that if you don't specify a generation, it assumes gen7 instead of gen6.
examples: (same applies for whatever format other than ou too)
```
gen7ou => gen7ou
gen6ou => ou
ou => gen7ou
gen5ou => gen5ou (same for all other older gens)
```

Sorry if the commit message isn't up-to-par, I couldn't think of a good one.