### PR TITLE
Properly report a near miss for an alias

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -365,8 +365,8 @@ exports.commands = {
 		let showDetails = (cmd === 'dt' || cmd === 'details');
 		if (newTargets && newTargets.length) {
 			for (let i = 0; i < newTargets.length; ++i) {
-				if (!newTargets[i].exactMatch && !i) {
-					buffer = "No Pok\u00e9mon, item, move, ability or nature named '" + target + "' was found. Showing the data of '" + newTargets[0].name + "' instead.\n";
+				if (newTargets[i].isInexact && !i) {
+					buffer = "No Pok\u00e9mon, item, move, ability or nature named '" + target + "' was found. Showing the data of '" + newTargets[0].isInexact + "' instead.\n";
 				}
 				if (newTargets[i].searchType === 'nature') {
 					let nature = Dex.getNature(newTargets[i].name);

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -982,9 +982,9 @@ class ModdedDex {
 			let res = this[searchFunctions[searchIn[i]]](target);
 			if (res.exists && res.gen <= this.gen) {
 				searchResults.push({
-					exactMatch: !isInexact,
+					isInexact: isInexact,
 					searchType: searchTypes[searchIn[i]],
-					name: res.name || isInexact,
+					name: res.name,
 				});
 			}
 		}


### PR DESCRIPTION
This restores the "No Pokémon, item, move, ability or nature named 'cn' was found. Showing the data of 'cm' instead." message, but continues to show you the data of "Calm Mind" as originally intended.

(Out of interest, the reason ROM was getting it "right" was because its `dataSearch` also returns the Dex object which was giving it the correct name, so I've double-checked this on a dummy server.)