### PR TITLE
Implement correct Perish Song mechanics

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -11486,14 +11486,13 @@ exports.BattleMovedex = {
 		pp: 5,
 		priority: 0,
 		flags: {sound: 1, distance: 1, authentic: 1},
-		onHitField: function (target, source) {
+		onHitField: function (target, source, move) {
 			let result = false;
 			let message = false;
 			for (let i = 0; i < this.sides.length; i++) {
 				for (let j = 0; j < this.sides[i].active.length; j++) {
 					if (this.sides[i].active[j] && this.sides[i].active[j].isActive) {
-						if (this.sides[i].active[j].hasAbility('soundproof')) {
-							this.add('-immune', this.sides[i].active[j], '[msg]', '[from] ability: Soundproof');
+						if (this.runEvent('TryHit', this.sides[i].active[j], source, move) === null) {
 							result = true;
 						} else if (!this.sides[i].active[j].volatiles['perishsong']) {
 							this.sides[i].active[j].addVolatile('perishsong');


### PR DESCRIPTION
- Liquid Voice + Perish Song will get absorbed by Storm Drain/Water Absorb
- Electrify Perish Song will trigger Lightningrod/Motor Drive/Volt Absorb
- ~Prankster Perish Song will fail against any Pokemon on the field affected by Psychic Terrain, except the user.~

I couldn't find anything that said the redirecting effects of Storm Drain/Lightningrod activated for the effect of Perish song, though.

@Marty-D can you confirm if this is the correct behaviour for Perish Song now? Or if something else is wrong. 