### PR TITLE
App: do not spawn double the workers when using the launch script

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,7 +106,6 @@ global.Chat = require('./chat');
 
 global.Rooms = require('./rooms');
 
-delete process.send; // in case we're a child process
 global.Verifier = require('./verifier');
 Verifier.PM.spawn();
 
@@ -141,12 +140,11 @@ exports.listen = function (port, bindAddress, workerCount) {
 };
 
 if (require.main === module) {
-	// if running with node app.js, set up the server directly
-	// (otherwise, wait for app.listen())
+	// Launch the server directly when app.js is the main module. Otherwise,
+	// in the case of app.js being imported as a module (e.g. unit tests),
+	// postpone launching until app.listen() is called.
 	let port;
-	if (process.argv[2]) {
-		port = parseInt(process.argv[2]); // eslint-disable-line radix
-	}
+	if (process.argv[2]) port = parseInt(process.argv[2]);
 	Sockets.listen(port);
 }
 

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -22,14 +22,15 @@ try {
 	child_process.execSync('npm install --production', {stdio: 'inherit'});
 }
 
-// Start the server
+// Start the server. We manually load app.js so it can be configured to run as
+// the main module, rather than this file being considered the main module.
+// This ensures any dependencies that were just installed can be found when
+// running on Windows and avoids any other potential side effects of the main
+// module not being app.js like it is assumed to be.
+//
+// The port the server should host on can be passed using the second argument
+// when launching with this file the same way app.js normally allows, e.g. to
+// host on port 9000:
+// $ ./pokemon-showdown 9000
 
-let port;
-if (process.argv[2]) {
-	port = parseInt(process.argv[2]);
-}
-
-// Bootstrap manually to ensure any dependencies that were just installed can
-// be found when running on Windows
-
-require('module')._load('./app', module, true).listen(port);
+require('module')._load('./app', module, true);

--- a/sockets.js
+++ b/sockets.js
@@ -24,7 +24,7 @@ if (cluster.isMaster) {
 	const workers = exports.workers = new Map();
 
 	const spawnWorker = exports.spawnWorker = function () {
-		let worker = cluster.fork({PSPORT: Config.port, PSBINDADDR: Config.bindaddress || '', PSNOSSL: Config.ssl ? 0 : 1});
+		let worker = cluster.fork({PSPORT: Config.port, PSBINDADDR: Config.bindaddress || '0.0.0.0', PSNOSSL: Config.ssl ? 0 : 1});
 		let id = worker.id;
 		workers.set(id, worker);
 		worker.on('message', data => {
@@ -485,7 +485,6 @@ if (cluster.isMaster) {
 		});
 	});
 	server.installHandlers(app, {});
-	if (!Config.bindaddress) Config.bindaddress = '0.0.0.0';
 	app.listen(Config.port, Config.bindaddress);
 	console.log(`Worker ${cluster.worker.id} now listening on ${Config.bindaddress}:${Config.port}`);
 


### PR DESCRIPTION
app.js already is the main module when using the launch script due to
the way the module's required. This also removes `exports.listen` from
app.js, since the launch script was the only place where it was used.
`Sockets.listen` no longer takes a bind address and number of workers to
use, since those parametres were entirely unused.