### PR TITLE
Make Hidden Type a Gen 7 format again

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -512,6 +512,7 @@ exports.Formats = [
 			"&bullet; <a href=\"https://www.smogon.com/forums/threads/3591194/\">Hidden Type</a>",
 		],
 
+		mod: 'gen7',
 		searchShow: false,
 		ruleset: ['[Gen 7] OU'],
 		onModifyTemplate: function (template, pokemon) {


### PR DESCRIPTION
In 7f7ac97 @TheImmortal removed Hidden Type's custom mod; unfortunately that meant that it switched to Gen 6 mechanics, so this switches it back to Gen 7 again.