### PR TITLE
Matchmaking: move battle logging back to Rooms.global

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -3259,7 +3259,7 @@ exports.commands = {
 			}
 			Matchmaker.searchBattle(user, target);
 		} else {
-			Matchmaker.cancelSearch(user);
+			Matchmaker.cancelSearch(user, target);
 		}
 	},
 

--- a/ladders-matchmaker.js
+++ b/ladders-matchmaker.js
@@ -150,25 +150,25 @@ class Matchmaker {
 		});
 	}
 
-	verifyPlayers(player1, player2) {
+	verifyPlayers(player1, player2, format) {
 		let p1 = (typeof player1 === 'string') ? Users(player1) : player1;
 		let p2 = (typeof player2 === 'string') ? Users(player2) : player2;
 		if (!p1 || !p2) {
-			this.cancelSearch(p1);
-			this.cancelSearch(p2);
+			this.cancelSearch(p1, format);
+			this.cancelSearch(p2, format);
 			return false;
 		}
 
 		if (p1 === p2) {
-			this.cancelSearch(p1);
-			this.cancelSearch(p2);
+			this.cancelSearch(p1, format);
+			this.cancelSearch(p2, format);
 			p1.popup("You can't battle your own account. Please use something like Private Browsing to battle yourself.");
 			return false;
 		}
 
 		if (Rooms.global.lockdown === true) {
-			this.cancelSearch(p1);
-			this.cancelSearch(p2);
+			this.cancelSearch(p1, format);
+			this.cancelSearch(p2, format);
 			p1.popup("The server is restarting. Battles will be available again in a few minutes.");
 			p2.popup("The server is restarting. Battles will be available again in a few minutes.");
 			return false;
@@ -178,7 +178,7 @@ class Matchmaker {
 	}
 
 	startBattle(p1, p2, format, p1team, p2team, options) {
-		if (!this.verifyPlayers(p1, p2)) return;
+		if (!this.verifyPlayers(p1, p2, format)) return;
 
 		let roomid = Rooms.global.prepBattleRoom(format);
 		let room = Rooms.createBattle(roomid, format, p1, p2, options);
@@ -186,8 +186,8 @@ class Matchmaker {
 		p2.joinRoom(room);
 		room.battle.addPlayer(p1, p1team);
 		room.battle.addPlayer(p2, p2team);
-		this.cancelSearch(p1);
-		this.cancelSearch(p2);
+		this.cancelSearch(p1, format);
+		this.cancelSearch(p2, format);
 		Rooms.global.onCreateBattleRoom(p1, p2, room, options);
 
 		return room;

--- a/ladders-matchmaker.js
+++ b/ladders-matchmaker.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-const fs = require('fs');
-
 const PERIODIC_MATCH_INTERVAL = 60 * 1000;
 
 function Search(userid, team, rating = 1000) {
@@ -24,45 +22,6 @@ function Search(userid, team, rating = 1000) {
 class Matchmaker {
 	constructor() {
 		this.searches = new Map();
-		if (('Config' in global) && Config.logladderip) {
-			this.ladderIpLog = fs.createWriteStream('logs/ladderip/ladderip.txt', {encoding: 'utf8', flags: 'a'});
-		} else {
-			// Prevent there from being two possible hidden classes an instance
-			// of Matchmaker can have.
-			this.ladderIpLog = new (require('stream')).Writable();
-		}
-
-		let lastBattle;
-		try {
-			lastBattle = fs.readFileSync('logs/lastbattle.txt', 'utf8');
-		} catch (e) {}
-		this.lastBattle = (!lastBattle || isNaN(lastBattle)) ? 0 : +lastBattle;
-
-		this.writeNumRooms = (() => {
-			let writing = false;
-			let lastBattle = -1; // last lastBattle to be written to file
-			return () => {
-				if (writing) return;
-
-				// batch writing lastbattle.txt for every 10 battles
-				if (lastBattle >= this.lastBattle) return;
-				lastBattle = this.lastBattle + 10;
-
-				let filename = 'logs/lastbattle.txt';
-				writing = true;
-				fs.writeFile(`${filename}.0`, '' + lastBattle, () => {
-					fs.rename(`${filename}.0`, filename, () => {
-						writing = false;
-						lastBattle = null;
-						filename = null;
-						if (lastBattle < this.lastBattle) {
-							setImmediate(() => this.writeNumRooms());
-						}
-					});
-				});
-			};
-		})();
-
 		this.periodicMatchInterval = setInterval(
 			() => this.periodicMatch(),
 			PERIODIC_MATCH_INTERVAL
@@ -191,20 +150,20 @@ class Matchmaker {
 		});
 	}
 
-	startBattle(p1, p2, format, p1team, p2team, options) {
-		p1 = Users.get(p1);
-		p2 = Users.get(p2);
+	verifyPlayers(player1, player2) {
+		let p1 = (typeof player1 === 'string') ? Users(player1) : player1;
+		let p2 = (typeof player2 === 'string') ? Users(player2) : player2;
 		if (!p1 || !p2) {
-			// most likely, a user was banned during the battle start procedure
 			this.cancelSearch(p1);
 			this.cancelSearch(p2);
-			return;
+			return false;
 		}
+
 		if (p1 === p2) {
 			this.cancelSearch(p1);
 			this.cancelSearch(p2);
 			p1.popup("You can't battle your own account. Please use something like Private Browsing to battle yourself.");
-			return;
+			return false;
 		}
 
 		if (Rooms.global.lockdown === true) {
@@ -212,40 +171,26 @@ class Matchmaker {
 			this.cancelSearch(p2);
 			p1.popup("The server is restarting. Battles will be available again in a few minutes.");
 			p2.popup("The server is restarting. Battles will be available again in a few minutes.");
-			return;
+			return false;
 		}
 
-		//console.log('BATTLE START BETWEEN: ' + p1.userid + ' ' + p2.userid);
-		let i = this.lastBattle + 1;
-		let roomPrefix = `battle-${format.toLowerCase().replace(/[^a-z0-9]+/g, '')}-`;
-		while (Rooms.rooms.has(`${roomPrefix}${i}`)) {
-			i++;
-		}
-		this.lastBattle = i;
-		this.writeNumRooms();
+		return true;
+	}
 
-		let newRoom = Rooms.createBattle(`${roomPrefix}${i}`, format, p1, p2, options);
-		p1.joinRoom(newRoom);
-		p2.joinRoom(newRoom);
-		newRoom.battle.addPlayer(p1, p1team);
-		newRoom.battle.addPlayer(p2, p2team);
+	startBattle(p1, p2, format, p1team, p2team, options) {
+		if (!this.verifyPlayers(p1, p2)) return;
+
+		let roomid = Rooms.global.prepBattleRoom(format);
+		let room = Rooms.createBattle(roomid, format, p1, p2, options);
+		p1.joinRoom(room);
+		p2.joinRoom(room);
+		room.battle.addPlayer(p1, p1team);
+		room.battle.addPlayer(p2, p2team);
 		this.cancelSearch(p1);
 		this.cancelSearch(p2);
-		if (Config.reportbattles) {
-			let reportRoom = Rooms(Config.reportbattles === true ? 'lobby' : Config.reportbattles);
-			if (reportRoom) {
-				reportRoom
-					.add(`|b|${newRoom.id}|${p1.getIdentity()}|${p2.getIdentity()}`)
-					.update();
-			}
-		}
-		if (Config.logladderip && options.rated) {
-			this.ladderIpLog.write(
-				`${p1.userid}: ${p1.latestIp}\n` +
-				`${p2.userid}: ${p2.latestIp}\n`
-			);
-		}
-		return newRoom;
+		Rooms.global.onCreateBattleRoom(p1, p2, room, options);
+
+		return room;
 	}
 }
 

--- a/test/application/ladders-matchmaker.js
+++ b/test/application/ladders-matchmaker.js
@@ -6,8 +6,21 @@ const {matchmaker, Matchmaker, Search} = require('../../ladders-matchmaker');
 const {Connection, User} = require('../../dev-tools/users-utils');
 
 describe('Matchmaker', function () {
+	const FORMATID = 'gen7ou';
+	const addSearch = (player, rating = 1000, formatid = FORMATID) => {
+		let search = new Search(player.userid, player.team, rating);
+		matchmaker.addSearch(search, player, formatid);
+		return search;
+	};
+	const destroyPlayer = player => {
+		player.resetName();
+		player.disconnectAll();
+		player.destroy();
+		return player;
+	};
+
 	before(function () {
-		matchmaker.ladderIpLog.end();
+		Rooms.global.ladderIpLog.end();
 		clearInterval(matchmaker.periodicMatchInterval);
 		matchmaker.periodicMatchInterval = null;
 	});
@@ -27,13 +40,8 @@ describe('Matchmaker', function () {
 	});
 
 	afterEach(function () {
-		this.p1.resetName();
-		this.p1.disconnectAll();
-		this.p1.destroy();
-
-		this.p2.resetName();
-		this.p2.disconnectAll();
-		this.p2.destroy();
+		this.p1 = destroyPlayer(this.p1);
+		this.p2 = destroyPlayer(this.p2);
 	});
 
 	after(function () {
@@ -41,12 +49,10 @@ describe('Matchmaker', function () {
 	});
 
 	it('should add a search', function () {
-		let formatid = 'gen7ou';
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		matchmaker.addSearch(s1, this.p1, formatid);
-		assert.ok(matchmaker.searches.has(formatid));
+		let s1 = addSearch(this.p1);
+		assert.ok(matchmaker.searches.has(FORMATID));
 
-		let formatSearches = matchmaker.searches.get(formatid);
+		let formatSearches = matchmaker.searches.get(FORMATID);
 		assert.ok(formatSearches instanceof Set);
 		assert.strictEqual(formatSearches.size, 1);
 		assert.strictEqual(s1.userid, this.p1.userid);
@@ -55,63 +61,51 @@ describe('Matchmaker', function () {
 	});
 
 	it('should matchmake users when appropriate', function () {
-		let formatid = 'gen7ou';
 		let {startBattle} = matchmaker;
 		matchmaker.startBattle = () => {
 			matchmaker.startBattle = startBattle;
-			assert.strictEqual(matchmaker.searches.get(formatid).size, 0);
+			assert.strictEqual(matchmaker.searches.get(FORMATID).size, 0);
 		};
 
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		let s2 = new Search(this.p2.userid, this.p2.team);
-		matchmaker.addSearch(s1, this.p1, formatid);
-		matchmaker.addSearch(s2, this.p2, formatid);
+		addSearch(this.p1);
+		addSearch(this.p2);
 	});
 
 	it('should matchmake users within a reasonable rating range', function () {
-		let formatid = 'gen7ou';
 		let {startBattle} = matchmaker;
 		matchmaker.startBattle = () => {
 			matchmaker.startBattle = startBattle;
-			assert.strictEqual(matchmaker.searches.get(formatid).size, 2);
+			assert.strictEqual(matchmaker.searches.get(FORMATID).size, 2);
 		};
 
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		let s2 = new Search(this.p2.userid, this.p2.team, 2000);
-		matchmaker.addSearch(s1, this.p1, formatid);
-		matchmaker.addSearch(s2, this.p2, formatid);
+		addSearch(this.p1);
+		addSearch(this.p2, 2000);
 		matchmaker.startBattle();
 	});
 
 	it('should cancel searches', function () {
-		let formatid = 'gen7ou';
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		matchmaker.addSearch(s1, this.p1, formatid);
+		addSearch(this.p1);
 		matchmaker.cancelSearch(this.p1);
-		assert.strictEqual(matchmaker.searches.get(formatid).size, 0);
+		assert.strictEqual(matchmaker.searches.get(FORMATID).size, 0);
 	});
 
 	it('should periodically matchmake users when appropriate', function () {
-		let formatid = 'gen7ou';
 		let {startBattle} = matchmaker;
 		matchmaker.startBattle = () => {
 			matchmaker.startBattle = startBattle;
 		};
 
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		let s2 = new Search(this.p2.userid, this.p2.team, 2000);
-		matchmaker.addSearch(s1, this.p1, formatid);
-		matchmaker.addSearch(s2, this.p2, formatid);
-		assert.strictEqual(matchmaker.searches.get(formatid).size, 2);
+		addSearch(this.p1);
+		let s2 = addSearch(this.p2, 2000);
+		assert.strictEqual(matchmaker.searches.get(FORMATID).size, 2);
 
 		s2.rating = 1000;
 		matchmaker.periodicMatch();
-		assert.strictEqual(matchmaker.searches.get(formatid).size, 0);
+		assert.strictEqual(matchmaker.searches.get(FORMATID).size, 0);
 	});
 
 	// FIXME: a race condition in battles and sockets breaks this test
 	it.skip('should create a new battle room after matchmaking', function () {
-		let formatid = 'gen7ou';
 		let {startBattle} = matchmaker;
 		matchmaker.startBattle = (...args) => {
 			matchmaker.startBattle = startBattle;
@@ -119,33 +113,64 @@ describe('Matchmaker', function () {
 			assert.ok(room instanceof Rooms.BattleRoom);
 		};
 
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		let s2 = new Search(this.p1.userid, this.p2.team);
-		matchmaker.addSearch(s1, this.p1, formatid);
-		matchmaker.addSearch(s2, this.p2, formatid);
+		addSearch(this.p1);
+		addSearch(this.p2);
 	});
 
 	it('should cancel search on disconnect', function () {
-		let formatid = 'gen7ou';
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		matchmaker.addSearch(s1, this.p1, formatid);
+		addSearch(this.p1);
 		this.p1.onDisconnect(this.p1.connections[0]);
-		assert.strictEqual(matchmaker.searches.get(formatid).size, 0);
+		assert.strictEqual(matchmaker.searches.get(FORMATID).size, 0);
 	});
 
 	it('should cancel search on leaving the global room', function () {
-		let formatid = 'gen7ou';
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		matchmaker.addSearch(s1, this.p1, formatid);
+		addSearch(this.p1);
 		this.p1.leaveRoom(Rooms.global, this.p1.connections[0], true);
-		assert.strictEqual(matchmaker.searches.get(formatid).size, 0);
+		assert.strictEqual(matchmaker.searches.get(FORMATID).size, 0);
 	});
 
 	it('should cancel search on merge', function () {
-		let formatid = 'gen7ou';
-		let s1 = new Search(this.p1.userid, this.p1.team);
-		matchmaker.addSearch(s1, this.p1, formatid);
+		addSearch(this.p1);
 		this.p2.merge(this.p1);
-		assert.strictEqual(matchmaker.searches.get(formatid).size, 0);
+		assert.strictEqual(matchmaker.searches.get(FORMATID).size, 0);
+	});
+
+	describe('#startBattle', function () {
+		beforeEach(function () {
+			this.s1 = addSearch(this.p1);
+			this.s2 = addSearch(this.p2);
+		});
+
+		afterEach(function () {
+			this.s1 = null;
+			this.s2 = null;
+		});
+
+		it('should prevent battles from starting if either player is no longer a user', function () {
+			this.p2 = destroyPlayer(this.p2);
+			let room = matchmaker.startBattle(this.p1, this.p2, FORMATID, this.s1.team, this.s2.team, {rated: 1000});
+			assert.strictEqual(room, undefined);
+		});
+
+		it('should prevent battles from starting if both players are identical', function () {
+			Object.assign(this.s2, this.s1);
+			let room = matchmaker.startBattle(this.p1, this.p2, FORMATID, this.s1.team, this.s2.team, {rated: 1000});
+			assert.strictEqual(room, undefined);
+		});
+
+		before(function () {
+			this.lockdown = Rooms.global.lockdown;
+			Rooms.global.lockdown = true;
+		});
+
+		after(function () {
+			Rooms.global.lockdown = this.lockdown;
+			this.lockdown = null;
+		});
+
+		it('should prevent battles from starting if the server is in lockdown', function () {
+			let room = matchmaker.startBattle(this.p1, this.p2, FORMATID, this.s1.team, this.s2.team, {rated: 1000});
+			assert.strictEqual(room, undefined);
+		});
 	});
 });

--- a/test/application/ladders-matchmaker.js
+++ b/test/application/ladders-matchmaker.js
@@ -85,7 +85,7 @@ describe('Matchmaker', function () {
 
 	it('should cancel searches', function () {
 		addSearch(this.p1);
-		matchmaker.cancelSearch(this.p1);
+		matchmaker.cancelSearch(this.p1, FORMATID);
 		assert.strictEqual(matchmaker.searches.get(FORMATID).size, 0);
 	});
 

--- a/test/application/rooms.js
+++ b/test/application/rooms.js
@@ -28,7 +28,7 @@ describe('Rooms features', function () {
 
 		let room;
 		before(function () {
-			matchmaker.ladderIpLog.end();
+			Rooms.global.ladderIpLog.end();
 			clearInterval(matchmaker.periodicMatchInterval);
 			matchmaker.periodicMatchInterval = null;
 		});


### PR DESCRIPTION
For now, logging should be dealt by the global room until logging can be
abstracted away from it. This makes it simpler to refactor the logic in
`Matchmaker#startBattle` to be handled by `Rooms.createBattle` where it belongs.