### PR TITLE
Fix adjacent foe-targeted moves in singles

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -3818,6 +3818,7 @@ class Battle extends Tools.BattleDex {
 	 * Returns whether a proposed target for a move is valid.
 	 */
 	validTargetLoc(targetLoc, source, targetType) {
+		if (targetLoc === 0) return true;
 		let numSlots = source.side.active.length;
 		if (!Math.abs(targetLoc) && Math.abs(targetLoc) > numSlots) return false;
 


### PR DESCRIPTION
The targetLoc validation was blocking the decision when the target type was "Adjacent Foes" and the targetLoc was 0, despite the decision being fine.
As far as I can tell, it's impossible for a targetLoc of 0 to be invalid, since (I assume) it picks one of the possible target locations by itself later in the code anyway.