### PR TITLE
Standardize 'requires' text in all help commands

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -491,7 +491,7 @@ exports.commands = {
 		targetUser.lastPM = user.userid;
 		user.lastPM = targetUser.userid;
 	},
-	pminfoboxhelp: ["/pminfobox [user], [html]- PMs an [html] infobox to [user]. Requires * ~"],
+	pminfoboxhelp: ["/pminfobox [user], [html]- PMs an [html] infobox to [user]. " + Chat.require('*')],
 
 	'!ignorepms': true,
 	blockpm: 'ignorepms',
@@ -595,7 +595,7 @@ exports.commands = {
 			this.sendReply("The chat room '" + target + "' was created.");
 		}
 	},
-	makechatroomhelp: ["/makechatroom [roomname] - Creates a new room named [roomname]. Requires: & ~"],
+	makechatroomhelp: ["/makechatroom [roomname] - Creates a new room named [roomname]. " + Chat.require('&')],
 
 	makegroupchat: function (target, room, user, connection, cmd) {
 		if (!user.autoconfirmed) {
@@ -695,7 +695,7 @@ exports.commands = {
 		}
 		return this.errorReply("The room '" + target + "' isn't registered.");
 	},
-	deregisterchatroomhelp: ["/deregisterchatroom [roomname] - Deletes room [roomname] after the next server restart. Requires: & ~"],
+	deregisterchatroomhelp: ["/deregisterchatroom [roomname] - Deletes room [roomname] after the next server restart. " + Chat.require('&')],
 
 	deletechatroom: 'deleteroom',
 	deletegroupchat: 'deleteroom',
@@ -737,7 +737,7 @@ exports.commands = {
 		targetRoom.update();
 		targetRoom.destroy();
 	},
-	deleteroomhelp: ["/deleteroom [roomname] - Deletes room [roomname]. Requires: & ~"],
+	deleteroomhelp: ["/deleteroom [roomname] - Deletes room [roomname]. " + Chat.require('&')],
 
 	hideroom: 'privateroom',
 	hiddenroom: 'privateroom',
@@ -814,9 +814,9 @@ exports.commands = {
 			room.privacySetter = new Set([user.userid]);
 		}
 	},
-	privateroomhelp: ["/secretroom - Makes a room secret. Secret rooms are visible to & and up. Requires: & ~",
-		"/hiddenroom [on/off] - Makes a room hidden. Hidden rooms are visible to % and up, and inherit global ranks. Requires: \u2606 & ~",
-		"/publicroom - Makes a room public. Requires: \u2606 & ~"],
+	privateroomhelp: ["/secretroom - Makes a room secret. Secret rooms are visible to & and up. " + Chat.require('&'),
+		"/hiddenroom [on/off] - Makes a room hidden. Hidden rooms are visible to % and up, and inherit global ranks. " + Chat.require('\u2606'),
+		"/publicroom - Makes a room public. " + Chat.require('\u2606')],
 
 	officialchatroom: 'officialroom',
 	officialroom: function (target, room, user) {
@@ -1046,7 +1046,7 @@ exports.commands = {
 		}
 		Rooms.global.writeChatRoomData();
 	},
-	roomownerhelp: ["/roomowner [username] - Appoints [username] as a room owner. Requires: & ~"],
+	roomownerhelp: ["/roomowner [username] - Appoints [username] as a room owner. " + Chat.require('&')],
 
 	'!roompromote': true,
 	roomdemote: 'roompromote',
@@ -1138,9 +1138,9 @@ exports.commands = {
 		if (room.chatRoomData) Rooms.global.writeChatRoomData();
 	},
 	roompromotehelp: [
-		"/roompromote OR /roomdemote [username], [group symbol] - Promotes/demotes the user to the specified room rank. Requires: @ * # & ~",
-		"/room[group] [username] - Promotes/demotes the user to the specified room rank. Requires: @ * # & ~",
-		"/roomdeauth [username] - Removes all room rank from the user. Requires: @ * # & ~",
+		"/roompromote OR /roomdemote [username], [group symbol] - Promotes/demotes the user to the specified room rank. " + Chat.require('@'),
+		"/room[group] [username] - Promotes/demotes the user to the specified room rank. " + Chat.require('@'),
+		"/roomdeauth [username] - Removes all room rank from the user. " + Chat.require('@'),
 	],
 
 	'!roomauth': true,
@@ -1286,7 +1286,7 @@ exports.commands = {
 		Punishments.roomBan(room, targetUser, null, null, target);
 		return true;
 	},
-	banhelp: ["/roomban [username], [reason] - Bans the user from the room you are in. Requires: @ # & ~"],
+	banhelp: ["/roomban [username], [reason] - Bans the user from the room you are in. " + Chat.require('@')],
 
 	unroomban: 'unban',
 	roomunban: 'unban',
@@ -1305,7 +1305,7 @@ exports.commands = {
 			this.errorReply("User '" + target + "' is not banned.");
 		}
 	},
