### PR TITLE
Random Battle: Improve level balancing

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2290,8 +2290,8 @@ exports.BattleScripts = {
 			Unown: 100,
 		};
 		let tier = template.tier;
-		if (tier.includes('Unreleased') && template.battleOnly) {
-			tier = baseTemplate.tier;
+		if (tier.includes('Unreleased') && baseTemplate.tier === 'Uber') {
+			tier = 'Uber';
 		}
 		if (tier.charAt(0) === '(') {
 			tier = tier.slice(1, -1);

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2283,9 +2283,6 @@ exports.BattleScripts = {
 			// Between OU and Uber
 			// Blaziken: 74, 'Blaziken-Mega': 74, 'Lucario-Mega': 74,
 
-			// Banned Ability
-			// Gothitelle: 74, Wobbuffet: 74,
-
 			// Holistic judgement
 			Unown: 100,
 		};
@@ -2298,6 +2295,22 @@ exports.BattleScripts = {
 		}
 		let level = levelScale[tier] || 75;
 		if (customScale[template.name]) level = customScale[template.name];
+
+		// Banned abilities
+		if (ability === 'Power Construct' || ability === 'Shadow Tag') {
+			level = 73;
+		} else if (ability === 'Drizzle') level = 76;
+
+		// Banned moves
+		if (hasMove['batonpass']) {
+			// Baton Pass Clause
+			if (hasMove['batonpass'] && (counter['speedsetup'] > 0 || ability === 'Speed Boost') && (counter['physicalsetup'] > 0 || counter['specialsetup'] > 0 || counter['mixedsetup'] > 0) && level < 74) {
+				level = 74;
+			} else if (level < 76) level = 76;
+		}
+
+		// Banned items
+		if (item === 'Mewnium-Z' && level < 76) level = 76;
 
 		// if (template.name === 'Slurpuff' && !counter.setupType) level = 81;
 		// if (template.name === 'Xerneas' && hasMove['geomancy']) level = 71;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2282,7 +2282,7 @@ exports.BattleScripts = {
 		let customScale = {
 			// Between OU and Uber
 			// Blaziken: 74, 'Blaziken-Mega': 74, 'Lucario-Mega': 74,
-			
+
 			// Banned Abilities
 			Gothitelle: 74, Wobbuffet: 74, Zygarde: 73, 'Zygarde-10%': 73,
 

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2280,11 +2280,8 @@ exports.BattleScripts = {
 			AG: 71,
 		};
 		let customScale = {
-			// Between OU and Uber
-			// Blaziken: 74, 'Blaziken-Mega': 74, 'Lucario-Mega': 74,
-
 			// Banned Abilities
-			Gothitelle: 74, Wobbuffet: 74, Zygarde: 73, 'Zygarde-10%': 73,
+			Gothitelle: 76, Politoed: 76, Wobbuffet: 76,
 
 			// Holistic judgement
 			Unown: 100,
@@ -2299,9 +2296,9 @@ exports.BattleScripts = {
 		let level = levelScale[tier] || 75;
 		if (customScale[template.name]) level = customScale[template.name];
 
-		// Baton Pass Clause
-		if (hasMove['batonpass'] && (counter['speedsetup'] > 0 || ability === 'Speed Boost') && (counter['physicalsetup'] > 0 || counter['specialsetup'] > 0 || counter['mixedsetup'] > 0) && level < 74) level = 74;
-
+		// Custom level based on moveset
+		if (ability === 'Power Construct') level = 73;
+		if (hasMove['batonpass'] && level < 75) level = 75;
 		// if (template.name === 'Slurpuff' && !counter.setupType) level = 81;
 		// if (template.name === 'Xerneas' && hasMove['geomancy']) level = 71;
 

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2299,14 +2299,18 @@ exports.BattleScripts = {
 		// Banned abilities
 		if (ability === 'Power Construct' || ability === 'Shadow Tag') {
 			level = 73;
-		} else if (ability === 'Drizzle') level = 76;
+		} else if (ability === 'Drizzle' && level < 76) {
+			level = 76;
+		}
 
 		// Banned moves
 		if (hasMove['batonpass']) {
 			// Baton Pass Clause
 			if (hasMove['batonpass'] && (counter['speedsetup'] > 0 || ability === 'Speed Boost') && (counter['physicalsetup'] > 0 || counter['specialsetup'] > 0 || counter['mixedsetup'] > 0) && level < 74) {
 				level = 74;
-			} else if (level < 76) level = 76;
+			} else if (level < 76) {
+				level = 76;
+			}
 		}
 
 		// Banned items

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2282,6 +2282,9 @@ exports.BattleScripts = {
 		let customScale = {
 			// Between OU and Uber
 			// Blaziken: 74, 'Blaziken-Mega': 74, 'Lucario-Mega': 74,
+			
+			// Banned Abilities
+			Gothitelle: 74, Wobbuffet: 74, Zygarde: 73, 'Zygarde-10%': 73,
 
 			// Holistic judgement
 			Unown: 100,
@@ -2296,25 +2299,8 @@ exports.BattleScripts = {
 		let level = levelScale[tier] || 75;
 		if (customScale[template.name]) level = customScale[template.name];
 
-		// Banned abilities
-		if (ability === 'Power Construct' || ability === 'Shadow Tag') {
-			level = 73;
-		} else if (ability === 'Drizzle' && level < 76) {
-			level = 76;
-		}
-
-		// Banned moves
-		if (hasMove['batonpass']) {
-			// Baton Pass Clause
-			if (hasMove['batonpass'] && (counter['speedsetup'] > 0 || ability === 'Speed Boost') && (counter['physicalsetup'] > 0 || counter['specialsetup'] > 0 || counter['mixedsetup'] > 0) && level < 74) {
-				level = 74;
-			} else if (level < 76) {
-				level = 76;
-			}
-		}
-
-		// Banned items
-		if (item === 'Mewnium-Z' && level < 76) level = 76;
+		// Baton Pass Clause
+		if (hasMove['batonpass'] && (counter['speedsetup'] > 0 || ability === 'Speed Boost') && (counter['physicalsetup'] > 0 || counter['specialsetup'] > 0 || counter['mixedsetup'] > 0) && level < 74) level = 74;
 
 		// if (template.name === 'Slurpuff' && !counter.setupType) level = 81;
 		// if (template.name === 'Xerneas' && hasMove['geomancy']) level = 71;


### PR DESCRIPTION
Even if you don't like lower tiers banning things like Drizzle, I must insist on Power Construct, Shadow Tag, and passing speed + another stat being considered Uber, or at least above OU in some way. Level 83 Smashpass Gorebyss was just plain unfair last gen, and so is level 75 Zygarde-Complete this gen.

Also, while I was laddering to try and make sure that this was really a problem and I wasn't just imagining it, I noticed that unreleased megas are getting the levels of their weaker base formes in every case, such that Mawile-Mega is running around at level 79. If I'm not mistaken, these megas will be tiered as OU to start when they get released, and their Randbats level should reflect this.