### PR TITLE
Fix imposter/transform/mimic in Automagic

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -278,7 +278,7 @@ exports.Formats = [
 		onAfterSecondaryEffect: function (target, source, move) {
 			let moreSetup = ['acupressure', 'bellydrum', 'stockpile'];
 			if (!source.types.includes("Ghost")) moreSetup.push("curse");
-			source.baseMoveset.forEach(curmove => {
+			source.moveset.forEach(curmove => {
 				let move = this.getMove(curmove.id);
 				if (moreSetup.includes(move.id) || (move.category === "Status" && move.boosts && move.target === "self")) {
 					this.useMove(move, source);
@@ -287,7 +287,7 @@ exports.Formats = [
 		},
 		onAfterMove: function (source, target, move) {
 			if (move.id !== "genesissupernova") return;
-			source.baseMoveset.forEach(curmove => {
+			source.moveset.forEach(curmove => {
 				let move = this.getMove(curmove.id);
 				if ((move.id === 'bellydrum' || (move.category === "Status" && move.boosts && move.target === "self")) && this.terrain === "psychicterrain") { // Confirm that it successfully set Psychic Terrain
 					this.useMove(move, source);


### PR DESCRIPTION
This fix allows pokémon using the aforementioned moves/abilities (e.g. Ditto) to activate setup moves when triggering secondary effects.