### PR TITLE
Random Battle: Remove Dragon Claw entirely if Outrage is present

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1629,6 +1629,10 @@ exports.BattleScripts = {
 					break;
 				case 'outrage':
 					if (hasMove['dracometeor'] && counter.damagingMoves.length < 3) rejected = true;
+					if (!rejected && !movePool.includes('dracometeor')) {
+						let dclaw = movePool.indexOf('dragonclaw');
+						if (dclaw >= 0) this.fastPop(movePool, dclaw);
+					}
 					break;
 				case 'chargebeam':
 					if (hasMove['thunderbolt'] && counter.Special < 3) rejected = true;


### PR DESCRIPTION
Almost guarantees the elimination of Dragon Claw + Outrage sets.