### PR TITLE
Refactor PRNG into its own class and clean up test usages of randomness

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -13,6 +13,7 @@
 'use strict';
 
 const Tools = require('./tools');
+const PRNG = require('./prng');
 
 class BattlePokemon {
 	constructor(set, side) {
@@ -1975,8 +1976,12 @@ class BattleSide {
 }
 
 class Battle extends Tools.BattleDex {
-
-	init(roomid, format, rated, send) {
+	/**
+	 * Initialises a Battle.
+	 *
+	 * @param {PRNG} [maybePrng]
+	 */
+	init(roomid, format, rated, send, maybePrng) {
 		this.log = [];
 		this.sides = [null, null];
 		this.roomid = roomid;
@@ -2000,9 +2005,6 @@ class Battle extends Tools.BattleDex {
 		this.queue = [];
 		this.faintQueue = [];
 		this.messageLog = [];
-
-		this.seed = this.generateSeed();
-		this.startingSeed = this.seed;
 
 		this.send = send || (() => {});
 
@@ -2030,6 +2032,8 @@ class Battle extends Tools.BattleDex {
 		this.events = null;
 
 		this.abilityOrder = 0;
+
+		this.prng = maybePrng || new PRNG();
 	}
 
 	static logReplay(data, isReplay) {
@@ -2041,115 +2045,8 @@ class Battle extends Tools.BattleDex {
 		return 'Battle: ' + this.format;
 	}
 
-	generateSeed() {
-		// use a random initial seed (64-bit, [high -> low])
-		return [
-			Math.floor(Math.random() * 0x10000),
-			Math.floor(Math.random() * 0x10000),
-			Math.floor(Math.random() * 0x10000),
-			Math.floor(Math.random() * 0x10000),
-		];
-	}
-
-	// This function is designed to emulate the on-cartridge PRNG for Gens 3 and 4, as described in
-	// http://www.smogon.com/ingame/rng/pid_iv_creation#pokemon_random_number_generator
-	// This RNG uses a 32-bit initial seed
-
-	// This function has three different results, depending on arguments:
-	// - random() returns a real number in [0, 1), just like Math.random()
-	// - random(n) returns an integer in [0, n)
-	// - random(m, n) returns an integer in [m, n)
-
-	// m and n are converted to integers via Math.floor. If the result is NaN, they are ignored.
-	/*
 	random(m, n) {
-		this.seed = (this.seed * 0x41C64E6D + 0x6073) >>> 0; // truncate the result to the last 32 bits
-		let result = this.seed >>> 16; // the first 16 bits of the seed are the random value
-		m = Math.floor(m);
-		n = Math.floor(n);
-		return (m ? (n ? (result % (n - m)) + m : result % m) : result / 0x10000);
-	}
-	*/
-
-	// This function is designed to emulate the on-cartridge PRNG for Gen 5 and uses a 64-bit initial seed
-
-	// This function has three different results, depending on arguments:
-	// - random() returns a real number in [0, 1), just like Math.random()
-	// - random(n) returns an integer in [0, n)
-	// - random(m, n) returns an integer in [m, n)
-
-	// m and n are converted to integers via Math.floor. If the result is NaN, they are ignored.
-
-	random(m, n) {
-		this.seed = this.nextFrame(); // Advance the RNG
-		let result = (this.seed[0] << 16 >>> 0) + this.seed[1]; // Use the upper 32 bits
-		m = Math.floor(m);
-		n = Math.floor(n);
-		if (!m) {
-			result = result / 0x100000000;
-		} else if (!n) {
-			result = Math.floor(result * m / 0x100000000);
-		} else {
-			result = Math.floor(result * (n - m) / 0x100000000) + m;
-		}
-		this.debug('randBW(' + (m ? (n ? m + ', ' + n : m) : '') + ') = ' + result);
-		return result;
-	}
-
-	nextFrame(n) {
-		let seed = this.seed;
-		n = n || 1;
-		for (let frame = 0; frame < n; ++frame) {
-			// The RNG is a Linear Congruential Generator (LCG) in the form: x_{n + 1} = (a x_n + c) % m
-			// Where: x_0 is the seed, x_n is the random number after n iterations,
-			//     a = 0x5D588B656C078965, c = 0x00269EC3 and m = 2^64
-			// Javascript doesnt handle such large numbers properly, so this function does it in 16-bit parts.
-			// x_{n + 1} = (x_n * a) + c
-			// Let any 64 bit number n = (n[0] << 48) + (n[1] << 32) + (n[2] << 16) + n[3]
-			// Then x_{n + 1} =
-			//     ((a[3] x_n[0] + a[2] x_n[1] + a[1] x_n[2] + a[0] x_n[3] + c[0]) << 48) +
-			//     ((a[3] x_n[1] + a[2] x_n[2] + a[1] x_n[3] + c[1]) << 32) +
-			//     ((a[3] x_n[2] + a[2] x_n[3] + c[2]) << 16) +
-			//     a[3] x_n[3] + c[3]
-			// Which can be generalised where b is the number of 16 bit words in the number:
-			//     (Notice how the a[] word starts at b-1, and decrements every time it appears again on the line;
-			//         x_n[] starts at b-<line#>-1 and increments to b-1 at the end of the line per line, limiting the length of the line;
-			//         c[] is at b-<line#>-1 for each line and the left shift is 16 * <line#>)
-			//     ((a[b-1] + x_n[b-1] + c[b-1]) << (16 * 0)) +
-			//     ((a[b-1] x_n[b-2] + a[b-2] x_n[b-1] + c[b-2]) << (16 * 1)) +
-			//     ((a[b-1] x_n[b-3] + a[b-2] x_n[b-2] + a[b-3] x_n[b-1] + c[b-3]) << (16 * 2)) +
-			//     ...
-			//     ((a[b-1] x_n[1] + a[b-2] x_n[2] + ... + a[2] x_n[b-2] + a[1] + x_n[b-1] + c[1]) << (16 * (b-2))) +
-			//     ((a[b-1] x_n[0] + a[b-2] x_n[1] + ... + a[1] x_n[b-2] + a[0] + x_n[b-1] + c[0]) << (16 * (b-1)))
-			// Which produces this equation: \sum_{l=0}^{b-1}\left(\sum_{m=b-l-1}^{b-1}\left\{a[2b-m-l-2] x_n[m]\right\}+c[b-l-1]\ll16l\right)
-			// This is all ignoring overflow/carry because that cannot be shown in a pseudo-mathematical equation.
-			// The below code implements a optimised version of that equation while also checking for overflow/carry.
-
-			let a = [0x5D58, 0x8B65, 0x6C07, 0x8965];
-			let c = [0, 0, 0x26, 0x9EC3];
-
-			let nextSeed = [0, 0, 0, 0];
-			let carry = 0;
-
-			for (let cN = seed.length - 1; cN >= 0; --cN) {
-				nextSeed[cN] = carry;
-				carry = 0;
-
-				let aN = seed.length - 1;
-				let seedN = cN;
-				for (; seedN < seed.length; --aN, ++seedN) {
-					let nextWord = a[aN] * seed[seedN];
-					carry += nextWord >>> 16;
-					nextSeed[cN] += nextWord & 0xFFFF;
-				}
-				nextSeed[cN] += c[cN];
-				carry += nextSeed[cN] >>> 16;
-				nextSeed[cN] &= 0xFFFF;
-			}
-
-			seed = nextSeed;
-		}
-		return seed;
+		return this.prng.next(m, n);
 	}
 
 	setWeather(status, source, sourceEffect) {
@@ -3493,7 +3390,8 @@ class Battle extends Tools.BattleDex {
 		if (this.rated) {
 			this.add('rated');
 		}
-		this.add('seed', Battle.logReplay.bind(this, this.startingSeed.join(',')));
+		// HACK here for backwards compatibility but ouchie
+		this.add('seed', Battle.logReplay.bind(this, this.prng.startingSeed.join(',')));
 
 		if (format.onBegin) {
 			format.onBegin.call(this);
@@ -5102,7 +5000,7 @@ class Battle extends Tools.BattleDex {
 			if (alreadyEnded !== undefined && this.ended && !alreadyEnded) {
 				if (this.rated || Config.logchallenges) {
 					let log = {
-						seed: this.startingSeed,
+						seed: this.prng.startingSeed,
 						turns: this.turn,
 						p1: this.p1.name,
 						p2: this.p2.name,

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const {PRNG} = require('./../prng');
 const CHOOSABLE_TARGETS = new Set(['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'adjacentFoe']);
 
 exports.BattleScripts = {
@@ -902,11 +903,11 @@ exports.BattleScripts = {
 		const teamGenerator = typeof format.team === 'string' && format.team.startsWith('random') ? format.team + 'Team' : '';
 		if (!teamGenerator && team) return team;
 		// Reinitialize the RNG seed to create random teams.
-		this.seed = this.generateSeed();
-		this.startingSeed = this.startingSeed.concat(this.seed);
+		const originalPrng = this.prng.clone();
+		this.prng = new PRNG();
 		team = this[teamGenerator || 'randomTeam'](side);
 		// Restore the default seed
-		this.seed = this.startingSeed.slice(0, 4);
+		this.seed = originalPrng;
 		return team;
 	},
 	randomCCTeam: function (side) {
@@ -3379,10 +3380,10 @@ exports.BattleScripts = {
 		let forceResult = (depth >= 4);
 
 		let availableTiers = ['Uber', 'OU', 'UU', 'RU', 'NU', 'PU'];
-		const prevSeed = this.seed;
-		this.seed = this.startingSeed.slice(0, 4);
+		const originalPrng = this.prng.clone();
+		this.prng = originalPrng.clone();
 		const chosenTier = availableTiers[this.random(availableTiers.length)];
-		this.seed = prevSeed;
+		this.prng = originalPrng;
 
 		let pokemon = [];
 

--- a/prng.js
+++ b/prng.js
@@ -1,0 +1,173 @@
+'use strict';
+// This function is designed to emulate the on-cartridge PRNG for Gens 3 and 4, as described in
+// http://www.smogon.com/ingame/rng/pid_iv_creation#pokemon_random_number_generator
+// This RNG uses a 32-bit initial seed
+// m and n are converted to integers via Math.floor. If the result is NaN, they are ignored.
+/*
+random(m, n) {
+	this.seed = (this.seed * 0x41C64E6D + 0x6073) >>> 0; // truncate the result to the last 32 bits
+	let result = this.seed >>> 16; // the first 16 bits of the seed are the random value
+	m = Math.floor(m)
+	n = Math.floor(n)
+	return (m ? (n ? (result % (n - m)) + m : result % m) : result / 0x10000)
+}
+*/
+
+// This function is designed to emulate the on-cartridge PRNG for Gen 5 and uses a 64-bit initial seed
+
+// This function has three different results, depending on arguments:
+// - random() returns a real number in [0, 1), just like Math.random()
+// - random(n) returns an integer in [0, n)
+// - random(m, n) returns an integer in [m, n)
+// m and n are converted to integers via Math.floor. If the result is NaN, they are ignored.
+class PRNG {
+	/**
+	 * Creates a new source of randomness for the given seed.
+	 *
+	 * @param {number[]} [seed]
+	 */
+	constructor(seed = PRNG.generateSeed()) {
+		// We slice() the seed so we get a copy of it instead of the original seed.
+		this.initialSeed = seed.slice();
+		this.seed = seed.slice();
+	}
+
+	/**
+	 * Getter to the initial seed.
+	 *
+	 * This should be considered a hack and is only here for backwards compatibility.
+	 */
+	get startingSeed() {
+		return this.initialSeed;
+	}
+
+	/**
+	 * Creates a clone of the current PRNG.
+	 *
+	 * The new PRNG will have its initial seed set to the seed of the current instance.
+	 */
+	clone() {
+		return new PRNG(this.seed);
+	}
+
+	/**
+	 * Retrieves the next random number in the sequence.
+	 *
+	 * @param {number} [from]
+	 * @param {number} [to]
+	 * @returns {number} a real number in [0, 1) if no arguments are specified
+	 * @returns {number} an integer in [0, from) if from is specified
+	 * @returns {number} an integer in [from, to) if from and to are specified
+	 */
+	next(from, to) {
+		this.seed = this.nextFrame(this.seed); // Advance the RNG
+		let result = (this.seed[0] << 16 >>> 0) + this.seed[1]; // Use the upper 32 bits
+		from = Math.floor(from);
+		to = Math.floor(to);
+		if (!from) {
+			result = result / 0x100000000;
+		} else if (!to) {
+			result = Math.floor(result * from / 0x100000000);
+		} else {
+			result = Math.floor(result * (to - from) / 0x100000000) + from;
+		}
+		return result;
+	}
+
+	/**
+		The RNG is a Linear Congruential Generator (LCG) in the form: `x_{n + 1} = (a x_n + c) % m`
+
+		Where: `x_0` is the seed, `x_n` is the random number after n iterations,
+
+		````
+		a = 0x5D588B656C078965
+		c = 0x00269EC3
+		m = 2^64
+		````
+
+		Javascript doesnt handle such large numbers properly, so this function does it in 16-bit parts.
+		````
+		x_{n + 1} = (x_n * a) + c
+		````
+
+		Let any 64 bit number:
+		````
+		n = (n[0] << 48) + (n[1] << 32) + (n[2] << 16) + n[3]
+		````
+
+		Then:
+		````
+		x_{n + 1} =
+			((a[3] x_n[0] + a[2] x_n[1] + a[1] x_n[2] + a[0] x_n[3] + c[0]) << 48) +
+			((a[3] x_n[1] + a[2] x_n[2] + a[1] x_n[3] + c[1]) << 32) +
+			((a[3] x_n[2] + a[2] x_n[3] + c[2]) << 16) +
+			a[3] x_n[3] + c[3]
+		````
+
+		Which can be generalised where b is the number of 16 bit words in the number:
+		````
+		((a[b-1] + x_n[b-1] + c[b-1]) << (16 * 0)) +
+		((a[b-1] x_n[b-2] + a[b-2] x_n[b-1] + c[b-2]) << (16 * 1)) +
+		((a[b-1] x_n[b-3] + a[b-2] x_n[b-2] + a[b-3] x_n[b-1] + c[b-3]) << (16 * 2)) +
+		...
+		((a[b-1] x_n[1] + a[b-2] x_n[2] + ... + a[2] x_n[b-2] + a[1] + x_n[b-1] + c[1]) << (16 * (b-2))) +
+		((a[b-1] x_n[0] + a[b-2] x_n[1] + ... + a[1] x_n[b-2] + a[0] + x_n[b-1] + c[0]) << (16 * (b-1)))
+		````
+
+		Which produces this equation:
+		````
+		\sum_{l=0}^{b-1}\left(\sum_{m=b-l-1}^{b-1}\left\{a[2b-m-l-2] x_n[m]\right\}+c[b-l-1]\ll16l\right)
+		````
+
+		Notice how the `a[]` word starts at `b-1`, and decrements every time it appears again on the line;
+		`x_n[]` starts at `b-<line#>-1` and increments to b-1 at the end of the line per line, limiting the length of the line;
+		`c[]` is at `b-<line#>-1` for each line and the left shift is `16 * <line#>`)
+
+		This is all ignoring overflow/carry because that cannot be shown in a pseudo-mathematical equation.
+		The below code implements a optimised version of that equation while also checking for overflow/carry.
+
+		@param {number} [framesToAdvance = 1]
+		@return {number[]} the new seed
+	*/
+	nextFrame(initialSeed, framesToAdvance = 1) {
+		// Use Slice so we don't actually alter the original seed.
+		let seed = initialSeed.slice();
+		for (let frame = 0; frame < framesToAdvance; ++frame) {
+			const a = [0x5D58, 0x8B65, 0x6C07, 0x8965];
+			const c = [0, 0, 0x26, 0x9EC3];
+
+			const nextSeed = [0, 0, 0, 0];
+			let carry = 0;
+
+			for (let cN = seed.length - 1; cN >= 0; --cN) {
+				nextSeed[cN] = carry;
+				carry = 0;
+
+				let aN = seed.length - 1;
+				for (let seedN = cN; seedN < seed.length; --aN, ++seedN) {
+					let nextWord = a[aN] * seed[seedN];
+					carry += nextWord >>> 16;
+					nextSeed[cN] += nextWord & 0xFFFF;
+				}
+				nextSeed[cN] += c[cN];
+				carry += nextSeed[cN] >>> 16;
+				nextSeed[cN] &= 0xFFFF;
+			}
+
+			seed = nextSeed;
+		}
+		return seed;
+	}
+
+	static generateSeed() {
+		// use a random initial seed (64-bit, [high -> low])
+		return [
+			Math.floor(Math.random() * 0x10000),
+			Math.floor(Math.random() * 0x10000),
+			Math.floor(Math.random() * 0x10000),
+			Math.floor(Math.random() * 0x10000),
+		];
+	}
+}
+
+module.exports = PRNG;

--- a/test/common.js
+++ b/test/common.js
@@ -2,6 +2,8 @@
 
 const assert = require('assert');
 const Tools = require('./../tools').includeFormats();
+const PRNG = require('./../prng');
+const BattleEngine = require('./../battle-engine');
 
 let battleNum = 1;
 const cache = new Map();
@@ -94,13 +96,19 @@ class TestTools {
 		return format;
 	}
 
-	createBattle(options, teams) {
+	createBattle(options, teams, prng = new PRNG(this.minRollSeed)) {
 		if (Array.isArray(options)) {
 			teams = options;
 			options = {};
 		}
 		const format = this.getFormat(options || {});
-		const battle = BattleEngine.construct(`battle-test-${battleNum++}`, format.id);
+		const battle = BattleEngine.construct(
+			`battle-test-${battleNum++}`,
+			format.id,
+			undefined,
+			undefined,
+			prng
+		);
 		if (options && options.partialDecisions) battle.supportPartialDecisions = true;
 		if (teams) {
 			for (let i = 0; i < teams.length; i++) {
@@ -110,6 +118,10 @@ class TestTools {
 			}
 		}
 		return battle;
+	}
+
+	createBattleWithPRNG(prng) {
+		return this.createBattle({}, [], prng);
 	}
 }
 

--- a/test/common.js
+++ b/test/common.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const Tools = require('./../tools').includeFormats();
 const PRNG = require('./../prng');
-const BattleEngine = require('./../battle-engine');
+const MockBattle = require('./mocks/Battle');
 
 let battleNum = 1;
 const cache = new Map();
@@ -20,6 +20,11 @@ const RULE_FLAGS = {
 function capitalize(word) {
 	return word.charAt(0).toUpperCase() + word.slice(1);
 }
+
+/**
+ * The default random number generator seed used if one is not given.
+ */
+const DEFAULT_SEED = [0x09917, 0x06924, 0x0e1c8, 0x06af0];
 
 class TestTools {
 	constructor(options) {
@@ -49,14 +54,6 @@ class TestTools {
 
 	gen(genNum) {
 		return this.mod('gen' + genNum);
-	}
-
-	get minRollSeed() {
-		return [0x09917, 0x06924, 0x0e1c8, 0x06af0];
-	}
-
-	get maxRollSeed() {
-		return [0x0967e, 0x0b79c, 0x06494, 0x068e3];
 	}
 
 	getFormat(options) {
@@ -96,13 +93,24 @@ class TestTools {
 		return format;
 	}
 
-	createBattle(options, teams, prng = new PRNG(this.minRollSeed)) {
+	/**
+	 * Creates a new Battle and returns it.
+	 *
+	 * @param {Object} [options]
+	 * @param {Team[]} [teams]
+	 * @param {PRNG} [prng] A pseudo-random number generator. If not provided, a pseudo-random number
+	 * generator will be generated for the user with a seed that is guaranteed to be the same across
+	 * test executions to help with determinism.
+	 * @returns {MockBattle} A mocked battle. This has mostly the same behaviour as regular Battles,
+	 * but some behaviour may differ specifically for testing.
+	 */
+	createBattle(options, teams, prng = new PRNG(DEFAULT_SEED)) {
 		if (Array.isArray(options)) {
 			teams = options;
 			options = {};
 		}
 		const format = this.getFormat(options || {});
-		const battle = BattleEngine.construct(
+		const battle = MockBattle.construct(
 			`battle-test-${battleNum++}`,
 			format.id,
 			undefined,
@@ -118,10 +126,6 @@ class TestTools {
 			}
 		}
 		return battle;
-	}
-
-	createBattleWithPRNG(prng) {
-		return this.createBattle({}, [], prng);
 	}
 }
 

--- a/test/main.js
+++ b/test/main.js
@@ -4,8 +4,6 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 const Module = require('module');
-const BattleEngine = require('../battle-engine');
-
 const mock = require('mock-fs-require-fix');
 
 const noop = () => {};
@@ -21,14 +19,6 @@ function getDirTypedContentsSync(dir, forceType) {
 
 function init(callback) {
 	require('./../app');
-
-	// Run the battle engine in the main process to keep our sanity
-	for (let listener of process.listeners('message')) {
-		process.removeListener('message', listener);
-	}
-
-	// Turn IPC methods into no-op
-	BattleEngine.Battle.prototype.receive = noop;
 
 	Rooms.RoomBattle.prototype.send = noop;
 	Rooms.RoomBattle.prototype.receive = noop;
@@ -117,4 +107,8 @@ describe('Native timer/event loop globals', function () {
 
 describe('Battle simulation', function () {
 	require('./simulator');
+});
+
+describe('mocks', function () {
+	require('./mocks/Battle.spec');
 });

--- a/test/main.js
+++ b/test/main.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 const Module = require('module');
+const BattleEngine = require('../battle-engine');
 
 const mock = require('mock-fs-require-fix');
 
@@ -22,7 +23,6 @@ function init(callback) {
 	require('./../app');
 
 	// Run the battle engine in the main process to keep our sanity
-	let BattleEngine = global.BattleEngine = require('./../battle-engine');
 	for (let listener of process.listeners('message')) {
 		process.removeListener('message', listener);
 	}

--- a/test/main.js
+++ b/test/main.js
@@ -6,7 +6,6 @@ const fs = require('fs');
 const Module = require('module');
 
 const mock = require('mock-fs-require-fix');
-const common = require('./common');
 
 const noop = () => {};
 
@@ -39,13 +38,6 @@ function init(callback) {
 	}
 
 	LoginServer.disabled = true;
-
-	// Deterministic tests
-	BattleEngine.Battle.prototype._init = BattleEngine.Battle.prototype.init;
-	BattleEngine.Battle.prototype.init = function (roomid, formatarg, rated) {
-		this._init(roomid, formatarg, rated);
-		this.seed = this.startingSeed = common.minRollSeed;
-	};
 
 	// Disable writing to modlog
 	Rooms.Room.prototype.modlog = noop;

--- a/test/mocks/Battle.js
+++ b/test/mocks/Battle.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const {Battle} = require('../../battle-engine');
+
+class MockBattle extends Battle {
+	init(roomid, format, rated, send, maybePrng) {
+		super.init(roomid, format, rated, send, maybePrng);
+		this.initialPrng = this.prng.clone();
+	}
+
+	// Intentionally left empty.
+	receive() {}
+
+	/**
+	 * Resets the random number generator of this battle to the state it was in
+	 * when it was created, including resetting its seed to its initial seed.
+	 */
+	resetRNG() {
+		this.prng = this.initialPrng.clone();
+	}
+}
+
+const battleProtoCache = new Map();
+// HACK Copy pasted from battle-engine
+// The ultimate idea obviously being to remove this from being necessary.
+function construct(roomid, format, rated, send, prng) {
+	format = Tools.getFormat(format);
+	const mod = format.mod || 'base';
+	if (!battleProtoCache.has(mod)) {
+		const tools = Tools.mod(mod);
+		const proto = Object.create(MockBattle.prototype);
+		Object.assign(proto, tools);
+		tools.install(proto);
+		battleProtoCache.set(mod, proto);
+	}
+	const battle = Object.create(battleProtoCache.get(mod));
+	MockBattle.prototype.init.call(battle, roomid, format, rated, send, prng);
+	return battle;
+}
+
+module.exports = {
+	MockBattle,
+	construct,
+};

--- a/test/mocks/Battle.spec.js
+++ b/test/mocks/Battle.spec.js
@@ -1,0 +1,14 @@
+'use strict';
+const assert = require('../assert');
+const Battle = require('./Battle');
+
+describe('Battle', function () {
+	it('should reset the PRNG to original when resetRNG is called', function () {
+		const battle = Battle.construct();
+		const initialPrng = battle.prng.clone();
+		battle.random();
+		assert.notDeepEqual(initialPrng, battle.prng, 'the prng should have changed');
+		battle.resetRNG();
+		assert.deepEqual(initialPrng, battle.prng, 'the prng was not reset');
+	});
+});

--- a/test/simulator/abilities/flashfire.js
+++ b/test/simulator/abilities/flashfire.js
@@ -2,7 +2,6 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
-const {PRNG} = require('../../../prng');
 
 let battle;
 
@@ -37,13 +36,11 @@ describe('Flash Fire', function () {
 	});
 
 	it('should lose the Flash Fire boost if its ability is changed', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattleWithPRNG(a);
+		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['sleeptalk', 'incinerate']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['incinerate', 'worryseed']}]);
 		battle.commitDecisions();
-		battle.prng = b;
+		battle.resetRNG();
 		p2.chooseMove('worryseed').foe.chooseMove('incinerate');
 		let damage = battle.p2.active[0].maxhp - battle.p2.active[0].hp;
 		assert.bounded(damage, [54, 65]);

--- a/test/simulator/abilities/flashfire.js
+++ b/test/simulator/abilities/flashfire.js
@@ -2,6 +2,7 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
+const {PRNG} = require('../../../prng');
 
 let battle;
 
@@ -36,11 +37,13 @@ describe('Flash Fire', function () {
 	});
 
 	it('should lose the Flash Fire boost if its ability is changed', function () {
-		battle = common.createBattle();
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattleWithPRNG(a);
 		battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['sleeptalk', 'incinerate']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['incinerate', 'worryseed']}]);
 		battle.commitDecisions();
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		p2.chooseMove('worryseed').foe.chooseMove('incinerate');
 		let damage = battle.p2.active[0].maxhp - battle.p2.active[0].hp;
 		assert.bounded(damage, [54, 65]);

--- a/test/simulator/abilities/multiscale.js
+++ b/test/simulator/abilities/multiscale.js
@@ -2,6 +2,7 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
+const {PRNG} = require('../../../prng');
 
 let battle;
 
@@ -11,7 +12,9 @@ describe('Multiscale', function () {
 	});
 
 	it('should halve damage when it is at full health', function () {
-		battle = common.createBattle();
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattleWithPRNG(a);
 		battle.join('p1', 'Guest 1', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moxie', moves: ['incinerate']}]);
 		let damage, curhp;
@@ -19,13 +22,15 @@ describe('Multiscale', function () {
 		battle.commitDecisions();
 		damage = pokemon.maxhp - pokemon.hp;
 		curhp = pokemon.hp;
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		battle.commitDecisions();
 		assert.strictEqual(damage, battle.modify(curhp - pokemon.hp, 0.5));
 	});
 
 	it('should be suppressed by Mold Breaker', function () {
-		battle = common.createBattle();
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattleWithPRNG(a);
 		battle.join('p1', 'Guest 1', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moldbreaker', moves: ['incinerate']}]);
 		let damage, curhp;
@@ -33,7 +38,7 @@ describe('Multiscale', function () {
 		battle.commitDecisions();
 		damage = pokemon.maxhp - pokemon.hp;
 		curhp = pokemon.hp;
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		battle.commitDecisions();
 		assert.strictEqual(curhp - pokemon.hp, damage);
 	});

--- a/test/simulator/abilities/multiscale.js
+++ b/test/simulator/abilities/multiscale.js
@@ -2,7 +2,6 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
-const {PRNG} = require('../../../prng');
 
 let battle;
 
@@ -12,9 +11,7 @@ describe('Multiscale', function () {
 	});
 
 	it('should halve damage when it is at full health', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattleWithPRNG(a);
+		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moxie', moves: ['incinerate']}]);
 		let damage, curhp;
@@ -22,15 +19,13 @@ describe('Multiscale', function () {
 		battle.commitDecisions();
 		damage = pokemon.maxhp - pokemon.hp;
 		curhp = pokemon.hp;
-		battle.prng = b;
+		battle.resetRNG();
 		battle.commitDecisions();
 		assert.strictEqual(damage, battle.modify(curhp - pokemon.hp, 0.5));
 	});
 
 	it('should be suppressed by Mold Breaker', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattleWithPRNG(a);
+		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moldbreaker', moves: ['incinerate']}]);
 		let damage, curhp;
@@ -38,7 +33,7 @@ describe('Multiscale', function () {
 		battle.commitDecisions();
 		damage = pokemon.maxhp - pokemon.hp;
 		curhp = pokemon.hp;
-		battle.prng = b;
+		battle.resetRNG();
 		battle.commitDecisions();
 		assert.strictEqual(curhp - pokemon.hp, damage);
 	});

--- a/test/simulator/abilities/unaware.js
+++ b/test/simulator/abilities/unaware.js
@@ -2,7 +2,6 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
-const {PRNG} = require('../../../prng');
 
 let battle;
 
@@ -12,9 +11,7 @@ describe('Unaware', function () {
 	});
 
 	it('should ignore attack stage changes when Pokemon with it are attacked', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattleWithPRNG(a);
+		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['softboiled']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hariyama', ability: 'thickfat', moves: ['vitalthrow', 'bellydrum']}]);
 		battle.commitDecisions();
@@ -22,15 +19,13 @@ describe('Unaware', function () {
 		let damage = pokemon.maxhp - pokemon.hp;
 		battle.choose('p2', 'move 2');
 		battle.commitDecisions();
-		battle.prng = b;
+		battle.resetRNG();
 		battle.commitDecisions();
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should not ignore attack stage changes when Pokemon with it attack', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattleWithPRNG(a);
+		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['moonblast', 'nastyplot']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'prankster', moves: ['splash']}]);
 		battle.commitDecisions();
@@ -39,45 +34,39 @@ describe('Unaware', function () {
 		battle.choose('p1', 'move 2');
 		battle.commitDecisions();
 		pokemon.hp = pokemon.maxhp;
-		battle.prng = b;
+		battle.resetRNG();
 		battle.commitDecisions();
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should ignore defense stage changes when Pokemon with it attack', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattleWithPRNG(a);
+		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['moonblast']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hariyama', ability: 'thickfat', item: 'laggingtail', moves: ['amnesia']}]);
 		battle.commitDecisions();
 		let pokemon = battle.p2.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
 		pokemon.hp = pokemon.maxhp;
-		battle.prng = b;
+		battle.resetRNG();
 		battle.commitDecisions();
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should not ignore defense stage changes when Pokemon with it are attacked', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattleWithPRNG(a);
+		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['irondefense']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'clearbody', moves: ['shadowsneak']}]);
 		battle.commitDecisions();
 		let pokemon = battle.p1.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
 		pokemon.hp = pokemon.maxhp;
-		battle.prng = b;
+		battle.resetRNG();
 		battle.commitDecisions();
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should be suppressed by Mold Breaker', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattleWithPRNG(a);
+		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['shadowsneak']}]);
 		battle.commitDecisions();
@@ -85,7 +74,7 @@ describe('Unaware', function () {
 		let damage = pokemon.maxhp - pokemon.hp;
 		battle.boost({atk: 2}, battle.p2.active[0]);
 		pokemon.hp = pokemon.maxhp;
-		battle.prng = b;
+		battle.resetRNG();
 		battle.commitDecisions();
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});

--- a/test/simulator/abilities/unaware.js
+++ b/test/simulator/abilities/unaware.js
@@ -2,6 +2,7 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
+const {PRNG} = require('../../../prng');
 
 let battle;
 
@@ -11,7 +12,9 @@ describe('Unaware', function () {
 	});
 
 	it('should ignore attack stage changes when Pokemon with it are attacked', function () {
-		battle = common.createBattle();
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattleWithPRNG(a);
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['softboiled']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hariyama', ability: 'thickfat', moves: ['vitalthrow', 'bellydrum']}]);
 		battle.commitDecisions();
@@ -19,13 +22,15 @@ describe('Unaware', function () {
 		let damage = pokemon.maxhp - pokemon.hp;
 		battle.choose('p2', 'move 2');
 		battle.commitDecisions();
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		battle.commitDecisions();
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should not ignore attack stage changes when Pokemon with it attack', function () {
-		battle = common.createBattle();
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattleWithPRNG(a);
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['moonblast', 'nastyplot']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'prankster', moves: ['splash']}]);
 		battle.commitDecisions();
@@ -34,39 +39,45 @@ describe('Unaware', function () {
 		battle.choose('p1', 'move 2');
 		battle.commitDecisions();
 		pokemon.hp = pokemon.maxhp;
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		battle.commitDecisions();
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should ignore defense stage changes when Pokemon with it attack', function () {
-		battle = common.createBattle();
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattleWithPRNG(a);
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['moonblast']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hariyama', ability: 'thickfat', item: 'laggingtail', moves: ['amnesia']}]);
 		battle.commitDecisions();
 		let pokemon = battle.p2.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
 		pokemon.hp = pokemon.maxhp;
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		battle.commitDecisions();
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should not ignore defense stage changes when Pokemon with it are attacked', function () {
-		battle = common.createBattle();
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattleWithPRNG(a);
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['irondefense']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'clearbody', moves: ['shadowsneak']}]);
 		battle.commitDecisions();
 		let pokemon = battle.p1.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
 		pokemon.hp = pokemon.maxhp;
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		battle.commitDecisions();
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should be suppressed by Mold Breaker', function () {
-		battle = common.createBattle();
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattleWithPRNG(a);
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['shadowsneak']}]);
 		battle.commitDecisions();
@@ -74,7 +85,7 @@ describe('Unaware', function () {
 		let damage = pokemon.maxhp - pokemon.hp;
 		battle.boost({atk: 2}, battle.p2.active[0]);
 		pokemon.hp = pokemon.maxhp;
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		battle.commitDecisions();
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});

--- a/test/simulator/misc/random-teams.js
+++ b/test/simulator/misc/random-teams.js
@@ -35,11 +35,10 @@ describe(`Random Team generator`, function () {
 		it(`should successfully create valid Gen ${gen} teams`, function () {
 			this.timeout(0);
 			battle = common.gen(gen).createBattle();
-			battle.seed = battle.generateSeed();
 
 			let teamCount = TOTAL_TEAMS;
 			while (teamCount--) {
-				let seed = battle.seed.slice();
+				let seed = battle.prng.seed.slice();
 				let team = null;
 				try {
 					team = battle.randomTeam(battle.p1);
@@ -61,11 +60,10 @@ describe(`Challenge Cup Team generator`, function () {
 		it(`should successfully create valid Gen ${gen} teams`, function () {
 			this.timeout(0);
 			battle = common.gen(gen).createBattle();
-			battle.seed = battle.generateSeed();
 
 			let teamCount = TOTAL_TEAMS;
 			while (teamCount--) {
-				let seed = battle.seed.slice();
+				let seed = battle.prng.seed.slice();
 				let team = null;
 				try {
 					team = battle.randomCCTeam(battle.p1);
@@ -87,11 +85,10 @@ describe(`Hackmons Cup Team generator`, function () {
 		it(`should successfully create valid Gen ${gen} teams`, function () {
 			this.timeout(0);
 			battle = common.gen(gen).createBattle();
-			battle.seed = battle.generateSeed();
 
 			let teamCount = TOTAL_TEAMS;
 			while (teamCount--) {
-				let seed = battle.seed.slice();
+				let seed = battle.prng.seed.slice();
 				let team = null;
 				try {
 					team = battle.randomHCTeam(battle.p1);

--- a/test/simulator/misc/statuses.js
+++ b/test/simulator/misc/statuses.js
@@ -2,6 +2,7 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
+const PRNG = require('./../../../prng');
 
 let battle;
 
@@ -20,14 +21,16 @@ describe('Burn', function () {
 	});
 
 	it('should halve damage from most Physical attacks', function () {
-		battle = common.createBattle([
+		const a = new PRNG(common.minRollSeed);
+		const b = a.clone();
+		battle = common.createBattle({}, [
 			[{species: 'Machamp', ability: 'noguard', moves: ['boneclub']}],
 			[{species: 'Sableye', ability: 'prankster', moves: ['splash', 'willowisp']}],
-		]);
+		], a);
 		const target = battle.p2.active[0];
 		battle.commitDecisions();
 		const baseDamage = target.maxhp - target.hp;
-		battle.seed = battle.startingSeed.slice();
+		battle.prng = b;
 		battle.p2.chooseMove('willowisp');
 		assert.hurtsBy(target, battle.modify(baseDamage, 0.5), () => battle.commitDecisions());
 	});

--- a/test/simulator/misc/statuses.js
+++ b/test/simulator/misc/statuses.js
@@ -2,7 +2,6 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
-const PRNG = require('./../../../prng');
 
 let battle;
 
@@ -21,16 +20,14 @@ describe('Burn', function () {
 	});
 
 	it('should halve damage from most Physical attacks', function () {
-		const a = new PRNG(common.minRollSeed);
-		const b = a.clone();
-		battle = common.createBattle({}, [
+		battle = common.createBattle([
 			[{species: 'Machamp', ability: 'noguard', moves: ['boneclub']}],
 			[{species: 'Sableye', ability: 'prankster', moves: ['splash', 'willowisp']}],
-		], a);
+		]);
 		const target = battle.p2.active[0];
 		battle.commitDecisions();
 		const baseDamage = target.maxhp - target.hp;
-		battle.prng = b;
+		battle.resetRNG();
 		battle.p2.chooseMove('willowisp');
 		assert.hurtsBy(target, battle.modify(baseDamage, 0.5), () => battle.commitDecisions());
 	});

--- a/test/simulator/moves/destinybond.js
+++ b/test/simulator/moves/destinybond.js
@@ -14,7 +14,6 @@ describe(`Destiny Bond`, function () {
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
 		battle.p1.chooseMove('destinybond').foe.chooseMove('calmmind');
-		battle.seed = common.minRollSeed;
 		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.false.fainted(battle.p2.active[0]);
@@ -25,7 +24,6 @@ describe(`Destiny Bond`, function () {
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
 		battle.p1.chooseMove('destinybond').foe.chooseMove('calmmind');
-		battle.seed = common.maxRollSeed;
 		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.false.fainted(battle.p2.active[0]);
@@ -37,7 +35,6 @@ describe(`Destiny Bond`, function () {
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
 		battle.p1.chooseMove('protect').foe.chooseMove('calmmind');
-		battle.seed = common.maxRollSeed;
 		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
@@ -64,7 +61,6 @@ describe(`Destiny Bond [Gen 6]`, function () {
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
 		battle.p1.chooseMove('destinybond').foe.chooseMove('calmmind');
-		battle.seed = common.minRollSeed;
 		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
@@ -75,7 +71,6 @@ describe(`Destiny Bond [Gen 6]`, function () {
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
 		battle.p1.chooseMove('destinybond').foe.chooseMove('calmmind');
-		battle.seed = common.maxRollSeed;
 		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);

--- a/test/simulator/moves/ragepowder.js
+++ b/test/simulator/moves/ragepowder.js
@@ -2,6 +2,7 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
+const BattleEngine = require('./../../../battle-engine');
 
 let battle;
 

--- a/test/simulator/moves/roost.js
+++ b/test/simulator/moves/roost.js
@@ -2,6 +2,7 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
+const BattleEngine = require('./../../../battle-engine');
 
 let battle;
 


### PR DESCRIPTION
This PR does a few things.

- Extracts the pseudo-random number generator that was embedded within `Battle` to it's own class named `PRNG`.
- Removes the reliance on a global `BattleEngine` property in tests so we can add a reliable mock without causing action at a distance. This is only required in a couple of places and I was able to replace this with a `require` instead. I am unsure if this will cause side effects (action at a distance seems to be a running theme), but all tests pass.
- Removes the duck-punch that caused `test/main.js` to overwrite the `BattleEngine.init` method and forcibly set it's own `this.seed` and `this.startingSeed` properties (Which are no longer necessary due to the `PRNG` class).
- Adds a mock class called `Battle` inside `mocks/Battle.js` that is created by `common.createBattle()`. This class augments the existing `Battle` class with a new method called `resetRandomNumberGenerator()`, which resets the random number generator within that instance to the RNG it was created with.

These changes are aimed at reducing the complexity of the `Battle` class, making it easier to test when pseudo-random number generators are involved and encapsulating the responsibility of pseudo-random number generation to a single class.

There were a few places where I couldn't prevent breaking encapsulation (these are mostly places where the seed is directly accessed for logging) without considerably changing function signatures, so I've left these things here and simply altered the access so it grabs `this.prng.seed` rather than `this.seed`.

I hope this helps.

----

Please note that 45035ca actually breaks a few tests and I'm not entirely sure why, but those breakages are resolved in 955a219. I can dig a bit further into why those break if you'd like.