### PR TITLE
Fix locks not locking logged out users by id

### DIFF
--- a/punishments.js
+++ b/punishments.js
@@ -407,8 +407,9 @@ Punishments.punish = function (user, punishment, recursionKeys) {
 		Punishments.ips.set(ip, punishment);
 		keys.add(ip);
 	}
-	if (!user.userid.startsWith('guest')) {
-		Punishments.userids.set(user.userid, punishment);
+	let lastUserId = user.getLastId();
+	if (!lastUserId.startsWith('guest')) {
+		Punishments.userids.set(lastUserId, punishment);
 	}
 	if (user.autoconfirmed) {
 		Punishments.userids.set(user.autoconfirmed, punishment);


### PR DESCRIPTION
Seems to have led to at least one case of accidental lock evasion.