### PR TITLE
Fix HTML and date field check in room-events

### DIFF
--- a/chat-plugins/room-events.js
+++ b/chat-plugins/room-events.js
@@ -33,6 +33,7 @@ exports.commands = {
 			if (!this.can('declare', null, room)) return false;
 			if (!room.events) room.events = {};
 			let [eventName, desc, ...date] = target.split('|');
+			date = date.join("|");
 			if (!eventName || !desc || !date) return this.errorReply("You're missing a command parameter - see /help roomevents for this command's syntax.");
 			desc = this.canHTML(desc);
 			if (desc === false) return false; // HTML issue - line above will be more specific

--- a/chat.js
+++ b/chat.js
@@ -714,7 +714,7 @@ class CommandContext {
 		}
 
 		// check for mismatched tags
-		let tags = html.toLowerCase().match(/<\/?(div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code)\b/g);
+		let tags = html.toLowerCase().match(/<\/?(div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code|table|td|tr)\b/g);
 		if (tags) {
 			let stack = [];
 			for (let i = 0; i < tags.length; i++) {


### PR DESCRIPTION
This PR is more of an "update" to fix room-events.

In response to the new [roomevent plugin][1], I've noticed that it's specifically done to allow HTML in the field for the events, and uses ``this.canHTML()`` to check in the ``/roomevents add`` command.
- adds the new tags to be checked for in ``this.canHTML()`` to prevent people from breaking the table and inserting more interesting things outside of the table.  This could potentially create impersonation of staff (having Zarel say funny things can always be a fun pastime in groupchats [surprisingly roomevents is allowed in gorupchats too!])

Example:
![bad foxie!](http://image.prntscr.com/image/a8f50e6956a94297a92624561c70b667.png)

- [] always exists. Join date with ``"|"`` before checking if it exists.

[1]: https://github.com/Zarel/Pokemon-Showdown/blob/master/chat-plugins/room-events.js