### PR TITLE
Fix crash in rooms.js when destroying rooms

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -1435,7 +1435,7 @@ class ChatRoom extends Room {
 			}
 		}
 
-		if (this.game) {
+		if (this.game && typeof this.game.destroy === 'function') {
 			this.game.destroy();
 		}
 


### PR DESCRIPTION
Currently crashes if this.game exists but this.game.destroy isn't a function.