### PR TITLE
Two turn move

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -258,7 +258,7 @@ exports.BattleScripts = {
 					lacksTarget = !this.isAdjacent(target, pokemon);
 				}
 			}
-			if (lacksTarget) {
+			if (lacksTarget && !move.flags['charge']) {
 				this.attrLastMove('[notarget]');
 				this.add('-notarget');
 				if (move.target === 'normal') pokemon.isStaleCon = 0;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -258,7 +258,7 @@ exports.BattleScripts = {
 					lacksTarget = !this.isAdjacent(target, pokemon);
 				}
 			}
-			if (lacksTarget && !move.flags['charge']) {
+			if (lacksTarget && (!move.flags['charge'] || pokemon.volatiles['twoturnmove'])) {
 				this.attrLastMove('[notarget]');
 				this.add('-notarget');
 				if (move.target === 'normal') pokemon.isStaleCon = 0;


### PR DESCRIPTION
Two turn move attacks should not fail when target faints and be redirected.
Attacks like solarbeam and fly should have their turn of charge (1st turn) and not fail if targets faint (healing wish), then redirect attack to new target for the next turn.