### PR TITLE
Roomsettings: Add UNO/Hangman and general fixes

### DIFF
--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -80,17 +80,17 @@ class RoomSettings {
 	stretching() {
 		if (!this.user.can('editroom', null, this.room)) return this.button(this.room.filterStretching ? 'filter stretching' : 'off', true);
 		if (this.room.filterStretching) {
-			return this.button('off', null, 'stretchfilter off') + ' ' + this.button('filter stretching', true);
+			return `${this.button('off', null, 'stretchfilter off')} ${this.button('filter stretching', true)}`;
 		} else {
-			return this.button('off', true) + ' ' + this.button('filter stretching', null, 'stretchfilter on');
+			return `${this.button('off', true)} ${this.button('filter stretching', null, 'stretchfilter on')}`;
 		}
 	}
 	capitals() {
 		if (!this.user.can('editroom', null, this.room)) return this.button(this.room.filterCaps ? 'filter capitals' : 'off', true);
 		if (this.room.filterCaps) {
-			return this.button('off', null, 'capsfilter off') + this.button('filter capitals', true);
+			return `${this.button('off', null, 'capsfilter off')} ${this.button('filter capitals', true)}`;
 		} else {
-			return this.button('off', true) + this.button('filter capitals', null, 'capsfilter on');
+			return `${this.button('off', true)} ${this.button('filter capitals', null, 'capsfilter on')}`;
 		}
 	}
 	slowchat() {
@@ -115,24 +115,42 @@ class RoomSettings {
 		if (!this.user.can('tournamentsmanagement', null, this.room)) return this.button(this.room.toursEnabled === true ? '@' : this.room.toursEnabled === '%' ? '%' : '#', true);
 
 		if (this.room.toursEnabled === true) {
-			return this.button('%', null, 'tournament enable %') + this.button('@', true) + this.button('#', null, 'tournament disable');
+			return `${this.button('%', null, 'tournament enable %')} ${this.button('@', true)} ${this.button('#', null, 'tournament disable')}`;
 		} else if (this.room.toursEnabled === '%') {
-			return this.button('%', true) + this.button('@', null, 'tournament enable @') + this.button('#', null, 'tournament disable');
+			return `${this.button('%', true)} ${this.button('@', null, 'tournament enable @')} ${this.button('#', null, 'tournament disable')}`;
 		} else {
-			return this.button('%', null, 'tournament enable %') + this.button('@', null, 'tournament enable @') + this.button('#', true);
+			return `${this.button('%', null, 'tournament enable %')} ${this.button('@', null, 'tournament enable @')} ${this.button('#', true)}`;
+		}
+	}
+	uno() {
+		if (!this.user.can('editroom', null, this.room)) return this.button(this.room.unoDisabled ? 'Disabled' : 'Enabled', true);
+		if (this.room.unoDisabled) {
+			return `${this.button('Enable', null, 'uno enable')} ${this.button('Disable', true)}`;
+		} else {
+			return `${this.button('Enable', true)} ${this.button('Disable', null, 'uno disable')}`;
+		}
+	}
+	hangman() {
+		if (!this.user.can('editroom', null, this.room)) return this.button(this.room.hangmanDisabled ? 'Disabled' : 'Enabled', true);
+		if (this.room.hangmanDisabled) {
+			return `${this.button('Enable', null, 'hangman enable')} ${this.button('Disable', true)}`;
+		} else {
+			return `${this.button('Enable', true)} ${this.button('Disable', null, 'hangman disable')}`;
 		}
 	}
 	generateDisplay(user, room, connection) {
-		let output = '<div class="infobox">Room Settings for ' + Chat.escapeHTML(this.room.title) + '<br />';
-		output += "<b>Modchat:</b> <br />" + this.modchat() + "<br />";
-		output += "<b>Modjoin:</b> <br />" + this.modjoin() + "<br />";
-		output += "<b>Stretch filter:</b> <br />" + this.stretching() + "<br />";
-		output += "<b>Caps filter:</b> <br />" + this.capitals() + "<br />";
-		output += "<b>Slowchat:</b> <br />" + this.slowchat() + "<br />";
-		output += "<b>Tournaments:</b> <br />" + this.tourStatus() + "<br />";
-		output += "</div>";
+		let output = `<div class="infobox">Room Settings for ${Chat.escapeHTML(this.room.title)}<br />`;
+		output += `<strong>Modchat:</strong> <br />${this.modchat()}<br />`;
+		output += `<strong>Modjoin:</strong> <br />${this.modjoin()}<br />`;
+		output += `<strong>Stretch filter:</strong> <br />${this.stretching()}<br />`;
+		output += `<strong>Caps filter:</strong> <br />${this.capitals()}<br />"`;
+		output += `<strong>Slowchat:</strong> <br />${this.slowchat()}<br />"`;
+		output += `<strong>Tournaments:</strong> <br />${this.tourStatus()}<br />`;
+		output += `<strong>UNO:</strong> <br />${this.uno()}<br />`;
+		output += `<strong>Hangman:</strong> <br />${this.hangman()}<br />`;
+		output += '</div>';
 
-		this.user.sendTo(this.room, '|uhtml' + (this.sameCommand ? '' : 'change') + '|roomsettings|' + output);
+		this.user.sendTo(this.room, `|uhtml${(this.sameCommand ? '' : 'change')}|roomsettings|${output}`);
 	}
 }
 
@@ -161,7 +179,7 @@ exports.commands = {
 		if (!this.can('modchat', null, room)) return false;
 
 		if (room.modchat && room.modchat.length <= 1 && Config.groupsranking.indexOf(room.modchat) > 1 && !user.can('modchatall', null, room)) {
-			return this.errorReply("/modchat - Access denied for removing a setting higher than " + Config.groupsranking[1] + ".");
+			return this.errorReply(`/modchat - Access denied for removing a setting higher than ${Config.groupsranking[1]}.`);
 		}
 		if (room.requestModchat) {
 			const error = room.requestModchat(user);
@@ -185,32 +203,32 @@ exports.commands = {
 			/* falls through */
 		default: {
 			if (!Config.groups[target]) {
-				this.errorReply("The rank '" + target + '" was unrecognized as a modchat level.');
+				this.errorReply(`The rank '${target}' was unrecognized as a modchat level.`);
 				return this.parse('/help modchat');
 			}
 			if (Config.groupsranking.indexOf(target) > 1 && !user.can('modchatall', null, room)) {
-				return this.errorReply("/modchat - Access denied for setting higher than " + Config.groupsranking[1] + ".");
+				return this.errorReply(`/modchat - Access denied for setting higher than ${Config.groupsranking[1]}.`);
 			}
 			let roomGroup = (room.auth && room.isPrivate === true ? ' ' : user.group);
 			if (room.auth && user.userid in room.auth) roomGroup = room.auth[user.userid];
 			if (Config.groupsranking.indexOf(target) > Math.max(1, Config.groupsranking.indexOf(roomGroup)) && !user.can('makeroom')) {
-				return this.errorReply("/modchat - Access denied for setting higher than " + roomGroup + ".");
+				return this.errorReply(`/modchat - Access denied for setting higher than ${roomGroup}.`);
 			}
 			room.modchat = target;
 			break;
 		}
 		}
 		if (currentModchat === room.modchat) {
-			return this.errorReply("Modchat is already set to " + currentModchat + ".");
+			return this.errorReply(`Modchat is already set to ${currentModchat}.`);
 		}
 		if (!room.modchat) {
-			this.add("|raw|<div class=\"broadcast-blue\"><b>Moderated chat was disabled!</b><br />Anyone may talk now.</div>");
+			this.add("|raw|<div class=\"broadcast-blue\"><strong>Moderated chat was disabled!</strong><br />Anyone may talk now.</div>");
 		} else {
 			const modchatSetting = Chat.escapeHTML(room.modchat);
-			this.add("|raw|<div class=\"broadcast-red\"><b>Moderated chat was set to " + modchatSetting + "!</b><br />Only users of rank " + modchatSetting + " and higher can talk.</div>");
+			this.add(`|raw|<div class=\"broadcast-red\"><strong>Moderated chat was set to ${modchatSetting}!</strong><br />Only users of rank ${modchatSetting} and higher can talk.</div>`);
 		}
 		if (room.battle && !room.modchat && !user.can('modchat')) room.requestModchat(null);
-		this.privateModCommand("(" + user.name + " set modchat to " + room.modchat + ")");
+		this.privateModCommand(`(${user.name} set modchat to ${room.modchat})`);
 
 		if (room.chatRoomData) {
 			room.chatRoomData.modchat = room.modchat;
@@ -226,9 +244,9 @@ exports.commands = {
 	inviteonly: function (target, room, user) {
 		if (!target) return this.parse('/help inviteonly');
 		if (target === 'on' || target === 'true' || target === 'yes') {
-			return this.parse('/modjoin +');
+			return this.parse("/modjoin +");
 		} else {
-			return this.parse('/modjoin ' + target);
+			return this.parse(`/modjoin ${target}`);
 		}
 	},
 	inviteonlyhelp: ["/inviteonly [on|off] - Sets modjoin +. Users can't join unless invited with /invite. Requires: # & ~",
@@ -248,7 +266,7 @@ exports.commands = {
 		if (target === 'off' || target === 'false') {
 			if (!room.modjoin) return this.errorReply(`Modjoin is already turned off in this room.`);
 			delete room.modjoin;
-			this.add(`|raw|<div class="broadcast-blue"><b>This room is no longer invite only!</b><br />Anyone may now join.</div>`);
+			this.add(`|raw|<div class="broadcast-blue"><strong>This room is no longer invite only!</strong><br />Anyone may now join.</div>`);
 			this.addModCommand(`${user.name} turned off modjoin.`);
 			if (room.chatRoomData) {
 				delete room.chatRoomData.modjoin;
@@ -258,7 +276,7 @@ exports.commands = {
 		} else if (target === 'sync') {
 			if (room.modjoin === true) return this.errorReply(`Modjoin is already set to sync modchat in this room.`);
 			room.modjoin = true;
-			this.add(`|raw|<div class="broadcast-red"><b>Moderated join is set to sync with modchat!</b><br />Only users who can speak in modchat can join.</div>`);
+			this.add(`|raw|<div class="broadcast-red"><strong>Moderated join is set to sync with modchat!</strong><br />Only users who can speak in modchat can join.</div>`);
 			this.addModCommand(`${user.name} set modjoin to sync with modchat.`);
 		} else if (target in Config.groups) {
 			if (room.battle && !user.can('makeroom') && target !== '+') return this.errorReply(`/modjoin - Access denied from setting modjoin past + in battles.`);
@@ -266,9 +284,9 @@ exports.commands = {
 			if (room.modjoin === target) return this.errorReply(`Modjoin is already set to ${target} in this room.`);
 			room.modjoin = target;
 			if (target === '+') {
-				this.add(`|raw|<div class="broadcast-red"><b>This room is now invite only!</b><br />Users must be rank + or invited with <code>/invite</code> to join</div>`);
+				this.add(`|raw|<div class="broadcast-red"><strong>This room is now invite only!</strong><br />Users must be rank + or invited with <code>/invite</code> to join</div>`);
 			} else {
-				this.add(`|raw|<div class="broadcast-red"><b>Moderated join was set to ${target}!</b><br />Only users of rank ${target} and higher can join.</div>`);
+				this.add(`|raw|<div class="broadcast-red"><strong>Moderated join was set to ${target}!</strong><br />Only users of rank ${target} and higher can join.</div>`);
 			}
 			this.addModCommand(`${user.name} set modjoin to ${target}.`);
 		} else {
@@ -280,7 +298,7 @@ exports.commands = {
 			room.chatRoomData.modjoin = room.modjoin;
 			Rooms.global.writeChatRoomData();
 		}
-		if (target === 'sync' && !room.modchat) this.parse('/modchat ' + Config.groupsranking[1]);
+		if (target === 'sync' && !room.modchat) this.parse(`/modchat ${Config.groupsranking[1]}`);
 		if (!room.isPrivate) this.parse('/hiddenroom');
 	},
 	modjoinhelp: ["/modjoin [+|%|@|*|&|~|#|off] - Sets modjoin. Users lower than the specified rank can't join this room. Requires: # & ~",
@@ -298,14 +316,14 @@ exports.commands = {
 		if (target === 'off' || target === 'disable' || target === 'false') {
 			if (!room.slowchat) return this.errorReply(`Slow chat is already disabled in this room.`);
 			room.slowchat = false;
-			this.add("|raw|<div class=\"broadcast-blue\"><b>Slow chat was disabled!</b><br />There is no longer a set minimum time between messages.</div>");
+			this.add("|raw|<div class=\"broadcast-blue\"><strong>Slow chat was disabled!</strong><br />There is no longer a set minimum time between messages.</div>");
 		} else if (targetInt) {
 			if (!user.can('bypassall') && room.userCount < SLOWCHAT_USER_REQUIREMENT) return this.errorReply(`This room must have at least ${SLOWCHAT_USER_REQUIREMENT} users to set slowchat; it only has ${room.userCount} right now.`);
 			if (room.slowchat === targetInt) return this.errorReply(`Slow chat is already set to ${room.slowchat} seconds in this room.`);
 			if (targetInt < SLOWCHAT_MINIMUM) targetInt = SLOWCHAT_MINIMUM;
 			if (targetInt > SLOWCHAT_MAXIMUM) targetInt = SLOWCHAT_MAXIMUM;
 			room.slowchat = targetInt;
-			this.add("|raw|<div class=\"broadcast-red\"><b>Slow chat was enabled!</b><br />Messages must have at least " + room.slowchat + " seconds between them.</div>");
+			this.add(`|raw|<div class=\"broadcast-red\"><strong>Slow chat was enabled!</strong><br />Messages must have at least ${room.slowchat} seconds between them.</div>`);
 		} else {
 			return this.parse("/help slowchat");
 		}
@@ -387,8 +405,11 @@ exports.commands = {
 			if (!room.banwords) room.banwords = [];
 
 			// Most of the regex code is copied from the client. TODO: unify them?
-			let words = target.match(/[^,]+(,\d*}[^,]*)?/g).map(word => word.replace(/\n/g, '').trim());
-
+			let words = target.match(/[^,]+(,\d*}[^,]*)?/g);
+			if (!words) return this.errorReply("You have not included any words to be banned.");
+			
+			words = words.map(word => word.replace(/\n/g, '').trim());
+			
 			for (let i = 0; i < words.length; i++) {
 				if (/[\\^$*+?()|{}[\]]/.test(words[i])) {
 					if (!user.can('makeroom')) return this.errorReply("Regex banwords are only allowed for leaders or above.");
@@ -396,22 +417,22 @@ exports.commands = {
 					try {
 						let test = new RegExp(words[i]); // eslint-disable-line no-unused-vars
 					} catch (e) {
-						return this.errorReply(e.message.substr(0, 28) === 'Invalid regular expression: ' ? e.message : 'Invalid regular expression: /' + words[i] + '/: ' + e.message);
+						return this.errorReply(e.message.substr(0, 28) === 'Invalid regular expression: ' ? e.message : `Invalid regular expression: /${words[i]}/: ${e.message}`);
 					}
 				}
 				if (room.banwords.indexOf(words[i]) > -1) {
-					return this.errorReply(words[i] + ' is already a banned phrase.');
+					return this.errorReply(`${words[i]} is already a banned phrase.`);
 				}
 			}
 
 			room.banwords = room.banwords.concat(words);
 			room.banwordRegex = null;
 			if (words.length > 1) {
-				this.privateModCommand("(The banwords '" + words.join(', ') + "' were added by " + user.name + ".)");
-				this.sendReply("Banned phrases succesfully added. The list is currently: " + room.banwords.join(', '));
+				this.privateModCommand(`(The banwords ${words.map(w => `'${w}'`).join(', ')} were added by ${user.name}.)`);
+				this.sendReply(`Banned phrases succesfully added. The list is currently: ${room.banwords.join(', ')}`);
 			} else {
-				this.privateModCommand("(The banword '" + words[0] + "' was added by " + user.name + ".)");
-				this.sendReply("Banned phrase succesfully added. The list is currently: " + room.banwords.join(', '));
+				this.privateModCommand(`(The banword '${words[0]}' was added by ${user.name}.)`);
+				this.sendReply(`Banned phrase succesfully added. The list is currently: ${room.banwords.join(', ')}`);
 			}
 
 			if (room.chatRoomData) {
@@ -426,23 +447,25 @@ exports.commands = {
 
 			if (!room.banwords) return this.errorReply("This room has no banned phrases.");
 
-			let words = target.match(/[^,]+(,\d*}[^,]*)?/g).map(word => word.replace(/\n/g, '').trim());
+			let words = target.match(/[^,]+(,\d*}[^,]*)?/g);
+			if (!words) return this.errorReply("You have not included any words to be banned.");
+			
+			words = words.map(word => word.replace(/\n/g, '').trim());
 
 			for (let i = 0; i < words.length; i++) {
 				let index = room.banwords.indexOf(words[i]);
 
-				if (index < 0) return this.errorReply(words[i] + " is not a banned phrase in this room.");
-
-				room.banwords.splice(index, 1);
+				if (index < 0) return this.errorReply(`${words[i]} is not a banned phrase in this room.`);
 			}
 
+			room.banwords = room.banwords.filter(w => !words.includes(w));
 			room.banwordRegex = null;
 			if (words.length > 1) {
-				this.privateModCommand("(The banwords '" + words.join(', ') + "' were removed by " + user.name + ".)");
-				this.sendReply("Banned phrases succesfully deleted. The list is currently: " + room.banwords.join(', '));
+				this.privateModCommand(`(The banwords ${words.map(w => `'${w}'`).join(', ')} were removed by ${user.name}.)`);
+				this.sendReply(`Banned phrases succesfully deleted. The list is currently: ${room.banwords.join(', ')}`);
 			} else {
-				this.privateModCommand("(The banword '" + words[0] + "' was removed by " + user.name + ".)");
-				this.sendReply("Banned phrase succesfully deleted. The list is currently: " + room.banwords.join(', '));
+				this.privateModCommand(`(The banword '${words[0]}' was removed by ${user.name}.)`);
+				this.sendReply(`Banned phrase succesfully deleted. The list is currently: ${room.banwords.join(', ')}`);
 			}
 
 			if (room.chatRoomData) {
@@ -456,7 +479,7 @@ exports.commands = {
 
 			if (!room.banwords) return this.sendReply("This room has no banned phrases.");
 
-			return this.sendReply("Banned phrases in room " + room.id + ": " + room.banwords.join(', '));
+			return this.sendReply(`Banned phrases in room ${room.id}: ${room.banwords.join(', ')}`);
 		},
 
 		"": function (target, room, user) {

--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -123,19 +123,19 @@ class RoomSettings {
 		}
 	}
 	uno() {
-		if (!this.user.can('editroom', null, this.room)) return this.button(this.room.unoDisabled ? 'Disabled' : 'Enabled', true);
+		if (!this.user.can('editroom', null, this.room)) return this.button(this.room.unoDisabled ? 'UNO disabled' : 'UNO enabled', true);
 		if (this.room.unoDisabled) {
-			return `${this.button('Enable', null, 'uno enable')} ${this.button('Disable', true)}`;
+			return `${this.button('UNO enable', null, 'uno enable')} ${this.button('UNO disable', true)}`;
 		} else {
-			return `${this.button('Enable', true)} ${this.button('Disable', null, 'uno disable')}`;
+			return `${this.button('UNO enable', true)} ${this.button('UNO disable', null, 'uno disable')}`;
 		}
 	}
 	hangman() {
 		if (!this.user.can('editroom', null, this.room)) return this.button(this.room.hangmanDisabled ? 'Disabled' : 'Enabled', true);
 		if (this.room.hangmanDisabled) {
-			return `${this.button('Enable', null, 'hangman enable')} ${this.button('Disable', true)}`;
+			return `${this.button('Hangman enable', null, 'hangman enable')} ${this.button('Hangman disable', true)}`;
 		} else {
-			return `${this.button('Enable', true)} ${this.button('Disable', null, 'hangman disable')}`;
+			return `${this.button('Hangman enable', true)} ${this.button('Hangman disable', null, 'hangman disable')}`;
 		}
 	}
 	generateDisplay(user, room, connection) {
@@ -143,8 +143,8 @@ class RoomSettings {
 		output += `<strong>Modchat:</strong> <br />${this.modchat()}<br />`;
 		output += `<strong>Modjoin:</strong> <br />${this.modjoin()}<br />`;
 		output += `<strong>Stretch filter:</strong> <br />${this.stretching()}<br />`;
-		output += `<strong>Caps filter:</strong> <br />${this.capitals()}<br />"`;
-		output += `<strong>Slowchat:</strong> <br />${this.slowchat()}<br />"`;
+		output += `<strong>Caps filter:</strong> <br />${this.capitals()}<br />`;
+		output += `<strong>Slowchat:</strong> <br />${this.slowchat()}<br />`;
 		output += `<strong>Tournaments:</strong> <br />${this.tourStatus()}<br />`;
 		output += `<strong>UNO:</strong> <br />${this.uno()}<br />`;
 		output += `<strong>Hangman:</strong> <br />${this.hangman()}<br />`;
@@ -406,7 +406,7 @@ exports.commands = {
 
 			// Most of the regex code is copied from the client. TODO: unify them?
 			let words = target.match(/[^,]+(,\d*}[^,]*)?/g);
-			if (!words) return this.errorReply("You have not included any words to be banned.");
+			if (!words) return this.parse('/help banword');
 
 			words = words.map(word => word.replace(/\n/g, '').trim());
 
@@ -448,7 +448,7 @@ exports.commands = {
 			if (!room.banwords) return this.errorReply("This room has no banned phrases.");
 
 			let words = target.match(/[^,]+(,\d*}[^,]*)?/g);
-			if (!words) return this.errorReply("You have not included any words to be banned.");
+			if (!words) return this.parse('/help banword');
 
 			words = words.map(word => word.replace(/\n/g, '').trim());
 

--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -407,9 +407,9 @@ exports.commands = {
 			// Most of the regex code is copied from the client. TODO: unify them?
 			let words = target.match(/[^,]+(,\d*}[^,]*)?/g);
 			if (!words) return this.errorReply("You have not included any words to be banned.");
-			
+
 			words = words.map(word => word.replace(/\n/g, '').trim());
-			
+
 			for (let i = 0; i < words.length; i++) {
 				if (/[\\^$*+?()|{}[\]]/.test(words[i])) {
 					if (!user.can('makeroom')) return this.errorReply("Regex banwords are only allowed for leaders or above.");
@@ -449,7 +449,7 @@ exports.commands = {
 
 			let words = target.match(/[^,]+(,\d*}[^,]*)?/g);
 			if (!words) return this.errorReply("You have not included any words to be banned.");
-			
+
 			words = words.map(word => word.replace(/\n/g, '').trim());
 
 			for (let i = 0; i < words.length; i++) {


### PR DESCRIPTION
- Style
    - Use template strings entirely throughout the file.
    - Consistency: always put a space between buttons in roomsettings display
    - &lt;b&gt; => &lt;strong&gt; - I know this has been contraversial before in https://github.com/Zarel/Pokemon-Showdown/pull/3247, but for the sake of screen-readers and consistency with the style in the newer files (which discourage the use of &lt;b&gt;, &lt;font&gt;, and &lt;center&gt; elements)
- Additions:
    - roomsettings section for UNO and hangman
- Fixes:
    - Banwords:
        - Fix crash from ``/banword add ,`` - if there's no match don't map
        - Remove banwords in ``/banword delete`` only
        - Make the modnote for adding/removing multiple banned words less misleading.