### PR TITLE
Remove voice ability to host a GTS GA.

### DIFF
--- a/chat-plugins/wifi.js
+++ b/chat-plugins/wifi.js
@@ -580,7 +580,7 @@ let commands = {
 		if (!amount || amount < 30 || amount > 100) return this.errorReply("Please enter a valid amount. For a GTS giveaway, you need to give away at least 30 mons, and no more than 100.");
 		let targetUser = Users(giver);
 		if (!targetUser || !targetUser.connected) return this.errorReply(`User '${giver}' is not online.`);
-		if (!this.can('warn', null, room) && !(this.can('broadcast', null, room) && user === targetUser)) return this.errorReply("Permission denied.");
+		if (!this.can('warn', null, room)) return this.errorReply("Permission denied.");
 		if (!targetUser.autoconfirmed) return this.errorReply(`User '${targetUser.name}' needs to be autoconfirmed to host a giveaway.`);
 		if (Giveaway.checkBanned(room, targetUser)) return this.errorReply(`User '${targetUser.name}' is giveaway banned.`);
 


### PR DESCRIPTION
GTS Giveaways can take an hour or more. Removing ability for voice users to perform this style of Giveaways. Discussed with @bumbadadabum 