### PR TITLE
Fix permissions for pminfobox

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -473,20 +473,18 @@ exports.commands = {
 		if (!this.can('addhtml', null, room)) return false;
 		if (!target) return this.parse("/help pminfobox");
 
-		target = this.canHTML(target);
+		target = this.canHTML(this.splitTarget(target));
 		if (!target) return;
-
-		target = this.splitTarget(target);
 		let targetUser = this.targetUser;
 
-		if (!targetUser || !targetUser.connected) return this.errorReply("User " + targetUser + " is not currently online.");
+		if (!targetUser || !targetUser.connected) return this.errorReply(`User ${this.targetUsername} is not currently online.`);
 		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
-		if (targetUser.ignorePMs) return this.errorReply("This user is currently ignoring PMs.");
-		if (targetUser.locked) return this.errorReply("This user is currently locked, so you cannot send them a pminfobox.");
+		if (targetUser.ignorePMs && targetUser.ignorePMs !== user.group && !user.can('lock')) return this.errorReply("This user is currently ignoring PMs.");
+		if (targetUser.locked && !user.can('lock')) return this.errorReply("This user is currently locked, so you cannot send them a pminfobox.");
 
 		// Apply the infobox to the message
-		target = '/raw <div class="infobox">' + target + '</div>';
-		let message = '|pm|' + user.getIdentity() + '|' + targetUser.getIdentity() + '|' + target;
+		target = `/raw <div class="infobox">${target}</div>`;
+		let message = `|pm|${user.getIdentity()}|${targetUser.getIdentity()}|${target}`;
 
 		user.send(message);
 		if (targetUser !== user) targetUser.send(message);


### PR DESCRIPTION
- check the actual html only in ``this.canHTML()``;
>-  prevents false positives of broken HTML such as ``/pminfobox sparkych<i>ld, <em>oops! :^)</em>``
>- prevents HTML exploitation such as ``/pminfobox SAO full <div>e, </div>Time to think outside the box ;)`` from working
- use proper blockpm permissions - staff can bypass the pmblocks, and excepted users (``/blockpms`` allow a ``target`` for groups to be whitelisted)
- staff __should be__ able to send pminfobox's to locked users as well.

- template strings!