### PR TITLE
Allow players to simultaneously request the battle timer

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -932,7 +932,7 @@ class BattleRoom extends Room {
 		this.resetUser = '';
 	}
 	requestKickInactive(user, force) {
-		if (this.resetTimer && user && (this.resetUser === user.userid || (user in this.game.players && this.resetUser === '+') || this.resetUser === '~')){
+		if (this.resetTimer && user && (this.resetUser === user.userid || (user in this.game.players && this.resetUser === '+') || this.resetUser === '~')) {
 			this.sendUser(user, '|inactive|The inactivity timer is already counting down.');
 			return false;
 		}

--- a/rooms.js
+++ b/rooms.js
@@ -933,9 +933,13 @@ class BattleRoom extends Room {
 	}
 	requestKickInactive(user, force) {
 		let timerSetByUser = user && (this.resetUser === user.userid || (user in this.game.players && this.resetUser === '+'));
-		if (this.resetTimer && (timerSetByUser || this.resetUser === '~')) {
-			this.sendUser(user, '|inactive|The inactivity timer is already counting down.');
-			return false;
+		if (this.resetTimer) {
+			if (timerSetByUser) {
+				this.sendUser(user, '|inactive|The inactivity timer is already counting down.');
+				return false;
+			} else if (this.resetUser === '~') {
+				return false;
+			}
 		}
 		if (user) {
 			if (!force && !(user in this.game.players)) return false;

--- a/rooms.js
+++ b/rooms.js
@@ -932,8 +932,8 @@ class BattleRoom extends Room {
 		this.resetUser = '';
 	}
 	requestKickInactive(user, force) {
-		let timerSetByUser = user && (this.resetUser === user.userid || (user in this.game.players && this.resetUser === '+'));
 		if (this.resetTimer) {
+			let timerSetByUser = user && (this.resetUser === user.userid || (user in this.game.players && this.resetUser === '+'));
 			if (timerSetByUser) {
 				this.sendUser(user, '|inactive|The inactivity timer is already counting down.');
 				return false;

--- a/rooms.js
+++ b/rooms.js
@@ -932,16 +932,22 @@ class BattleRoom extends Room {
 		this.resetUser = '';
 	}
 	requestKickInactive(user, force) {
-		if (this.resetTimer && user && (this.resetUser === user.userid || (user in this.game.players && this.resetUser === '+') || this.resetUser === '~')) {
+		let timerSetByUser = user && (this.resetUser === user.userid || (user in this.game.players && this.resetUser === '+'));
+		if (this.resetTimer && (timerSetByUser || this.resetUser === '~')) {
 			this.sendUser(user, '|inactive|The inactivity timer is already counting down.');
 			return false;
 		}
 		if (user) {
 			if (!force && !(user in this.game.players)) return false;
 			if (user in this.game.players && this.resetTimer) {
-				// both players want the timer on
-				this.resetUser = '+';
-				this.send('|inactive|Battle timer has been requested by both players; it will now stay ON until they both turn it off, or until it is forced off by staff.');
+				for (let p in this.game.players) {
+					if (p.userid === this.resetUser) {
+						// both players want the timer on
+						this.resetUser = '+';
+						this.send('|inactive|Battle timer has been requested by both players; it will now stay ON until they both turn it off, or until it is forced off by staff.');
+						break;
+					}
+				}
 			} else {
 				this.resetUser = user.userid;
 				this.send('|inactive|Battle timer is now ON; inactive players will automatically lose when time\'s up. (requested by ' + user.name + ')');

--- a/rooms.js
+++ b/rooms.js
@@ -932,17 +932,25 @@ class BattleRoom extends Room {
 		this.resetUser = '';
 	}
 	requestKickInactive(user, force) {
-		if (this.resetTimer) {
-			if (user) this.sendUser(user, '|inactive|The inactivity timer is already counting down.');
+		if (this.resetTimer && user && (this.resetUser === user.userid || (user in this.game.players && this.resetUser === '+') || this.resetUser === '~')){
+			this.sendUser(user, '|inactive|The inactivity timer is already counting down.');
 			return false;
 		}
 		if (user) {
 			if (!force && !(user in this.game.players)) return false;
-			this.resetUser = user.userid;
-			this.send('|inactive|Battle timer is now ON: inactive players will automatically lose when time\'s up. (requested by ' + user.name + ')');
+			if (user in this.game.players && this.resetTimer) {
+				// both players want the timer on
+				this.resetUser = '+';
+				this.send('|inactive|Battle timer has been requested by both players; it will now stay ON until they both turn it off, or until it is forced off by staff.');
+			} else {
+				this.resetUser = user.userid;
+				this.send('|inactive|Battle timer is now ON; inactive players will automatically lose when time\'s up. (requested by ' + user.name + ')');
+			}
+			// don't restart the timer
+			if (this.resetTimer) return true;
 		} else if (user === false) {
 			this.resetUser = '~';
-			this.add('|inactive|Battle timer is ON: inactive players will automatically lose when time\'s up.');
+			this.add('|inactive|Battle timer is now ON; inactive players will automatically lose when time\'s up.');
 		}
 
 		// a tick is 10 seconds
@@ -986,8 +994,18 @@ class BattleRoom extends Room {
 		}
 	}
 	stopKickInactive(user, force) {
-		if (!force && user && user.userid !== this.resetUser) return false;
+		if (!force && user && (user.userid !== this.resetUser || !(user in this.game.players) || this.resetUser !== '+')) return false;
 		if (this.resetTimer) {
+			if (this.resetUser === '+' && user in this.game.players) {
+				// the other player still wants the timer on
+				for (let p in this.game.players) {
+					if (p && p !== user) {
+						this.resetTimer = p.userid;
+						this.send('|inactive|Player ' + user.name + ' has requested that the timer be turned off. It will stay ON until ' + p.name + ' also turns it off, or until it is forced off.');
+						return true;
+					}
+				}
+			}
 			clearTimeout(this.resetTimer);
 			this.resetTimer = null;
 			this.send('|inactiveoff|Battle timer is now OFF.');


### PR DESCRIPTION
This allows both players to request that the timer be turned on, which helps prevent one of them from timer-stalling by repeatedly toggling the timer on and off. It also allows staff to stop such a thing by turning the timer on themselves.