### PR TITLE
Update Random Doubles

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -6092,7 +6092,7 @@ exports.BattleFormatsData = {
 	},
 	silvally: {
 		randomBattleMoves: ["swordsdance", "return", "doubleedge", "crunch", "flamecharge", "flamethrower", "icebeam", "uturn", "ironhead"],
-		randomDoubleBattleMoves: ["protect", "doubledge", "uturn", "crunch", "icebeam", "partingshot", "flamecharge", "partingshot", "swordsdance", "explosion"],
+		randomDoubleBattleMoves: ["protect", "doubleedge", "uturn", "crunch", "icebeam", "partingshot", "flamecharge", "partingshot", "swordsdance", "explosion"],
 		tier: "New",
 	},
 	silvallybug: {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -3050,8 +3050,8 @@ exports.BattleScripts = {
 				rejectAbility = !counter['inaccurate'];
 			} else if (ability === 'Defiant' || ability === 'Moxie') {
 				rejectAbility = !counter['Physical'] && !hasMove['batonpass'];
-			} else if (ability === 'Gluttony') {
-				rejectAbility = !hasMove['bellydrum'];
+			} else if (ability === 'Simple') {
+				rejectAbility = !counter.setupType;
 			} else if (ability === 'Limber') {
 				rejectAbility = template.types.includes('Electric');
 			} else if (ability === 'Lightning Rod') {
@@ -3259,7 +3259,7 @@ exports.BattleScripts = {
 		// medium priority
 		} else if (ability === 'Guts') {
 			item = hasType['Fire'] ? 'Toxic Orb' : 'Flame Orb';
-		} else if (ability === 'Marvel Scale' && hasMove['psychoshift']) {
+		} else if (ability === 'Marvel Scale') {
 			item = 'Flame Orb';
 		} else if (counter.Physical >= 4 && template.baseStats.spe > 55 && !hasMove['fakeout'] && !hasMove['suckerpunch'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && ability !== 'Sturdy' && ability !== 'Multiscale') {
 			item = 'Life Orb';

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -3334,9 +3334,8 @@ exports.BattleScripts = {
 		if (templateAbility === 'Huge Power' || templateAbility === 'Pure Power') {
 			bst += baseStats.atk;
 		} else if (templateAbility === 'Parental Bond') {
-			bst += 0.5 * (counter.Physical > counter.Special ? baseStats.atk : baseStats.spa);
+			bst += 0.25 * (counter.Physical > counter.Special ? baseStats.atk : baseStats.spa);
 		} else if (templateAbility === 'Protean') {
-			// Holistic judgment. Don't boost Protean as much as Parental Bond
 			bst += 0.3 * (counter.Physical > counter.Special ? baseStats.atk : baseStats.spa);
 		} else if (templateAbility === 'Fur Coat') {
 			bst += baseStats.def;


### PR DESCRIPTION
Wiki Berry and the like are so good in doubles that Gluttony is worth it for them, even without Belly Drum. Simple, on the other hand, is actually a detriment without any setup moves. Also, there are no Pokemon with both Marvel Scale and Psycho Shift, so I'll assume that's an error caused by copy/pasting from Magic Guard.