### PR TITLE
Add per turn highlighting to UNO

### DIFF
--- a/chat-plugins/uno.js
+++ b/chat-plugins/uno.js
@@ -179,7 +179,7 @@ class UNOgame extends Rooms.RoomGame {
 
 		clearTimeout(this.timer);
 		let player = this.players[this.currentPlayer];
-		this.room.send(`${player.name}'s turn.`);
+		this.room.add(`|c|~|${player.name}'s turn.`);
 		this.state = 'play';
 		if (player.cardLock) delete player.cardLock;
 		player.sendDisplay();


### PR DESCRIPTION
This allows for users to be highlighted on their turns (currently a big problem) and also allows users to know if it's their turn in cases of disconnections (the current code does not).