### PR TITLE
Z-moves should use Imposter/Transformed species

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -772,7 +772,7 @@ exports.BattleScripts = {
 		if (!skipChecks) {
 			if (pokemon.side.zMoveUsed) return;
 			if (!item.zMove) return;
-			if (item.zMoveUser && !item.zMoveUser.includes(pokemon.species)) return;
+			if (item.zMoveUser && !item.zMoveUser.includes(pokemon.template.species)) return;
 			let moveData = pokemon.getMoveData(move);
 			if (!moveData || !moveData.pp) return; // Draining the PP of the base move prevents the corresponding Z-move from being used.
 		}
@@ -815,7 +815,7 @@ exports.BattleScripts = {
 		if (pokemon.side.zMoveUsed) return;
 		let item = pokemon.getItem();
 		if (!item.zMove) return;
-		if (item.zMoveUser && !item.zMoveUser.includes(pokemon.species)) return;
+		if (item.zMoveUser && !item.zMoveUser.includes(pokemon.template.species)) return;
 		let atLeastOne = false;
 		let zMoves = [];
 		for (let i = 0; i < pokemon.moves.length; i++) {


### PR DESCRIPTION
Reported here with video: http://www.smogon.com/forums/posts/7335549
Obviously they need the appropriate Z-crystal so this is a bit niche, but it does mean that Mew can't use Genesis Supernova after a Transform, even if it still happens to have Psychic.