### PR TITLE
Gen 2: Once again combine SpA and SpD DVs into the same value

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -397,7 +397,11 @@ class Validator {
 					problems.push(`${name} has an HP DV of ${hpDV}, but its Atk, Def, Spe, and Spc DVs give it an HP DV of ${expectedHpDV}.`);
 				}
 				if (set.ivs.spa !== set.ivs.spd) {
-					problems.push(`${name} has differnt SpA and SpD DVs (its SpA and SpD DVs has to be equal).`);
+					if (tools.gen === 2) {
+						problems.push(`${name} has different SpA and SpD DVs, which is not possible in Gen 2.`);
+					} else {
+						set.ivs.spd = set.ivs.spa;
+					}
 				}
 				if (tools.gen > 1 && !template.gender) {
 					// Gen 2 gender is calculated from the Atk DV.

--- a/team-validator.js
+++ b/team-validator.js
@@ -396,6 +396,9 @@ class Validator {
 				if (expectedHpDV !== hpDV) {
 					problems.push(`${name} has an HP DV of ${hpDV}, but its Atk, Def, Spe, and Spc DVs give it an HP DV of ${expectedHpDV}.`);
 				}
+				if (set.ivs.spa !== set.ivs.spd) {
+					problems.push(`${name} has differnt SpA and SpD DVs (its SpA and SpD DVs has to be equal).`);
+				}
 				if (tools.gen > 1 && !template.gender) {
 					// Gen 2 gender is calculated from the Atk DV.
 					// High Atk DV <-> M. The meaning of "high" depends on the gender ratio.


### PR DESCRIPTION
In commit e8b60c1e908b2ea27a120caa8b1325d22ac7b1e4 this line was apparently lost which made sure Special Attack and Special Defense IVs were the same in Gen 2.

This closes #3459 I believe.