### PR TITLE
Matchmaker: fix sockets race condition when starting battles

### DIFF
--- a/ladders-matchmaker.js
+++ b/ladders-matchmaker.js
@@ -183,8 +183,8 @@ class Matchmaker {
 		let roomid = Rooms.global.prepBattleRoom(format);
 		let room = Rooms.createBattle(roomid, format, p1, p2, options);
 		p1.joinRoom(room);
-		p2.joinRoom(room);
 		room.battle.addPlayer(p1, p1team);
+		p2.joinRoom(room);
 		room.battle.addPlayer(p2, p2team);
 		this.cancelSearch(p1, format);
 		this.cancelSearch(p2, format);

--- a/test/application/ladders-matchmaker.js
+++ b/test/application/ladders-matchmaker.js
@@ -104,8 +104,7 @@ describe('Matchmaker', function () {
 		assert.strictEqual(matchmaker.searches.get(FORMATID).size, 0);
 	});
 
-	// FIXME: a race condition in battles and sockets breaks this test
-	it.skip('should create a new battle room after matchmaking', function () {
+	it('should create a new battle room after matchmaking', function () {
 		let {startBattle} = matchmaker;
 		matchmaker.startBattle = (...args) => {
 			matchmaker.startBattle = startBattle;


### PR DESCRIPTION
BattleRoom#update expects the room's corresponding subchannel object in
sockets workers to already exist before broadcasting chat updates, but
there is no way for it to be able to check if this is true or not. When
the matchmaker would start a battle, it would cause BattleRoom#update
to fire when joining the second player's user object to the room, but
before any of the players had had their sockets moved to the
appropriate subchannel yet. Waiting until after adding the first player
to the battle to deal with the second player fixes this.