### PR TITLE
Gen 2: Use more specific pokemon ids in para/sleep messages

### DIFF
--- a/mods/gen2/statuses.js
+++ b/mods/gen2/statuses.js
@@ -19,7 +19,7 @@ exports.BattleStatuses = {
 		onBeforeMovePriority: 2,
 		onBeforeMove: function (pokemon) {
 			if (this.random(4) === 0) {
-				this.add('cant', pokemon.id, 'par');
+				this.add('cant', pokemon, 'par');
 				return false;
 			}
 		},
@@ -27,7 +27,7 @@ exports.BattleStatuses = {
 	slp: {
 		effectType: 'Status',
 		onStart: function (target) {
-			this.add('-status', target.id, 'slp');
+			this.add('-status', target, 'slp');
 			// 1-5 turns
 			this.effectData.time = this.random(2, 6);
 		},
@@ -38,7 +38,7 @@ exports.BattleStatuses = {
 				pokemon.cureStatus();
 				return;
 			}
-			this.add('cant', pokemon.id, 'slp');
+			this.add('cant', pokemon, 'slp');
 			if (move.sleepUsable) {
 				return;
 			}


### PR DESCRIPTION
Pokemon.toString() looks like ``p2a: Name`` while Pokemon.id is just ``p2: Name``. This means that the latter does not uniquely identify a pokemon when their names are the same. Because of this, the client could spew error messages because it tried to animate a pokemon with the same name that had fainted already. Example: http://replay.pokemonshowdown.com/gen2ou-569298289 turn 23.
The fact that the Standard GSC/RBY rulesets don't include Nickname Clause somewhat facilitated this, I don't know if that's intentional or an oversight.