### PR TITLE
Fix MakePlayer

### DIFF
--- a/room-game.js
+++ b/room-game.js
@@ -79,7 +79,7 @@ class RoomGame {
 	}
 
 	makePlayer(user) {
-		return new RoomGamePlayer(user);
+		return new RoomGamePlayer(user, this);
 	}
 
 	removePlayer(user) {


### PR DESCRIPTION
Right now, RoomGame.MakePlayer doesn't pass the current game to RoomGamePlayer, causing line 27 to cause a crash (all other room games [like Trivia, Scavengers, Uno, and Battles] currently have their own players/MakePlayer function, but one that does not have its own player would need this to be fixed).