### PR TITLE
/join - Allow comma separated rooms

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1353,7 +1353,7 @@ exports.commands = {
 			user.tryJoinRoom(tarRoom, connection);
 		}
 	},
-	joinhelp: ["/join [roomname] - Attempt to join the room [roomname]. Seperate rooms with commas to attempt to join multiple rooms at once."],
+	joinhelp: ["/join [roomname] - Attempt to join the room [roomname]. Separate rooms with commas to attempt to join multiple rooms at once."],
 
 	'!part': true,
 	leave: 'part',

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1344,16 +1344,16 @@ exports.commands = {
 	join: function (target, room, user, connection) {
 		if (!target) return this.parse('/help join');
 		target = target.split(',');
+		let failed = [];
 		for (let i = 0; i < target.length; i++) {
 			let tarRoom = target[i].trim();
 			if (tarRoom.startsWith('http://')) tarRoom = tarRoom.slice(7);
 			if (tarRoom.startsWith('https://')) tarRoom = tarRoom.slice(8);
 			if (tarRoom.startsWith('play.pokemonshowdown.com/')) tarRoom = tarRoom.slice(25);
 			if (tarRoom.startsWith('psim.us/')) tarRoom = tarRoom.slice(8);
-			if (user.tryJoinRoom(tarRoom, connection) === null) {
-				connection.sendTo(target, "|noinit|namerequired|The room '" + tarRoom + "' does not exist or requires a login to join.");
-			}
+			if (user.tryJoinRoom(tarRoom, connection) === null) failed.push(tarRoom);
 		}
+		if (failed.length) connection.sendTo(target.join(','), `|noinit|namerequired|The room${(failed.length > 1 ? `s` : ``)} '${failed.join(', ')}' do${(failed.length > 1 ? `` : `es`)} not exist or require${(failed.length > 1 ? `s` : ``)} a login to join.`);
 	},
 	joinhelp: ["/join [roomname] - Attempt to join the room [roomname]. Seperate rooms with commas to attempt to join multiple rooms at once."],
 

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1350,7 +1350,7 @@ exports.commands = {
 			if (tarRoom.startsWith('https://')) tarRoom = tarRoom.slice(8);
 			if (tarRoom.startsWith('play.pokemonshowdown.com/')) tarRoom = tarRoom.slice(25);
 			if (tarRoom.startsWith('psim.us/')) tarRoom = tarRoom.slice(8);
-			user.tryJoinRoom(tarRoom, connection)
+			user.tryJoinRoom(tarRoom, connection);
 		}
 	},
 	joinhelp: ["/join [roomname] - Attempt to join the room [roomname]. Seperate rooms with commas to attempt to join multiple rooms at once."],

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1343,15 +1343,19 @@ exports.commands = {
 	j: 'join',
 	join: function (target, room, user, connection) {
 		if (!target) return this.parse('/help join');
-		if (target.startsWith('http://')) target = target.slice(7);
-		if (target.startsWith('https://')) target = target.slice(8);
-		if (target.startsWith('play.pokemonshowdown.com/')) target = target.slice(25);
-		if (target.startsWith('psim.us/')) target = target.slice(8);
-		if (user.tryJoinRoom(target, connection) === null) {
-			connection.sendTo(target, "|noinit|namerequired|The room '" + target + "' does not exist or requires a login to join.");
+		target = target.split(',');
+		for (let i = 0; i < target.length; i++) {
+			let tarRoom = target.trim();
+			if (tarRoom.startsWith('http://')) tarRoom = tarRoom.slice(7);
+			if (tarRoom.startsWith('https://')) tarRoom = tarRoom.slice(8);
+			if (tarRoom.startsWith('play.pokemonshowdown.com/')) tarRoom = tarRoom.slice(25);
+			if (tarRoom.startsWith('psim.us/')) tarRoom = tarRoom.slice(8);
+			if (user.tryJoinRoom(tarRoom, connection) === null) {
+				connection.sendTo(target, "|noinit|namerequired|The room '" + tarRoom + "' does not exist or requires a login to join.");
+			}
 		}
 	},
-	joinhelp: ["/join [roomname] - Attempt to join the room [roomname]."],
+	joinhelp: ["/join [roomname] - Attempt to join the room [roomname]. Seperate rooms with commas to attempt to join multiple rooms at once."],
 
 	'!part': true,
 	leave: 'part',

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1344,16 +1344,14 @@ exports.commands = {
 	join: function (target, room, user, connection) {
 		if (!target) return this.parse('/help join');
 		target = target.split(',');
-		let failed = [];
 		for (let i = 0; i < target.length; i++) {
 			let tarRoom = target[i].trim();
 			if (tarRoom.startsWith('http://')) tarRoom = tarRoom.slice(7);
 			if (tarRoom.startsWith('https://')) tarRoom = tarRoom.slice(8);
 			if (tarRoom.startsWith('play.pokemonshowdown.com/')) tarRoom = tarRoom.slice(25);
 			if (tarRoom.startsWith('psim.us/')) tarRoom = tarRoom.slice(8);
-			if (user.tryJoinRoom(tarRoom, connection) === null) failed.push(tarRoom);
+			user.tryJoinRoom(tarRoom, connection)
 		}
-		if (failed.length) connection.sendTo(target.join(','), `|noinit|namerequired|The room${(failed.length > 1 ? `s` : ``)} '${failed.join(', ')}' do${(failed.length > 1 ? `` : `es`)} not exist or require${(failed.length > 1 ? `s` : ``)} a login to join.`);
 	},
 	joinhelp: ["/join [roomname] - Attempt to join the room [roomname]. Seperate rooms with commas to attempt to join multiple rooms at once."],
 

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1345,7 +1345,7 @@ exports.commands = {
 		if (!target) return this.parse('/help join');
 		target = target.split(',');
 		for (let i = 0; i < target.length; i++) {
-			let tarRoom = target.trim();
+			let tarRoom = target[i].trim();
 			if (tarRoom.startsWith('http://')) tarRoom = tarRoom.slice(7);
 			if (tarRoom.startsWith('https://')) tarRoom = tarRoom.slice(8);
 			if (tarRoom.startsWith('play.pokemonshowdown.com/')) tarRoom = tarRoom.slice(25);


### PR DESCRIPTION
Allows things such as `/join lobby, tournaments, help, mafia`

I removed the error message from the command because `user#tryJoinRoom` is sending the exact same error message as the old code. I could remove the error from `user#tryJoinRoom` and instead add one that reports all the rooms the user failed to join in `/join`, though im not sure if anything else calls `user#tryJoinRoom` without handling its own error message. 

Suggestions are appreciated.