-	unbanhelp: ["/roomunban [username] - Unbans the user from the room you are in. Requires: @ # & ~"],
+	unbanhelp: ["/roomunban [username] - Unbans the user from the room you are in. " + Chat.require('@')],
 
 	'!autojoin': true,
 	autojoin: function (target, room, user, connection) {
@@ -1374,7 +1374,7 @@ exports.commands = {
 		this.add('|unlink|' + userid);
 		if (userid !== toId(this.inputUsername)) this.add('|unlink|' + toId(this.inputUsername));
 	},
-	warnhelp: ["/warn OR /k [username], [reason] - Warns a user showing them the Pok\u00e9mon Showdown Rules and [reason] in an overlay. Requires: % @ # & ~"],
+	warnhelp: ["/warn OR /k [username], [reason] - Warns a user showing them the Pok\u00e9mon Showdown Rules and [reason] in an overlay. " + Chat.require('%')],
 
 	redirect: 'redir',
 	redir: function (target, room, user, connection) {
@@ -1405,7 +1405,7 @@ exports.commands = {
 		this.addModCommand("" + targetUser.name + " was redirected to room " + targetRoom.title + " by " + user.name + ".");
 		targetUser.leaveRoom(room);
 	},
-	redirhelp: ["/redirect OR /redir [username], [roomname] - Attempts to redirect the user [username] to the room [roomname]. Requires: % @ & ~"],
+	redirhelp: ["/redirect OR /redir [username], [roomname] - Attempts to redirect the user [username] to the room [roomname]. " + Chat.require('%')],
 
 	m: 'mute',
 	mute: function (target, room, user, connection, cmd) {
@@ -1439,14 +1439,14 @@ exports.commands = {
 
 		room.mute(targetUser, muteDuration, false);
 	},
-	mutehelp: ["/mute OR /m [username], [reason] - Mutes a user with reason for 7 minutes. Requires: % @ * # & ~"],
+	mutehelp: ["/mute OR /m [username], [reason] - Mutes a user with reason for 7 minutes. " + Chat.require('%')],
 
 	hm: 'hourmute',
 	hourmute: function (target) {
 		if (!target) return this.parse('/help hourmute');
 		this.run('mute');
 	},
-	hourmutehelp: ["/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. Requires: % @ * # & ~"],
+	hourmutehelp: ["/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. " + Chat.require('%')],
 
 	um: 'unmute',
 	unmute: function (target, room, user) {
@@ -1464,7 +1464,7 @@ exports.commands = {
 			this.errorReply("" + (targetUser ? targetUser.name : this.targetUsername) + " is not muted.");
 		}
 	},
-	unmutehelp: ["/unmute [username] - Removes mute from user. Requires: % @ * # & ~"],
+	unmutehelp: ["/unmute [username] - Removes mute from user. " + Chat.require('%')],
 
 	forcelock: 'lock',
 	l: 'lock',
@@ -1533,7 +1533,7 @@ exports.commands = {
 		Punishments.lock(targetUser, null, null, target);
 		return true;
 	},
-	lockhelp: ["/lock OR /l [username], [reason] - Locks the user from talking in all chats. Requires: % @ * & ~"],
+	lockhelp: ["/lock OR /l [username], [reason] - Locks the user from talking in all chats. " + Chat.require('%')],
 
 	wl: 'weeklock',
 	weeklock: function (target, room, user, connection, cmd) {
@@ -1599,7 +1599,7 @@ exports.commands = {
 		Punishments.lock(targetUser, Date.now() + 7 * 24 * 60 * 60 * 1000, null, target);
 		return true;
 	},
-	weeklockhelp: ["/weeklock OR /wl [username], [reason] - Locks the user from talking in all chats for one week. Requires: % @ * & ~"],
+	weeklockhelp: ["/weeklock OR /wl [username], [reason] - Locks the user from talking in all chats for one week. " + Chat.require('%')],
 
 	unlock: function (target, room, user) {
 		if (!target) return this.parse('/help unlock');
@@ -1625,7 +1625,7 @@ exports.commands = {
 			this.errorReply("User '" + target + "' is not locked.");
 		}
 	},
-	unlockhelp: ["/unlock [username] - Unlocks the user. Requires: % @ * & ~"],
+	unlockhelp: ["/unlock [username] - Unlocks the user. " + Chat.require('%')],
 
 	forceglobalban: 'globalban',
 	gban: 'globalban',
@@ -1696,7 +1696,7 @@ exports.commands = {
 		this.globalModlog("BAN", targetUser, " by " + user.name + (target ? ": " + target : ""));
 		return true;
 	},
-	globalbanhelp: ["/globalban OR /gban [username], [reason] - Kick user from all rooms and ban user's IP address with reason. Requires: @ * & ~"],
+	globalbanhelp: ["/globalban OR /gban [username], [reason] - Kick user from all rooms and ban user's IP address with reason. " + Chat.require('@')],
 
 	globalunban: 'unglobalban',
 	unglobalban: function (target, room, user) {
@@ -1712,7 +1712,7 @@ exports.commands = {
 			this.errorReply("User '" + target + "' is not globally banned.");
 		}
 	},
-	unglobalbanhelp: ["/unglobalban [username] - Unban a user. Requires: @ * & ~"],
+	unglobalbanhelp: ["/unglobalban [username] - Unban a user. " + Chat.require('@')],
 
 	unbanall: function (target, room, user) {
 		if (!this.can('rangeban')) return false;
@@ -1730,7 +1730,7 @@ exports.commands = {
 		Punishments.savePunishments();
 		this.addModCommand("All bans and locks have been lifted by " + user.name + ".");
 	},
-	unbanallhelp: ["/unbanall - Unban all IP addresses. Requires: & ~"],
+	unbanallhelp: ["/unbanall - Unban all IP addresses. " + Chat.require('&')],
 
 	deroomvoiceall: function (target, room, user) {
 		if (!this.can('editroom', null, room)) return false;
@@ -1760,7 +1760,7 @@ exports.commands = {
 		}
 		this.addModCommand("All " + count + " roomvoices have been cleared by " + user.name + ".");
 	},
-	deroomvoiceallhelp: ["/deroomvoiceall - Devoice all roomvoiced users. Requires: # & ~"],
+	deroomvoiceallhelp: ["/deroomvoiceall - Devoice all roomvoiced users. " + Chat.require('#')],
 
 	rangeban: 'banip',
 	banip: function (target, room, user) {
@@ -1779,7 +1779,7 @@ exports.commands = {
 		Punishments.banRange(targetIp, target);
 		this.addModCommand(`${user.name} hour-banned the ${targetDesc}: ${target}`);
 	},
-	baniphelp: ["/banip [ip] - Globally bans this IP or IP range for an hour. Accepts wildcards to ban ranges. Existing users on the IP will not be banned. Requires: & ~"],
+	baniphelp: ["/banip [ip] - Globally bans this IP or IP range for an hour. Accepts wildcards to ban ranges. Existing users on the IP will not be banned. " + Chat.require('&')],
 
 	unrangeban: 'unbanip',
 	unbanip: function (target, room, user) {
@@ -1794,7 +1794,7 @@ exports.commands = {
 		Punishments.ips.delete(target);
 		this.addModCommand("" + user.name + " unbanned the " + (target.charAt(target.length - 1) === '*' ? "IP range" : "IP") + ": " + target);
 	},
-	unbaniphelp: ["/unbanip [ip] - Unbans. Accepts wildcards to ban ranges. Requires: & ~"],
+	unbaniphelp: ["/unbanip [ip] - Unbans. Accepts wildcards to ban ranges. " + Chat.require('&')],
 
 	rangelock: 'lockip',
 	lockip: function (target, room, user) {
@@ -1815,7 +1815,7 @@ exports.commands = {
 		Punishments.lockRange(targetIp, target);
 		this.addModCommand(`${user.name} hour-locked the ${targetDesc}: ${target}`);
 	},
-	lockiphelp: ["/lockip [ip] - Globally locks this IP or IP range for an hour. Accepts wildcards to ban ranges. Existing users on the IP will not be banned. Requires: & ~"],
+	lockiphelp: ["/lockip [ip] - Globally locks this IP or IP range for an hour. Accepts wildcards to ban ranges. Existing users on the IP will not be banned. " + Chat.require('&')],
 
 	unrangelock: 'unlockip',
 	rangeunlock: 'unlockip',
@@ -1847,7 +1847,7 @@ exports.commands = {
 		if (!this.can('receiveauthmessages', null, room)) return false;
 		return this.privateModCommand("(" + user.name + " notes: " + target + ")");
 	},
-	modnotehelp: ["/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ * # & ~"],
+	modnotehelp: ["/modnote [note] - Adds a moderator note that can be read through modlog. " + Chat.require('%')],
 
 	globalpromote: 'promote',
 	promote: function (target, room, user, connection, cmd) {
@@ -1904,7 +1904,7 @@ exports.commands = {
 
 		if (targetUser) targetUser.updateIdentity();
 	},
-	promotehelp: ["/promote [username], [group] - Promotes the user to the specified group. Requires: & ~"],
+	promotehelp: ["/promote [username], [group] - Promotes the user to the specified group. " + Chat.require('&')],
 
 	confirmuser: 'trustuser',
 	trustuser: function (target) {
@@ -1924,14 +1924,14 @@ exports.commands = {
 		targetUser.setGroup(Config.groupsranking[0], true);
 		this.sendReply("User '" + name + "' is now trusted.");
 	},
-	trustuserhelp: ["/trustuser [username] - Trusts the user (makes them immune to locks). Requires: & ~"],
+	trustuserhelp: ["/trustuser [username] - Trusts the user (makes them immune to locks). " + Chat.require('&')],
 
 	globaldemote: 'demote',
 	demote: function (target) {
 		if (!target) return this.parse('/help demote');
 		this.run('promote');
 	},
-	demotehelp: ["/demote [username], [group] - Demotes the user to the specified group. Requires: & ~"],
+	demotehelp: ["/demote [username], [group] - Demotes the user to the specified group. " + Chat.require('&')],
 
 	forcepromote: function (target, room, user) {
 		// warning: never document this command in /help
@@ -1976,7 +1976,7 @@ exports.commands = {
 		this.add('|raw|<div class="broadcast-blue"><b>' + Chat.escapeHTML(target) + '</b></div>');
 		this.logModCommand(user.name + " declared " + target);
 	},
-	declarehelp: ["/declare [message] - Anonymously announces a message. Requires: # * & ~"],
+	declarehelp: ["/declare [message] - Anonymously announces a message. " + Chat.require('#')],
 
 	htmldeclare: function (target, room, user) {
 		if (!target) return this.parse('/help htmldeclare');
@@ -1988,7 +1988,7 @@ exports.commands = {
 		this.add('|raw|<div class="broadcast-blue"><b>' + target + '</b></div>');
 		this.logModCommand(user.name + " declared " + target);
 	},
-	htmldeclarehelp: ["/htmldeclare [message] - Anonymously announces a message using safe HTML. Requires: ~"],
+	htmldeclarehelp: ["/htmldeclare [message] - Anonymously announces a message using safe HTML. " + Chat.require('~')],
 
 	gdeclare: 'globaldeclare',
 	globaldeclare: function (target, room, user) {
@@ -2002,7 +2002,7 @@ exports.commands = {
 		});
 		this.logModCommand(user.name + " globally declared " + target);
 	},
-	globaldeclarehelp: ["/globaldeclare [message] - Anonymously announces a message to every room on the server. Requires: ~"],
+	globaldeclarehelp: ["/globaldeclare [message] - Anonymously announces a message to every room on the server. " + Chat.require('~')],
 
 	cdeclare: 'chatdeclare',
 	chatdeclare: function (target, room, user) {
@@ -2016,7 +2016,7 @@ exports.commands = {
 		});
 		this.logModCommand(user.name + " globally declared (chat level) " + target);
 	},
-	chatdeclarehelp: ["/cdeclare [message] - Anonymously announces a message to all chatrooms on the server. Requires: ~"],
+	chatdeclarehelp: ["/cdeclare [message] - Anonymously announces a message to all chatrooms on the server. " + Chat.require('~')],
 
 	'!announce': true,
 	wall: 'announce',
@@ -2030,7 +2030,7 @@ exports.commands = {
 
 		return '/announce ' + target;
 	},
-	announcehelp: ["/announce OR /wall [message] - Makes an announcement. Requires: % @ * # & ~"],
+	announcehelp: ["/announce OR /wall [message] - Makes an announcement. " + Chat.require('%')],
 
 	fr: 'forcerename',
 	forcerename: function (target, room, user) {
@@ -2054,7 +2054,7 @@ exports.commands = {
 		targetUser.send("|nametaken||" + user.name + " considers your name inappropriate" + (reason ? ": " + reason : "."));
 		return true;
 	},
-	forcerenamehelp: ["/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. Requires: % @ * & ~"],
+	forcerenamehelp: ["/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. " + Chat.require('%')],
 
 	nl: 'namelock',
 	namelock: function (target, room, user) {
@@ -2084,7 +2084,7 @@ exports.commands = {
 		targetUser.popup(`|modal|${user.name} has locked your name and you can't change names anymore${reasonText}`);
 		return true;
 	},
-	namelockhelp: ["/namelock OR /nl [username], [reason] - Name locks a user and shows them the [reason]. Requires: % @ * & ~"],
+	namelockhelp: ["/namelock OR /nl [username], [reason] - Name locks a user and shows them the [reason]. " + Chat.require('%')],
 
 	unl: 'unnamelock',
 	unnamelock: function (target, room, user) {
@@ -2107,7 +2107,7 @@ exports.commands = {
 			this.errorReply("User '" + target + "' is not namelocked.");
 		}
 	},
-	unnamelockhelp: ["/unnamelock [username] - Unnamelocks the user. Requires: % @ * & ~"],
+	unnamelockhelp: ["/unnamelock [username] - Unnamelocks the user. " + Chat.require('%')],
 
 	hidetext: function (target, room, user) {
 		if (!target) return this.parse('/help hidetext');
@@ -2189,7 +2189,7 @@ exports.commands = {
 		Punishments.roomBlacklist(room, targetUser, null, null, target);
 		return true;
 	},
-	blacklisthelp: ["/blacklist [username], [reason] - Blacklists the user from the room you are in for a year. Requires: # & ~"],
+	blacklisthelp: ["/blacklist [username], [reason] - Blacklists the user from the room you are in for a year. " + Chat.require('#')],
 
 	blacklistname: function (target, room, user) {
 		if (!target) return this.parse('/help blacklistname');
@@ -2226,7 +2226,7 @@ exports.commands = {
 		this.addModCommand("" + targets.join(', ') + (targets.length > 1 ? " were" : " was") + " nameblacklisted by " + user.name + ".");
 		return true;
 	},
-	blacklistnamehelp: ["/blacklistname [username1, username2, etc.] | reason - Blacklists the given username(s) from the room you are in for a year. Requires: # & ~"],
+	blacklistnamehelp: ["/blacklistname [username1, username2, etc.] | reason - Blacklists the given username(s) from the room you are in for a year. " + Chat.require('#')],
 
 	unab: 'unblacklist',
 	unblacklist: function (target, room, user) {
@@ -2244,7 +2244,7 @@ exports.commands = {
 			this.errorReply("User '" + target + "' is not blacklisted.");
 		}
 	},
-	unblacklisthelp: ["/unblacklist [username] - Unblacklists the user from the room you are in. Requires: # & ~"],
+	unblacklisthelp: ["/unblacklist [username] - Unblacklists the user from the room you are in. " + Chat.require('#')],
 
 	unblacklistall: function (target, room, user) {
 		if (!this.can('editroom', null, room)) return false;
@@ -2264,7 +2264,7 @@ exports.commands = {
 		this.addModCommand(`All blacklists in this room have been lifted by ${user.name}.`);
 		this.logEntry(`Unblacklisted users: ${unblacklisted.join(', ')}`);
 	},
-	unblacklistallhelp: ["/unblacklistall - Unblacklists all blacklisted users in the current room. Requires #, &, ~"],
+	unblacklistallhelp: ["/unblacklistall - Unblacklists all blacklisted users in the current room. " + Chat.require('#')],
 
 	blacklists: 'showblacklist',
 	showbl: 'showblacklist',
@@ -2332,7 +2332,7 @@ exports.commands = {
 		if (note) note = ` (${note})`;
 		return this.addModCommand(`The IP '${ip}' was marked as shared by ${user.name}.${note}`);
 	},
-	marksharedhelp: ["/markshared [ip] - Marks an IP address as shared. Requires @, &, ~"],
+	marksharedhelp: ["/markshared [ip] - Marks an IP address as shared. " + Chat.require('@')],
 
 	unmarkshared: function (target, room, user) {
 		if (!target) return this.parse('/help unmarkshared');
@@ -2344,7 +2344,7 @@ exports.commands = {
 		Punishments.removeSharedIp(target);
 		return this.addModCommand(`The IP '${target}' was unmarked as shared by ${user.name}.`);
 	},
-	unmarksharedhelp: ["/unmarkshared [ip] - Unmarks a shared IP address. Requires @, &, ~"],
+	unmarksharedhelp: ["/unmarkshared [ip] - Unmarks a shared IP address. " + Chat.require('@')],
 
 	modlog: function (target, room, user, connection) {
 		let lines = 0;
@@ -2487,7 +2487,7 @@ exports.commands = {
 	modloghelp: ["/modlog [roomid|all|public], [n] - Roomid defaults to current room.",
 		"If n is a number or omitted, display the last n lines of the moderator log. Defaults to 20.",
 		"If n is not a number, search the moderator log for 'n' on room's log [roomid]. If you set [all] as [roomid], searches for 'n' on all rooms's logs.",
-		"If you set [public] as [roomid], searches for 'n' in all public room's logs, excluding battles. Requires: % @ * # & ~"],
+		"If you set [public] as [roomid], searches for 'n' in all public room's logs, excluding battles. " + Chat.require('%')],
 
 	/*********************************************************
 	 * Server management commands
@@ -2581,7 +2581,7 @@ exports.commands = {
 		}
 		this.errorReply("Your hot-patch command was unrecognized.");
 	},
-	hotpatchhelp: ["Hot-patching the game engine allows you to update parts of Showdown without interrupting currently-running battles. Requires: ~",
+	hotpatchhelp: ["Hot-patching the game engine allows you to update parts of Showdown without interrupting currently-running battles. " + Chat.require('~'),
 		"Hot-patching has greater memory requirements than restarting.",
 		"/hotpatch chat - reload chat-commands.js and the chat-plugins",
 		"/hotpatch battles - spawn new simulator processes",
@@ -2722,7 +2722,7 @@ exports.commands = {
 
 		this.logEntry(user.name + " used /lockdown");
 	},
-	lockdownhelp: ["/lockdown - locks down the server, which prevents new battles from starting so that the server can eventually be restarted. Requires: ~"],
+	lockdownhelp: ["/lockdown - locks down the server, which prevents new battles from starting so that the server can eventually be restarted. " + Chat.require('~')],
 
 	prelockdown: function (target, room, user) {
 		if (!this.can('lockdown')) return false;
@@ -2816,7 +2816,7 @@ exports.commands = {
 			process.exit();
 		}, 10000);
 	},
-	killhelp: ["/kill - kills the server. Can't be done unless the server is in lockdown state. Requires: ~"],
+	killhelp: ["/kill - kills the server. Can't be done unless the server is in lockdown state. " + Chat.require('~')],
 
 	loadbanlist: function (target, room, user, connection) {
 		if (!this.can('hotpatch')) return false;
@@ -2827,7 +2827,7 @@ exports.commands = {
 			error => connection.sendTo(room, "Something went wrong while loading ipbans.txt: " + error)
 		);
 	},
-	loadbanlisthelp: ["/loadbanlist - Loads the bans located at ipbans.txt. The command is executed automatically at startup. Requires: ~"],
+	loadbanlisthelp: ["/loadbanlist - Loads the bans located at ipbans.txt. The command is executed automatically at startup. " + Chat.require('~')],
 
 	refreshpage: function (target, room, user) {
 		if (!this.can('hotpatch')) return false;
@@ -2877,7 +2877,7 @@ exports.commands = {
 		}
 		this.logEntry(user.name + " used /crashfixed");
 	},
-	crashfixedhelp: ["/crashfixed - Ends the active lockdown caused by a crash without the need of a restart. Requires: ~"],
+	crashfixedhelp: ["/crashfixed - Ends the active lockdown caused by a crash without the need of a restart. " + Chat.require('~')],
 
 	memusage: 'memoryusage',
 	memoryusage: function (target) {
@@ -3153,7 +3153,7 @@ exports.commands = {
 			this.errorReply("/kickbattle - User isn't in battle.");
 		}
 	},
-	kickbattlehelp: ["/kickbattle [username], [reason] - Kicks a user from a battle with reason. Requires: % @ * & ~"],
+	kickbattlehelp: ["/kickbattle [username], [reason] - Kicks a user from a battle with reason. " + Chat.require('%')],
 
 	kickinactive: function (target, room, user) {
 		if (room.requestKickInactive) {
@@ -3221,8 +3221,8 @@ exports.commands = {
 			this.logModCommand(user.name + " forced a win for " + target + ".");
 		}
 	},
-	forcewinhelp: ["/forcetie - Forces the current match to end in a tie. Requires: & ~",
-		"/forcewin [user] - Forces the current match to end in a win for a user. Requires: & ~"],
+	forcewinhelp: ["/forcetie - Forces the current match to end in a tie. " + Chat.require('&'),
+		"/forcewin [user] - Forces the current match to end in a win for a user. " + Chat.require('&')],
 
 	/*********************************************************
 	 * Challenging and searching commands

--- a/chat-plugins/hangman.js
+++ b/chat-plugins/hangman.js
@@ -223,7 +223,7 @@ exports.commands = {
 
 			return this.privateModCommand("(A game of hangman was started by " + user.name + ".)");
 		},
-		createhelp: ["/hangman create [word], [hint] - Makes a new hangman game. Requires: % @ * # & ~"],
+		createhelp: ["/hangman create [word], [hint] - Makes a new hangman game. " + Chat.require('%')],
 
 		guess: function (target, room, user) {
 			if (!target) return this.parse('/help guess');
@@ -246,7 +246,7 @@ exports.commands = {
 			room.game.end();
 			return this.privateModCommand("(The game of hangman was ended by " + user.name + ".)");
 		},
-		endhelp: ["/hangman end - Ends the game of hangman before the man is hanged or word is guessed. Requires: % @ * # & ~"],
+		endhelp: ["/hangman end - Ends the game of hangman before the man is hanged or word is guessed. " + Chat.require('%')],
 
 		disable: function (target, room, user) {
 			if (!this.can('gamemanagement', null, room)) return;
@@ -290,12 +290,12 @@ exports.commands = {
 	hangmanhelp: [
 		"/hangman allows users to play the popular game hangman in PS rooms.",
 		"Accepts the following commands:",
-		"/hangman create [word], [hint] - Makes a new hangman game. Requires: % @ * # & ~",
+		"/hangman create [word], [hint] - Makes a new hangman game. " + Chat.require('%'),
 		"/hangman guess [letter] - Makes a guess for the letter entered.",
 		"/hangman guess [word] - Same as a letter, but guesses an entire word.",
 		"/hangman display - Displays the game.",
-		"/hangman end - Ends the game of hangman before the man is hanged or word is guessed. Requires: % @ * # & ~",
-		"/hangman [enable/disable] - Enables or disables hangman from being started in a room. Requires: # & ~",
+		"/hangman end - Ends the game of hangman before the man is hanged or word is guessed. " + Chat.require('%'),
+		"/hangman [enable/disable] - Enables or disables hangman from being started in a room. " + Chat.require('#'),
 	],
 
 	guess: function (target, room, user) {

--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -164,7 +164,7 @@ exports.commands = {
 		this.sendReplyBox(buf);
 	},
 	whoishelp: ["/whois - Get details on yourself: alts, group, IP address, and rooms.",
-		"/whois [username] - Get details on a username: alts (Requires: % @ * & ~), group, IP address (Requires: @ * & ~), and rooms."],
+		"/whois [username] - Get details on a username: alts (" + Chat.require('%') + "), group, IP address (" + Chat.require('@') + "), and rooms."],
 
 	'!offlinewhois': true,
 	checkpunishment: 'offlinewhois',
@@ -245,7 +245,7 @@ exports.commands = {
 			this.sendReply('IP ' + target + ': ' + (host || "ERROR"));
 		});
 	},
-	hosthelp: ["/host [ip] - Gets the host for a given IP. Requires: & ~"],
+	hosthelp: ["/host [ip] - Gets the host for a given IP. " + Chat.require('&')],
 
 	'!ipsearch': true,
 	searchip: 'ipsearch',
@@ -295,7 +295,7 @@ exports.commands = {
 		}
 		return this.sendReply(results.join('; '));
 	},
-	ipsearchhelp: ["/ipsearch [ip|range|host] - Find all users with specified IP, IP range, or host. Requires: & ~"],
+	ipsearchhelp: ["/ipsearch [ip|range|host] - Find all users with specified IP, IP range, or host. " + Chat.require('&')],
 
 	/*********************************************************
 	 * Client fallback
@@ -494,7 +494,7 @@ exports.commands = {
 		this.sendReply(buffer);
 	},
 	datahelp: ["/data [pokemon/item/move/ability] - Get details on this pokemon/item/move/ability/nature.",
-		"!data [pokemon/item/move/ability] - Show everyone these details. Requires: + % @ * # & ~"],
+		"!data [pokemon/item/move/ability] - Show everyone these details. " + Chat.require('+')],
 
 	'!details': true,
 	dt: 'details',
@@ -503,7 +503,7 @@ exports.commands = {
 		this.run('data');
 	},
 	detailshelp: ["/details [pokemon] - Get additional details on this pokemon/item/move/ability/nature.",
-		"!details [pokemon] - Show everyone these details. Requires: + % @ * # & ~"],
+		"!details [pokemon] - Show everyone these details. " + Chat.require('+')],
 
 	'!weakness': true,
 	weaknesses: 'weakness',
@@ -582,8 +582,8 @@ exports.commands = {
 	},
 	weaknesshelp: ["/weakness [pokemon] - Provides a Pok\u00e9mon's resistances, weaknesses, and immunities, ignoring abilities.",
 		"/weakness [type 1]/[type 2] - Provides a type or type combination's resistances, weaknesses, and immunities, ignoring abilities.",
-		"!weakness [pokemon] - Shows everyone a Pok\u00e9mon's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ * # & ~",
-		"!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ * # & ~"],
+		"!weakness [pokemon] - Shows everyone a Pok\u00e9mon's resistances, weaknesses, and immunities, ignoring abilities. " + Chat.require('+'),
+		"!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. " + Chat.require('+')],
 
 	'!effectiveness': true,
 	eff: 'effectiveness',
@@ -1081,7 +1081,7 @@ exports.commands = {
 	},
 	groupshelp: ["/groups - Explains what the symbols (like % and @) before people's names mean.",
 		"/groups [global|room] - Explains only global or room symbols.",
-		"!groups - Shows everyone that information. Requires: + % @ * # & ~"],
+		"!groups - Shows everyone that information. " + Chat.require('+')],
 
 	'!punishments': true,
 	punishments: function (target, room, user) {
@@ -1102,7 +1102,7 @@ exports.commands = {
 		);
 	},
 	punishmentshelp: ["/punishments - Explains punishments.",
-		"!punishments - Show everyone that information. Requires: + % @ * # & ~"],
+		"!punishments - Show everyone that information. " + Chat.require('+')],
 
 	'!opensource': true,
 	repo: 'opensource',
@@ -1120,7 +1120,7 @@ exports.commands = {
 		);
 	},
 	opensourcehelp: ["/opensource - Links to PS's source code repository.",
-		"!opensource - Show everyone that information. Requires: + % @ * # & ~"],
+		"!opensource - Show everyone that information. " + Chat.require('+')],
 
 	'!staff': true,
 	staff: function (target, room, user) {
@@ -1161,7 +1161,7 @@ exports.commands = {
 		this.sendReplyBox("You can <button name=\"avatars\">change your avatar</button> by clicking on it in the <button name=\"openOptions\"><i class=\"fa fa-cog\"></i> Options</button> menu in the upper right. Custom avatars are only obtainable by staff.");
 	},
 	avatarshelp: ["/avatars - Explains how to change avatars.",
-		"!avatars - Show everyone that information. Requires: + % @ * # & ~"],
+		"!avatars - Show everyone that information. " + Chat.require('+')],
 
 	'!optionsbutton': true,
 	optionbutton: 'optionsbutton',
@@ -1190,7 +1190,7 @@ exports.commands = {
 		);
 	},
 	introhelp: ["/intro - Provides an introduction to competitive Pok\u00e9mon.",
-		"!intro - Show everyone that information. Requires: + % @ * # & ~"],
+		"!intro - Show everyone that information. " + Chat.require('+')],
 
 	'!smogintro': true,
 	mentoring: 'smogintro',
@@ -1214,7 +1214,7 @@ exports.commands = {
 		);
 	},
 	calchelp: ["/calc - Provides a link to a damage calculator",
-		"!calc - Shows everyone a link to a damage calculator. Requires: + % @ * # & ~"],
+		"!calc - Shows everyone a link to a damage calculator. " + Chat.require('+')],
 
 	'!cap': true,
 	capintro: 'cap',
@@ -1229,7 +1229,7 @@ exports.commands = {
 		);
 	},
 	caphelp: ["/cap - Provides an introduction to the Create-A-Pok\u00e9mon project.",
-		"!cap - Show everyone that information. Requires: + % @ * # & ~"],
+		"!cap - Show everyone that information. " + Chat.require('+')],
 
 	'!gennext': true,
 	gennext: function (target, room, user) {
@@ -1277,7 +1277,7 @@ exports.commands = {
 		}
 	},
 	othermetashelp: ["/om - Provides links to information on the Other Metagames.",
-		"!om - Show everyone that information. Requires: + % @ * # & ~"],
+		"!om - Show everyone that information. " + Chat.require('+')],
 
 	'!formathelp': true,
 	banlists: 'formathelp',
@@ -1470,8 +1470,8 @@ exports.commands = {
 		}
 	},
 	ruleshelp: ["/rules - Show links to room rules and global rules.",
-		"!rules - Show everyone links to room rules and global rules. Requires: + % @ * # & ~",
-		"/rules [url] - Change the room rules URL. Requires: # & ~"],
+		"!rules - Show everyone links to room rules and global rules. " + Chat.require('+'),
+		"/rules [url] - Change the room rules URL. " + Chat.require('#')],
 
 	'!faq': true,
 	faq: function (target, room, user) {
@@ -1504,7 +1504,7 @@ exports.commands = {
 		this.sendReplyBox(buffer.join("<br />"));
 	},
 	faqhelp: ["/faq [theme] - Provides a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them.",
-		"!faq [theme] - Shows everyone a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them. Requires: + % @ * # & ~"],
+		"!faq [theme] - Shows everyone a link to the FAQ. Add deviation, doubles, randomcap, restart, or staff for a link to these questions. Add all for all of them. " + Chat.require('+')],
 
 	'!smogdex': true,
 	analysis: 'smogdex',
@@ -1645,7 +1645,7 @@ exports.commands = {
 		}
 	},
 	smogdexhelp: ["/analysis [pokemon], [generation], [format] - Links to the Smogon University analysis for this Pok\u00e9mon in the given generation.",
-		"!analysis [pokemon], [generation], [format] - Shows everyone this link. Requires: + % @ * # & ~"],
+		"!analysis [pokemon], [generation], [format] - Shows everyone this link. " + Chat.require('+')],
 
 	'!veekun': true,
 	veekun: function (target, broadcast, user) {
@@ -1716,7 +1716,7 @@ exports.commands = {
 		}
 	},
 	veekunhelp: ["/veekun [pokemon] - Links to Veekun website for this pokemon/item/move/ability/nature.",
-		"!veekun [pokemon] - Shows everyone this link. Requires: + % @ * # & ~"],
+		"!veekun [pokemon] - Shows everyone this link. " + Chat.require('+')],
 
 	'!register': true,
 	register: function () {
@@ -1887,9 +1887,11 @@ exports.commands = {
 
 		this.sendReply('|raw|<img src="' + Chat.escapeHTML(image) + '" ' + 'style="width: ' + Chat.escapeHTML(width) + '; height: ' + Chat.escapeHTML(height) + '" />');
 	},
-	showimagehelp: ["/showimage [url], [width], [height] - Show an image. " +
+	showimagehelp: [
+		"/showimage [url], [width], [height] - Show an image. " +
 		"Any CSS units may be used for the width or height (default: px)." +
-		"Requires: # & ~"],
+		Chat.require('#'),
+	],
 
 	htmlbox: function (target, room, user, connection, cmd, message) {
 		if (!target) return this.parse('/help htmlbox');
@@ -1918,7 +1920,7 @@ exports.commands = {
 	},
 	htmlboxhelp: [
 		"/htmlbox [message] - Displays a message, parsing HTML code contained.",
-		"!htmlbox [message] - Shows everyone a message, parsing HTML code contained. Requires: ~ & #",
+		"!htmlbox [message] - Shows everyone a message, parsing HTML code contained. " + Chat.require('#'),
 	],
 };
 

--- a/chat-plugins/jeopardy.js
+++ b/chat-plugins/jeopardy.js
@@ -493,14 +493,14 @@ let commands = {
 			"edit - Edits the grid. Run this command by itself for more detailed help<br />" +
 			"export [category number], [start], [end] - Exports data from the grid. start and end are optional<br />" +
 			"import [category number], [start], [end], [data] - Imports data into the grid. start and end are optional<br />" +
-			"create [categories], [questions per category] - Creates a jeopardy match. Parameters are optional, and default to maximum values. Requires: % @ * # & ~<br />" +
-			"start - Starts the match. Requires: % @ * # & ~<br />" +
-			"end - Forcibly ends the match. Requires: % @ * # & ~<br />" +
+			"create [categories], [questions per category] - Creates a jeopardy match. Parameters are optional, and default to maximum values. " + Chat.require('%') + "<br />" +
+			"start - Starts the match. " + Chat.require('%') + "<br />" +
+			"end - Forcibly ends the match. " + Chat.require('%') + "<br />" +
 			"adduser [user] - Add a user to the match<br />" +
 			"removeuser [user] - Remove a user from the match<br />" +
 			"select [category number], [question number] - Select a question<br />" +
 			"a/answer [answer] - Attempt to answer the question<br />" +
-			"incorrect/correct - Marks the current answer as correct or not. Requires: % @ * # & ~<br />" +
+			"incorrect/correct - Marks the current answer as correct or not. " + Chat.require('%') + "<br />" +
 			"skip - Skips the current question<br />" +
 			"wager [amount] - Wager some amount of points. 'all' is also accepted"
 		);

--- a/chat-plugins/poll.js
+++ b/chat-plugins/poll.js
@@ -221,7 +221,7 @@ exports.commands = {
 			this.logEntry("" + user.name + " used " + message);
 			return this.privateModCommand("(A poll was started by " + user.name + ".)");
 		},
-		newhelp: ["/poll create [question], [option1], [option2], [...] - Creates a poll. Requires: % @ * # & ~"],
+		newhelp: ["/poll create [question], [option1], [option2], [...] - Creates a poll. " + Chat.require('%')],
 
 		vote: function (target, room, user) {
 			if (!room.poll) return this.errorReply("There is no poll running in this room.");
@@ -272,7 +272,10 @@ exports.commands = {
 				}
 			}
 		},
-		timerhelp: ["/poll timer [minutes] - Sets the poll to automatically end after [minutes] minutes. Requires: % @ * # & ~", "/poll timer clear - Clears the poll's timer. Requires: % @ * # & ~"],
+		timerhelp: [
+			"/poll timer [minutes] - Sets the poll to automatically end after [minutes] minutes. " + Chat.require('%'),
+			"/poll timer clear - Clears the poll's timer. " + Chat.require('%'),
+		],
 
 		results: function (target, room, user) {
 			if (!room.poll) return this.errorReply("There is no poll running in this room.");
@@ -293,7 +296,7 @@ exports.commands = {
 			delete room.poll;
 			return this.privateModCommand("(The poll was ended by " + user.name + ".)");
 		},
-		endhelp: ["/poll end - Ends a poll and displays the results. Requires: % @ * # & ~"],
+		endhelp: ["/poll end - Ends a poll and displays the results. " + Chat.require('%')],
 
 		show: 'display',
 		display: function (target, room, user, connection) {
@@ -316,13 +319,13 @@ exports.commands = {
 	pollhelp: [
 		"/poll allows rooms to run their own polls. These polls are limited to one poll at a time per room.",
 		"Accepts the following commands:",
-		"/poll create [question], [option1], [option2], [...] - Creates a poll. Requires: % @ * # & ~",
-		"/poll htmlcreate [question], [option1], [option2], [...] - Creates a poll, with HTML allowed in the question and options. Requires: # & ~",
+		"/poll create [question], [option1], [option2], [...] - Creates a poll. " + Chat.require('%'),
+		"/poll htmlcreate [question], [option1], [option2], [...] - Creates a poll, with HTML allowed in the question and options. " + Chat.require('#'),
 		"/poll vote [number] - Votes for option [number].",
-		"/poll timer [minutes] - Sets the poll to automatically end after [minutes]. Requires: % @ * # & ~",
+		"/poll timer [minutes] - Sets the poll to automatically end after [minutes]. " + Chat.require('%'),
 		"/poll results - Shows the results of the poll without voting. NOTE: you can't go back and vote after using this.",
 		"/poll display - Displays the poll",
-		"/poll end - Ends a poll and displays the results. Requires: % @ * # & ~",
+		"/poll end - Ends a poll and displays the results. " + Chat.require('%'),
 	],
 };
 

--- a/chat-plugins/room-events.js
+++ b/chat-plugins/room-events.js
@@ -71,7 +71,7 @@ exports.commands = {
 	},
 	roomeventshelp: [
 		"/roomevents - Displays a list of upcoming room-specific events.",
-		"/roomevents add [event name] | [event description] | [event date/time] - Adds a room event. Requires: # & ~",
-		"/roomevents remove [event name] - Deletes an event. Requires: # & ~",
+		"/roomevents add [event name] | [event description] | [event date/time] - Adds a room event. " + Chat.require('#'),
+		"/roomevents remove [event name] - Deletes an event. " + Chat.require('#'),
 	],
 };

--- a/chat-plugins/room-faqs.js
+++ b/chat-plugins/room-faqs.js
@@ -102,8 +102,8 @@ exports.commands = {
 	roomfaqhelp: [
 		"/roomfaq - Shows the list of all available FAQ topics",
 		"/roomfaq <topic> - Shows the FAQ for <topic>.",
-		"/addfaq <topic>, <text> - Adds an entry for <topic> in this room or updates it. Requires: # & ~",
-		"/addalias <alias>, <topic> - Adds <alias> as an alias for <topic>, displaying it when users use /roomfaq <alias>. Requires: # & ~",
-		"/removefaq <topic> - Removes the entry for <topic> in this room. If used on an alias, removes the alias. Requires: # & ~",
+		"/addfaq <topic>, <text> - Adds an entry for <topic> in this room or updates it. " + Chat.require('#'),
+		"/addalias <alias>, <topic> - Adds <alias> as an alias for <topic>, displaying it when users use /roomfaq <alias>. " + Chat.require('#'),
+		"/removefaq <topic> - Removes the entry for <topic> in this room. If used on an alias, removes the alias. " + Chat.require('#'),
 	],
 };

--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -231,7 +231,7 @@ exports.commands = {
 			return this.parse('/modjoin ' + target);
 		}
 	},
-	inviteonlyhelp: ["/inviteonly [on|off] - Sets modjoin +. Users can't join unless invited with /invite. Requires: # & ~",
+	inviteonlyhelp: ["/inviteonly [on|off] - Sets modjoin +. Users can't join unless invited with /invite. " + Chat.require('#'),
 		"/ioo - Shortcut for /inviteonly on"],
 
 	modjoin: function (target, room, user) {
@@ -283,8 +283,8 @@ exports.commands = {
 		if (target === 'sync' && !room.modchat) this.parse('/modchat ' + Config.groupsranking[1]);
 		if (!room.isPrivate) this.parse('/hiddenroom');
 	},
-	modjoinhelp: ["/modjoin [+|%|@|*|&|~|#|off] - Sets modjoin. Users lower than the specified rank can't join this room. Requires: # & ~",
-		"/modjoin [sync|off] - Sets modjoin. Only users who can speak in modchat can join this room. Requires: # & ~"],
+	modjoinhelp: ["/modjoin [+|%|@|*|&|~|#|off] - Sets modjoin. Users lower than the specified rank can't join this room. " + Chat.require('#'),
+		"/modjoin [sync|off] - Sets modjoin. Only users who can speak in modchat can join this room. " + Chat.require('#')],
 
 	slowchat: function (target, room, user) {
 		if (!target) {
@@ -317,8 +317,8 @@ exports.commands = {
 			Rooms.global.writeChatRoomData();
 		}
 	},
-	slowchathelp: ["/slowchat [number] - Sets a limit on how often users in the room can send messages, between 2 and 60 seconds. Requires @ * # & ~",
-		"/slowchat off - Disables slowchat in the room. Requires @ * # & ~"],
+	slowchathelp: ["/slowchat [number] - Sets a limit on how often users in the room can send messages, between 2 and 60 seconds. " + Chat.require('@'),
+		"/slowchat off - Disables slowchat in the room. " + Chat.require('@')],
 
 	stretching: 'stretchfilter',
 	stretchingfilter: 'stretchfilter',
@@ -347,7 +347,7 @@ exports.commands = {
 			Rooms.global.writeChatRoomData();
 		}
 	},
-	stretchfilterhelp: ["/stretchfilter [on/off] - Toggles filtering messages in the room for stretchingggggggg. Requires # & ~"],
+	stretchfilterhelp: ["/stretchfilter [on/off] - Toggles filtering messages in the room for stretchingggggggg. " + Chat.require('#')],
 
 	capitals: 'capsfilter',
 	capitalsfilter: 'capsfilter',
@@ -376,7 +376,7 @@ exports.commands = {
 			Rooms.global.writeChatRoomData();
 		}
 	},
-	capsfilterhelp: ["/capsfilter [on/off] - Toggles filtering messages in the room for EXCESSIVE CAPS. Requires # & ~"],
+	capsfilterhelp: ["/capsfilter [on/off] - Toggles filtering messages in the room for EXCESSIVE CAPS. " + Chat.require('#')],
 
 	banwords: 'banword',
 	banword: {
@@ -464,8 +464,8 @@ exports.commands = {
 		},
 	},
 	banwordhelp: [
-		"/banword add [words] - Adds the comma-separated list of phrases (& or ~ can also input regex) to the banword list of the current room. Requires: # & ~",
-		"/banword delete [words] - Removes the comma-separated list of phrases from the banword list. Requires: # & ~",
-		"/banword list - Shows the list of banned words in the current room. Requires: % @ * # & ~",
+		"/banword add [words] - Adds the comma-separated list of phrases (& or ~ can also input regex) to the banword list of the current room. " + Chat.require('#'),
+		"/banword delete [words] - Removes the comma-separated list of phrases from the banword list. " + Chat.require('#'),
+		"/banword list - Shows the list of banned words in the current room. " + Chat.require('%'),
 	],
 };

--- a/chat-plugins/scavengers.js
+++ b/chat-plugins/scavengers.js
@@ -291,13 +291,13 @@ exports.commands = {
 			'- /scavrank [user] - View the rank of the specified user on the official leaderboard. If no name is given, view your own.<br />' +
 			'<br />' +
 			'<strong>Staff commands:</strong><br />' +
-			'- /starthunt <em>hint | answer | hint | answer | hint | answer</em> - Start a new scavenger hunt (Requires: % @ * # & ~)<br />' +
-			'- /startofficialhunt <em>hint | answer | hint | answer | hint | answer</em> - Start an official hunt with 60 seconds blitz period (Requires: % @ * # & ~)<br />' +
-			'- /endhunt - Finish the current hunt and announce the winners (Requires: % @ * # & ~)<br />' +
-			'- /resethunt - Reset the scavenger hunt to mint status (Requires: % @ * # & ~)<br />' +
-			'- /scavrmpoints [user],[num] - Remove [num] points from [user] on the official leaderboard (Requires: % @ * # & ~)<br />' +
-			'- /scavaddpoints [user],[num] - Add [num] points to [user] on the official leaderboard (Requires: % @ * # & ~)<br />' +
-			'- /scavresetlb - Reset the official leaderboard (Require: # & ~)'
+			'- /starthunt <em>hint | answer | hint | answer | hint | answer</em> - Start a new scavenger hunt (' + Chat.require('%') + ')<br />' +
+			'- /startofficialhunt <em>hint | answer | hint | answer | hint | answer</em> - Start an official hunt with 60 seconds blitz period (' + Chat.require('%') + ')<br />' +
+			'- /endhunt - Finish the current hunt and announce the winners (' + Chat.require('%') + ')<br />' +
+			'- /resethunt - Reset the scavenger hunt to mint status (' + Chat.require('%') + ')<br />' +
+			'- /scavrmpoints [user],[num] - Remove [num] points from [user] on the official leaderboard (' + Chat.require('%') + ')<br />' +
+			'- /scavaddpoints [user],[num] - Add [num] points to [user] on the official leaderboard (' + Chat.require('%') + ')<br />' +
+			'- /scavresetlb - Reset the official leaderboard (' + Chat.require('#') + ')'
 		);
 	},
 };

--- a/chat-plugins/thehappyplace.js
+++ b/chat-plugins/thehappyplace.js
@@ -41,6 +41,6 @@ exports.commands = {
 	quoteofthedayhelp: 'qotdhelp',
 	qotdhelp: [
 		"/qotd - View the current Inspirational Quote of the Day.",
-		"/qotd [quote] - Set the Inspirational Quote of the Day. Requires: @ # & ~",
+		"/qotd [quote] - Set the Inspirational Quote of the Day. " + Chat.require('@'),
 	],
 };

--- a/chat-plugins/thestudio.js
+++ b/chat-plugins/thestudio.js
@@ -236,7 +236,7 @@ let commands = {
 		room.aotdVote.display(false);
 		this.privateModCommand(`(${user.name} has started nominations for the Artist of the Day.)`);
 	},
-	starthelp: ["/aotd start - Starts nominations for the Artist of the Day. Requires: % @ # & ~"],
+	starthelp: ["/aotd start - Starts nominations for the Artist of the Day. " + Chat.require('%')],
 
 	end: function (target, room, user) {
 		if (room !== theStudio) return this.errorReply('This command can only be used in The Studio.');
@@ -248,7 +248,7 @@ let commands = {
 
 		this.privateModCommand(`(${user.name} has ended nominations for the Artist of the Day.)`);
 	},
-	endhelp: ["/aotd end - End nominations for the Artist of the Day and set it to a randomly selected artist. Requires: % @ # & ~"],
+	endhelp: ["/aotd end - End nominations for the Artist of the Day and set it to a randomly selected artist. " + Chat.require('%')],
 
 	nom: function (target, room, user) {
 		if (room !== theStudio) return this.errorReply('This command can only be used in The Studio.');
@@ -279,7 +279,7 @@ let commands = {
 			room.aotdVote.displayTo(connection);
 		}
 	},
-	viewhelp: ["/aotd view - View the current nominations for the Artist of the Day. Requires: % @ * # & ~"],
+	viewhelp: ["/aotd view - View the current nominations for the Artist of the Day. " + Chat.require('%')],
 
 	remove: function (target, room, user) {
 		if (room !== theStudio) return this.errorReply('This command can only be used in The Studio.');
@@ -297,7 +297,7 @@ let commands = {
 			this.sendReply(`User '${name}' has no nomination for the Artist of the Day.`);
 		}
 	},
-	removehelp: ["/aotd remove [username] - Remove a user's nomination for the Artist of the Day and prevent them from voting again until the next round. Requires: % @ * # & ~"],
+	removehelp: ["/aotd remove [username] - Remove a user's nomination for the Artist of the Day and prevent them from voting again until the next round. " + Chat.require('%')],
 
 	set: function (target, room, user) {
 		if (room !== theStudio) return this.errorReply('This command can only be used in The Studio.');
@@ -347,7 +347,7 @@ let commands = {
 			return this.privateModCommand(`(${user.name} changed the following propert${Chat.plural(keys, 'ies', 'y')} of the Artist of the Day: ${keys.join(', ')})`);
 		}
 	},
-	sethelp: ["/aotd set property: value[, property: value] - Set the artist, quote, song, link or image for the current Artist of the Day. Requires: % @ * # & ~"],
+	sethelp: ["/aotd set property: value[, property: value] - Set the artist, quote, song, link or image for the current Artist of the Day. " + Chat.require('%')],
 
 	winners: function (target, room, user, connection) {
 		if (room !== theStudio) return this.errorReply('This command can only be used in The Studio.');
@@ -377,11 +377,11 @@ exports.commands = {
 	aotdhelp: [
 		"The Studio: Artist of the Day plugin commands:",
 		"- /aotd - View the Artist of the Day.",
-		"- /aotd start - Start nominations for the Artist of the Day. Requires: % @ * # & ~",
+		"- /aotd start - Start nominations for the Artist of the Day. " + Chat.require('%'),
 		"- /aotd nom [artist] - Nominate an artist for the Artist of the Day.",
-		"- /aotd remove [username] - Remove a user's nomination for the Artist of the Day and prevent them from voting again until the next round. Requires: % @ * # & ~",
-		"- /aotd end - End nominations for the Artist of the Day and set it to a randomly selected artist. Requires: % @ * # & ~",
-		"- /aotd set property: value[, property: value] - Set the artist, quote, song, link or image for the current Artist of the Day. Requires: % @ * # & ~",
+		"- /aotd remove [username] - Remove a user's nomination for the Artist of the Day and prevent them from voting again until the next round. " + Chat.require('%'),
+		"- /aotd end - End nominations for the Artist of the Day and set it to a randomly selected artist. " + Chat.require('%'),
+		"- /aotd set property: value[, property: value] - Set the artist, quote, song, link or image for the current Artist of the Day. " + Chat.require('%'),
 		"- /aotd winners [year] - Displays a list of previous artists of the day of the past year. Optionally, specify a year to see all winners in that year.",
 	],
 };

--- a/chat-plugins/trivia.js
+++ b/chat-plugins/trivia.js
@@ -785,7 +785,7 @@ const commands = {
 
 		room.game = new _Trivia(room, mode, category, length, questions);
 	},
-	newhelp: ["/trivia new [mode], [category], [length] - Begin a new trivia game. Requires: + % @ # & ~"],
+	newhelp: ["/trivia new [mode], [category], [length] - Begin a new trivia game. " + Chat.require('+')],
 
 	join: function (target, room, user) {
 		if (room.id !== 'trivia') return this.errorReply("This command can only be used in Trivia.");
@@ -815,7 +815,7 @@ const commands = {
 		let res = room.game.kick(targetUser, user);
 		if (typeof res === 'string') this.sendReply(res);
 	},
-	kickhelp: ["/trivia kick [username] - Kick players from a trivia game by username. Requires: % @ # & ~"],
+	kickhelp: ["/trivia kick [username] - Kick players from a trivia game by username. " + Chat.require('%')],
 
 	leave: function (target, room, user) {
 		if (room.id !== 'trivia') return this.errorReply("This command can only be used in Trivia.");
@@ -842,7 +842,7 @@ const commands = {
 		let res = room.game.start();
 		if (typeof res === 'string') this.sendReply(res);
 	},
-	starthelp: ["/trivia start - Ends the signup phase of a trivia game and begins the game. Requires: + % @ # & ~"],
+	starthelp: ["/trivia start - Ends the signup phase of a trivia game and begins the game. " + Chat.require('+')],
 
 	answer: function (target, room, user) {
 		if (room.id !== 'trivia') return this.errorReply("This command can only be used in Trivia.");
@@ -870,7 +870,7 @@ const commands = {
 
 		room.game.end(user);
 	},
-	endhelp: ["/trivia end - Forcibly end a trivia game. Requires: + % @ # & ~"],
+	endhelp: ["/trivia end - Forcibly end a trivia game. " + Chat.require('+')],
 
 	'': 'status',
 	players: 'status',
@@ -962,7 +962,7 @@ const commands = {
 		this.privateModCommand("(" + user.name + " submitted question '" + target[1] + "' for review.)");
 	},
 	submithelp: ["/trivia submit [category] | [question] | [answer1], [answer2] ... [answern] - Add a question to the submission database for staff to review."],
-	addhelp: ["/trivia add [category] | [question] | [answer1], [answer2], ... [answern] - Add a question to the question database. Requires: % @ # & ~"],
+	addhelp: ["/trivia add [category] | [question] | [answer1], [answer2], ... [answern] - Add a question to the question database. " + Chat.require('%')],
 
 	review: function (target, room) {
 		if (room.id !== 'questionworkshop') return this.errorReply('This command can only be used in Question Workshop.');
@@ -985,7 +985,7 @@ const commands = {
 
 		this.sendReply(buffer);
 	},
-	reviewhelp: ["/trivia review - View the list of submitted questions. Requires: @ # & ~"],
+	reviewhelp: ["/trivia review - View the list of submitted questions. " + Chat.require('@')],
 
 	reject: 'accept',
 	accept: function (target, room, user, connection, cmd) {
@@ -1069,8 +1069,8 @@ const commands = {
 
 		this.errorReply("'" + target + "' is an invalid argument. View /help trivia for more information.");
 	},
-	accepthelp: ["/trivia accept [index1], [index2], ... [indexn] OR all - Add questions from the submission database to the question database using their index numbers or ranges of them. Requires: @ # & ~"],
-	rejecthelp: ["/trivia reject [index1], [index2], ... [indexn] OR all - Remove questions from the submission database using their index numbers or ranges of them. Requires: @ # & ~"],
+	accepthelp: ["/trivia accept [index1], [index2], ... [indexn] OR all - Add questions from the submission database to the question database using their index numbers or ranges of them. " + Chat.require('@')],
+	rejecthelp: ["/trivia reject [index1], [index2], ... [indexn] OR all - Remove questions from the submission database using their index numbers or ranges of them. " + Chat.require('@')],
 
 	delete: function (target, room, user) {
 		if (room.id !== 'questionworkshop') return this.errorReply('This command can only be used in Question Workshop.');
@@ -1094,7 +1094,7 @@ const commands = {
 
 		this.errorReply("Question '" + target + "' was not found in the question database.");
 	},
-	deletehelp: ["/trivia delete [question] - Delete a question from the trivia database. Requires: % @ # & ~"],
+	deletehelp: ["/trivia delete [question] - Delete a question from the trivia database. " + Chat.require('%')],
 
 	qs: function (target, room, user) {
 		if (room.id !== 'questionworkshop') return this.errorReply('This command can only be used in Question Workshop.');
@@ -1155,7 +1155,7 @@ const commands = {
 	},
 	qshelp: [
 		"/trivia qs - View the distribution of questions in the question database.",
-		"/trivia qs [category] - View the questions in the specified category. Requires: % @ # & ~",
+		"/trivia qs [category] - View the questions in the specified category. " + Chat.require('%'),
 	],
 
 	search: function (target, room, user) {
@@ -1188,7 +1188,7 @@ const commands = {
 
 		this.sendReply(buffer);
 	},
-	searchhelp: ["/trivia search [type], [query] - Searches for questions based on their type and their query. Valid types: submissions, subs, questions, qs. Requires: + % @ * & ~"],
+	searchhelp: ["/trivia search [type], [query] - Searches for questions based on their type and their query. Valid types: submissions, subs, questions, qs. " + Chat.require('+')],
 
 	rank: function (target, room, user) {
 		if (room.id !== 'trivia') return this.errorReply("This command can only be used in Trivia.");
@@ -1268,7 +1268,7 @@ const commands = {
 		}
 		this.errorReply("Invalid target. Valid targets: enable, disable");
 	},
-	ugmhelp: ["/trivia ugm [setting] - Enable or disable UGM mode. Requires: # & ~"],
+	ugmhelp: ["/trivia ugm [setting] - Enable or disable UGM mode. " + Chat.require('#')],
 };
 
 module.exports = {
@@ -1299,28 +1299,28 @@ module.exports = {
 			"- Medium: 35 point score cap. The winner gains 4 leaderboard points.",
 			"- Long: 50 point score cap. The winner gains 5 leaderboard points.",
 			"Game commands:",
-			"- /trivia new [mode], [category], [length] - Begin signups for a new trivia game. Requires: + % @ # & ~",
+			"- /trivia new [mode], [category], [length] - Begin signups for a new trivia game. " + Chat.require('+'),
 			"- /trivia join - Join a trivia game during signups.",
-			"- /trivia start - Begin the game once enough users have signed up. Requires: + % @ # & ~",
+			"- /trivia start - Begin the game once enough users have signed up. " + Chat.require('+'),
 			"- /ta [answer] - Answer the current question.",
-			"- /trivia kick [username] - Disqualify a participant from the current trivia game. Requires: % @ # & ~",
+			"- /trivia kick [username] - Disqualify a participant from the current trivia game. " + Chat.require('%'),
 			"- /trivia leave - Makes the player leave the game.",
-			"- /trivia end - End a trivia game. Requires: + % @ # ~",
+			"- /trivia end - End a trivia game. " + Chat.require('+'),
 			"Question modifying commands:",
 			"- /trivia submit [category] | [question] | [answer1], [answer2] ... [answern] - Add a question to the submission database for staff to review.",
-			"- /trivia review - View the list of submitted questions. Requires: @ # & ~",
-			"- /trivia accept [index1], [index2], ... [indexn] OR all - Add questions from the submission database to the question database using their index numbers or ranges of them. Requires: @ # & ~",
-			"- /trivia reject [index1], [index2], ... [indexn] OR all - Remove questions from the submission database using their index numbers or ranges of them. Requires: @ # & ~",
-			"- /trivia add [category] | [question] | [answer1], [answer2], ... [answern] - Add a question to the question database. Requires: % @ # & ~",
-			"- /trivia delete [question] - Delete a question from the trivia database. Requires: % @ # & ~",
+			"- /trivia review - View the list of submitted questions. " + Chat.require('@'),
+			"- /trivia accept [index1], [index2], ... [indexn] OR all - Add questions from the submission database to the question database using their index numbers or ranges of them. " + Chat.require('@'),
+			"- /trivia reject [index1], [index2], ... [indexn] OR all - Remove questions from the submission database using their index numbers or ranges of them. " + Chat.require('@'),
+			"- /trivia add [category] | [question] | [answer1], [answer2], ... [answern] - Add a question to the question database. " + Chat.require('%'),
+			"- /trivia delete [question] - Delete a question from the trivia database. " + Chat.require('%'),
 			"- /trivia qs - View the distribution of questions in the question database.",
-			"- /trivia qs [category] - View the questions in the specified category. Requires: % @ # & ~",
+			"- /trivia qs [category] - View the questions in the specified category. " + Chat.require('%'),
 			"Informational commands:",
-			"- /trivia search [type], [query] - Searches for questions based on their type and their query. Valid types: submissions, subs, questions, qs. Requires: + % @ # & ~",
+			"- /trivia search [type], [query] - Searches for questions based on their type and their query. Valid types: submissions, subs, questions, qs. " + Chat.require('+'),
 			"- /trivia status [player] - lists the player's standings (your own if no player is specified) and the list of players in the current trivia game.",
 			"- /trivia rank [username] - View the rank of the specified user. If none is given, view your own.",
 			"- /trivia ladder - View information about the top 15 users on the trivia leaderboard.",
-			"- /trivia ugm [setting] - Enable or disable UGM mode. Requires: # & ~",
+			"- /trivia ugm [setting] - Enable or disable UGM mode. " + Chat.require('#'),
 		],
 	},
 };

--- a/chat-plugins/wifi.js
+++ b/chat-plugins/wifi.js
@@ -569,13 +569,13 @@ let commands = {
 		case 'staff':
 			if (!this.can('broadcast', null, room)) return;
 			reply = '<strong>Staff commands:</strong><br />' +
-			        '- question or qg <em>User | OT | TID | Friend Code | Prize | Question | Answer[ | Answer2 | Answer3]</em> - Start a new question giveaway (voices can only host for themselves, staff can for all users) (Requires: + % @ * # & ~)<br />' +
-			        '- lottery or lg <em>User | OT | TID | Friend Code | Prize[| Number of Winners]</em> - Starts a lottery giveaway (voices can only host for themselves, staff can for all users) (Requires: + % @ * # & ~)<br />' +
+			        '- question or qg <em>User | OT | TID | Friend Code | Prize | Question | Answer[ | Answer2 | Answer3]</em> - Start a new question giveaway (voices can only host for themselves, staff can for all users) (' + Chat.require('+') + ')<br />' +
+			        '- lottery or lg <em>User | OT | TID | Friend Code | Prize[| Number of Winners]</em> - Starts a lottery giveaway (voices can only host for themselves, staff can for all users) (' + Chat.require('+') + ')<br />' +
 			        '- changequestion - Changes the question of a question giveaway (Requires: giveaway host)<br />' +
 			        '- changeanswer - Changes the answer of a question giveaway (Requires: giveaway host)<br />' +
 					'- viewanswer - Shows the answer in a question giveaway (only to giveaway host/giver)<br />' +
-					'- ban - Temporarily bans a user from entering giveaways (Requires: % @ * # & ~)<br />' +
-			        '- end - Forcibly ends the current giveaway (Requires: % @ * # & ~)<br />';
+					'- ban - Temporarily bans a user from entering giveaways (' + Chat.require('%') + ')<br />' +
+			        '- end - Forcibly ends the current giveaway (' + Chat.require('%') + ')<br />';
 			break;
 		case 'game':
 		case 'giveaway':
@@ -592,7 +592,7 @@ let commands = {
 			if (!this.runBroadcast()) return;
 			reply = '<b>Wi-Fi room Giveaway help and info</b><br />' +
 			'- help user - shows list of participation commands<br />' +
-			'- help staff - shows giveaway staff commands (Requires: + % @ * # & ~)';
+			'- help staff - shows giveaway staff commands (' + Chat.require('+') + ')';
 		}
 		this.sendReplyBox(reply);
 	},

--- a/chat.js
+++ b/chat.js
@@ -861,6 +861,24 @@ Chat.escapeHTML = function (str) {
 };
 
 /**
+ * Sends the required rank text for help commands.
+ *
+ * @param  {string} rank
+ * @return {string}
+ */
+Chat.require = function (rank) {
+	if (!Config.groups[rank]) return "";
+	let startIndex = Config.groupsranking.indexOf(rank);
+	let buff = [];
+	for (let i = 0; i < Config.groupsranking.length; i++) {
+		if (i >= startIndex && (Config.groupsranking[i] !== '\u2606' || rank === '\u2606')) {
+			buff.push(Config.groupsranking[i]);
+		}
+	}
+	return `Requires: ${buff.join(' ')}`;
+};
+
+/**
  * Template string tag function for escaping HTML
  *
  * @param  {string[]} strings


### PR DESCRIPTION
This introduces Chat#require which accepts the lowest rank a command requires and then returns all ranks above it (excluding player) so that all help command 'requires' text will be standardized throughout PS.