### PR TITLE
Send team size at the start of battles

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -2678,6 +2678,7 @@ class Battle extends Dex.ModdedDex {
 
 		if (avatar) player.avatar = avatar;
 		this.add('player', player.id, player.name, avatar);
+		this.add('teamsize', player.id, player.pokemon.length);
 
 		this.start();
 		return player;


### PR DESCRIPTION
In generation 1-4, during Link/Wifi battles you know how many pokemon your opponent has before all Pokemon have been revealed. PS currently doesn't at any point (without team preview) reveal the max number of Pokemon that your opponent has unless it's 6. This fixes that.

Relevant client change as well: https://github.com/Zarel/Pokemon-Showdown-Client/pull/915