### PR TITLE
Give Natures a Generation

### DIFF
--- a/sim/dex.js
+++ b/sim/dex.js
@@ -729,6 +729,7 @@ class ModdedDex {
 			if (!nature.name) nature.name = name;
 			nature.toString = this.effectToString;
 			if (!nature.effectType) nature.effectType = 'Nature';
+			if (!nature.gen) nature.gen = 3;
 		}
 		return nature;
 	}


### PR DESCRIPTION
This makes them work in `dataSearch` again.

Also included are some leftovers from the fix in PR #3525 - if we're not going to report matched aliases then we can remove all of the support code for reporting matched aliases.