### PR TITLE
Fix Triple Hit mechanics in Gen 2

### DIFF
--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -699,6 +699,11 @@ exports.BattleMovedex = {
 			},
 		},
 	},
+	triplekick: {
+		inherit: true,
+		multiaccuracy: false,
+		multihit: [1, 3],
+	},
 	whirlwind: {
 		inherit: true,
 		onTryHit: function () {


### PR DESCRIPTION
- Don't use multi accuracy setting
- Set multihit between 1 and 3 randomly, as it has been mentioned in the issue https://github.com/Zarel/Pokemon-Showdown/issues/3239 (scripts __should__ automatically do a random distribution if the ratio is not between 2 and 5)