### PR TITLE
Scavengers: Remove extra space in UI

### DIFF
--- a/chat-plugins/scavengers.js
+++ b/chat-plugins/scavengers.js
@@ -149,7 +149,7 @@ exports.commands = {
 		}
 		if (scavengers.participants[user.userid].room >= 3) return this.sendReply('You have finished the current scavenger hunt.');
 		let roomnum = scavengers.participants[user.userid].room;
-		this.sendReply(`You are on hint number ${(roomnum + 1)} : ${scavengers.hints[roomnum]}`);
+		this.sendReply(`You are on hint number ${(roomnum + 1)}: ${scavengers.hints[roomnum]}`);
 	},
 	endhunt: function (target, room, user) {
 		if (room.id !== 'scavengers') return this.errorReply("This command can only be used in the Scavengers room.");


### PR DESCRIPTION
This extra space was introduced in https://github.com/Zarel/Pokemon-Showdown/commit/549c1f89f2b9d2f813ae7114fe489ba248fe106d when changing this line to use template strings.

Also, add a new line back to the end of the file.