### PR TITLE
Random Battle: Only reject moves if they can be replaced

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1472,6 +1472,8 @@ exports.BattleScripts = {
 
 			counter = this.queryMoves(moves, hasType, hasAbility, movePool);
 
+			if (!movePool.length) break;
+
 			// Iterate through the moves again, this time to cull them:
 			for (let k = 0; k < moves.length; k++) {
 				let moveid = moves[k];
@@ -2629,6 +2631,8 @@ exports.BattleScripts = {
 			}
 
 			counter = this.queryMoves(moves, hasType, hasAbility);
+
+			if (!movePool.length) break;
 
 			// Iterate through the moves again, this time to cull them:
 			for (let k = 0; k < moves.length; k++) {


### PR DESCRIPTION
The only times a Pokémon wouldn't benefit from having more moves is if they're Sleep Talk Xerneas in gen 6 AG or a Last Resort mon, and neither of those are possible in random battle. That said, if something like those does get added, this will need changing to account for that.