### PR TITLE
Prevent permalocked users from getting unlocked

### DIFF
--- a/users.js
+++ b/users.js
@@ -721,6 +721,7 @@ class User {
 			} else if (userType === '4') {
 				this.autoconfirmed = userid;
 			} else if (userType === '5') {
+				this.permalocked = userid;
 				Punishments.lock(this, Date.now() + PERMALOCK_CACHE_TIME, userid, `Permalocked as ${name}`);
 			} else if (userType === '6') {
 				Punishments.ban(this, Date.now() + PERMALOCK_CACHE_TIME, userid, `Permabanned as ${name}`);
@@ -933,6 +934,10 @@ class User {
 			this.isStaff = (staffRoom && staffRoom.auth && staffRoom.auth[this.userid]);
 		}
 		if (this.trusted) {
+			if (this.locked && this.permalocked) {
+				Monitor.log(`[CrisisMonitor] Trusted user '${this.userid}' is ${this.permalocked !== this.userid ? `an alt of permalocked user '${this.permalocked}'` : `a permalocked user`}, and was automatically demoted from ${this.distrust()}.`);
+				return;
+			}
 			this.locked = false;
 			this.namelocked = false;
 		}


### PR DESCRIPTION
Prevents permalocked users from getting freed due to a previous trusted status.

- notifies side servers about newly permalocked users easier, and prevents further issues/crimes from being committed.
- doesn't free permalocked users anymore on side servers to commit more crimes.  