### PR TITLE
UNO: Add suppressing and general fixes

### DIFF
--- a/chat-plugins/uno.js
+++ b/chat-plugins/uno.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const maxTime = 30; // seconds
+const maxTime = 60; // seconds
 
 const rgbGradients = {
 	'Green': "rgba(0, 122, 0, 1), rgba(0, 185, 0, 0.9)",
@@ -24,7 +24,7 @@ const textColors = {
 	'Yellow': "rgb(175, 165, 40)",
 	'Blue': "rgb(75, 75, 255)",
 	'Red': "rgb(255, 0, 0)",
-	'Black': "inherit",
+	'Black': 'inherit',
 };
 
 const textShadow = 'text-shadow: 1px 0px black, -1px 0px black, 0px -1px black, 0px 1px black, 2px -2px black;';
@@ -34,7 +34,7 @@ function cardHTML(card, fullsize) {
 	let background = rgbGradients[card.color];
 	if (surface === 'R') surface = '<i class="fa fa-refresh" aria-hidden="true"></i>';
 
-	return `<button class="button" style="font-size: 14px; font-weight: bold; color: white; ${textShadow} padding-bottom: 117px; text-align: left; height: 135px; width: ${fullsize ? "72" : "37"}px; border-radius: 10px 2px 2px 3px; color: white; background: ${card.color}; background: -webkit-linear-gradient(${background}); background: -o-linear-gradient(${background}); background: -moz-linear-gradient(${background}); background: linear-gradient(${background})" name=send value="/uno play ${card.name}">${surface}</button>`;
+	return `<button class="button" style="font-size: 14px; font-weight: bold; color: white; ${textShadow} padding-bottom: 117px; text-align: left; height: 135px; width: ${fullsize ? '72' : '37'}px; border-radius: 10px 2px 2px 3px; color: white; background: ${card.color}; background: -webkit-linear-gradient(${background}); background: -o-linear-gradient(${background}); background: -moz-linear-gradient(${background}); background: linear-gradient(${background})" name=send value="/uno play ${card.name}">${surface}</button>`;
 }
 
 function createDeck() {
@@ -51,14 +51,14 @@ function createDeck() {
 	}
 
 	return [...basic, ...basic, // two copies of the basic stuff (total 96)
-		...[0, 1, 2, 3].map(v => ({color: colors[v], value: "0", name: colors[v] + " 0"})), // the 4 0s
-		...[0, 1, 2, 3].map(v => ({color: "Black", value: "Wild", name: "Wild"})), // wild cards
-		...[0, 1, 2, 3].map(v => ({color: "Black", value: "+4", name: "Wild +4"})), // wild +4 cards
+		...[0, 1, 2, 3].map(v => ({color: colors[v], value: '0', name: colors[v] + ' 0'})), // the 4 0s
+		...[0, 1, 2, 3].map(v => ({color: 'Black', value: 'Wild', name: 'Wild'})), // wild cards
+		...[0, 1, 2, 3].map(v => ({color: 'Black', value: '+4', name: "Wild +4"})), // wild +4 cards
 	]; // 108 cards
 }
 
 class UNOgame extends Rooms.RoomGame {
-	constructor(room, cap) {
+	constructor(room, cap, suppressMessages) {
 		super(room);
 
 		if (room.gameNumber) {
@@ -67,14 +67,17 @@ class UNOgame extends Rooms.RoomGame {
 			room.gameNumber = 1;
 		}
 
+		cap = parseInt(cap) || 6;
+		if (cap < 2) cap = 2;
+
+		this.playerCap = cap;
 		this.allowRenames = true;
-		this.playerCap = parseInt(cap) || 6;
 		this.maxTime = maxTime;
 
-		this.gameid = "uno";
-		this.title = "UNO";
+		this.gameid = 'uno';
+		this.title = 'UNO';
 
-		this.state = "signups";
+		this.state = 'signups';
 
 		this.currentPlayer = null;
 		this.deck = Tools.shuffle(createDeck());
@@ -82,11 +85,16 @@ class UNOgame extends Rooms.RoomGame {
 		this.topCard = null;
 
 		this.direction = 1;
+
+		this.suppressMessages = suppressMessages || false;
+		this.spectators = {};
+
+		this.sendToRoom(`|uhtml|uno-${this.room.gameNumber}|<div class="broadcast-green"><p style="font-size: 14pt; text-align: center">A new game of <strong>UNO</strong> is starting!</p><p style="font-size: 9pt; text-align: center"><button name="send" value="/uno join">Join</button><br />Or use <strong>/uno join</strong> to join the game.</p>${(this.suppressMessages ? `<p style="font-size: 6pt; text-align: center">Game messages will be shown to only players.  If you would like to spectate the game, use <strong>/uno spectate</strong></p>` : '')}</div>`, true);
 	}
 
 	onStart() {
 		if (this.playerCount < 2) return false;
-		this.sendToRoom(`|uhtmlchange|uno-${this.room.gameNumber}|<div class="infobox">The game of UNO has started.</div>`);
+		this.sendToRoom(`|uhtmlchange|uno-${this.room.gameNumber}|<div class="infobox">The game of UNO has started.</div>`, true);
 		this.state = 'play';
 
 		this.onNextPlayer();  // determines the first player
@@ -100,7 +108,7 @@ class UNOgame extends Rooms.RoomGame {
 		do {
 			this.topCard = this.drawCard(1)[0];
 			this.discards.unshift(this.topCard);
-		} while (this.topCard.color === "Black");
+		} while (this.topCard.color === 'Black');
 
 		this.sendToRoom(`|raw|The top card is <span style="color: ${textColors[this.topCard.color]}">${this.topCard.name}</span>.`);
 
@@ -109,12 +117,18 @@ class UNOgame extends Rooms.RoomGame {
 	}
 
 	joinGame(user) {
-		if (this.state === 'signups' && this.addPlayer(user)) return true;
+		if (this.state === 'signups' && this.addPlayer(user)) {
+			this.sendToRoom(`${user.name} has joined the game of UNO.`);
+			return true;
+		}
 		return false;
 	}
 
 	leaveGame(user) {
-		if (this.state === 'signups' && this.removePlayer(user)) return true;
+		if (this.state === 'signups' && this.removePlayer(user)) {
+			this.sendToRoom(`${user.name} has left the game of UNO.`);
+			return true;
+		}
 		return false;
 	}
 
@@ -152,12 +166,30 @@ class UNOgame extends Rooms.RoomGame {
 			clearTimeout(this.timer);
 			this.nextTurn();
 		}
+
+		// put that player's cards into the discard pile to prevent cards from being permanently lost
+		this.discards.push(...this.players[userid].hand);
+
 		this.removePlayer({userid: userid});
 		return name;
 	}
 
-	sendToRoom(msg) {
-		this.room.add(msg).update();
+	sendToRoom(msg, overrideSuppress) {
+		if (!this.suppressMessages || overrideSuppress) {
+			this.room.add(msg).update();
+		} else {
+			// send to the players first
+			for (let i in this.players) {
+				this.players[i].sendRoom(msg);
+			}
+
+			// send to spectators
+			for (let i in this.spectators) {
+				if (i in this.players) continue; // don't double send to users already in the game.
+				let user = Users.getExact(i);
+				if (user) user.sendTo(this.id, msg);
+			}
+		}
 	}
 
 	getPlayers(showCards) {
@@ -166,7 +198,7 @@ class UNOgame extends Rooms.RoomGame {
 			return playerList.sort().map(id => Chat.escapeHTML(this.players[id].name));
 		}
 		if (this.direction === -1) playerList = playerList.reverse();
-		return playerList.map(id => `${(this.currentPlayer && this.currentPlayer === id ? "<strong>" : "")}${Chat.escapeHTML(this.players[id].name)} (${this.players[id].hand.length}) ${(this.currentPlayer && this.currentPlayer === id ? "</strong>" : "")}`);
+		return playerList.map(id => `${(this.currentPlayer && this.currentPlayer === id ? '<strong>' : '')}${Chat.escapeHTML(this.players[id].name)} (${this.players[id].hand.length}) ${(this.currentPlayer && this.currentPlayer === id ? '</strong>' : "")}`);
 	}
 
 	nextTurn(starting) {
@@ -179,7 +211,7 @@ class UNOgame extends Rooms.RoomGame {
 
 		clearTimeout(this.timer);
 		let player = this.players[this.currentPlayer];
-		this.room.add(`|c|~|${player.name}'s turn.`);
+		this.sendToRoom(`|c|~|${player.name}'s turn.`);
 		this.state = 'play';
 		if (player.cardLock) delete player.cardLock;
 		player.sendDisplay();
@@ -234,7 +266,7 @@ class UNOgame extends Rooms.RoomGame {
 
 		// check for legal play
 		if (player.cardLock && player.cardLock !== cardName) return `You can only play ${player.cardLock} after drawing.`;
-		if (card.color !== 'Black' && card.color !== (this.changedColor || this.topCard.color) && card.value !== this.topCard.value) return `You cannot play this card - you can only play: Wild cards, ${(this.changedColor ? "and" : "")} ${(this.changedColor || this.topCard.color)} cards${this.changedColor ? "" : ` and ${this.topCard.value}'s`}.`;
+		if (card.color !== 'Black' && card.color !== (this.changedColor || this.topCard.color) && card.value !== this.topCard.value) return `You cannot play this card - you can only play: Wild cards, ${(this.changedColor ? 'and' : '')} ${(this.changedColor || this.topCard.color)} cards${this.changedColor ? "" : ` and ${this.topCard.value}'s`}.`;
 		if (card.value === '+4' && !player.canPlayWildFour()) return "You cannot play Wild +4 when you still have a card with the same color as the top card.";
 
 		clearTimeout(this.timer); // reset the autodq timer.
@@ -267,21 +299,21 @@ class UNOgame extends Rooms.RoomGame {
 		const colorDisplay = `|uhtml|uno-hand|<table style="width: 100%; border: 1px solid black"><tr><td style="width: 50%"><button style="width: 100%; background-color: red; border: 2px solid rgba(0 , 0 , 0 , 0.59); border-radius: 5px; padding: 5px" name=send value="/uno color Red">Red</button></td><td style="width: 50%"><button style="width: 100%; background-color: blue; border: 2px solid rgba(0 , 0 , 0 , 0.59); border-radius: 5px; color: white; padding: 5px" name=send value="/uno color Blue">Blue</button></td></tr><tr><td style="width: 50%"><button style="width: 100%; background-color: green; border: 2px solid rgba(0 , 0 , 0 , 0.59); border-radius: 5px; padding: 5px" name=send value="/uno color Green">Green</button></td><td style="width: 50%"><button style="width: 100%; background-color: yellow; border: 2px solid rgba(0 , 0 , 0 , 0.59); border-radius: 5px; padding: 5px" name=send value="/uno color Yellow">Yellow</button></td></tr></table>`;
 
 		switch (value) {
-		case "Reverse":
+		case 'Reverse':
 			this.direction *= -1;
 			this.sendToRoom("The direction of the game has changed.");
 			if (!initialize && this.playerCount === 2) this.onNextPlayer(); // in 2 player games, reverse sends the turn back to the player.
 			break;
-		case "Skip":
+		case 'Skip':
 			this.onNextPlayer();
 			this.sendToRoom(this.players[this.currentPlayer].name + "'s turn has been skipped.");
 			break;
-		case "+2":
+		case '+2':
 			this.onNextPlayer();
 			this.sendToRoom(this.players[this.currentPlayer].name + " has been forced to draw 2 cards.");
 			this.onDrawCard({userid: this.currentPlayer}, 2);
 			break;
-		case "+4":
+		case '+4':
 			this.players[this.currentPlayer].sendRoom(colorDisplay);
 			this.state = 'color';
 			// apply to the next in line, since the current player still has to choose the color
@@ -294,9 +326,9 @@ class UNOgame extends Rooms.RoomGame {
 				this.eliminate(this.currentPlayer);
 			}, this.maxTime * 1000);
 			break;
-		case "Wild":
+		case 'Wild':
 			this.players[this.currentPlayer].sendRoom(colorDisplay);
-			this.state = "color";
+			this.state = 'color';
 			this.timer = setTimeout(() => {
 				this.sendToRoom(`${this.players[this.currentPlayer].name} has been automatically disqualified.`);
 				this.eliminate(this.currentPlayer);
@@ -307,7 +339,7 @@ class UNOgame extends Rooms.RoomGame {
 	}
 
 	onSelectcolor(user, color) {
-		if (!["Red", "Blue", "Green", "Yellow"].includes(color) || user.userid !== this.currentPlayer || this.state !== 'color') return false;
+		if (!['Red', 'Blue', 'Green', 'Yellow'].includes(color) || user.userid !== this.currentPlayer || this.state !== 'color') return false;
 		this.changedColor = color;
 		this.sendToRoom(`The color has been changed to ${color}.`);
 		clearTimeout(this.timer);
@@ -326,7 +358,7 @@ class UNOgame extends Rooms.RoomGame {
 
 		let player = this.players[user.userid];
 		player.hand.push(...drawnCards);
-		player.sendRoom(`|raw|You have drawn the following card${drawnCards.length > 1 ? "s" : ""}: ${drawnCards.map(card => `<span style="color: ${textColors[card.color]}">${card.name}</span>`).join(", ")}.`);
+		player.sendRoom(`|raw|You have drawn the following card${drawnCards.length > 1 ? 's' : ''}: ${drawnCards.map(card => `<span style="color: ${textColors[card.color]}">${card.name}</span>`).join(', ')}.`);
 		return drawnCards;
 	}
 
@@ -338,6 +370,7 @@ class UNOgame extends Rooms.RoomGame {
 		for (let i = 0; i < count; i++) {
 			if (!this.deck.length) {
 				this.deck = this.discards.length ? Tools.shuffle(this.discards) : Tools.shuffle(createDeck()); // shuffle the cards back into the deck, or if there are no discards, add another deck into the game.
+				this.discards = []; // clear discard pile
 			}
 			drawnCards.push(this.deck.pop());
 		}
@@ -371,13 +404,13 @@ class UNOgame extends Rooms.RoomGame {
 	}
 
 	onWin(player) {
-		this.sendToRoom(`|raw|<div class="broadcast-green">Congratulations to ${player.name} for winning the game of UNO!</div>`);
+		this.sendToRoom(`|raw|<div class="broadcast-green">Congratulations to ${player.name} for winning the game of UNO!</div>`, true);
 		this.destroy();
 	}
 
 	destroy() {
 		clearTimeout(this.timer);
-		this.sendToRoom(`|uhtmlchange|uno-${this.room.gameNumber}|<div class="infobox">The game of UNO has ended.</div>`);
+		this.sendToRoom(`|uhtmlchange|uno-${this.room.gameNumber}|<div class="infobox">The game of UNO has ended.</div>`, true);
 
 		// deallocate games for each player.
 		for (let i in this.players) {
@@ -419,8 +452,8 @@ class UNOgamePlayer extends Rooms.RoomGamePlayer {
 	}
 
 	sendDisplay() {
-		let hand = this.buildHand().join("");
-		let players = `<p><strong>Players (${this.game.playerCount}):</strong></p>${this.game.getPlayers(true).join("<br />")}`;
+		let hand = this.buildHand().join('');
+		let players = `<p><strong>Players (${this.game.playerCount}):</strong></p>${this.game.getPlayers(true).join('<br />')}`;
 		let draw = '<button class="button" style="width: 30%; background: rgba(0, 0, 255, 0.05)" name=send value="/uno draw">Draw a card!</button>';
 		let pass = '<button class="button" style=" width: 30%; background: rgba(255, 0, 0, 0.05)" name=send value="/uno pass">Pass!</button>';
 
@@ -470,13 +503,18 @@ exports.commands = {
 		// moderation commands
 		new: 'create',
 		make: 'create',
-		create: function (target, room, user) {
+		createpublic: 'create',
+		makepublic: 'create',
+		createprivate: 'create',
+		makeprivate: 'create',
+		create: function (target, room, user, connection, cmd) {
 			if (!this.can('minigame', null, room)) return;
 			if (room.unoDisabled) return this.errorReply("UNO is currently disabled for this room.");
 			if (room.game) return this.errorReply("There is already a game in progress in this room.");
 
-			room.game = new UNOgame(room, target);
-			room.add(`|uhtml|uno-${room.gameNumber}|<div class="broadcast-green"><p style="font-size: 14pt; text-align: center">A new game of <strong>UNO</strong> is starting!</p><p style="font-size: 9pt; text-align: center">Use <strong>/uno join</strong> to join the game.</p></div>`).update();
+			let suppressMessages = cmd.includes('private') || !(cmd.includes('public') || room.id === 'gamecorner');
+
+			room.game = new UNOgame(room, target, suppressMessages);
 			this.privateModCommand(`(A game of UNO was created by ${user.name}.)`);
 		},
 
@@ -583,21 +621,59 @@ exports.commands = {
 		getusers: function (target, room, user) {
 			if (!room.game || room.game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.runBroadcast()) return false;
-			this.sendReplyBox(`<strong>Players (${room.game.playerCount})</strong>:<br />${room.game.getPlayers().join(", ")}`);
+			this.sendReplyBox(`<strong>Players (${room.game.playerCount})</strong>:<br />${room.game.getPlayers().join(', ')}`);
 		},
 
 		help: function (target, room, user) {
 			this.parse('/help uno');
 		},
+
+		// suppression commands
+		suppress: function (target, room, user) {
+			if (!room.game || room.game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			if (!this.can('minigame', null, room)) return;
+
+			target = toId(target);
+			let state = target === 'on' ? true : target === 'off' ? false : undefined;
+
+			if (state === undefined) return this.sendReply(`Suppression of UNO game messages is currently ${(room.game.suppressMessages ? 'on' : 'off')}.`);
+			if (state === room.game.suppressMessages) return this.errorReply(`Suppression of UNO game messages is already ${(room.game.suppressMessages ? 'on' : 'off')}.`);
+
+			room.game.suppressMessages = state;
+
+			this.addModCommand(`${user.name} has turned ${(state ? 'on' : 'off')} suppression of UNO game messages.`);
+		},
+
+		spectate: function (target, room, user) {
+			if (!room.game || room.game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+
+			if (!room.game.suppressMessages) return this.errorReply("The current UNO game is not suppressing messages.");
+			if (user.userid in room.game.spectators) return this.errorReply("You are already spectating this game.");
+
+			room.game.spectators[user.userid] = 1;
+			this.sendReply("You are now spectating this private UNO game.");
+		},
+
+		unspectate: function (target, room, user) {
+			if (!room.game || room.game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+
+			if (!room.game.suppressMessages) return this.errorReply("The current UNO game is not suppressing messages.");
+			if (!(user.userid in room.game.spectators)) return this.errorReply("You are currently not spectating this game.");
+
+			delete room.game.spectators[user.userid];
+			this.sendReply("You are no longer spectating this private UNO game.");
+		},
 	},
 
 	unohelp: [
-		"/uno create [player cap] - creates a new UNO game with an optional player cap (default player cap at 6). Requires: % @ * # & ~",
+		"/uno create [player cap] - creates a new UNO game with an optional player cap (default player cap at 6). Use the command `createpublic` to force a public game or `createprivate` to force a private game. Requires: % @ * # & ~",
 		"/uno timer [amount] - sets an auto disqualification timer for `amount` seconds. Requires: % @ * # & ~",
 		"/uno end - ends the current game of UNO. Requires: % @ * # & ~",
 		"/uno start - starts the current game of UNO. Requires: % @ * # & ~",
 		"/uno disqualify [player] - disqualifies the player from the game. Requires: % @ * # & ~",
 		"/uno hand - displays your own hand.",
 		"/uno getusers - displays the players still in the game.",
+		"/uno [spectate | unspectate] - spectate / unspectate the current private UNO game.",
+		"/uno suppress [on | off] - Toggles suppression of game messages.",
 	],
 };


### PR DESCRIPTION
- Add suppressing of game messages
    - Default suppress game messages in rooms not named "game corner"
    - Add additional commands to start public/private forced games
    - Added command ``/uno suppress`` to toggle suppressing of games mid-game
    - Added commands ``/uno spectate`` and ``/uno unspectate`` to allow people in the room to view the [private] game.
    - Announce if a UNO game is public or private at start.
- General fixes
    - Change default timer to 60 seconds
    - Use ``'single quotes'`` in place of double quotes in a few places
    - Put cards belonging to any eliminated player (through disqualification) into the discard pile to avoid cards being lost (for those who want to count cards)
    - Clear the discard pile whenever shuffling the deck to prevent messing up the total count of the cards
    - Reapply the Join button from Spandan (https://github.com/Zarel/Pokemon-Showdown/commit/ade78bd2c7af499702a8484a8362139430086514) that was accidentally removed in the style refactor by panpawn (https://github.com/Zarel/Pokemon-Showdown/commit/79462da881713dc0c013056bf7848493590d154d)
