### PR TITLE
Dex: fix dataSearch

### DIFF
--- a/sim/dex.js
+++ b/sim/dex.js
@@ -984,7 +984,7 @@ class ModdedDex {
 				searchResults.push({
 					exactMatch: !isInexact,
 					searchType: searchTypes[searchIn[i]],
-					name: isInexact || res.name,
+					name: res.name || isInexact,
 				});
 			}
 		}


### PR DESCRIPTION
Use the result's name first instead of inexact search term if search is found.