### PR TITLE
Users: fix RoomGame connection update

### DIFF
--- a/users.js
+++ b/users.js
@@ -886,8 +886,7 @@ class User {
 				}
 				room.onJoin(this, connection);
 				this.inRooms.add(roomid);
-			}
-			if (room.game && room.game.onUpdateConnection) {
+			} else if (room.game && room.game.onUpdateConnection) {
 				room.game.onUpdateConnection(this, connection);
 			}
 		});


### PR DESCRIPTION
- prevents onConnect from being called twice in onUpdateConnection AND in joinRoom for autojoin.

Controlled crash stack showing ``onConnect`` being called twice through autojoin:
```
CRASH: Error: onConnect
    at ScavengerHunt.onConnect (/home/ubuntu/workspace/suppress/chat-plugins/scavengers.js:137:9)
    at ChatRoom.onConnect (/home/ubuntu/workspace/suppress/rooms.js:1369:51)
    at User.joinRoom (/home/ubuntu/workspace/suppress/users.js:1181:9)
    at User.tryJoinRoom (/home/ubuntu/workspace/suppress/users.js:1143:25)
    at CommandContext.autojoin (/home/ubuntu/workspace/suppress/chat-commands.js:1334:13)
    at CommandContext.run (/home/ubuntu/workspace/suppress/chat.js:292:28)
    at CommandContext.parse (/home/ubuntu/workspace/suppress/chat.js:138:19)
    at Object.Chat.parse (/home/ubuntu/workspace/suppress/chat.js:807:17)
    at User.processChatQueue (/home/ubuntu/workspace/suppress/users.js:1433:9)
    at Timeout.chatQueueTimeout.setTimeout [as _onTimeout] (/home/ubuntu/workspace/suppress/users.js:1413:15)

Additional information:
  user = Guest 2
  room = global
  pmTarget = undefined
  message = /autojoin gamecorner,scavengers



CRASH: Error: onConnect
    at ScavengerHunt.onConnect (/home/ubuntu/workspace/suppress/chat-plugins/scavengers.js:137:9)
    at ScavengerHunt.onUpdateConnection (/home/ubuntu/workspace/suppress/room-game.js:174:28)
    at connection.inRooms.forEach.roomid (/home/ubuntu/workspace/suppress/users.js:891:15)
    at Set.forEach (native)
    at User.mergeConnection (/home/ubuntu/workspace/suppress/users.js:878:22)
    at User.merge (/home/ubuntu/workspace/suppress/users.js:833:9)
    at User.handleRename (/home/ubuntu/workspace/suppress/users.js:738:9)
    at User.validateRename (/home/ubuntu/workspace/suppress/users.js:698:8)
    at Verifier.verify.then.success (/home/ubuntu/workspace/suppress/users.js:652:10)
    at process._tickCallback (internal/process/next_tick.js:103:7)
```