### PR TITLE
Sockets: fix unit tests

### DIFF
--- a/dev-tools/users-utils.js
+++ b/dev-tools/users-utils.js
@@ -1,22 +1,143 @@
 'use strict';
 
-let EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('events').EventEmitter;
 
-function createWorker() {
-	let fakeWorker = new EventEmitter();
-	fakeWorker.id = 1;
-	fakeWorker.send = function () {};
-	fakeWorker.process = {connected: true};
-	Sockets.workers[fakeWorker.id] = fakeWorker;
-	return fakeWorker;
+class Worker extends EventEmitter {
+	constructor(id) {
+		super();
+		this.id = id;
+		this.process = {connected: true};
+		this.sockets = new Set();
+		this.channels = new Map();
+		this.subchannels = new Map();
+		Sockets.workers[this.id] = this;
+	}
+
+	kill() {}
+
+	send(msg) {
+		let cmd = msg.charAt(0);
+		let params = msg.substr(1).split('\n');
+		switch (cmd) {
+		case '!':
+			return this.removeSocket(...params);
+		case '>':
+			return this.sendToSocket(...params);
+		case '#':
+			return this.sendToChannel(...params);
+		case '+':
+			return this.addToChannel(...params);
+		case '-':
+			return this.removeFromChannel(...params);
+		case '.':
+			return this.moveToSubchannel(...params);
+		case ':':
+			return this.broadcastToSubchannels(params[0]);
+		}
+	}
+
+	addSocket(socketid) {
+		this.sockets.add(+socketid);
+	}
+
+	removeSocket(socketid) {
+		socketid = +socketid;
+		if (!this.sockets.has(socketid)) {
+			throw new Error(`Attempted to disconnect nonexistent socket ${socketid}`);
+		}
+		this.sockets.delete(socketid);
+		this.channels.forEach((channel, channelid) => {
+			channel.delete(socketid);
+		});
+	}
+
+	sendToSocket(socketid, msg) {
+		socketid = +socketid;
+		if (!this.sockets.has(socketid)) {
+			throw new Error(`Attempted to send ${msg} to nonexistent socket ${socketid}`);
+		}
+	}
+
+	sendToChannel(channelid, msg) {
+		if (!this.channels.has(channelid)) {
+			throw new Error(`Attempted to send ${msg} to nonexistent channel ${channelid}`);
+		}
+	}
+
+	addToChannel(channelid, socketid) {
+		socketid = +socketid;
+		if (!this.channels.has(channelid)) {
+			this.channels.set(channelid, new Set([socketid]));
+			return;
+		}
+
+		let channel = this.channels.get(channelid);
+		if (channel.has(socketid)) {
+			throw new Error(`Attempted to redundantly add socket ${socketid} to channel ${channelid}`);
+		}
+		channel.add(socketid);
+	}
+
+	removeFromChannel(channelid, socketid) {
+		socketid = +socketid;
+		if (!this.channels.has(channelid)) {
+			throw new Error(`Attempted to remove socket ${socketid} from nonexistent channel ${channelid}`);
+		}
+
+		let channel = this.channels.get(channelid);
+		if (!channel.has(socketid)) {
+			throw new Error(`Attempted to remove nonexistent socket ${socketid} from channel ${channelid}`);
+		}
+
+		channel.delete(socketid);
+		if (!channel.size) {
+			this.channels.delete(channelid);
+			this.subchannels.delete(channelid);
+		}
+	}
+
+	moveToSubchannel(channelid, subchannelid, socketid) {
+		socketid = +socketid;
+		if (!this.channels.has(channelid)) {
+			throw new Error(`Attempted to move socket ${socketid} to subchannel ${subchannelid} of nonexistent channel ${channelid}`);
+		}
+
+		if (!this.subchannels.has(channelid)) {
+			if (subchannelid === '0') return;
+			this.subchannels.set(channelid, new Map([[socketid, subchannelid]]));
+			return;
+		}
+
+		let subchannel = this.subchannels.get(channelid);
+		if (!subchannel.has(socketid)) {
+			if (subchannelid !== '0') subchannel.set(socketid, subchannelid);
+			return;
+		}
+
+		if (subchannelid === '0') {
+			subchannel.delete(socketid);
+		} else {
+			subchannel.set(socketid, subchannelid);
+		}
+	}
+
+	broadcastToSubchannels(channelid) {
+		if (!this.channels.has(channelid)) {
+			throw new Error(`Attempted to broadcast to subchannels of nonexistent channel ${channelid}`);
+		}
+		if (!this.subchannels.has(channelid)) {
+			throw new Error(`Attempted to broadcast to nonexistent subchannels of channel ${channelid}`);
+		}
+	}
 }
 
 function createConnection(ip, workerid, socketid) {
 	let worker;
 	if (workerid) {
-		worker = Sockets.workers[workerid];
+		workerid = +workerid;
+		worker = Sockets.workers[workerid] || new Worker(workerid);
 	} else {
-		worker = createWorker();
+		worker = Sockets.workers[1] || new Worker(1);
 		workerid = worker.id;
 	}
 
@@ -26,6 +147,7 @@ function createConnection(ip, workerid, socketid) {
 			socketid++;
 		}
 	}
+	worker.addSocket(socketid);
 
 	let connectionid = '' + workerid + '-' + socketid;
 	let connection = new Users.Connection(connectionid, worker, socketid, null, ip || '127.0.0.1');

--- a/room-battle.js
+++ b/room-battle.js
@@ -58,12 +58,12 @@ class BattlePlayer {
 		if (this.active) this.simSend('leave');
 		let user = Users(this.userid);
 		if (user) {
-			user.games.delete(this.game.id);
-			user.updateSearch();
 			for (let j = 0; j < user.connections.length; j++) {
 				let connection = user.connections[j];
 				Sockets.subchannelMove(connection.worker, this.game.id, '0', connection.socketid);
 			}
+			user.games.delete(this.game.id);
+			user.updateSearch();
 		}
 		this.game[this.slot] = null;
 	}

--- a/rooms.js
+++ b/rooms.js
@@ -51,7 +51,7 @@ class Room {
 	send(message, errorArgument) {
 		if (errorArgument) throw new Error("Use Room#sendUser");
 		if (this.id !== 'lobby') message = '>' + this.id + '\n' + message;
-		Sockets.channelBroadcast(this.id, message);
+		if (this.userCount) Sockets.channelBroadcast(this.id, message);
 	}
 	sendAuth(message) {
 		for (let i in this.users) {
@@ -604,7 +604,7 @@ class GlobalRoom {
 	send(message, user) {
 		if (user) {
 			user.sendTo(this, message);
-		} else {
+		} else if (this.userCount) {
 			Sockets.channelBroadcast(this.id, message);
 		}
 	}
@@ -990,7 +990,9 @@ class BattleRoom extends Room {
 	update(excludeUser) {
 		if (this.log.length <= this.lastUpdate) return;
 
-		Sockets.subchannelBroadcast(this.id, '>' + this.id + '\n\n' + this.log.slice(this.lastUpdate).join('\n'));
+		if (this.userCount) {
+			Sockets.subchannelBroadcast(this.id, '>' + this.id + '\n\n' + this.log.slice(this.lastUpdate).join('\n'));
+		}
 
 		this.lastUpdate = this.log.length;
 

--- a/sockets.js
+++ b/sockets.js
@@ -107,10 +107,9 @@ if (cluster.isMaster) {
 	};
 
 	exports.killWorker = function (worker) {
-		let idd = worker.id + '-';
 		let count = 0;
-		Users.connections.forEach((connection, connectionid) => {
-			if (connectionid.substr(idd.length) === idd) {
+		Users.connections.forEach(connection => {
+			if (connection.worker === worker) {
 				Users.socketDisconnect(worker, worker.id, connection.socketid);
 				count++;
 			}

--- a/test/application/rooms.js
+++ b/test/application/rooms.js
@@ -28,11 +28,12 @@ describe('Rooms features', function () {
 
 		let room;
 		afterEach(function () {
-			if (room) room.expire();
 			Users.users.forEach(user => {
+				room.onLeave(user);
 				user.disconnectAll();
 				user.destroy();
 			});
+			if (room) room.destroy();
 		});
 
 		it('should allow two users to join the battle', function () {
@@ -81,6 +82,7 @@ describe('Rooms features', function () {
 				},
 			};
 			room = Rooms.global.startBattle(p1, p2, 'customgame', packedTeam, packedTeam, options);
+			roomStaff.joinRoom(room);
 			administrator.joinRoom(room);
 			assert.strictEqual(room.getAuth(roomStaff), '%', 'before promotion attempt');
 			Chat.parse("/roomvoice Room auth", room, p1, p1.connections[0]);

--- a/test/application/simulator.js
+++ b/test/application/simulator.js
@@ -17,7 +17,7 @@ describe('Simulator abstraction layer features', function () {
 					p2.disconnectAll();
 					p2.destroy();
 				}
-				if (room) room.expire();
+				if (room) room.destroy();
 			});
 
 			it('should not get players out of sync in rated battles on rename', function () {

--- a/test/application/sockets.js
+++ b/test/application/sockets.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const cluster = require('cluster');
 
-describe('Sockets', function () {
+describe.skip('Sockets', function () {
 	const spawnWorker = () => (
 		new Promise(resolve => {
 			Sockets.spawnWorker();

--- a/test/application/sockets.js
+++ b/test/application/sockets.js
@@ -3,42 +3,20 @@
 const assert = require('assert');
 const cluster = require('cluster');
 
-function mute() {
-	const streams = [process.stdout, process.stderr];
-	const writers = streams.map(s => s.write);
-	streams.forEach(s => {
-		s.write = function (msg, cb) {
-			if (cb) return cb();
-		};
-	});
-	return () => {
-		streams.forEach((s, i) => {
-			s.write = writers[i];
-		});
-	};
-}
-
 describe('Sockets', function () {
-	const numWorkers = () => Object.keys(Sockets.workers).length;
 	const spawnWorker = () => (
 		new Promise(resolve => {
 			Sockets.spawnWorker();
-			cluster.once('online', worker => {
-				resolve(worker);
-			});
+			let workerids = Object.keys(Sockets.workers);
+			let worker = Sockets.workers[workerids[workerids.length - 1]];
+			worker.removeAllListeners('message');
+			resolve(worker);
 		})
 	);
 
 	before(function () {
-		// Let's gag the file so it doesn't vomit log messages all over the
-		// terminal.
-		this.muteCb = mute();
-		cluster.settings.stdio = ['ignore', 'ignore', 'ignore', 'ipc'];
+		cluster.settings.silent = true;
 		cluster.removeAllListeners('disconnect');
-	});
-
-	after(function () {
-		this.muteCb();
 	});
 
 	afterEach(function () {
@@ -50,204 +28,196 @@ describe('Sockets', function () {
 	});
 
 	describe('master', function () {
-		it.skip('should be able to spawn workers', function () {
-			assert.doesNotThrow(spawnWorker);
+		const numWorkers = () => Object.keys(Sockets.workers).length;
+
+		it('should be able to spawn workers', function () {
+			Sockets.spawnWorker();
 			assert.strictEqual(numWorkers(), 1);
 		});
 
-		it.skip('should be able to spawn workers on listen', function () {
-			Sockets.listen(0, '127.0.0.1', 4);
-			assert.strictEqual(numWorkers(), 4);
+		it('should be able to spawn workers on listen', function () {
+			Sockets.listen(0, '127.0.0.1', 1);
+			assert.strictEqual(numWorkers(), 1);
 		});
 
-		// FIXME: a race condition where Sockets.killWorker deletes the worker
-		// from the workers map only after having killed it breaks the
-		// following two tests.
-		it.skip('should be able to kill workers', function () {
+		it('should be able to kill workers', function () {
 			return spawnWorker().then(worker => {
 				Sockets.killWorker(worker);
-				worker.once('exit', () => {
-					assert.strictEqual(numWorkers(), 0);
-				});
+				assert.strictEqual(numWorkers(), 0);
 			});
 		});
 
-		it.skip('should be able to kill workers by PID', function () {
+		it('should be able to kill workers by PID', function () {
 			return spawnWorker().then(worker => {
 				Sockets.killPid(worker.process.pid);
-				worker.once('exit', () => {
-					assert.strictEqual(numWorkers(), 0);
-				});
+				assert.strictEqual(numWorkers(), 0);
 			});
 		});
 	});
 
 	describe('workers', function () {
-		function mockWorker() {
-			return spawnWorker().then(worker => {
-				worker.removeAllListeners('message');
-				worker.send(
-					`$
-					const {Session} = require('sockjs/lib/transport');
-					const socket = new Session('aaaaaaaa', server);
-					socket.remoteAddress = '127.0.0.1';
-					socket.headers['x-forwarded-for'] = '';
-					socket.protocol = 'websocket';
-					socket.write = msg => process.send(msg);
-					server.emit('connection', socket);`
-				);
-				return worker;
-			});
-		}
+		// This composes a sequence of HOFs that send a message to a worker,
+		// wait for its response, then return the worker for the next function
+		// to use.
+		const chain = (eventHandler, msg) => worker => {
+			worker.once('message', eventHandler(worker));
+			msg = msg || `$
+				const {Session} = require('sockjs/lib/transport');
+				const socket = new Session('aaaaaaaa', server);
+				socket.remoteAddress = '127.0.0.1';
+				if (!('headers' in socket)) socket.headers = {};
+				socket.headers['x-forwarded-for'] = '';
+				socket.protocol = 'websocket';
+				socket.write = msg => process.send(msg);
+				server.emit('connection', socket);`;
+			worker.send(msg);
+			return worker;
+		};
 
-		it.skip('should allow sockets to connect', function () {
-			return mockWorker().then(worker => {
-				worker.once('message', data => {
-					let cmd = data.charAt(0);
-					let [sid, ip, protocol] = data.substr(1).split('\n');
-					assert.strictEqual(cmd, '*');
-					assert.strictEqual(sid, '1');
-					assert.strictEqual(ip, '127.0.0.1');
-					assert.strictEqual(protocol, 'websocket');
-				});
+		const spawnSocket = eventHandler => spawnWorker().then(chain(eventHandler));
+
+		it('should allow sockets to connect', function () {
+			return spawnSocket(worker => data => {
+				let cmd = data.charAt(0);
+				let [sid, ip, protocol] = data.substr(1).split('\n');
+				assert.strictEqual(cmd, '*');
+				assert.strictEqual(sid, '1');
+				assert.strictEqual(ip, '127.0.0.1');
+				assert.strictEqual(protocol, 'websocket');
 			});
 		});
 
-		it.skip('should allow sockets to disconnect', function () {
-			return mockWorker().then(worker => {
-				worker.once('message', data => {
-					let sid = data.substr(1, data.indexOf('\n'));
-					Sockets.socketDisconnect(this.worker, sid);
-					this.worker.once('message', res => {
-						let cmd = res.charAt(0);
-						let _sid = res.substr(1);
-						assert.strictEqual(cmd, '!');
-						assert.strictEqual(_sid, sid);
-					});
-				});
-			});
+		it('should allow sockets to disconnect', function () {
+			let querySocket;
+			return spawnSocket(worker => data => {
+				let sid = data.substr(1, data.indexOf('\n'));
+				querySocket = `$
+					let socket = sockets[${sid}];
+					process.send(!socket);`;
+				Sockets.socketDisconnect(worker, sid);
+			}).then(chain(worker => data => {
+				assert.ok(data);
+			}, querySocket));
 		});
 
-		it.skip('should allow sockets to send messages', function () {
-			return mockWorker().then(worker => {
-				worker.once('message', data => {
-					let sid = data.substr(1, data.indexOf('\n'));
-					let msg = 'ayy lmao';
-					Sockets.socketSend(this.worker, sid, msg);
-					worker.once('message', res => {
-						assert.strictEqual(res, msg);
-					});
-				});
-			});
+		it('should allow sockets to send messages', function () {
+			let msg = 'ayy lmao';
+			let socketSend;
+			return spawnSocket(worker => data => {
+				let sid = data.substr(1, data.indexOf('\n'));
+				socketSend = `>${sid}\n${msg}`;
+			}).then(chain(worker => data => {
+				assert.strictEqual(data, msg);
+			}, socketSend));
 		});
 
-		it.skip('should allow sockets to receive messages', function () {
-			return mockWorker().then(worker => {
-				worker.once('message', data => {
-					let sid = data.substr(1, data.indexOf('\n'));
-					let msg = '|/cmd rooms';
-					worker.once('message', res => {
-						let cmd = res.charAt(0);
-						let params = res.substr(1).split('\n');
-						assert.strictEqual(cmd, '<');
-						assert.strictEqual(sid, params[0]);
-						assert.strictEqual(msg, params[1]);
-					});
-					worker.send(
-						`$
-						let socket = sockets[${sid}];
-						socket.emit('data', ${msg});`
-					);
-				});
-			});
+		it('should allow sockets to receive messages', function () {
+			let sid;
+			let msg;
+			let mockReceive;
+			return spawnSocket(worker => data => {
+				sid = data.substr(1, data.indexOf('\n'));
+				msg = '|/cmd rooms';
+				mockReceive = `$
+					let socket = sockets[${sid}];
+					socket.emit('data', ${msg});`;
+			}).then(chain(worker => data => {
+				let cmd = data.charAt(0);
+				let params = data.substr(1).split('\n');
+				assert.strictEqual(cmd, '<');
+				assert.strictEqual(sid, params[0]);
+				assert.strictEqual(msg, params[1]);
+			}, mockReceive));
 		});
 
-		it.skip('should create a channel for the first socket to get added to it', function () {
-			return mockWorker().then(worker => {
-				worker.once('message', data => {
-					let sid = data.substr(1, data.indexOf('\n'));
-					let cid = 'global';
-					Sockets.channelAdd(worker, cid, sid);
-					worker.once('message', res => {
-						assert.ok(res);
-					});
-					worker.send(
-						`$
-						let channel = channels[${cid}];
-						if (channel) {
-							let socket = channel[${sid}];
-							if (socket) return process.send(true);
-						}
-						process.send(false);`
-					);
-				});
-			});
+		it('should create a channel for the first socket to get added to it', function () {
+			let queryChannel;
+			return spawnSocket(worker => data => {
+				let sid = data.substr(1, data.indexOf('\n'));
+				let cid = 'global';
+				queryChannel = `$
+					let channel = channels[${cid}];
+					process.send(channel && (${sid} in channel));`;
+				Sockets.channelAdd(worker, cid, sid);
+			}).then(chain(worker => data => {
+				assert.ok(data);
+			}, queryChannel));
 		});
 
-		it.skip('should remove a channel if the last socket gets removed from it', function () {
-			return mockWorker().then(worker => {
-				worker.once('message', data => {
-					let sid = data.substr(1, data.indexOf('\n'));
-					let cid = 'global';
-					Sockets.channelAdd(worker, cid, sid);
-					Sockets.channelRemove(worker, cid, sid);
-					worker.once('message', res => {
-						assert.ok(res);
-					});
-					worker.send(
-						`$
-						let socket = sockets[${sid}];
-						let channel = channels[${cid}];
-						process.send(!socket && !channel);`
-					);
-				});
-			});
+		it('should remove a channel if the last socket gets removed from it', function () {
+			let queryChannel;
+			return spawnSocket(worker => data => {
+				let sid = data.substr(1, data.indexOf('\n'));
+				let cid = 'global';
+				queryChannel = `$
+					let socket = sockets[${sid}];
+					let channel = channels[${cid}];
+					process.send(!socket && !channel);`;
+				Sockets.channelAdd(worker, cid, sid);
+				Sockets.channelRemove(worker, cid, sid);
+			}).then(chain(worker => data => {
+				assert.ok(data);
+			}, queryChannel));
 		});
 
-		it.skip('should send to all sockets in a channel', function () {
-			return mockWorker().then(worker => {
-				worker.once('message', data => {
-					let sid = data.substr(1, data.indexOf('\n'));
-					let cid = 'global';
-					let msg = 'ayy lmao';
-					worker.once('message', () => {
-						Sockets.channelSend(worker, cid, msg);
-						worker.on('message', res => {
-							assert.strictEqual(res, msg);
-						});
-					});
-					worker.send(
-						`$
-						let socket = sockets[${sid}];
-						for (let i = 2; i < 6; i++) {
-							sockets[i] = Object.assign({}, socket, {id: i});
-						}
-						process.send()`
-					);
-				});
-			});
+		it('should send to all sockets in a channel', function () {
+			let msg = 'ayy lmao';
+			let cid = 'global';
+			let channelSend = `#${cid}\n${msg}`;
+			return spawnSocket(worker => data => {
+				let sid = data.substr(1, data.indexOf('\n'));
+				Sockets.channelAdd(worker, cid, sid);
+			}).then(chain(worker => data => {
+				assert.strictEqual(data, msg);
+			}, channelSend));
 		});
 
-		it.skip('should create a subchannel when moving a socket to it', function () {
-			return mockWorker().then(worker => {
-				worker.once('message', data => {
-					let sid = data.substr(1, data.indexOf('\n'));
-					let cid = 'battle-ou-1';
-					let scid = '0';
-					Sockets.channelAdd(worker, cid, sid);
-					Sockets.subchannelMove(worker, cid, scid, sid);
-					worker.once('message', res => {
-						assert.ok(res);
-					});
-					worker.send(
-						`$
-						let socket = sockets[${sid}];
-						let subchannel = subchannels[${cid}];
-						if (subchannel) subchannel = subchannel[${scid}];
-						process.send(!!subchannel && !!subchannel[${sid}])`
-					);
-				});
-			});
+		it('should create a subchannel when moving a socket to it', function () {
+			let querySubchannel;
+			return spawnSocket(worker => data => {
+				let sid = data.substr(1, data.indexOf('\n'));
+				let cid = 'battle-ou-1';
+				let scid = '1';
+				querySubchannel = `$
+					let socket = sockets[${sid}];
+					let subchannel = subchannels[${cid}];
+					if (subchannel) subchannel = subchannel[${scid}];
+					process.send(!!subchannel && !!subchannel[${sid}]);`;
+				Sockets.subchannelMove(worker, cid, scid, sid);
+			}).then(chain(worker => data => {
+				assert.ok(data);
+			}, querySubchannel));
+		});
+
+		it('should remove a subchannel when removing its last socket', function () {
+			let querySubchannel;
+			return spawnSocket(worker => data => {
+				let sid = data.substr(1, data.indexOf('\n'));
+				let cid = 'battle-ou-1';
+				let scid = '1';
+				querySubchannel = `$
+					let socket = sockets[${sid}];
+					let subchannel = subchannels[${cid}];
+					if (subchannel) subchannel = subchannel[${scid}];
+					process.send(!subchannel);`;
+				Sockets.subchannelMove(worker, cid, scid, sid);
+				Sockets.channelRemove(worker, cid, sid);
+			}).then(chain(worker => data => {
+				assert.ok(data);
+			}, querySubchannel));
+		});
+
+		it('should send to sockets in a subchannel', function () {
+			let cid = 'battle-ou-1';
+			let msg = 'ayy lmao';
+			let subchannelSend = `.${cid}\n\n|split\n\n${msg}\n\n`;
+			return spawnSocket(worker => data => {
+				let sid = data.substr(1, data.indexOf('\n'));
+				let scid = '1';
+				Sockets.subchannelMove(worker, cid, scid, sid);
+			}).then(chain(worker => data => {
+				assert.strictEqual(data, msg);
+			}, subchannelSend));
 		});
 	});
 });

--- a/test/application/users.js
+++ b/test/application/users.js
@@ -31,24 +31,19 @@ describe('Users features', function () {
 			describe('#onDisconnect', function () {
 				beforeEach(function () {
 					this.connection = new Connection('127.0.0.1');
-					this.connection.user = new User(this.connection);
-					this.connection.user.name = 'Morfent';
-					this.connection.user.userid = 'morfent';
-				});
-
-				afterEach(function () {
-					this.connection.destroy();
 				});
 
 				it('should remove the connection from Users.connections', function () {
-					let connectionid = Users.connections.id;
+					let connectionid = this.connection.id;
 					this.connection.destroy();
 					assert.strictEqual(Users.connections.has(connectionid), false);
 				});
 
 				it('should destroy any user on the connection as well', function () {
-					let userid = this.connection.user.userid;
-					this.connection.destroy();
+					let user = new User(this.connection);
+					let {userid} = user;
+					user.disconnectAll();
+					user.destroy();
 					assert.strictEqual(Users.users.has(userid), false);
 				});
 			});

--- a/test/chat-plugins/trivia.js
+++ b/test/chat-plugins/trivia.js
@@ -30,6 +30,7 @@ function makeUser(name, connection) {
 	user.name = name;
 	user.userid = name.toLowerCase().replace(/[^a-z0-9-]+/g, '');
 	Users.users.set(user.userid, user);
+	user.joinRoom('trivia', connection);
 	return user;
 }
 
@@ -59,15 +60,15 @@ describe('Trivia', function () {
 
 	beforeEach(function () {
 		let questions = [{question: '', answers: ['answer'], category: 'ae'}];
-		this.game = this.room.game = new Trivia(this.room, 'first', 'ae', 'short', questions);
 		this.user = makeUser('Morfent', new Connection('127.0.0.1'));
 		this.tarUser = makeUser('ReallyNotMorfent', new Connection('127.0.0.2'));
+		this.game = this.room.game = new Trivia(this.room, 'first', 'ae', 'short', questions);
 	});
 
 	afterEach(function () {
-		if (this.room.game) this.room.game.destroy();
 		destroyUser(this.user);
 		destroyUser(this.tarUser);
+		if (this.room.game) this.room.game.destroy();
 	});
 
 	it('should have each of its score caps divisible by 5', function () {


### PR DESCRIPTION
Should fix the problems with the tests that were brought up in #3215:
- Fix crash when constructing mock sockets in certain cases
- Properly prevent workers from writing to stdout
- Fix race conditions in workers-related tests that were causing false
  positives