### PR TITLE
Fix Prankster and Magic Bounce interaction

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -115,7 +115,7 @@ exports.BattleScripts = {
 		}
 		if (this.activeMove) {
 			move.priority = this.activeMove.priority;
-			move.pranksterBoosted = this.activeMove.pranksterBoosted;
+			move.pranksterBoosted = move.hasBounced ? false : this.activeMove.pranksterBoosted;
 		}
 		let baseTarget = move.target;
 		if (!target && target !== false) target = this.resolveTarget(pokemon, move);


### PR DESCRIPTION
Fixes http://www.smogon.com/forums/posts/7087130

I'm not entirely convinced this doesn't break anything else, but it passes all the tests...
```
Turn 1
Liepard used Magic Coat!
Liepard shrouded itself with Magic Coat!
The opposing Sableye used Will-O-Wisp!
Liepard bounced the Will-O-Wisp back!
(In gen 7, Dark is immune to Prankster moves.)
It doesn't affect the opposing Sableye...
Turn 2
Liepard used Thunder Wave!
(In gen 7, Dark is immune to Prankster moves.)
It doesn't affect the opposing Sableye...
The opposing Sableye used Will-O-Wisp!
(In gen 7, Dark is immune to Prankster moves.)
It doesn't affect Liepard...
Turn 3
The opposing Sableye's Sablenite is reacting to Quite Quiet's Mega Bracelet!
The opposing Sableye has Mega Evolved into Mega Sableye!
Liepard used Thunder Wave!
[Opposing Sableye's Magic Bounce!]
The opposing Sableye bounced the Thunder Wave back!
Liepard is paralyzed! It may be unable to move!
```