### PR TITLE
Typescript: install @types/node dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "private": true,
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^7.0.18",
     "eslint": "^3.2.2",
     "mocha": "^3.0.0",
     "mock-fs-require-fix": "~1.0.0"


### PR DESCRIPTION
This makes Typescript aware of Node globals that it otherwise wouldn't
be, like `__dirname` and `module`. tsconfig.json doesn't fix this on its
own.