### PR TITLE
Change choice API

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -298,8 +298,7 @@ exports.BattleFormats = {
 			}
 		},
 		onTeamPreview: function () {
-			let lengthData = this.getFormat().teamLength;
-			this.makeRequest('teampreview', lengthData && lengthData.battle || '');
+			this.makeRequest('teampreview');
 		},
 	},
 	littlecup: {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "devDependencies": {
     "eslint": "^3.2.2",
     "mocha": "^3.0.0",
-    "mock-fs-require-fix": "~1.0.0",
-    "fuzzur": "0.1.2"
+    "mock-fs-require-fix": "~1.0.0"
   }
 }

--- a/room-battle.js
+++ b/room-battle.js
@@ -233,6 +233,11 @@ class Battle {
 			let player = this[lines[2]];
 			if (player) {
 				player.sendRoom(lines[3]);
+				if (lines[3].startsWith('|error|[Invalid choice]')) {
+					let request = this.requests[player.slot];
+					this.requests[player.slot][2] = false;
+					this.requests[player.slot][3] = '';
+				}
 			}
 			break;
 		}

--- a/rooms.js
+++ b/rooms.js
@@ -851,9 +851,17 @@ class BattleRoom extends Room {
 	getInactiveSide() {
 		let p1active = this.battle.p1 && this.battle.p1.active;
 		let p2active = this.battle.p2 && this.battle.p2.active;
+
+		if (p1active && this.battle.requests.p1) {
+			if (!this.battle.requests.p1[2]) p1active = false;
+		}
+		if (p2active && this.battle.requests.p2) {
+			if (!this.battle.requests.p2[2]) p2active = false;
+		}
+
 		if (p1active && !p2active) return 1;
 		if (p2active && !p1active) return 0;
-		return this.battle.inactiveSide;
+		return -1;
 	}
 	sendPlayer(num, message) {
 		let player = this.getPlayer(num);

--- a/test/common.js
+++ b/test/common.js
@@ -115,6 +115,7 @@ class TestTools {
 			undefined,
 			prng
 		);
+		battle.LEGACY_API_DO_NOT_USE = true;
 		if (options && options.partialDecisions) battle.supportPartialDecisions = true;
 		if (teams) {
 			for (let i = 0; i < teams.length; i++) {

--- a/test/simulator/misc/choice-parser.js
+++ b/test/simulator/misc/choice-parser.js
@@ -2,14 +2,6 @@
 
 const assert = require('./../../assert');
 const common = require('./../../common');
-const fuzzer = require('fuzzur').mutate;
-
-const FUZZER_ITERATIONS = 20;
-
-function serializeChoices(parsedChoice) {
-	if (!parsedChoice) return '';
-	return parsedChoice.map(choiceData => choiceData[1] ? choiceData.join(' ') : choiceData[0]).join(', ');
-}
 
 let battle;
 
@@ -23,47 +15,36 @@ describe('Choice parser', function () {
 			]);
 
 			const validDecision = 'team 1';
-			assert(battle.parseChoice(battle.p1, validDecision));
-			assert(battle.parseChoice(battle.p2, validDecision));
+			assert(battle.choose('p1', validDecision));
+			battle.p1.clearChoice();
+			assert(battle.choose('p2', validDecision));
+			battle.p1.clearChoice();
 
-			let remainingIterations = FUZZER_ITERATIONS;
-			while (remainingIterations--) {
-				const side = battle.sides[remainingIterations % 2];
-				const mutatedDecision = fuzzer(validDecision);
-				if (!mutatedDecision.startsWith('team ')) {
-					assert.false(battle.parseChoice(side, mutatedDecision), `Decision '${mutatedDecision}' should be rejected`);
-				}
+			const badDecisions = ['move 1', 'move 2 mega', 'switch 1', 'pass', 'shift'];
+			for (const badDecision of badDecisions) {
+				assert.false(battle.choose('p1', badDecision), `Decision '${badDecision}' should be rejected`);
 			}
 		});
 
-		it('should reject empty or non-numerical choice details', function () {
+		it('should reject non-numerical choice details', function () {
 			battle = common.createBattle({preview: true}, [
 				[{species: "Mew", ability: 'synchronize', moves: ['recover']}],
 				[{species: "Rhydon", ability: 'prankster', moves: ['splash']}],
 			]);
 
 			battle.sides.forEach(side => {
-				assert.false(battle.parseChoice(side, 'team'));
-				assert.false(battle.parseChoice(side, 'team '));
-				assert.false(battle.parseChoice(side, 'team  '));
-				assert.false(battle.parseChoice(side, 'team Rhydon'));
-				assert.false(battle.parseChoice(side, 'team Mew'));
-				assert.false(battle.parseChoice(side, 'team first'));
-
-				let totalIterations = Math.ceil(FUZZER_ITERATIONS / 2);
-				while (totalIterations--) {
-					const data = fuzzer('1').trim();
-					if (isNaN(data)) assert.false(battle.parseChoice(side, `team ${data}`));
-				}
+				assert.false(battle.choose(side.id, 'team Rhydon'));
+				assert.false(battle.choose(side.id, 'team Mew'));
+				assert.false(battle.choose(side.id, 'team first'));
 			});
 		});
 	});
 
 	describe('Switch requests', function () {
 		describe('Generic', function () {
-			it('should reject empty or non-numerical input for `switch` choices', function () {
+			it('should reject non-numerical input for `switch` choices', function () {
 				battle = common.createBattle();
-				const p1 = battle.join('p1', 'Guest 1', 1, [
+				battle.join('p1', 'Guest 1', 1, [
 					{species: "Mew", ability: 'synchronize', moves: ['lunardance']},
 					{species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl']},
 				]);
@@ -71,26 +52,17 @@ describe('Choice parser', function () {
 
 				battle.commitDecisions();
 
-				assert.false(battle.parseChoice(p1, 'switch'));
-				assert.false(battle.parseChoice(p1, 'switch '));
-				assert.false(battle.parseChoice(p1, 'switch  '));
-				assert.false(battle.parseChoice(p1, 'switch Rhydon'));
-				assert.false(battle.parseChoice(p1, 'switch Bulbasaur'));
-				assert.false(battle.parseChoice(p1, 'switch first'));
-				assert.false(battle.parseChoice(p1, 'switch second'));
-
-				let totalIterations = Math.ceil(FUZZER_ITERATIONS / 2);
-				while (totalIterations--) {
-					const data = fuzzer('2').trim();
-					if (isNaN(data)) assert.false(battle.parseChoice(p1, `switch ${data}`, `Decision 'switch ${data}' should be rejected`));
-				}
+				assert.false(battle.choose('p1', 'switch Rhydon'));
+				assert.false(battle.choose('p1', 'switch Bulbasaur'));
+				assert.false(battle.choose('p1', 'switch first'));
+				assert.false(battle.choose('p1', 'switch second'));
 			});
 		});
 
 		describe('Singles', function () {
 			it('should accept only `switch` choices', function () {
 				battle = common.createBattle();
-				const p1 = battle.join('p1', 'Guest 1', 1, [
+				battle.join('p1', 'Guest 1', 1, [
 					{species: "Mew", ability: 'synchronize', moves: ['lunardance']},
 					{species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl']},
 				]);
@@ -98,23 +70,21 @@ describe('Choice parser', function () {
 
 				battle.commitDecisions();
 
-				const validDecision = 'switch 2';
-				assert(battle.parseChoice(p1, validDecision));
-
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const mutatedDecision = fuzzer(validDecision);
-					if (!mutatedDecision.startsWith('switch ')) {
-						assert.false(battle.parseChoice(p1, mutatedDecision), `Decision '${mutatedDecision}' should be rejected`);
-					}
+				const badDecisions = ['move 1', 'move 2 mega', 'team 1', 'pass', 'shift'];
+				for (const badDecision of badDecisions) {
+					assert.false(battle.choose('p1', badDecision), `Decision '${badDecision}' should be rejected`);
 				}
+
+				const validDecision = 'switch 2';
+				assert(battle.choose('p1', validDecision));
+				battle.p1.clearChoice();
 			});
 		});
 
 		describe('Doubles/Triples', function () {
 			it('should accept only `switch` and `pass` choices', function () {
 				battle = common.createBattle({gameType: 'doubles'});
-				const p1 = battle.join('p1', 'Guest 1', 1, [
+				battle.join('p1', 'Guest 1', 1, [
 					{species: "Pineco", ability: 'sturdy', moves: ['selfdestruct']},
 					{species: "Geodude", ability: 'sturdy', moves: ['selfdestruct']},
 					{species: "Koffing", ability: 'levitate', moves: ['smog']},
@@ -126,27 +96,17 @@ describe('Choice parser', function () {
 				]);
 				battle.commitDecisions(); // Both p1 active Pokémon faint
 
-				const validDecisions = ['pass', 'switch 3'];
-				validDecisions.forEach(leftDecision => {
-					validDecisions.forEach(rightDecision => {
-						assert(battle.parseChoice(p1, `${leftDecision}, ${rightDecision}`), `Decision '${leftDecision}, ${rightDecision}' should be valid`);
-					});
-				});
-
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const side = battle.sides[remainingIterations % 2];
-					const mutatedDecisions = Tools.shuffle(validDecisions.map(fuzzer)).slice(0, 2);
-					if (mutatedDecisions.some(decision => decision && !decision.startsWith('switch ') && !decision.startsWith('pass '))) {
-						const choiceString = mutatedDecisions.join(', ');
-						assert.false(battle.parseChoice(side, choiceString), `Decision '${choiceString}' should be rejected`);
-					}
+				const badDecisions = ['move 1', 'move 2 mega', 'team 1', 'shift'];
+				for (const badDecision of badDecisions) {
+					assert.false(battle.choose('p1', badDecision), `Decision '${badDecision}' should be rejected`);
 				}
+
+				assert(battle.choose('p1', `pass, switch 3`), `Decision 'pass, switch 3' should be valid`);
 			});
 
 			it('should reject choice details for `pass` choices', function () {
 				battle = common.createBattle({gameType: 'doubles'});
-				const p1 = battle.join('p1', 'Guest 1', 1, [
+				battle.join('p1', 'Guest 1', 1, [
 					{species: "Pineco", ability: 'sturdy', moves: ['selfdestruct']},
 					{species: "Geodude", ability: 'sturdy', moves: ['selfdestruct']},
 					{species: "Koffing", ability: 'levitate', moves: ['smog']},
@@ -161,119 +121,51 @@ describe('Choice parser', function () {
 				const switchChoice = 'switch 3';
 				const passChoice = 'pass';
 
-				assert.false(battle.parseChoice(p1, `${switchChoice}, ${passChoice} 1`));
-				assert.false(battle.parseChoice(p1, `${passChoice} 1, ${switchChoice}`));
-				assert.false(battle.parseChoice(p1, `${switchChoice}, ${passChoice} a`));
-				assert.false(battle.parseChoice(p1, `${passChoice} a, ${switchChoice}`));
-
-				let totalIterations = Math.ceil(FUZZER_ITERATIONS / 2);
-				while (totalIterations--) {
-					const data = fuzzer('2').replace(/[\s,]/g, '');
-					if (data) {
-						const decisions = totalIterations % 2 ? [switchChoice, `passChoice ${data}`] : [`passChoice ${data}`, switchChoice];
-						assert.false(battle.parseChoice(p1, decisions.join(', ')));
-					}
-				}
+				assert.false(battle.choose('p1', `${switchChoice}, ${passChoice} 1`));
+				assert.false(battle.choose('p1', `${passChoice} 1, ${switchChoice}`));
+				assert.false(battle.choose('p1', `${switchChoice}, ${passChoice} a`));
+				assert.false(battle.choose('p1', `${passChoice} a, ${switchChoice}`));
 			});
 		});
 	});
 
 	describe('Move requests', function () {
 		describe('Generic', function () {
-			it('should be unaware of disabled moves', function () {
-				battle = common.createBattle();
-				const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Mew", item: 'assaultvest', ability: 'shadowtag', moves: ['recover']}]);
-				const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Rhydon", item: 'assaultvest', ability: 'shadowtag', moves: ['splash']}]);
-
-				battle.sides.forEach(side => assert(battle.parseChoice(side, 'move 1')));
-				assert.strictEqual(serializeChoices(battle.parseChoice(p1, 'move recover')), 'move recover');
-				assert.strictEqual(serializeChoices(battle.parseChoice(p2, 'move sketch')), 'move sketch');
-			});
-
-			it('should be unaware of trapped Pokémon', function () {
-				battle = common.createBattle();
-				battle.join('p1', 'Guest 1', 1, [
-					{species: "Mew", item: 'assaultvest', ability: 'shadowtag', moves: ['recover']},
-					{species: "Bulbasaur", item: '', ability: 'overgrow', moves: ['tackle', 'growl']},
-				]);
-				battle.join('p2', 'Guest 2', 1, [
-					{species: "Rhydon", item: 'assaultvest', ability: 'shadowtag', moves: ['splash']},
-					{species: "Charmander", item: '', ability: 'blaze', moves: ['tackle', 'growl']},
-				]);
-
-				battle.sides.forEach(side => assert(battle.parseChoice(side, 'switch 2')));
-			});
-
 			it('should reject `pass` choices for non-fainted Pokémon', function () {
 				battle = common.createBattle();
 				battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['recover']}]);
 				battle.join('p2', 'Guest 2', 1, [{species: "Rhydon", ability: 'prankster', moves: ['splash']}]);
 
-				battle.sides.forEach(side => assert.false(battle.parseChoice(side, 'pass')));
+				battle.sides.forEach(side => assert.false(battle.choose(side.id, 'pass')));
 			});
 		});
 
 		describe('Singles', function () {
 			it('should accept only `move` and `switch` choices', function () {
 				battle = common.createBattle();
-				const p1 = battle.join('p1', 'Guest 1', 1, [
+				battle.join('p1', 'Guest 1', 1, [
 					{species: "Mew", ability: 'synchronize', moves: ['lunardance', 'recover']},
 					{species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl']},
 				]);
-				const p2 = battle.join('p2', 'Guest 2', 1, [
+				battle.join('p2', 'Guest 2', 1, [
 					{species: "Rhydon", ability: 'prankster', moves: ['splash', 'horndrill']},
 					{species: "Charmander", ability: 'blaze', moves: ['tackle', 'growl']},
 				]);
 
 				const validDecisions = ['move 1', 'move 2', 'switch 2'];
-				validDecisions.forEach(decision => {
-					assert(battle.parseChoice(p1, decision, `Decision '${decision}' should be valid`));
-					assert(battle.parseChoice(p2, decision, `Decision '${decision}' should be valid`));
-				});
+				for (const decision of validDecisions) {
+					assert(battle.choose('p1', decision), `Decision '${decision}' should be valid`);
+					battle.p1.clearChoice();
+				}
 
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const side = battle.sides[remainingIterations % 2];
-					const mutatedDecision = Tools.shuffle(validDecisions.map(fuzzer))[0];
-					if (!mutatedDecision.startsWith('move ') && !mutatedDecision.startsWith('switch ')) {
-						assert.false(battle.parseChoice(side, mutatedDecision), `Decision '${mutatedDecision}' should be rejected`);
-					}
+				const badDecisions = ['move 1 zmove', 'move 2 mega', 'team 1', 'pass', 'shift'];
+				for (const badDecision of badDecisions) {
+					assert.false(battle.choose('p1', badDecision), `Decision '${badDecision}' should be rejected`);
 				}
 			});
 		});
 
 		describe('Doubles', function () {
-			it('should accept only `move` and `switch` choices for healthy Pokémon', function () {
-				battle = common.createBattle({gameType: 'doubles'});
-				const p1 = battle.join('p1', 'Guest 1', 1, [
-					{species: "Pineco", ability: 'sturdy', moves: ['selfdestruct']},
-					{species: "Geodude", ability: 'sturdy', moves: ['selfdestruct']},
-					{species: "Koffing", ability: 'levitate', moves: ['smog']},
-				]);
-				battle.join('p2', 'Guest 2', 1, [
-					{species: "Skarmory", ability: 'sturdy', moves: ['roost']},
-					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
-					{species: "Ekans", ability: 'shedskin', moves: ['wrap']},
-				]);
-
-				const validDecisions = ['move 1', 'switch 3'];
-				validDecisions.forEach(leftDecision => {
-					validDecisions.forEach(rightDecision => {
-						assert(battle.parseChoice(p1, `${leftDecision}, ${rightDecision}`), `Decision '${leftDecision}, ${rightDecision}' should be valid`);
-					});
-				});
-
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const side = battle.sides[remainingIterations % 2];
-					const mutatedDecisions = Tools.shuffle(validDecisions.map(fuzzer)).slice(0, 2).map(decision => decision.trim());
-					if (mutatedDecisions.some(decision => decision && !decision.startsWith('move ') && !decision.startsWith('switch '))) {
-						const choiceString = mutatedDecisions.join(', ');
-						assert.false(battle.parseChoice(side, choiceString), `Decision '${choiceString}' should be rejected for ${side}`);
-					}
-				}
-			});
-
 			it('should enforce `pass` choices for fainted Pokémon', function () {
 				battle = common.createBattle({gameType: 'doubles'});
 				const p1 = battle.join('p1', 'Guest 1', 1, [
@@ -286,135 +178,48 @@ describe('Choice parser', function () {
 					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 				]);
 				battle.commitDecisions(); // Both p1 active Pokémon faint
-				p1.choosePass().chooseSwitch(3); // Koffing switches in at slot #2
+				battle.choose('p1', 'pass, switch 3'); // Koffing switches in at slot #2
 
 				assert.fainted(p1.active[0]);
 				assert.species(p1.active[1], 'Koffing');
 				assert.false.fainted(p1.active[1]);
 
-				assert(battle.parseChoice(p1, 'move smog'));
-
-				const validDecisions = ['move smog', 'move 1'];
-				validDecisions.forEach(decision => {
-					assert.strictEqual(serializeChoices(battle.parseChoice(p1, `${decision}`)), `pass, ${decision}`, `Decision '${decision}' should be valid`);
-					assert.strictEqual(serializeChoices(battle.parseChoice(p1, `pass, ${decision}`)), `pass, ${decision}`, `Decision 'pass, ${decision}' should be valid`);
-				});
-
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const mutatedDecision = fuzzer(validDecisions[remainingIterations % 2]).replace(/[\s,]/g, '');
-					if (mutatedDecision !== 'pass') {
-						validDecisions.forEach(healthyDecision => assert.false(battle.parseChoice(p1, `${mutatedDecision}, ${healthyDecision}`)));
-					}
-				}
+				assert(battle.choose('p1', 'move smog 2'));
+				assert.strictEqual(battle.p1.getChoice(true), `pass, move smog 2`, `Decision mismatch`);
 			});
 		});
 
 		describe('Triples', function () {
 			it('should accept only `move` and `switch` choices for a healthy Pokémon on the center', function () {
 				battle = common.createBattle({gameType: 'triples'});
-				const p1 = battle.join('p1', 'Guest 1', 1, [
+				battle.join('p1', 'Guest 1', 1, [
 					{species: "Pineco", ability: 'sturdy', moves: ['selfdestruct']},
 					{species: "Geodude", ability: 'sturdy', moves: ['selfdestruct']},
 					{species: "Gastly", ability: 'levitate', moves: ['lick']},
+					{species: "Forretress", ability: 'levitate', moves: ['spikes']},
 				]);
-				const p2 = battle.join('p2', 'Guest 2', 1, [
+				battle.join('p2', 'Guest 2', 1, [
 					{species: "Skarmory", ability: 'sturdy', moves: ['roost']},
 					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 					{species: "Golem", ability: 'sturdy', moves: ['defensecurl']},
 				]);
 
 				const validDecisions = ['move 1', 'switch 4'];
-				const otherDecisions = ['move 1', 'move 1'];
 
 				validDecisions.forEach(decision => {
-					const choiceString = [otherDecisions[0]].concat([decision]).concat(otherDecisions[1]).join(', ');
-					assert(battle.parseChoice(p1, choiceString), `Decision '${choiceString}' should be valid`);
-					assert(battle.parseChoice(p2, choiceString), `Decision '${choiceString}' should be valid`);
+					const choiceString = `move 1, ${decision}, move 1 1`;
+					assert(battle.choose('p1', choiceString), `Decision '${choiceString}' should be valid`);
+					battle.p1.clearChoice();
 				});
 
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const side = battle.sides[remainingIterations % 2];
-					const mutatedDecision = fuzzer('').replace(/[\s,]/g, '');
-					if (mutatedDecision && !mutatedDecision.startsWith('move') && !mutatedDecision.startsWith('switch ') && !mutatedDecision.startsWith('shift ')) {
-						const choiceString = [otherDecisions[0]].concat([mutatedDecision]).concat(otherDecisions[1]).join(', ');
-						assert.false(battle.parseChoice(side, choiceString));
-					}
+				const badDecisions = ['move 1 zmove', 'move 2 mega', 'team 1', 'pass', 'shift'];
+				for (const badDecision of badDecisions) {
+					const choiceString = `move 1, ${badDecision}, move 1 1`;
+					assert.false(battle.choose('p1', choiceString), `Decision '${choiceString}' should be rejected`);
 				}
 			});
 
 			it('should accept only `move`, `switch` and `shift` choices for a healthy Pokémon on the left', function () {
-				battle = common.createBattle({gameType: 'triples'});
-				const p1 = battle.join('p1', 'Guest 1', 1, [
-					{species: "Pineco", ability: 'sturdy', moves: ['selfdestruct']},
-					{species: "Geodude", ability: 'sturdy', moves: ['selfdestruct']},
-					{species: "Gastly", ability: 'levitate', moves: ['lick']},
-					{species: "Forretress", ability: 'levitate', moves: ['spikes']},
-				]);
-				const p2 = battle.join('p2', 'Guest 2', 1, [
-					{species: "Skarmory", ability: 'sturdy', moves: ['roost']},
-					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
-					{species: "Golem", ability: 'sturdy', moves: ['defensecurl']},
-					{species: "Magnezone", ability: 'magnetpull', moves: ['discharge']},
-				]);
-
-				const validDecisions = ['move 1', 'switch 4', 'shift'];
-				const otherDecisions = ['move 1', 'move 1'];
-
-				validDecisions.forEach(decision => {
-					const choiceString = [decision].concat(otherDecisions).join(', ');
-					assert(battle.parseChoice(p1, choiceString), `Decision '${choiceString}' should be valid`);
-					assert(battle.parseChoice(p2, choiceString), `Decision '${choiceString}' should be valid`);
-				});
-
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const side = battle.sides[remainingIterations % 2];
-					const mutatedDecision = fuzzer('').replace(/[\s,]/g, '');
-					if (mutatedDecision && !mutatedDecision.startsWith('move') && !mutatedDecision.startsWith('switch ') && !mutatedDecision.startsWith('shift ')) {
-						const choiceString = [mutatedDecision].concat(otherDecisions).join(', ');
-						assert.false(battle.parseChoice(side, choiceString));
-					}
-				}
-			});
-
-			it('should accept only `move`, `switch` and `shift` choices for a healthy Pokémon on the right', function () {
-				battle = common.createBattle({gameType: 'triples'});
-				const p1 = battle.join('p1', 'Guest 1', 1, [
-					{species: "Pineco", ability: 'sturdy', moves: ['selfdestruct']},
-					{species: "Geodude", ability: 'sturdy', moves: ['selfdestruct']},
-					{species: "Gastly", ability: 'levitate', moves: ['lick']},
-					{species: "Forretress", ability: 'levitate', moves: ['spikes']},
-				]);
-				const p2 = battle.join('p2', 'Guest 2', 1, [
-					{species: "Skarmory", ability: 'sturdy', moves: ['roost']},
-					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
-					{species: "Golem", ability: 'sturdy', moves: ['defensecurl']},
-					{species: "Magnezone", ability: 'magnetpull', moves: ['discharge']},
-				]);
-
-				const validDecisions = ['move 1', 'switch 4', 'shift'];
-				const otherDecisions = ['move 1', 'move 1'];
-
-				validDecisions.forEach(decision => {
-					const choiceString = otherDecisions.concat([decision]).join(', ');
-					assert(battle.parseChoice(p1, choiceString), `Decision '${choiceString}' should be valid`);
-					assert(battle.parseChoice(p2, choiceString), `Decision '${choiceString}' should be valid`);
-				});
-
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const side = battle.sides[remainingIterations % 2];
-					const mutatedDecision = fuzzer('').replace(/[\s,]/g, '');
-					if (mutatedDecision && !mutatedDecision.startsWith('move') && !mutatedDecision.startsWith('switch ') && !mutatedDecision.startsWith('shift ')) {
-						const choiceString = otherDecisions.concat([mutatedDecision]).join(', ');
-						assert.false(battle.parseChoice(side, choiceString));
-					}
-				}
-			});
-
-			it('should reject choice details for `shift` choices', function () {
 				battle = common.createBattle({gameType: 'triples'});
 				battle.join('p1', 'Guest 1', 1, [
 					{species: "Pineco", ability: 'sturdy', moves: ['selfdestruct']},
@@ -429,17 +234,48 @@ describe('Choice parser', function () {
 					{species: "Magnezone", ability: 'magnetpull', moves: ['discharge']},
 				]);
 
-				const validDecision = 'shift';
-				const otherDecisions = ['move 1', 'move 1'];
+				const validDecisions = ['move 1', 'switch 4', 'shift'];
 
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const side = battle.sides[remainingIterations % 2];
-					const choiceData = fuzzer('').replace(/[\s,]/g, '');
-					if (choiceData.trim().length) {
-						const mutatedDecision = [`${validDecision} ${choiceData}`].concat(otherDecisions).join(', ');
-						assert.false(battle.parseChoice(side, mutatedDecision));
-					}
+				validDecisions.forEach(decision => {
+					const choiceString = `${decision}, move 1, move 1 1`;
+					assert(battle.choose('p1', choiceString), `Decision '${choiceString}' should be valid`);
+					battle.p1.clearChoice();
+				});
+
+				const badDecisions = ['move 1 zmove', 'move 2 mega', 'team 1', 'pass'];
+				for (const badDecision of badDecisions) {
+					const choiceString = `${badDecision}, move 1, move 1 1`;
+					assert.false(battle.choose('p1', choiceString), `Decision '${choiceString}' should be rejected`);
+				}
+			});
+
+			it('should accept only `move`, `switch` and `shift` choices for a healthy Pokémon on the right', function () {
+				battle = common.createBattle({gameType: 'triples'});
+				battle.join('p1', 'Guest 1', 1, [
+					{species: "Pineco", ability: 'sturdy', moves: ['selfdestruct']},
+					{species: "Geodude", ability: 'sturdy', moves: ['selfdestruct']},
+					{species: "Gastly", ability: 'levitate', moves: ['lick']},
+					{species: "Forretress", ability: 'levitate', moves: ['spikes']},
+				]);
+				battle.join('p2', 'Guest 2', 1, [
+					{species: "Skarmory", ability: 'sturdy', moves: ['roost']},
+					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
+					{species: "Golem", ability: 'sturdy', moves: ['defensecurl']},
+					{species: "Magnezone", ability: 'magnetpull', moves: ['discharge']},
+				]);
+
+				const validDecisions = ['move 1 1', 'switch 4', 'shift'];
+
+				validDecisions.forEach(decision => {
+					const choiceString = `move 1, move 1, ${decision}`;
+					assert(battle.choose('p1', choiceString), `Decision '${choiceString}' should be valid`);
+					battle.p1.clearChoice();
+				});
+
+				const badDecisions = ['move 1 zmove', 'move 2 mega', 'team 1', 'pass', 'shift blah'];
+				for (const badDecision of badDecisions) {
+					const choiceString = `move 1, move 1, ${badDecision}`;
+					assert.false(battle.choose('p1', choiceString), `Decision '${choiceString}' should be rejected`);
 				}
 			});
 
@@ -458,33 +294,24 @@ describe('Choice parser', function () {
 				]);
 				battle.commitDecisions(); // All p1 active Pokémon faint
 
-				p1.choosePass().chooseSwitch(4).chooseDefault(); // Forretress switches in to slot #3
+				p1.choosePass().chooseSwitch(4).chooseDefault(); // Forretress switches in to slot #2
 				assert.species(p1.active[1], 'Forretress');
 
 				const validDecisions = ['move spikes', 'move 1'];
 				validDecisions.forEach(decision => {
-					assert.strictEqual(serializeChoices(battle.parseChoice(p1, decision)), `pass, ${decision}, pass`);
-					assert.strictEqual(serializeChoices(battle.parseChoice(p1, `pass, ${decision}, pass`)), `pass, ${decision}, pass`);
-					assert.strictEqual(serializeChoices(battle.parseChoice(p1, `pass, ${decision}`)), `pass, ${decision}, pass`);
-					assert.strictEqual(serializeChoices(battle.parseChoice(p1, `${decision}, pass`)), `pass, ${decision}, pass`);
+					battle.choose('p1', decision);
+					assert.strictEqual(battle.p1.getChoice(true), `pass, move spikes, pass`);
+					battle.p1.clearChoice();
+					battle.choose('p1', `pass, ${decision}, pass`);
+					assert.strictEqual(battle.p1.getChoice(true), `pass, move spikes, pass`);
+					battle.p1.clearChoice();
+					battle.choose('p1', `pass, ${decision}`);
+					assert.strictEqual(battle.p1.getChoice(true), `pass, move spikes, pass`);
+					battle.p1.clearChoice();
+					battle.choose('p1', `${decision}, pass`);
+					assert.strictEqual(battle.p1.getChoice(true), `pass, move spikes, pass`);
+					battle.p1.clearChoice();
 				});
-
-				let remainingIterations = FUZZER_ITERATIONS;
-				while (remainingIterations--) {
-					const forryDecision = Tools.shuffle(validDecisions.slice())[0];
-					const mutatedDecisions = ([
-						Math.random() > 0.5 ? Tools.shuffle(validDecisions.map(fuzzer))[0].replace(/[\s,]/g, '') : '',
-					].concat([
-						forryDecision,
-					]).concat([
-						Math.random() > 0.5 ? Tools.shuffle(validDecisions.map(fuzzer))[0].replace(/[\s,]/g, '') : '',
-					]));
-
-					if (mutatedDecisions[0] && mutatedDecisions[0] !== 'pass' || mutatedDecisions[2] && mutatedDecisions[2] !== 'pass') {
-						const mutatedDecision = mutatedDecisions.filter(choice => choice).join(', ');
-						assert.false(battle.parseChoice(p1, mutatedDecision), `Decision '${mutatedDecision}' should be rejected`);
-					}
-				}
 			});
 		});
 	});

--- a/test/simulator/misc/decisions.js
+++ b/test/simulator/misc/decisions.js
@@ -118,38 +118,6 @@ describe('Decisions', function () {
 				done();
 			}, 40);
 		});
-
-		it('should allow input of move commands in a per Pokémon basis', function () {
-			battle = common.createBattle({gameType: 'doubles', partialDecisions: true}, [
-				[{species: "Mew", ability: 'synchronize', moves: ['recover']}, {species: "Bulbasaur", ability: 'overgrow', moves: ['growl', 'synthesis']}],
-				[{species: "Pupitar", ability: 'shedskin', moves: ['surf']}, {species: "Arceus", ability: 'multitype', moves: ['calmmind']}],
-				// Pupitar is faster than Bulbasaur
-			]);
-
-			battle.choose('p1', 'move recover');
-			battle.choose('p1', 'move growl');
-			battle.choose('p2', 'move surf');
-			battle.choose('p2', 'move calmmind');
-
-			assert.strictEqual(battle.turn, 2);
-			assert.statStage(battle.p2.active[0], 'atk', -1);
-
-			battle.choose('p1', 'move recover');
-			battle.choose('p1', 'move synthesis');
-			battle.choose('p2', 'move surf');
-			battle.choose('p2', 'move calmmind');
-
-			assert.strictEqual(battle.turn, 3);
-			assert.fullHP(battle.p1.active[1]);
-
-			battle.choose('p1', 'move recover');
-			battle.choose('p1', 'move 2');
-			battle.choose('p2', 'move 1');
-			battle.choose('p2', 'move calmmind');
-
-			assert.strictEqual(battle.turn, 4);
-			assert.fullHP(battle.p1.active[1]);
-		});
 	});
 
 	describe('Move requests', function () {
@@ -552,7 +520,7 @@ describe('Decisions', function () {
 				battle = common.createBattle({preview: true}, SINGLES_TEAMS.illusion);
 				const teamOrder = Tools.shuffle(BASE_TEAM_ORDER.slice());
 
-				teamOrder.forEach(slot => battle.choose('p1', 'team ' + slot));
+				battle.choose('p1', 'team ' + teamOrder.join(''));
 				battle.p2.chooseDefault();
 
 				teamOrder.forEach((oSlot, index) => assert.species(battle.p1.pokemon[index], SINGLES_TEAMS.illusion[0][oSlot - 1].species));
@@ -566,7 +534,7 @@ describe('Decisions', function () {
 				battle = common.createBattle({preview: true, gameType: 'doubles'}, DOUBLES_TEAMS.full);
 				const teamOrder = Tools.shuffle(BASE_TEAM_ORDER.slice());
 
-				teamOrder.forEach(slot => battle.choose('p1', 'team ' + slot));
+				battle.choose('p1', 'team ' + teamOrder.join(''));
 				battle.p2.chooseDefault();
 
 				teamOrder.forEach((oSlot, index) => assert.species(battle.p1.pokemon[index], DOUBLES_TEAMS.full[0][oSlot - 1].species));
@@ -580,7 +548,7 @@ describe('Decisions', function () {
 				battle = common.createBattle({preview: true, gameType: 'triples'}, TRIPLES_TEAMS.full);
 				const teamOrder = Tools.shuffle(BASE_TEAM_ORDER.slice());
 
-				teamOrder.forEach(slot => battle.choose('p1', 'team ' + slot));
+				battle.choose('p1', 'team ' + teamOrder.join(''));
 				battle.p2.chooseDefault();
 
 				teamOrder.forEach((oSlot, index) => assert.species(battle.p1.pokemon[index], TRIPLES_TEAMS.full[0][oSlot - 1].species));
@@ -1187,134 +1155,6 @@ describe('Decision extensions', function () {
 			});
 		}
 	});
-
-	describe('Undo > Partial Decisions', function () {
-		const DOUBLES = {gameType: 'doubles', cancel: true, partialDecisions: true};
-		const TRIPLES = {gameType: 'triples', cancel: true, partialDecisions: true};
-
-		it(`should support to revoke move decisions on move requests`, function () {
-			let didFullUndo = false;
-			for (const finalIndex of [0, 0, 1, 2]) {
-				battle = common.createBattle(TRIPLES, TRIPLES_TEAMS.default);
-
-				for (let i = 0; i <= finalIndex; i++) {
-					battle.choose('p1', 'move 1');
-				}
-				battle.undoChoice('p1', didFullUndo ? 1 : true);
-				didFullUndo = true;
-				battle.choose('p1', 'switch 4');
-				for (let i = finalIndex + 1; i < 3; i++) {
-					battle.choose('p1', 'move 1');
-				}
-
-				battle.p2.chooseDefault();
-				assert.species(battle.p1.active[finalIndex], TRIPLES_TEAMS.default[0][3].species);
-
-				if (finalIndex !== 2) battle.destroy();
-			}
-		});
-
-		it(`should support to revoke switch decisions on move requests`, function () {
-			let didFullUndo = false;
-			for (const finalIndex of [0, 0, 1, 2]) {
-				battle = common.createBattle(TRIPLES, TRIPLES_TEAMS.default);
-
-				for (let i = 0; i < finalIndex; i++) {
-					battle.choose('p1', 'move 1');
-				}
-				battle.choose('p1', 'switch 4');
-				battle.undoChoice('p1', didFullUndo ? 1 : void 0);
-				didFullUndo = true;
-				battle.choose('p1', 'move 1');
-				for (let i = finalIndex + 1; i < 3; i++) {
-					battle.choose('p1', 'move 1');
-				}
-				battle.p2.chooseDefault();
-				assert.strictEqual(battle.p1.active[finalIndex].lastMove, TRIPLES_TEAMS.default[0][finalIndex].moves[0]);
-
-				if (finalIndex !== 2) battle.destroy();
-			}
-		});
-
-		it(`should support to revoke shift decisions on move requests`, function () {
-			battle = common.createBattle(TRIPLES, TRIPLES_TEAMS.default);
-
-			battle.choose('p1', 'shift');
-			battle.undoChoice('p1');
-			for (let i = 0; i < 3; i++) battle.choose('p1', 'move 1');
-			battle.p2.chooseDefault();
-
-			TRIPLES_TEAMS.default[0].slice(0, 3).map(set => set.species).forEach((species, index) => assert.species(battle.p1.active[index], species));
-			battle.destroy();
-
-			battle = common.createBattle(TRIPLES, TRIPLES_TEAMS.default);
-
-			battle.choose('p1', 'shift');
-			battle.undoChoice('p1', 1);
-			for (let i = 0; i < 3; i++) battle.choose('p1', 'move 1');
-			battle.p2.chooseDefault();
-
-			TRIPLES_TEAMS.default[0].slice(0, 3).map(set => set.species).forEach((species, index) => assert.species(battle.p1.active[index], species));
-			battle.destroy();
-
-			battle = common.createBattle(TRIPLES, TRIPLES_TEAMS.default);
-
-			for (let i = 0; i < 2; i++) battle.choose('p1', 'move 1');
-			battle.choose('p1', 'shift');
-			battle.undoChoice('p1', 1);
-			battle.p2.chooseDefault();
-
-			TRIPLES_TEAMS.default[0].slice(0, 3).map(set => set.species).forEach((species, index) => assert.species(battle.p1.active[index], species));
-		});
-
-		it(`should support to revoke switch decisions on switch requests`, function () {
-			battle = common.createBattle(DOUBLES, DOUBLES_TEAMS.default);
-			battle.commitDecisions();
-
-			battle.choose('p1', 'switch 3');
-			battle.undoChoice('p1');
-			battle.choose('p1', 'switch 4, switch 3');
-
-			[DOUBLES_TEAMS.default[0][3], DOUBLES_TEAMS.default[0][2]].map(set => set.species).forEach((species, index) => assert.species(battle.p1.active[index], species));
-		});
-
-		it(`should support to revoke pass decisions on switch requests`, function () {
-			battle = common.createBattle(DOUBLES, DOUBLES_TEAMS.forcePass);
-			battle.commitDecisions();
-
-			battle.choose('p1', 'pass');
-			battle.undoChoice('p1');
-			battle.choose('p1', 'switch 3, pass');
-
-			[DOUBLES_TEAMS.forcePass[0][2], DOUBLES_TEAMS.forcePass[0][1]].map(set => set.species).forEach((species, index) => assert.species(battle.p1.active[index], species));
-		});
-
-		it(`should support to revoke team order decisions on team preview requests`, function () {
-			const TEAM_ORDER = [1, 2, 3, 4, 5, 6];
-			for (let i = 0; i < 20; i++) {
-				battle = common.createBattle(Object.assign({preview: true}, DOUBLES), DOUBLES_TEAMS.full);
-				const wrongOrder = TEAM_ORDER.slice(0, 1).concat(Tools.shuffle(TEAM_ORDER.slice(1)));
-				const rightOrder = TEAM_ORDER.slice(0, 1).concat(Tools.shuffle(TEAM_ORDER.slice(1)));
-				const divergeIndex = wrongOrder.findIndex((elem, index) => rightOrder[index] !== elem);
-				if (divergeIndex < 0) continue;
-				const finalIndex = divergeIndex + Math.floor(Math.random() * (5 - divergeIndex));
-				const undoSteps = finalIndex - divergeIndex + 1;
-
-				for (let j = 0; j <= finalIndex; j++) {
-					battle.choose('p1', 'team ' + wrongOrder[j]);
-				}
-				battle.undoChoice('p1', undoSteps);
-				for (let j = divergeIndex; j < 6; j++) {
-					battle.choose('p1', 'team ' + rightOrder[j]);
-				}
-				assert(battle.p1.getDecisionsFinished(), `Decisions for ${battle.p1} not finished`);
-				battle.p2.chooseDefault();
-				rightOrder.map(slot => DOUBLES_TEAMS.full[0][slot - 1].species).forEach((species, index) => assert.species(battle.p1.pokemon[index], species));
-
-				if (i < 19) battle.destroy();
-			}
-		});
-	});
 });
 
 describe('Decision internals', function () {
@@ -1421,9 +1261,9 @@ describe('Decision internals', function () {
 		]);
 
 		p1.chooseMove(1);
-		assert(p1.choiceData.decisions.length > 0);
+		assert(p1.choice.actions.length > 0);
 		battle.undoChoice('p1');
-		assert.false(p1.choiceData.decisions.length > 0);
+		assert.false(p1.choice.actions.length > 0);
 		p1.chooseDefault();
 		p2.chooseDefault();
 
@@ -1446,9 +1286,9 @@ describe('Decision internals', function () {
 		battle.commitDecisions();
 
 		p1.chooseSwitch(3);
-		assert(p1.choiceData.decisions.length > 0);
+		assert(p1.choice.actions.length > 0);
 		battle.undoChoice('p1');
-		assert.false(p1.choiceData.decisions.length > 0);
+		assert.false(p1.choice.actions.length > 0);
 		p1.choosePass().chooseSwitch(3);
 
 		assert.fainted(p1.active[0]);
@@ -1470,9 +1310,9 @@ describe('Decision internals', function () {
 		battle.commitDecisions();
 
 		p1.choosePass();
-		assert(p1.choiceData.decisions.length > 0);
+		assert(p1.choice.actions.length > 0);
 		battle.undoChoice('p1');
-		assert.false(p1.choiceData.decisions.length > 0);
+		assert.false(p1.choice.actions.length > 0);
 		p1.choosePass().chooseSwitch(3);
 
 		assert.fainted(p1.active[0]);
@@ -1494,9 +1334,9 @@ describe('Decision internals', function () {
 		]);
 
 		p1.chooseShift();
-		assert(p1.choiceData.decisions.length > 0);
+		assert(p1.choice.actions.length > 0);
 		battle.undoChoice('p1');
-		assert.false(p1.choiceData.decisions.length > 0);
+		assert.false(p1.choice.actions.length > 0);
 		p1.chooseMove(1).chooseMove(1).chooseShift();
 		p2.chooseDefault();
 


### PR DESCRIPTION
Hi, I'm making a pullreq for this change so everyone who works on the battle engine will see this.

Basically, the choice API is changing (again). This is relevant for test writing and other things.

Going forward, I'm thinking our tests should use a function like `makeChoices` which would look something like:

```js
battle.makeChoices(`pass, switch 5`, `move 2 mega, auto`);
```

which I think is much more readable than

```js
battle.p1.choosePass().chooseSwitch(5).foe.chooseMove(2, null, 'mega').chooseDefault();
```

So far, the changes are:

- `side.choose*` are no longer chainable, and no longer auto-commit (i.e. they will no longer auto-continue the battle if all choices have been made)
- `side.chooseSkip` has been merged into `side.choosePass`
- `side.chooseDefault` has been renamed `side.autoChoose`
- `side.resolveDecision` has been merged into `side.autoChoose`
- partial decision undo is no longer supported
- `side.getDecisionsFinished` has been renamed `side.isChoiceDone`
- `side.choiceData.finalDecision` has been renamed `side.choice.cantUndo`
- `side.choiceData.decisions === true` is no longer a valid state (`side.isChoiceDone()` now just checks for `!side.currentRequest`)
- `side.choiceData.choices` has been removed (`getChoice` autogenerates it from `side.choice` now)
- `side.choiceData.decisions` has been renamed `side.choice.actions`
- `side.choiceData.switchCounters.switch` is now a count-down counter named `side.choice. forcedSwitchesLeft`
- `side.choiceData.switchCounters.pass` is now a count-down counter named `side.choice. forcedPassesLeft`
- `side.choiceData.enterIndices` has been renamed `side.choice.switchIns`
- `side.choiceData.leaveIndices` has been removed – `side.choice.actions` already tracks which slots are leaving
- `side.choiceData.skipsIndices` has been removed – `side.choice.actions` already tracks which slots are not leaving
- `battle.parseDecision` has been removed - its parsing is now fiveish lines in `battle.choice`, and its validation is now in the `side.choose*` functions
- `side.makeRequest` no longer has a second argument - team preview limits are now extracted directly from the format.
- invalid choices now emit choice errors, currently sent as `|error|[Invalid choice]` to the player who made them.

For compatibility with the old API used in our tests (since I really don't want to rewrite every single test):

You can set `battle.LEGACY_API_DO_NOT_USE` to `true`. This:

- will allow you to use `side.chooseDefault` again
- will make `side.choose*` chainable and auto-commit again

This is, of course, a legacy API that I want to drop eventually and replace with the `makeChoices` system mentioned at the top.