### PR TITLE
Room-games: dont rename players to their guest accounts

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2067,7 +2067,7 @@ exports.commands = {
 		let entry = targetUser.name + " was forced to choose a new name by " + user.name + (reason ? ": " + reason : "");
 		this.privateModCommand("(" + entry + ")");
 		Matchmaker.cancelSearch(targetUser);
-		targetUser.resetName();
+		targetUser.resetName(true);
 		targetUser.send("|nametaken||" + user.name + " considers your name inappropriate" + (reason ? ": " + reason : "."));
 		return true;
 	},

--- a/chat-plugins/uno.js
+++ b/chat-plugins/uno.js
@@ -137,9 +137,9 @@ class UNOgame extends Rooms.RoomGame {
 		return new UNOgamePlayer(user, this);
 	}
 
-	onRename(user, oldUserid, isJoining) {
+	onRename(user, oldUserid, isJoining, isForceRenamed) {
 		if (!(oldUserid in this.players) || user.userid === oldUserid) return false;
-		if (!user.named) {
+		if (!user.named && !isForceRenamed) {
 			user.games.delete(this.id);
 			user.updateSearch();
 			return; // dont set users to their guest accounts.

--- a/chat-plugins/uno.js
+++ b/chat-plugins/uno.js
@@ -139,6 +139,7 @@ class UNOgame extends Rooms.RoomGame {
 
 	onRename(user, oldUserid, isJoining) {
 		if (!(oldUserid in this.players) || user.userid === oldUserid) return false;
+		if (!user.named) return; // dont set users to their guest accounts.
 		this.players[user.userid] = this.players[oldUserid];
 		if (user.userid !== oldUserid) delete this.players[oldUserid]; // only run if it's a rename that involves a change of userid
 

--- a/chat-plugins/uno.js
+++ b/chat-plugins/uno.js
@@ -139,7 +139,11 @@ class UNOgame extends Rooms.RoomGame {
 
 	onRename(user, oldUserid, isJoining) {
 		if (!(oldUserid in this.players) || user.userid === oldUserid) return false;
-		if (!user.named) return; // dont set users to their guest accounts.
+		if (!user.named) {
+			user.games.delete(this.id);
+			user.updateSearch();
+			return; // dont set users to their guest accounts.
+		}
 		this.players[user.userid] = this.players[oldUserid];
 		if (user.userid !== oldUserid) delete this.players[oldUserid]; // only run if it's a rename that involves a change of userid
 

--- a/room-battle.js
+++ b/room-battle.js
@@ -299,7 +299,7 @@ class Battle {
 	onUpdateConnection(user, connection) {
 		this.onConnect(user, connection);
 	}
-	onRename(user, oldUserid) {
+	onRename(user, oldUserid, isJoining, isForceRenamed) {
 		if (user.userid === oldUserid) return;
 		if (!this.players) {
 			// !! should never happen but somehow still does
@@ -314,7 +314,7 @@ class Battle {
 			}
 			return;
 		}
-		if (!this.allowRenames) {
+		if (!this.allowRenames && !isForceRenamed && !isJoining) {
 			let player = this.players[oldUserid];
 			if (player) this.forfeit(null, " forfeited by changing their name.", player.slotNum);
 			if (!(user.userid in this.players)) {

--- a/room-game.js
+++ b/room-game.js
@@ -153,14 +153,14 @@ class RoomGame {
 	// need to handle the other events.
 
 	onRename(user, oldUserid) {
-		if (!this.allowRenames) {
+		if (!this.allowRenames || !user.named) {
 			if (!(user.userid in this.players)) {
 				user.games.delete(this.id);
+				user.updateSearch();
 			}
 			return;
 		}
 		if (!(oldUserid in this.players)) return;
-		if (!user.named) return; // allow users that have logged out to join back on the name they last used.
 		if (user.userid === oldUserid) {
 			this.players[user.userid].name = user.name;
 		} else {

--- a/room-game.js
+++ b/room-game.js
@@ -152,8 +152,8 @@ class RoomGame {
 	// the game should be sent during `onConnect`. You should rarely
 	// need to handle the other events.
 
-	onRename(user, oldUserid) {
-		if (!this.allowRenames || !user.named) {
+	onRename(user, oldUserid, isJoining, isForceRenamed) {
+		if (!this.allowRenames || (!user.named && !isForceRenamed)) {
 			if (!(user.userid in this.players)) {
 				user.games.delete(this.id);
 				user.updateSearch();

--- a/room-game.js
+++ b/room-game.js
@@ -160,6 +160,7 @@ class RoomGame {
 			return;
 		}
 		if (!(oldUserid in this.players)) return;
+		if (!user.named) return; // allow users that have logged out to join back on the name they last used.
 		if (user.userid === oldUserid) {
 			this.players[user.userid].name = user.name;
 		} else {

--- a/users.js
+++ b/users.js
@@ -525,8 +525,8 @@ class User {
 	canPromote(sourceGroup, targetGroup) {
 		return this.can('promote', {group:sourceGroup}) && this.can('promote', {group:targetGroup});
 	}
-	resetName() {
-		return this.forceRename('Guest ' + this.guestNum);
+	resetName(isForceRenamed) {
+		return this.forceRename('Guest ' + this.guestNum, false, isForceRenamed);
 	}
 	updateIdentity(roomid) {
 		if (roomid) {
@@ -586,7 +586,7 @@ class User {
 		for (let roomid of this.games) {
 			let game = Rooms(roomid).game;
 			if (!game || game.ended) continue; // should never happen
-			if (game.allowRenames) continue;
+			if (game.allowRenames || !this.named) continue;
 			this.popup(`You can't change your name right now because you're in the middle of a rated game.`);
 			return false;
 		}
@@ -758,7 +758,7 @@ class User {
 		}
 		return false;
 	}
-	forceRename(name, registered) {
+	forceRename(name, registered, isForceRenamed) {
 		// skip the login server
 		let userid = toId(name);
 
@@ -808,7 +808,7 @@ class User {
 				this.games.delete(roomid);
 				return;
 			}
-			room.game.onRename(this, oldid, joining);
+			room.game.onRename(this, oldid, joining, isForceRenamed);
 		});
 		this.inRooms.forEach(roomid => {
 			Rooms(roomid).onRename(this, oldid, joining);


### PR DESCRIPTION
- prevents users from being unable to rejoin games if they ``/logout`` (the server will rename you back to your guest account if you use /logout, thus barring re-entry or re-joining to certain IP limiting room-games)