### PR TITLE
Random Battle: Respect non-Pokemon bans

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2283,9 +2283,6 @@ exports.BattleScripts = {
 			// Between OU and Uber
 			// Blaziken: 74, 'Blaziken-Mega': 74, 'Lucario-Mega': 74,
 
-			// Banned Ability
-			// Gothitelle: 74, Wobbuffet: 74,
-
 			// Holistic judgement
 			Unown: 100,
 		};
@@ -2298,6 +2295,22 @@ exports.BattleScripts = {
 		}
 		let level = levelScale[tier] || 75;
 		if (customScale[template.name]) level = customScale[template.name];
+
+		// Banned abilities
+		if (ability === 'Power Construct' || ability === 'Shadow Tag') {
+			level = 73;
+		} else if (ability === 'Drizzle') level = 76;
+
+		// Banned moves
+		if (hasMove['batonpass']) {
+			// Baton Pass Clause
+			if (hasMove['batonpass'] && (counter['speedsetup'] > 0 || ability === 'Speed Boost') && (counter['physicalsetup'] > 0 || counter['specialsetup'] > 0 || counter['mixedsetup'] > 0) && level < 74) {
+				level = 74;
+			} else if (level < 76) level = 76;
+		}
+
+		// Banned items
+		if (item === 'Mewnium-Z' && level < 76) level = 76;
 
 		// if (template.name === 'Slurpuff' && !counter.setupType) level = 81;
 		// if (template.name === 'Xerneas' && hasMove['geomancy']) level = 71;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2299,14 +2299,18 @@ exports.BattleScripts = {
 		// Banned abilities
 		if (ability === 'Power Construct' || ability === 'Shadow Tag') {
 			level = 73;
-		} else if (ability === 'Drizzle') level = 76;
+		} else if (ability === 'Drizzle' && level < 76) {
+			level = 76;
+		}
 
 		// Banned moves
 		if (hasMove['batonpass']) {
 			// Baton Pass Clause
 			if (hasMove['batonpass'] && (counter['speedsetup'] > 0 || ability === 'Speed Boost') && (counter['physicalsetup'] > 0 || counter['specialsetup'] > 0 || counter['mixedsetup'] > 0) && level < 74) {
 				level = 74;
-			} else if (level < 76) level = 76;
+			} else if (level < 76) {
+				level = 76;
+			}
 		}
 
 		// Banned items


### PR DESCRIPTION
If the TLs decide something is too good for their tier, then it's too good for that tier's level in Randbats. With this in mind, it's probably worth removing Baton Pass as an option from all the Pokemon in BL2 and below that would prefer not to lose their their level bonus because of one move.

On Wobbufett and Gothitelle's levels being made 73 by this: they might not be great in Uber, but Randbats has no team preview, so they're impossible to play around until they come in, and by then it's usually too late.