### PR TITLE
Fix Weather Ball Z-Move

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -103,7 +103,12 @@ exports.BattleScripts = {
 	 */
 	useMove: function (move, pokemon, target, sourceEffect, zMove) {
 		if (!sourceEffect && this.effect.id) sourceEffect = this.effect;
-		if (zMove || (sourceEffect && sourceEffect.isZ)) {
+		if (zMove && move.id === 'weatherball') {
+			let baseMove = move;
+			this.singleEvent('ModifyMove', move, null, pokemon, target, move, move);
+			move = this.getZMoveCopy(move, pokemon);
+			if (move.type !== 'Normal') sourceEffect = baseMove;
+		} else if (zMove || (sourceEffect && sourceEffect.isZ)) {
 			move = this.getZMoveCopy(move, pokemon);
 		} else {
 			move = this.getMoveCopy(move);


### PR DESCRIPTION
This fixes the Z-Weather Ball interaction with weather. As far as I'm aware, every other type-changing move retains their base typing with Z-Moves, so Weather Ball should be the only exception here?

There might be a better way than to rely on Weather Ball's `onModifyMove` to resolve the typing, but without reimplementing it again, I don't know how.