### PR TITLE
Rooms: Get rid of roomgames when destroyed

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -1434,6 +1434,10 @@ class ChatRoom extends Room {
 				Rooms.aliases.delete(this.aliases[i]);
 			}
 		}
+		
+		if (this.game) {
+			this.game.destroy();
+		}
 
 		// Clear any active timers for the room
 		if (this.muteTimer) {

--- a/rooms.js
+++ b/rooms.js
@@ -1434,7 +1434,7 @@ class ChatRoom extends Room {
 				Rooms.aliases.delete(this.aliases[i]);
 			}
 		}
-		
+
 		if (this.game) {
 			this.game.destroy();
 		}


### PR DESCRIPTION
Before UNO, chat room roomgames never had players so running ``room.game.destroy()`` wasn't absolutely necessary.   This pull request does the same check to chat rooms that happens in roomgames for battle rooms, and destroys games, and removes them from the ``user.games`` map when a chatroom (or more specifically a groupchat that caused the crash on PS) is removed from the ``Rooms.rooms`` object.

Fixes the following crash:
```
CRASH: TypeError: Cannot read property 'game' of undefined
    at User.rename (/home/ubuntu/workspace/memes/users.js:587:28)
    at CommandContext.trn (/home/ubuntu/workspace/memes/chat-commands.js:3469:8)
    at CommandContext.run (/home/ubuntu/workspace/memes/chat.js:292:28)
    at CommandContext.parse (/home/ubuntu/workspace/memes/chat.js:138:19)
    at Object.Chat.parse (/home/ubuntu/workspace/memes/chat.js:807:17)
    at User.chat (/home/ubuntu/workspace/memes/users.js:1405:9)
    at Function.Users.socketReceive (/home/ubuntu/workspace/memes/users.js:1602:12)
    at Worker.worker.on.data (/home/ubuntu/workspace/memes/sockets.js:53:11)
    at emitTwo (events.js:111:20)
    at Worker.emit (events.js:191:7)
```