### PR TITLE
Tools: Fix happiness parsing bug

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -1153,7 +1153,7 @@ class BattleDex {
 				if (i !== j) misc = buf.substring(i, j).split(',', 3);
 			}
 			if (misc) {
-				set.happiness = Number(misc[0]);
+				set.happiness = (misc[0] ? Number(misc[0]) : 255);
 				set.hpType = misc[1];
 				set.pokeball = misc[2];
 			}


### PR DESCRIPTION
When parsing happiness, (`Number(misc[0])`) if `misc[0]` is an empty string, (undefined, which normally points to 255) `Number` will parse that as `0`. This fixes that. This bug only occured when a pokemon had hidden power, and it was a set type (ex: Hidden Power Water not Hidden Power). And only really came up when the pokemon had return too.