### PR TITLE
Effect: don't override inherited properties from moreData

### DIFF
--- a/sim/dex-data.js
+++ b/sim/dex-data.js
@@ -102,10 +102,10 @@ class Effect {
 
 		Object.assign(this, data);
 		if (moreData) Object.assign(this, moreData);
-		this.name = Tools.getString(data.name).trim();
-		this.fullname = Tools.getString(data.fullname) || this.name;
+		this.name = Tools.getString(this.name).trim();
+		this.fullname = Tools.getString(this.fullname) || this.name;
 		this.id = toId(this.name);
-		this.effectType = Tools.getString(data.effectType) || "Effect";
+		this.effectType = Tools.getString(this.effectType) || "Effect";
 		this.exists = !!(this.exists && this.id);
 	}
 	toString() {


### PR DESCRIPTION
- caused weather effects passed in through ``moreData`` to be marked as simply ``"Effect"``
    - as a result, sandstorm and hail will damage Rock/Ground/Steel and Ice types  respectively
- this fix makes ``Effect`` inherit the ``effectType`` from ``moreData`` if it doesn't exist in the primary ``data`` variable passed into the constructor