### PR TITLE
Sockets: Go rewrite

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -25,6 +25,14 @@ exports.workers = 1;
 // TODO: allow SSL to actually be possible to use for third-party servers at
 // some point.
 
+// golang - toggle using Go instead of Node for sockets workers
+//   Node workers are more unstable at handling connections because of bugs in
+//   sockjs-node, but sending/receiving messages over connections on Go workers
+//   is slightly slower due to the extra work involved in performing IPC with
+//   them safely. This should be left set to false unless you know what you are
+//   doing.
+exports.golang = false;
+
 // proxyip - proxy IPs with trusted X-Forwarded-For headers
 //   This can be either false (meaning not to trust any proxies) or an array
 //   of strings. Each string should be either an IP address or a subnet given
@@ -32,7 +40,7 @@ exports.workers = 1;
 //   know what you are doing.
 exports.proxyip = false;
 
-// ofe - write heapdumps if sockets.js workers run out of memory.
+// ofe - write heapdumps if Node sockets workers run out of memory
 //   If you wish to enable this, you will need to install ofe, as it is not a
 //   installed by default:
 //     $ npm install --no-save ofe

--- a/dev-tools/sockets.js
+++ b/dev-tools/sockets.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const {Session, SockJSConnection} = require('sockjs/lib/transport');
+
+const chars = 'abcdefghijklmnopqrstuvwxyz1234567890-';
+let sessionidCount = 0;
+
+/**
+ * @return string
+ */
+function generateSessionid() {
+	let ret = '';
+	let idx = sessionidCount;
+	for (let i = 0; i < 8; i++) {
+		ret = chars[idx % chars.length] + ret;
+		idx = idx / chars.length | 0;
+	}
+	sessionidCount++;
+	return ret;
+}
+
+/**
+ * @param {string} sessionid
+ * @param {{options: {{}}} config
+ * @return SockJSConnection
+ */
+exports.createSocket = function (sessionid = generateSessionid(), config = {options: {}}) {
+	let session = new Session(sessionid, config);
+	let socket = new SockJSConnection(session);
+	socket.remoteAddress = '127.0.0.1';
+	socket.protocol = 'websocket';
+	return socket;
+};
+
+// TODO: move worker mocks here, use require('../sockets-workers').Multiplexer to stub IPC

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,33 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/node": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.1.tgz",
-      "integrity": "sha512-bys2VRs6H7HP8S26aHgPWSiSX7q81TToe5HSSvl5bQjoSElQ2SwbGw2p6/DSDb7Vr0oKhewFao9ZuTn8DSag9Q==",
+    "@types/cloud-env": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/cloud-env/-/cloud-env-0.2.0.tgz",
+      "integrity": "sha512-18AOYo8HyJYEmKcTt/wD4e6HGEInmKLEOWrE6qL8ran0DfyCbmxzR3R1sJKv4XjPHJOyyiXV4bH6tEnuwSgSBQ==",
       "dev": true
+    },
+    "@types/mime": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.1.tgz",
+      "integrity": "sha512-rek8twk9C58gHYqIrUlJsx8NQMhlxqHzln9Z9ODqiNgv3/s+ZwIrfr+djqzsnVM12xe9hL98iJ20lj2RvCBv6A==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "8.0.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
+      "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ==",
+      "dev": true
+    },
+    "@types/node-static": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node-static/-/node-static-0.7.0.tgz",
+      "integrity": "sha512-4SImtzapcVt+rQEAKVtbT0eh2D895DKnyrRkDgcSpw+LNnol9zlJPcU6yDvjWrEV/6nBSPQqzY0AP69v5v2iEQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "1.3.1",
+        "@types/node": "8.0.28"
+      }
     },
     "@types/nodemailer": {
       "version": "1.3.33",
@@ -16,28 +38,43 @@
       "integrity": "sha512-PONEJf/LwNcqgU/GpMIAquSBFdq+kCdpYI9TdoeGcTfLCsXzWunKzv4bUQs8zfKGz97CLymgoL0fMLYpOu+/1A==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.1",
-        "@types/nodemailer-direct-transport": "1.0.29",
-        "@types/nodemailer-smtp-transport": "2.7.2"
+        "@types/node": "8.0.28",
+        "@types/nodemailer-direct-transport": "1.0.30",
+        "@types/nodemailer-smtp-transport": "2.7.3"
       }
     },
     "@types/nodemailer-direct-transport": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.29.tgz",
-      "integrity": "sha1-Ake7RzT4u/k5gkGxa0ECLhMD3fE=",
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.30.tgz",
+      "integrity": "sha512-gH49BNkXM8EZb/UgI4hUwWwTW3izRx5L+0VyohKkbVijvfUIhn7RALSpBjCUyXzEj0XZSNmQMFVc97Lj0z8UIw==",
       "dev": true,
       "requires": {
         "@types/nodemailer": "1.3.33"
       }
     },
     "@types/nodemailer-smtp-transport": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz",
-      "integrity": "sha512-sFeTdk87Xk4ADTs7HY32Thr/sD06HJHPbmjuCOGtqVhSnMeVPf3OQAU3d4oW9bhccRLpjCWUds00CrbuU/iLzw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.3.tgz",
+      "integrity": "sha512-HxKPBErWelYVIWiKkUl06IaG4ojEMDtH6cAlojKgjsqwF8UQun4QeahYCWLCkA8/vKOX0G6VV1Vu2Z4x4ovqLQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.1",
+        "@types/node": "8.0.28",
         "@types/nodemailer": "1.3.33"
+      }
+    },
+    "@types/ofe": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/ofe/-/ofe-0.5.0.tgz",
+      "integrity": "sha512-d/yCVOHDKVLQxzXLjU3cXol59ctzrfKkjzcWrGfy3fnacZUUbs8fTBWjqRcY+dr4v/yVNOy+jLL3q2/OM1LOCQ==",
+      "dev": true
+    },
+    "@types/sockjs": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.31.tgz",
+      "integrity": "sha512-6d+6cH187jHWoUP07fzDQkC1fATu7TXMNJaCKwMwpcjkRvAK4T7bDw8sukL3rE8A/ZEPmo94YghsgCkI2/V8kw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.28"
       }
     },
     "acorn-jsx": {
@@ -719,7 +756,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {

--- a/package.json
+++ b/package.json
@@ -47,10 +47,14 @@
   "private": true,
   "license": "MIT",
   "devDependencies": {
+    "@types/cloud-env": "^0.2.0",
+    "@types/node": "^8.0.28",
+    "@types/node-static": "^0.7.0",
+    "@types/nodemailer": "^1.3.33",
+    "@types/ofe": "^0.5.0",
+    "@types/sockjs": "^0.3.31",
     "eslint": "^4.0.0",
     "mocha": "^3.0.0",
-    "@types/node": "^8.0.1",
-    "@types/nodemailer": "^1.3.33",
     "typescript": "^2.5.0-dev.20170622"
   }
 }

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -40,6 +40,88 @@ try {
 }
 
 if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
+	// Check if the server is configured to use Go, and ensure the required
+	// environment variables and dependencies are available if that is the case
+
+	let config;
+	try {
+		config = require('./config/config');
+	} catch (e) {}
+
+	if (config && config.golang) {
+		// GOPATH and GOROOT are optional to a degree, but we need them in order
+		// to be able to handle Go dependencies. Since Go only cares about the
+		// first path in the list, so will we.
+		const GOPATH = child_process.execSync('go env GOPATH', {stdio: null, encoding: 'utf8'})
+			.trim()
+			.split(path.delimiter)[0]
+			.replace(/^"(.*)"$/, '$1');
+		if (!GOPATH) {
+			// Should never happen, but it does on Bash on Ubuntu on Windows.
+			console.error('There is no $GOPATH environment variable set.');
+			process.exit(1);
+		}
+
+		const dependencies = ['github.com/gorilla/mux', 'github.com/igm/sockjs-go/sockjs'];
+		let packages = child_process.execSync('go list all', {stdio: null, encoding: 'utf8'});
+		for (let dep of dependencies) {
+			if (!packages.includes(dep)) {
+				console.log(`Installing ${dep}...`);
+				child_process.execSync(`go install ${dep}`, {stdio: 'inherit'});
+			}
+		}
+
+		let stat;
+		let needsSrcDir = false;
+		try {
+			stat = fs.lstatSync(path.resolve(GOPATH, 'src/github.com/Zarel'));
+		} catch (e) {
+			needsSrcDir = true;
+		} finally {
+			if (stat && !stat.isDirectory()) {
+				needsSrcDir = true;
+			}
+		}
+
+		let srcPath = path.resolve(process.cwd(), 'sockets');
+		let tarPath = path.resolve(GOPATH, 'src/github.com/Zarel/Pokemon-Showdown/sockets');
+		if (needsSrcDir) {
+			try {
+				fs.mkdirSync(path.resolve(GOPATH, 'src/github.com/Zarel'));
+				fs.mkdirSync(path.resolve(GOPATH, 'src/github.com/Zarel/Pokemon-Showdown'));
+			} catch (e) {
+				console.error(`Cannot make go source directory for the sockets library files! Symlink them manually from ${srcPath} to ${tarPath}`);
+				process.exit(1);
+			}
+		}
+
+		try {
+			stat = fs.lstatSync(tarPath);
+		} catch (e) {}
+
+		if (!stat || !stat.isSymbolicLink()) {
+			// Windows requires administrator privileges to make symlinks, so we
+			// make junctions instead. For our purposes they're compatible enough
+			// with symlinks on UNIX-like OSes.
+			let symlinkType = (process.platform === 'win32') ? 'junction' : 'dir';
+			try {
+				fs.symlinkSync(srcPath, tarPath, symlinkType);
+			} catch (e) {
+				console.error(`Cannot make go source directory for the sockets library files! Symlink them manually from ${srcPath} to ${tarPath}`);
+				process.exit(1);
+			}
+		}
+
+		console.log('Building Go source libs...');
+		try {
+			child_process.execSync('go install github.com/Zarel/Pokemon-Showdown/sockets', {stdio: 'inherit'});
+		} catch (e) {
+			// Go will show the errors that caused compiling Go's files to fail, so
+			// there's no reason to bother logging anything of our own.
+			process.exit(1);
+		}
+	}
+
 	// Start the server. We manually load app.js so it can be configured to run as
 	// the main module, rather than this file being considered the main module.
 	// This ensures any dependencies that were just installed can be found when

--- a/sockets-workers.js
+++ b/sockets-workers.js
@@ -1,0 +1,598 @@
+/**
+ * Connections
+ * Pokemon Showdown - http://pokemonshowdown.com/
+ *
+ * Abstraction layer for multi-process SockJS connections.
+ *
+ * This file handles all the communications between the users' browsers and
+ * the main process.
+ *
+ * @license MIT license
+ */
+
+'use strict';
+
+const cluster = require('cluster');
+const fs = require('fs');
+const path = require('path');
+
+// IPC command tokens
+const EVAL = '$';
+const SOCKET_CONNECT = '*';
+const SOCKET_DISCONNECT = '!';
+const SOCKET_RECEIVE = '<';
+const SOCKET_SEND = '>';
+const CHANNEL_ADD = '+';
+const CHANNEL_REMOVE = '-';
+const CHANNEL_BROADCAST = '#';
+const SUBCHANNEL_MOVE = '.';
+const SUBCHANNEL_BROADCAST = ':';
+
+// Subchannel IDs
+const DEFAULT_SUBCHANNEL_ID = '0';
+const P1_SUBCHANNEL_ID = '1';
+const P2_SUBCHANNEL_ID = '2';
+
+// Regex for splitting subchannel broadcasts between subchannels.
+const SUBCHANNEL_MESSAGE_REGEX = /\|split\n([^\n]*)\n([^\n]*)\n([^\n]*)\n[^\n]*/g;
+
+/**
+ * Manages the worker's state for sockets, channels, and
+ * subchannels. This is responsible for parsing all outgoing and incoming
+ * messages.
+ */
+class Multiplexer {
+	constructor() {
+		/** @type {number} */
+		this.socketCounter = 0;
+		/** @type {Map<string, any>} */
+		this.sockets = new Map();
+		/** @type {Map<string, Map<string, string>>} */
+		this.channels = new Map();
+		/** @type {?NodeJS.Timer} */
+		this.cleanupInterval = setInterval(() => this.sweepClosedSockets(), 10 * 60 * 1000);
+	}
+
+	/**
+	 * Mitigates a potential bug in SockJS or Faye-Websocket where
+	 * sockets fail to emit a 'close' event after having disconnected.
+	 */
+	sweepClosedSockets() {
+		this.sockets.forEach(socket => {
+			if (socket.protocol === 'xhr-streaming' &&
+					socket._session &&
+					socket._session.recv) {
+				socket._session.recv.didClose();
+			}
+
+			// A ghost connection's `_session.to_tref._idlePrev` (and `_idleNext`) property is `null` while
+			// it is an object for normal users. Under normal circumstances, those properties should only be
+			// `null` when the timeout has already been called, but somehow it's not happening for some connections.
+			// Simply calling `_session.timeout_cb` (the function bound to the aformentioned timeout) manually
+			// on those connections kills those connections. For a bit of background, this timeout is the timeout
+			// that sockjs sets to wait for users to reconnect within that time to continue their session.
+			if (socket._session &&
+					socket._session.to_tref &&
+					!socket._session.to_tref._idlePrev) {
+				socket._session.timeout_cb();
+			}
+		});
+
+		// Don't bother deleting the sockets from our map; their close event
+		// handler will deal with it.
+	}
+
+	/**
+	 * Sends an IPC message to the parent process.
+	 *
+	 * @param {string} token
+	 * @param {string[]} params
+	 */
+	sendUpstream(token, ...params) {
+		let message = `${token}${params.join('\n')}`;
+		if (process.send) process.send(message);
+	}
+
+	/**
+	 * Parses the params in a downstream message sent as a
+	 * command.
+	 *
+	 * @param {string} params
+	 * @param {number} count
+	 * @return {string[]}
+	 */
+	parseParams(params, count) {
+		let i = 0;
+		let idx = 0;
+		let ret = [];
+		while (i++ < count) {
+			let newIdx = params.indexOf('\n', idx);
+			if (newIdx < 0) {
+				// No remaining newlines; just use the rest of the string as
+				// the last parametre.
+				ret.push(params.slice(idx));
+				break;
+			}
+
+			let param = params.slice(idx, newIdx);
+			if (i === count) {
+				// We reached the number of parametres needed, but there is
+				// still some remaining string left. Glue it to the last one.
+				param += `\n${params.slice(newIdx + 1)}`;
+			} else {
+				idx = newIdx + 1;
+			}
+
+			ret.push(param);
+		}
+
+		return ret;
+	}
+
+	/**
+	 * Parses downstream messages.
+	 *
+	 * @param {string} data
+	 * @return {boolean}
+	 */
+	receiveDownstream(data) {
+		// console.log(`worker received: ${data}`);
+		let token = data.charAt(0);
+		let params = data.substr(1);
+		switch (token) {
+		case EVAL:
+			return this.onEval(params);
+		case SOCKET_DISCONNECT:
+			return this.onSocketDisconnect(params);
+		case SOCKET_SEND:
+			// @ts-ignore
+			return this.onSocketSend(...this.parseParams(params, 2));
+		case CHANNEL_ADD:
+			// @ts-ignore
+			return this.onChannelAdd(...this.parseParams(params, 2));
+		case CHANNEL_REMOVE:
+			// @ts-ignore
+			return this.onChannelRemove(...this.parseParams(params, 2));
+		case CHANNEL_BROADCAST:
+			// @ts-ignore
+			return this.onChannelBroadcast(...this.parseParams(params, 2));
+		case SUBCHANNEL_MOVE:
+			// @ts-ignore
+			return this.onSubchannelMove(...this.parseParams(params, 3));
+		case SUBCHANNEL_BROADCAST:
+			// @ts-ignore
+			return this.onSubchannelBroadcast(...this.parseParams(params, 2));
+		default:
+			console.error(`Sockets: attempted to send unknown IPC message with token ${token}: ${params}`);
+			return false;
+		}
+	}
+
+	/**
+	 * Safely tries to destroy a socket's connection.
+	 *
+	 * @param {any} socket
+	 */
+	tryDestroySocket(socket) {
+		try {
+			socket.destroy();
+		} catch (e) {}
+	}
+
+	/**
+	 * Eval handler for downstream messages.
+	 *
+	 * @param {string} expr
+	 * @return {boolean}
+	 */
+	onEval(expr) {
+		try {
+			eval(expr);
+			return true;
+		} catch (e) {}
+		return false;
+	}
+
+	/**
+	 * Sockets.socketConnect message handler.
+	 *
+	 * @param {any} socket
+	 * @return {boolean}
+	 */
+	onSocketConnect(socket) {
+		if (!socket) return false;
+		if (!socket.remoteAddress) {
+			this.tryDestroySocket(socket);
+			return false;
+		}
+
+		let socketid = '' + this.socketCounter++;
+		let ip = socket.remoteAddress;
+		let ips = socket.headers['x-forwarded-for'] || '';
+		this.sockets.set(socketid, socket);
+		this.sendUpstream(SOCKET_CONNECT, socketid, ip, ips, socket.protocol);
+
+		socket.on('data', /** @param {string} message */ message => {
+			this.onSocketReceive(socketid, message);
+		});
+
+		socket.on('close', () => {
+			this.sendUpstream(SOCKET_DISCONNECT, socketid);
+			this.sockets.delete(socketid);
+			this.channels.forEach((channel, channelid) => {
+				if (!channel || !channel.has(socketid)) return;
+				channel.delete(socketid);
+				if (!channel.size) this.channels.delete(channelid);
+			});
+		});
+
+		return true;
+	}
+
+	/**
+	 * Sockets.socketDisconnect message handler.
+	 * @param {string} socketid
+	 * @return {boolean}
+	 */
+	onSocketDisconnect(socketid) {
+		let socket = this.sockets.get(socketid);
+		if (!socket) return false;
+
+		this.tryDestroySocket(socket);
+		return true;
+	}
+
+	/**
+	 * Sockets.socketSend message handler.
+	 *
+	 * @param {string} socketid
+	 * @param {string} message
+	 * @return {boolean}
+	 */
+	onSocketSend(socketid, message) {
+		let socket = this.sockets.get(socketid);
+		if (!socket) return false;
+
+		socket.write(message);
+		return true;
+	}
+
+	/**
+	 * onmessage event handler for sockets. Passes the message
+	 * upstream.
+	 *
+	 * @param {string} socketid
+	 * @param {string} message
+	 * @return {boolean}
+	 */
+	onSocketReceive(socketid, message) {
+		// Drop empty messages (DDOS?).
+		if (!message) return false;
+
+		// Drop >100KB messages.
+		if (message.length > 100 * 1024) {
+			console.log(`Dropping client message ${message.length / 1024}KB...`);
+			console.log(message.slice(0, 160));
+			return false;
+		}
+
+		// Drop legacy JSON messages.
+		if ((typeof message !== 'string') || message.startsWith('{')) return false;
+
+		// Drop invalid messages (again, DDOS?).
+		if (message.endsWith('|') || !message.includes('|')) return false;
+
+		this.sendUpstream(SOCKET_RECEIVE, socketid, message);
+		return true;
+	}
+
+	/**
+	 * Sockets.channelAdd message handler.
+	 *
+	 * @param {string} channelid
+	 * @param {string} socketid
+	 * @return {boolean}
+	 */
+	onChannelAdd(channelid, socketid) {
+		if (!this.sockets.has(socketid)) return false;
+
+		if (this.channels.has(channelid)) {
+			let channel = this.channels.get(channelid);
+			if (!channel || channel.has(socketid)) return false;
+			channel.set(socketid, DEFAULT_SUBCHANNEL_ID);
+		} else {
+			let channel = new Map([[socketid, DEFAULT_SUBCHANNEL_ID]]);
+			this.channels.set(channelid, channel);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sockets.channelRemove message handler.
+	 *
+	 * @param {string} channelid
+	 * @param {string} socketid
+	 * @return {boolean}
+	 */
+	onChannelRemove(channelid, socketid) {
+		let channel = this.channels.get(channelid);
+		if (!channel || !channel.has(socketid)) return false;
+
+		channel.delete(socketid);
+		if (!channel.size) this.channels.delete(channelid);
+		return true;
+	}
+
+	/**
+	 * Sockets.channelSend and Sockets.channelBroadcast message
+	 * handler.
+	 *
+	 * @param {string} channelid
+	 * @param {string} message
+	 * @return {boolean}
+	 */
+	onChannelBroadcast(channelid, message) {
+		let channel = this.channels.get(channelid);
+		if (!channel) return false;
+
+		channel.forEach(
+			/**
+			 * @param {string} subchannelid
+			 * @param {string} socketid
+			 */
+			(subchannelid, socketid) => {
+				let socket = this.sockets.get(socketid);
+				socket.write(message);
+			}
+		);
+
+		return true;
+	}
+
+	/**
+	 * Sockets.subchannelMove message handler.
+	 *
+	 * @param {string} channelid
+	 * @param {string} subchannelid
+	 * @param {string} socketid
+	 * @return {boolean}
+	 */
+	onSubchannelMove(channelid, subchannelid, socketid) {
+		if (!this.sockets.has(socketid)) return false;
+
+		if (this.channels.has(channelid)) {
+			let channel = this.channels.get(channelid);
+			if (channel) channel.set(socketid, subchannelid);
+		} else {
+			let channel = new Map([[socketid, subchannelid]]);
+			this.channels.set(channelid, channel);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sockets.subchannelBroadcast message handler.
+	 *
+	 * @param {string} channelid
+	 * @param {string} message
+	 * @return {boolean}
+	 */
+	onSubchannelBroadcast(channelid, message) {
+		let channel = this.channels.get(channelid);
+		if (!channel) return false;
+
+		let msgs = {};
+		channel.forEach(
+			/**
+			 * @param {string} subchannelid
+			 * @param {string} socketid
+			 */
+			(subchannelid, socketid) => {
+				let socket = this.sockets.get(socketid);
+				if (!socket) return;
+
+				if (!(subchannelid in msgs)) {
+					switch (subchannelid) {
+					case DEFAULT_SUBCHANNEL_ID:
+						msgs[subchannelid] = message.replace(SUBCHANNEL_MESSAGE_REGEX, '$1');
+						break;
+					case P1_SUBCHANNEL_ID:
+						msgs[subchannelid] = message.replace(SUBCHANNEL_MESSAGE_REGEX, '$2');
+						break;
+					case P2_SUBCHANNEL_ID:
+						msgs[subchannelid] = message.replace(SUBCHANNEL_MESSAGE_REGEX, '$3');
+						break;
+					}
+				}
+
+				socket.write(msgs[subchannelid]);
+			}
+		);
+
+		return true;
+	}
+
+	/**
+	 * Cleans up the properties of the multiplexer once an internal message
+	 * from the parent process dictates that the worker disconnect. We can't
+	 * use the 'disconnect' handler for this because at that point the worker
+	 * is already disconnected.
+	 */
+	destroy() {
+		// @ts-ignore
+		clearInterval(this.cleanupInterval);
+		this.cleanupInterval = null;
+		this.sockets.forEach(socket => this.tryDestroySocket(socket));
+		this.sockets.clear();
+		this.channels.clear();
+	}
+}
+
+if (cluster.isWorker) {
+	// @ts-ignore
+	global.Config = require('./config/config');
+
+	// @ts-ignore
+	if (process.env.PSPORT) Config.port = +process.env.PSPORT;
+	// @ts-ignore
+	if (process.env.PSBINDADDR) Config.bindaddress = process.env.PSBINDADDR;
+	// @ts-ignore
+	if (+process.env.PSNOSSL) Config.ssl = null;
+
+	if (Config.ofe) {
+		try {
+			require.resolve('ofe');
+		} catch (e) {
+			if (e.code !== 'MODULE_NOT_FOUND') throw e; // should never happen
+			throw new Error(
+				'ofe is not installed, but it is a required dependency if Config.ofe is set to true! ' +
+				'Run npm install ofe and restart the server.'
+			);
+		}
+
+		// Create a heapdump if the process runs out of memory.
+		require('ofe').call();
+	}
+
+	// Graceful crash.
+	process.on('uncaughtException', err => {
+		if (Config.crashguard) require('./crashlogger')(err, `Socket process ${cluster.worker.id} (${process.pid})`, true);
+	});
+
+	let app = require('http').createServer();
+	/** @type {?NodeJS.Server} */
+	let appssl = null;
+	if (Config.ssl) {
+		let key;
+		try {
+			key = path.resolve(__dirname, Config.ssl.options.key);
+			if (!fs.lstatSync(key).isFile()) throw new Error();
+			try {
+				key = fs.readFileSync(key);
+			} catch (e) {
+				require('./crashlogger')(new Error(`Failed to read the configured SSL private key PEM file:\n${e.stack}`), `Socket process ${cluster.worker.id} (${process.pid})`, true);
+			}
+		} catch (e) {
+			console.warn('SSL private key config values will not support HTTPS server option values in the future. Please set it to use the absolute path of its PEM file.');
+			key = Config.ssl.options.key;
+		}
+
+		let cert;
+		try {
+			cert = path.resolve(__dirname, Config.ssl.options.cert);
+			if (!fs.lstatSync(cert).isFile()) throw new Error();
+			try {
+				cert = fs.readFileSync(cert);
+			} catch (e) {
+				require('./crashlogger')(new Error(`Failed to read the configured SSL certificate PEM file:\n${e.stack}`), `Socket process ${cluster.worker.id} (${process.pid})`, true);
+			}
+		} catch (e) {
+			console.warn('SSL certificate config values will not support HTTPS server option values in the future. Please set it to use the absolute path of its PEM file.');
+			cert = Config.ssl.options.cert;
+		}
+
+		if (key && cert) {
+			try {
+				// In case there are additional SSL config settings besides the key and cert...
+				appssl = require('https').createServer(Object.assign({}, Config.ssl.options, {key, cert}));
+			} catch (e) {
+				require('./crashlogger')(new Error(`The SSL settings are misconfigured:\n${e.stack}`), `Socket process ${cluster.worker.id} (${process.pid})`, true);
+			}
+		}
+	}
+
+	const StaticServer = require('node-static').Server;
+	const roomidRegex = /^\/[A-Za-z0-9][A-Za-z0-9-]*\/?$/;
+	const cssServer = new StaticServer('./config');
+	const avatarServer = new StaticServer('./config/avatars');
+	const staticServer = new StaticServer('./static');
+	/**
+	 * @param {any} req
+	 * @param {any} res
+	 */
+	const staticRequestHandler = (req, res) => {
+		// console.log(`static rq: ${req.socket.remoteAddress}:${req.socket.remotePort} -> ${req.socket.localAddress}:${req.socket.localPort} - ${req.method} ${req.url} ${request.httpVersion} - ${req.rawHeaders.join('|')}`);
+		req.resume();
+		req.addListener('end', () => {
+			if (Config.customhttpresponse &&
+					Config.customhttpresponse(req, res)) {
+				return;
+			}
+
+			let server = staticServer;
+			if (req.url === '/custom.css') {
+				server = cssServer;
+			} else if (req.url.startsWith('/avatars/')) {
+				req.url = req.url.substr(8);
+				server = avatarServer;
+			} else if (roomidRegex.test(req.url)) {
+				req.url = '/';
+			}
+
+			server.serve(req, res, e => {
+				// @ts-ignore
+				if (e && e.status === 404) {
+					staticServer.serveFile('404.html', 404, {}, req, res);
+				}
+			});
+		});
+	};
+
+	app.on('request', staticRequestHandler);
+	if (appssl) appssl.on('request', staticRequestHandler);
+
+	// Launch the SockJS server.
+	const sockjs = require('sockjs');
+	const server = sockjs.createServer({
+		sockjs_url: '//play.pokemonshowdown.com/js/lib/sockjs-1.1.1-nwjsfix.min.js',
+		log(severity, message) {
+			if (severity === 'error') console.error(`Sockets worker SockJS error: ${message}`);
+		},
+		prefix: '/showdown',
+	});
+
+	// Instantiate SockJS' multiplexer. This takes messages received downstream
+	// from the parent process and distributes them across the sockets they are
+	// targeting, as well as handling user disconnects and passing user
+	// messages upstream.
+	const multiplexer = new Multiplexer();
+
+	process.on('message', data => {
+		multiplexer.receiveDownstream(data);
+	});
+
+	// Clean up any remaining connections on disconnect. If this isn't done,
+	// the process will not exit until any remaining connections have been destroyed.
+	// Afterwards, the worker process will die on its own.
+	process.once('disconnect', () => {
+		multiplexer.destroy();
+		app.close();
+		/** @type {?NodeJS.Server} */
+		if (appssl) appssl.close();
+	});
+
+	server.on('connection', /** @param {any} socket */ socket => {
+		multiplexer.onSocketConnect(socket);
+	});
+
+	server.installHandlers(app, {});
+	app.listen(Config.port, Config.bindaddress);
+	if (appssl) {
+		// @ts-ignore
+		server.installHandlers(appssl, {});
+		appssl.listen(Config.ssl.port, Config.bindaddress);
+	}
+
+	require('./repl').start(
+		`sockets-${cluster.worker.id}-${process.pid}`,
+		/** @param {string} cmd */
+		cmd => eval(cmd)
+	);
+}
+
+module.exports = {
+	SUBCHANNEL_MESSAGE_REGEX,
+	Multiplexer,
+};

--- a/sockets/lib/commands.go
+++ b/sockets/lib/commands.go
@@ -1,0 +1,87 @@
+/**
+ * Commands
+ * https://pokemonshowdown.com/
+ *
+ * Commands are an abstraction over IPC messages sent to and received from the
+ * parent process. Each message follows a specific syntax: a one character
+ * token, followed by any number of parametres separated by newlines. Commands
+ * give the multiplexer and IPC connection a simple way to determine which
+ * struct it's meant to be handled by, before enqueueing it to be distributed
+ * to workers to finally process their payload concurrently.
+ */
+
+package sockets
+
+import "strings"
+
+// IPC message types
+const (
+	SOCKET_CONNECT       byte = '*'
+	SOCKET_DISCONNECT    byte = '!'
+	SOCKET_RECEIVE       byte = '<'
+	SOCKET_SEND          byte = '>'
+	CHANNEL_ADD          byte = '+'
+	CHANNEL_REMOVE       byte = '-'
+	CHANNEL_BROADCAST    byte = '#'
+	SUBCHANNEL_MOVE      byte = '.'
+	SUBCHANNEL_BROADCAST byte = ':'
+)
+
+var PARAM_COUNTS = map[byte]int{
+	SOCKET_CONNECT:       4,
+	SOCKET_DISCONNECT:    1,
+	SOCKET_RECEIVE:       2,
+	SOCKET_SEND:          2,
+	CHANNEL_ADD:          2,
+	CHANNEL_REMOVE:       2,
+	CHANNEL_BROADCAST:    2,
+	SUBCHANNEL_MOVE:      3,
+	SUBCHANNEL_BROADCAST: 2,
+}
+
+type Command struct {
+	token  byte      // Token designating the type of command.
+	params []string  // The command parametre list, parsed.
+	target CommandIO // The target to process this command.
+}
+
+// The multiplexer and the IPC connection both implement this interface. Its
+// purpose is solely to allow the two structs to be used in Command.
+type CommandIO interface {
+	Process(*Command) error // Invokes one of its methods using the command's token and parametres.
+}
+
+func NewCommand(msg string, target CommandIO) *Command {
+	token := msg[0]
+	count := PARAM_COUNTS[token]
+	params := strings.SplitN(msg[1:], "\n", count)
+	return &Command{
+		token:  token,
+		params: params,
+		target: target,
+	}
+}
+
+func BuildCommand(target CommandIO, token byte, params ...string) *Command {
+	return &Command{
+		token:  token,
+		params: params,
+		target: target,
+	}
+}
+
+func (c *Command) Token() byte {
+	return c.token
+}
+
+func (c *Command) Params() []string {
+	return c.params
+}
+
+func (c *Command) Message() string {
+	return string(c.token) + strings.Join(c.params, "\n")
+}
+
+func (c *Command) Process() error {
+	return c.target.Process(c)
+}

--- a/sockets/lib/commands_test.go
+++ b/sockets/lib/commands_test.go
@@ -1,0 +1,26 @@
+package sockets
+
+import "testing"
+
+type testTarget struct {
+	CommandIO
+}
+
+func TestCommands(t *testing.T) {
+	tokens := []byte{
+		SOCKET_CONNECT,
+		SOCKET_DISCONNECT,
+		SOCKET_RECEIVE,
+		SOCKET_SEND,
+		CHANNEL_ADD,
+		CHANNEL_REMOVE,
+		CHANNEL_BROADCAST,
+		SUBCHANNEL_MOVE,
+		SUBCHANNEL_BROADCAST,
+	}
+
+	cmds := make([]*Command, len(tokens))
+	for i, token := range tokens {
+		cmds[i] = NewCommand(string(token)+"1\n2\n3\n4", testTarget{})
+	}
+}

--- a/sockets/lib/config.go
+++ b/sockets/lib/config.go
@@ -1,0 +1,38 @@
+/**
+ * Config
+ * https://pokemonshowdown.com/
+ *
+ * Config is a struct representing the config settings the parent process
+ * passed to us by stringifying pertinent settings as JSON and assigning it to
+ * the $PS_CONFIG environment variable.
+ */
+
+package sockets
+
+import (
+	"encoding/json"
+	"os"
+)
+
+type sslcert struct {
+	Cert string `json:"cert"` // Path to the SSL certificate.
+	Key  string `json:"key"`  // Path to the SSL key.
+}
+
+type sslconf struct {
+	Port    string  `json:"port"`              // HTTPS server port.
+	Options sslcert `json:"options,omitempty"` // SSL config settings.
+}
+
+type config struct {
+	Workers     int     `json:"workers"`       // Number of workers for the master to spawn.
+	Port        string  `json:"port"`          // HTTP server port.
+	BindAddress string  `json:"bindAddress"`   // HTTP/HTTPS server(s) hostname.
+	SSL         sslconf `json:"ssl,omitempty"` // HTTPS config settings.
+}
+
+func NewConfig(envVar string) (c config, err error) {
+	configEnv := os.Getenv(envVar)
+	err = json.Unmarshal([]byte(configEnv), &c)
+	return
+}

--- a/sockets/lib/config_test.go
+++ b/sockets/lib/config_test.go
@@ -1,0 +1,36 @@
+package sockets
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	var c config
+	cj := []byte(`{"workers": 1, "port": ":8000", "bindAddress": "0.0.0.0", "ssl": null}`)
+	err := json.Unmarshal(cj, &c)
+	if err != nil {
+		t.Errorf("Sockets: failed to parse config JSON with SSL being null: %v", err)
+	}
+	if c.SSL.Port != "" || c.SSL.Options.Cert != "" || c.SSL.Options.Key != "" {
+		t.Errorf("Sockets: config failed to omit null SSL config")
+	}
+
+	c.SSL = sslconf{
+		Port: ":443",
+		Options: sslcert{
+			Cert: "",
+			Key:  "",
+		},
+	}
+
+	cj, _ = json.Marshal(c)
+	if err != nil {
+		t.Errorf("Sockets: failed to stringify config JSON: %v", err)
+	}
+
+	err = json.Unmarshal(cj, &c)
+	if err != nil {
+		t.Errorf("Sockets: failed to parse config JSON containing SSL config")
+	}
+}

--- a/sockets/lib/ipc.go
+++ b/sockets/lib/ipc.go
@@ -1,0 +1,128 @@
+/**
+ * IPC - Inter-Process Communication
+ * https://pokemonshowdown.com/
+ *
+ * This handles all communication between us and the parent process. The parent
+ * process creates a local TCP server using a random port. The port is passed
+ * down to us through the $PS_IPC_PORT environment variable. A TCP connection
+ * to the parent's server is created, allowing us to send messages back and
+ * forth.
+ */
+
+package sockets
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+// This must be a byte that stringifies to either a hexadecimal escape code.
+// Otherwise, it would be possible for someone to send a message with the
+// delimiter and break up messages.
+const DELIM byte = '\x03'
+
+type Connection struct {
+	addr      *net.TCPAddr // Parent process' TCP server address.
+	conn      *net.TCPConn // Connection to the parent process' TCP server.
+	mux       *Multiplexer // Target for commands originating from here.
+	listening bool         // Whether or not this is connected and listening for IPC messages.
+}
+
+func NewConnection(envVar string) (*Connection, error) {
+	port := os.Getenv(envVar)
+	addr, err := net.ResolveTCPAddr("tcp", "localhost"+port)
+	if err != nil {
+		return nil, fmt.Errorf("Sockets: failed to parse TCP address to connect to the parent process with: %v", err)
+	}
+
+	conn, err := net.DialTCP("tcp", nil, addr)
+	if err != nil {
+		return nil, fmt.Errorf("Sockets: failed to connect to TCP server: %v", err)
+	}
+
+	c := &Connection{
+		addr:      addr,
+		conn:      conn,
+		listening: false,
+	}
+
+	return c, nil
+}
+
+func (c *Connection) Listening() bool {
+	return c.listening
+}
+
+func (c *Connection) Listen(mux *Multiplexer) {
+	if c.listening {
+		return
+	}
+
+	c.mux = mux
+	c.listening = true
+
+	go func() {
+		reader := bufio.NewReader(c.conn)
+		for {
+			token, err := reader.ReadBytes(DELIM)
+			if err != nil {
+				c.conn.Close()
+				c.listening = false
+				break
+			}
+
+			var msg string
+			err = json.Unmarshal(token[:len(token)-1], &msg)
+			if err != nil {
+				fmt.Printf("Sockets: error parsing a downstream IPC message: %v\n", err)
+				continue
+			}
+
+			go func() {
+				cmd := NewCommand(msg, c.mux)
+				CmdQueue <- cmd
+			}()
+
+			time.Sleep(1 * time.Nanosecond)
+		}
+	}()
+}
+
+// Final step in evaluating commands targeted at the IPC connection.
+func (c *Connection) Process(cmd *Command) error {
+	// fmt.Printf("Sockets => IPC: %v\n", cmd.Message())
+	if !c.listening {
+		return fmt.Errorf("Sockets: can't process connection commands when the connection isn't listening yet")
+	}
+
+	msg := cmd.Message()
+	_, err := c.write(msg)
+	return err
+}
+
+func (c *Connection) Close() error {
+	if !c.listening {
+		return nil
+	}
+
+	return c.conn.Close()
+}
+
+func (c *Connection) write(msg string) (int, error) {
+	if !c.listening {
+		return 0, fmt.Errorf("Sockets: can't write messages over a connection that isn't listening yet...")
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return 0, fmt.Errorf("Sockets: failed to parse upstream IPC message: %v", err)
+	}
+
+	// The max allowed length for a message that Multiplexer.socketReceive will
+	// not drop is short enough for us not to need to buffer here.
+	return c.conn.Write(append(data, DELIM))
+}

--- a/sockets/lib/ipc_test.go
+++ b/sockets/lib/ipc_test.go
@@ -1,0 +1,38 @@
+package sockets
+
+import (
+	"net"
+	"os"
+	"testing"
+)
+
+func TestConnection(t *testing.T) {
+	port := ":3000"
+	ln, err := net.Listen("tcp", "localhost"+port)
+	defer ln.Close()
+	if err != nil {
+		t.Errorf("Sockets: failed to launch TCP server on port %v: %v", port, err)
+	}
+
+	envVar := "PS_IPC_PORT"
+	err = os.Setenv(envVar, port)
+	if err != nil {
+		t.Errorf("Sockets: failed to set %v environment variable: %v", envVar, port)
+	}
+
+	conn, err := NewConnection(envVar)
+	defer conn.Close()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	mux := NewMultiplexer()
+	mux.Listen(conn)
+	conn.Listen(mux)
+
+	cmd := BuildCommand(mux, SOCKET_SEND, "0", "|ayy lmao")
+	err = conn.Process(cmd)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+}

--- a/sockets/lib/master.go
+++ b/sockets/lib/master.go
@@ -1,0 +1,82 @@
+/**
+ * Master - Master/Worker pattern implementation
+ * https://pokemonshowdown.com/
+ *
+ * This makes it possible to parse messages from sockets and the parent process
+ * concurrently. A command queue stores commands created by the multiplexer and
+ * IPC connection. The master contains a pool of command channels belonging to
+ * workers. Once a command is available in the queue, the master takes a
+ * worker's command channel from its pool and enqueues it. The worker takes the
+ * command and processes it before enqueueing its command channel back into the
+ * master's pool. The workers are distributed round-robin, much like Node's
+ * cluster module (when not using Windows).
+ */
+
+package sockets
+
+// A global command channel for the multiplexer and IPC connection to enqueue
+// their new commands to be processed by the workers.
+var CmdQueue = make(chan *Command)
+
+type master struct {
+	wpool chan chan *Command // Pool of worker command queues.
+	count int                // Number of workers.
+}
+
+func NewMaster(count int) *master {
+	wpool := make(chan chan *Command, count)
+	return &master{
+		wpool: wpool,
+		count: count,
+	}
+}
+
+// Create the initial set of workers and make them listen before the master.
+func (m *master) Spawn() {
+	for i := 0; i < m.count; i++ {
+		w := newWorker(m.wpool)
+		w.listen()
+	}
+}
+
+// Listen for new commands to remove from the command queue and pass to the
+// first available worker.
+func (m *master) Listen() {
+	for {
+		cmd := <-CmdQueue
+		cmdch := <-m.wpool
+		cmdch <- cmd
+	}
+}
+
+type worker struct {
+	wpool chan chan *Command // The master's pool of worker command queues.
+	cmdch chan *Command      // Queue for incoming commands from CmdQueue.
+	quit  chan bool          // Channel used to kill the worker when needed.
+}
+
+func newWorker(wpool chan chan *Command) *worker {
+	cmdch := make(chan *Command)
+	quit := make(chan bool)
+	return &worker{
+		wpool: wpool,
+		cmdch: cmdch,
+		quit:  quit,
+	}
+}
+
+func (w *worker) listen() {
+	go func() {
+		for {
+			w.wpool <- w.cmdch
+			select {
+			case cmd := <-w.cmdch:
+				// Invokes *Multiplexer.Process or *Connection.Process, where
+				// the command is finally handled and used to update state.
+				cmd.target.Process(cmd)
+			case <-w.quit:
+				return
+			}
+		}
+	}()
+}

--- a/sockets/lib/master_test.go
+++ b/sockets/lib/master_test.go
@@ -1,0 +1,85 @@
+package sockets
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/igm/sockjs-go/sockjs"
+)
+
+type testSocket struct {
+	sockjs.Session
+}
+
+func (ts testSocket) Send(msg string) error {
+	return nil
+}
+
+func (ts testSocket) Close(code uint32, signal string) error {
+	return nil
+}
+
+func (ts testSocket) Request() *http.Request {
+	return &http.Request{}
+}
+
+func TestMasterListen(t *testing.T) {
+	t.Parallel()
+	ln, _ := net.Listen("tcp", "localhost:3000")
+	defer ln.Close()
+
+	conn, _ := NewConnection("PS_IPC_PORT")
+	defer conn.Close()
+
+	mux := NewMultiplexer()
+	mux.Listen(conn)
+	conn.Listen(mux)
+
+	m := NewMaster(4)
+	m.Spawn()
+	go m.Listen()
+
+	for i := 0; i < m.count*250; i++ {
+		id := strconv.Itoa(i)
+		t.Run("Worker/Multiplexer command #"+id, func(t *testing.T) {
+			go func(id string, mux *Multiplexer, conn *Connection) {
+				mux.smux.Lock()
+				sid := strconv.FormatUint(mux.nsid, 10)
+				mux.sockets[sid] = testSocket{}
+				mux.nsid++
+				mux.smux.Unlock()
+
+				cmd := BuildCommand(mux, SOCKET_DISCONNECT, sid)
+				cmd.Process()
+				if len(CmdQueue) != 0 {
+					t.Error("Sockets: master failed to pass command struct from worker to multiplexer")
+				}
+
+				mux.socketRemove(sid, true)
+			}(id, mux, conn)
+		})
+		t.Run("Worker/Connection command #"+id, func(t *testing.T) {
+			go func(id string, mux *Multiplexer, conn *Connection) {
+				mux.smux.Lock()
+				sid := strconv.FormatUint(mux.nsid, 10)
+				mux.sockets[sid] = testSocket{}
+				mux.nsid++
+				mux.smux.Unlock()
+
+				cmd := BuildCommand(conn, SOCKET_CONNECT, sid, "0.0.0.0", "", "websocket")
+				cmd.Process()
+				if len(CmdQueue) != 0 {
+					t.Error("Sockets: master failed to pass command struct from worker to connection")
+				}
+
+				mux.socketRemove(sid, true)
+			}(id, mux, conn)
+		})
+	}
+
+	for len(m.wpool) > 0 {
+		<-m.wpool
+	}
+}

--- a/sockets/lib/multiplexer.go
+++ b/sockets/lib/multiplexer.go
@@ -1,0 +1,373 @@
+/**
+ * Multiplexer - Socket/Channel/Subchannel state machine
+ * https://pokemonshowdown.com/
+ *
+ * This keeps track of the sockets that connect to the SockJS server. Sockets
+ * are stored in the multiplexer to allow the parent process to manipulate them
+ * as it pleases. Channels represent rooms in the parent process; subchannels
+ * split battle rooms into three groups: side 1, side 2, and spectators.
+ * Certain messages will display differently depending on which subchannel the
+ * user's socket is in.
+ */
+
+package sockets
+
+import (
+	"fmt"
+	"net"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/igm/sockjs-go/sockjs"
+)
+
+// Subchannel IDs
+const (
+	DEFAULT_SUBCHANNEL_ID byte = '0'
+	P1_SUBCHANNEL_ID      byte = '1'
+	P2_SUBCHANNEL_ID      byte = '2'
+)
+
+// Map of socket IDs to subchannel IDs.
+type Channel map[string]byte
+
+type Multiplexer struct {
+	nsid     uint64                    // Socket ID counter.
+	sockets  map[string]sockjs.Session // Map of socket IDs to sockets.
+	smux     sync.RWMutex              // nsid and sockets mutex.
+	channels map[string]Channel        // Map of channel (i.e. room) IDs to channels.
+	cmux     sync.RWMutex              // channels mutex.
+	scre     *regexp.Regexp            // Regex for splitting subchannel broadcasts into their three messages.
+	conn     *Connection               // Target for commands originating from here.
+}
+
+func NewMultiplexer() *Multiplexer {
+	sockets := make(map[string]sockjs.Session)
+	channels := make(map[string]Channel)
+	scre := regexp.MustCompile(`\|split\n([^\n]*)\n([^\n]*)\n([^\n]*)\n[^\n]*`)
+	return &Multiplexer{
+		sockets:  sockets,
+		channels: channels,
+		scre:     scre,
+	}
+}
+
+func (m *Multiplexer) Listen(conn *Connection) {
+	m.conn = conn
+}
+
+func (m *Multiplexer) Process(cmd *Command) (err error) {
+	// fmt.Printf("IPC => Sockets: %v\n", cmd.Message())
+	params := cmd.Params()
+
+	// Parse the command's params and call the appropriate method.
+	switch token := cmd.Token(); token {
+	case SOCKET_DISCONNECT:
+		sid := params[0]
+		err = m.socketRemove(sid, true)
+	case SOCKET_SEND:
+		sid := params[0]
+		msg := params[1]
+		err = m.socketSend(sid, msg)
+	case SOCKET_RECEIVE:
+		sid := params[0]
+		msg := params[1]
+		err = m.socketReceive(sid, msg)
+	case CHANNEL_ADD:
+		cid := params[0]
+		sid := params[1]
+		err = m.channelAdd(cid, sid)
+	case CHANNEL_REMOVE:
+		cid := params[0]
+		sid := params[1]
+		err = m.channelRemove(cid, sid)
+	case CHANNEL_BROADCAST:
+		cid := params[0]
+		msg := params[1]
+		err = m.channelBroadcast(cid, msg)
+	case SUBCHANNEL_MOVE:
+		cid := params[0]
+		scid := params[1][0]
+		sid := params[2]
+		err = m.subchannelMove(cid, scid, sid)
+	case SUBCHANNEL_BROADCAST:
+		cid := params[0]
+		msg := params[1]
+		err = m.subchannelBroadcast(cid, msg)
+	default:
+		err = fmt.Errorf("Sockets: received unknown message of type %v: %v", cmd.Token(), cmd.Message())
+	}
+
+	if err != nil {
+		// Message timing error.
+		// fmt.Printf("%v\n", err)
+	}
+
+	return
+}
+
+func (m *Multiplexer) socketAdd(s sockjs.Session) (sid string) {
+	nsid := atomic.LoadUint64(&m.nsid)
+	sid = strconv.FormatUint(nsid, 10)
+	atomic.AddUint64(&m.nsid, 1)
+
+	m.smux.Lock()
+	m.sockets[sid] = s
+	m.smux.Unlock()
+
+	if !m.conn.Listening() {
+		s.Close(1000, "Normal closure")
+		return
+	}
+
+	req := s.Request()
+	ip, _, _ := net.SplitHostPort(req.RemoteAddr)
+	ips := req.Header.Get("X-Forwarded-For")
+	protocol := path.Base(req.URL.Path)
+
+	go func() {
+		cmd := BuildCommand(m.conn, SOCKET_CONNECT, sid, ip, ips, protocol)
+		CmdQueue <- cmd
+	}()
+
+	time.Sleep(1 * time.Nanosecond)
+
+	return
+}
+
+func (m *Multiplexer) socketRemove(sid string, forced bool) error {
+	m.cmux.Lock()
+	for cid, c := range m.channels {
+		if _, ok := c[sid]; ok {
+			delete(c, sid)
+			if len(c) == 0 {
+				delete((*m).channels, cid)
+			}
+		}
+	}
+	m.cmux.Unlock()
+
+	m.smux.Lock()
+	defer m.smux.Unlock()
+
+	s, ok := m.sockets[sid]
+	if ok {
+		delete((*m).sockets, sid)
+	} else {
+		return fmt.Errorf("Sockets: attempted to remove non-existent socket of ID %v", sid)
+	}
+
+	if forced {
+		s.Close(1000, "Normal closure")
+		return nil
+	}
+
+	if m.conn.Listening() {
+		go func() {
+			cmd := BuildCommand(m.conn, SOCKET_DISCONNECT, sid)
+			CmdQueue <- cmd
+		}()
+
+		time.Sleep(1 * time.Nanosecond)
+	}
+
+	return nil
+}
+
+func (m *Multiplexer) socketReceive(sid string, msg string) error {
+	m.smux.RLock()
+	defer m.smux.RUnlock()
+
+	if _, ok := m.sockets[sid]; ok {
+		// Drop empty messages (DDOS?).
+		if len(msg) == 0 {
+			return nil
+		}
+
+		// Drop >100KB messages.
+		if len(msg) > 100*1024 {
+			fmt.Printf("Dropping client message %vKB...\n%v\n", len(msg)/1024, msg[:160])
+			return nil
+		}
+
+		// Drop legacy JSON messages.
+		if strings.HasPrefix(msg, "{") {
+			return nil
+		}
+
+		// Drop invalid messages (again, DDOS?).
+		if strings.HasSuffix(msg, "|") || !strings.Contains(msg, "|") {
+			return nil
+		}
+
+		if m.conn.Listening() {
+			go func() {
+				cmd := BuildCommand(m.conn, SOCKET_RECEIVE, sid, msg)
+				CmdQueue <- cmd
+			}()
+
+			time.Sleep(1 * time.Nanosecond)
+		}
+
+		return nil
+	}
+
+	// This should never happen. If it does, it's likely a SockJS bug.
+	return fmt.Errorf("Sockets: received message for a non-existent socket of ID %v: %v", sid, msg)
+}
+
+func (m *Multiplexer) socketSend(sid string, msg string) error {
+	m.smux.RLock()
+	defer m.smux.RUnlock()
+
+	if s, ok := m.sockets[sid]; ok {
+		s.Send(msg)
+		return nil
+	}
+
+	return fmt.Errorf("Sockets: attempted to send to non-existent socket of ID %v: %v", sid, msg)
+}
+
+func (m *Multiplexer) channelAdd(cid string, sid string) error {
+	m.cmux.Lock()
+	defer m.cmux.Unlock()
+
+	c, ok := m.channels[cid]
+	if !ok {
+		c = make(Channel)
+		m.channels[cid] = c
+	}
+
+	c[sid] = DEFAULT_SUBCHANNEL_ID
+
+	return nil
+}
+
+func (m *Multiplexer) channelRemove(cid string, sid string) error {
+	m.cmux.Lock()
+	defer m.cmux.Unlock()
+
+	c, ok := m.channels[cid]
+	if ok {
+		if _, ok = c[sid]; !ok {
+			return fmt.Errorf("Sockets: failed to remove non-existent socket of ID %v from channel %v", sid, cid)
+		}
+	} else {
+		// This happens on user-initiated disconnect. Mitigate until this race
+		// condition is fixed.
+		return nil
+	}
+
+	delete(c, sid)
+	if len(c) == 0 {
+		delete((*m).channels, cid)
+	}
+
+	return nil
+}
+
+func (m *Multiplexer) channelBroadcast(cid string, msg string) error {
+	m.cmux.RLock()
+	defer m.cmux.RUnlock()
+
+	c, ok := m.channels[cid]
+	if !ok {
+		// This happens occasionally when the sole user in a room leaves.
+		// Mitigate until this race condition is fixed.
+		return nil
+	}
+
+	m.smux.RLock()
+	defer m.smux.RUnlock()
+
+	for sid := range c {
+		var s sockjs.Session
+		if s, ok = m.sockets[sid]; ok {
+			s.Send(msg)
+		} else {
+			return fmt.Errorf("Sockets: attempted to broadcast to non-existent socket of ID %v in channel %v: %v", sid, cid, msg)
+		}
+	}
+
+	return nil
+}
+
+func (m *Multiplexer) subchannelMove(cid string, scid byte, sid string) error {
+	m.cmux.Lock()
+	defer m.cmux.Unlock()
+
+	c, ok := m.channels[cid]
+	if !ok {
+		return fmt.Errorf("Sockets: attempted to move socket of ID %v in non-existent channel %v to subchannel %v", sid, cid, scid)
+	}
+
+	c[sid] = scid
+	return nil
+}
+
+func (m *Multiplexer) subchannelBroadcast(cid string, msg string) error {
+	m.cmux.RLock()
+	defer m.cmux.RUnlock()
+
+	c, ok := m.channels[cid]
+	if !ok {
+		return fmt.Errorf("Sockets: attempted to broadcast to subchannels in channel %v, which doesn't exist: %v", cid, msg)
+	}
+
+	m.smux.RLock()
+	defer m.smux.RUnlock()
+
+	msgs := make(map[byte]string)
+	for sid, scid := range c {
+		s, ok := m.sockets[sid]
+		if !ok {
+			return fmt.Errorf("Sockets: attempted to broadcast to subchannels in channel %v, but socket of ID %v doesn't exist: %v", cid, sid, msg)
+		}
+
+		if _, ok := msgs[scid]; !ok {
+			switch scid {
+			case DEFAULT_SUBCHANNEL_ID:
+				msgs[scid] = m.scre.ReplaceAllString(msg, "$1")
+			case P1_SUBCHANNEL_ID:
+				msgs[scid] = m.scre.ReplaceAllString(msg, "$2")
+			case P2_SUBCHANNEL_ID:
+				msgs[scid] = m.scre.ReplaceAllString(msg, "$3")
+			}
+		}
+
+		s.Send(msgs[scid])
+	}
+
+	return nil
+}
+
+// This is the HTTP handler for the SockJS server. This is where new sockets
+// arrive for us to use.
+func (m *Multiplexer) Handler(s sockjs.Session) {
+	sid := m.socketAdd(s)
+	for {
+		msg, err := s.Recv()
+		if err != nil {
+			if err == sockjs.ErrSessionNotOpen {
+				// User disconnected.
+			} else {
+				fmt.Printf("Sockets: SockJS error on message receive for socket of ID %v: %v\n", sid, err)
+			}
+			break
+		}
+
+		if err = m.socketReceive(sid, msg); err != nil {
+			fmt.Printf("%v\n", err)
+			break
+		}
+	}
+
+	if err := m.socketRemove(sid, false); err != nil {
+		fmt.Printf("%v\n", err)
+	}
+}

--- a/sockets/lib/multiplexer_test.go
+++ b/sockets/lib/multiplexer_test.go
@@ -1,0 +1,131 @@
+package sockets
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestMultiplexer(t *testing.T) {
+	port := ":3000"
+	ln, _ := net.Listen("tcp", "localhost"+port)
+	defer ln.Close()
+
+	conn, _ := NewConnection("PS_IPC_PORT")
+	defer conn.Close()
+	mux := NewMultiplexer()
+	mux.Listen(conn)
+	// Do not make the connection listen.
+
+	ts := testSocket{}
+	t.Run("socketAdd", func(t *testing.T) {
+		sid := mux.socketAdd(ts)
+		if len(mux.sockets) != 1 {
+			t.Errorf("Sockets: expected sockets length to be %v, but is actually %v", 1, len(mux.sockets))
+		}
+		delete((*mux).sockets, sid)
+	})
+	t.Run("socketRemove", func(t *testing.T) {
+		sid := mux.socketAdd(ts)
+		if err := mux.socketRemove(sid, true); err != nil {
+			t.Errorf("%v", err)
+		}
+		if len(mux.sockets) != 0 {
+			t.Errorf("Sockets: expected sockets length to be %v, but is actually %v", 0, len(mux.sockets))
+		}
+		if err := mux.socketRemove(sid, true); err == nil {
+			t.Errorf("Sockets: did not remove socket of ID %v on socket remove", sid)
+		}
+
+		sid = mux.socketAdd(ts)
+		if err := mux.socketRemove(sid, false); err != nil {
+			t.Errorf("%v", err)
+		}
+		if err := mux.socketRemove(sid, false); err == nil {
+			t.Errorf("Sockets: did not remove socket of ID %v on socket remove", sid)
+		}
+	})
+	t.Run("socketSend", func(t *testing.T) {
+		sid := mux.socketAdd(ts)
+		if err := mux.socketSend(sid, ">global\n|ayy lmao"); err != nil {
+			t.Errorf("%v", err)
+		}
+		mux.socketRemove(sid, true)
+	})
+	t.Run("channelAdd", func(t *testing.T) {
+		sid := mux.socketAdd(ts)
+		cid := "global"
+		if err := mux.channelAdd(cid, sid); err != nil {
+			t.Errorf("%v", err)
+		}
+		if len(mux.channels) != 1 {
+			t.Errorf("Sockets: expected channels length to be %v, but is actually %v", 1, len(mux.channels))
+		}
+		if err := mux.channelAdd(cid, sid); err != nil {
+			t.Errorf("%v", err)
+		}
+		mux.channelRemove(cid, sid)
+		mux.socketRemove(sid, true)
+	})
+	t.Run("channelRemove", func(t *testing.T) {
+		sid := mux.socketAdd(ts)
+		cid := "global"
+		mux.channelAdd(cid, sid)
+		if err := mux.channelRemove(cid, sid); err != nil {
+			t.Errorf("%v", err)
+		}
+		if len(mux.channels) != 0 {
+			t.Errorf("Sockets: expected channels length to be %v, but is actually %v", 0, len(mux.channels))
+		}
+		if err := mux.channelRemove(cid, sid); err != nil {
+			t.Errorf("%v", err)
+		}
+		mux.socketRemove(sid, true)
+	})
+	t.Run("channelBroadcast", func(t *testing.T) {
+		sid := mux.socketAdd(ts)
+		cid := "global"
+		mux.channelAdd(cid, sid)
+		if err := mux.channelBroadcast(cid, "|raw|ayy lmao"); err != nil {
+			t.Errorf("%v", err)
+		}
+		mux.channelRemove(cid, sid)
+		if err := mux.channelBroadcast(cid, "|raw|ayy lmao"); err != nil {
+			t.Errorf("%v", err)
+		}
+		mux.socketRemove(sid, true)
+	})
+	t.Run("subchannelMove", func(t *testing.T) {
+		sid := mux.socketAdd(ts)
+		cid := "global"
+		mux.channelAdd(cid, sid)
+		if err := mux.subchannelMove(cid, P1_SUBCHANNEL_ID, sid); err != nil {
+			t.Errorf("%v", err)
+		}
+		if scid := mux.channels[cid][sid]; scid != P1_SUBCHANNEL_ID {
+			t.Errorf("Sockets: expected subchannel for socket of ID %v in channel %v to be %v, but is actually %v", sid, cid, P1_SUBCHANNEL_ID, scid)
+		}
+		mux.channelRemove(cid, sid)
+		mux.socketRemove(sid, true)
+	})
+	t.Run("subchannelBroadcast", func(t *testing.T) {
+		msg := "|split\n0\n1\n2\n|\n|split\n3\n4\n5\n|"
+		scids := []byte{DEFAULT_SUBCHANNEL_ID, P1_SUBCHANNEL_ID, P2_SUBCHANNEL_ID}
+		for idx, scid := range scids {
+			amsg := mux.scre.ReplaceAllString(msg, fmt.Sprintf("$%v", idx+1))
+			if emsg := fmt.Sprintf("%v\n%v", idx, idx+3); emsg != amsg {
+				t.Errorf("Sockets: expected broadcast to subchannel of ID %v to be %v, but is actually %v", string(scid), emsg, amsg)
+			}
+		}
+
+		sid := mux.socketAdd(ts)
+		cid := "global"
+		mux.channelAdd(cid, sid)
+		mux.subchannelMove(cid, P1_SUBCHANNEL_ID, sid)
+		if err := mux.subchannelBroadcast(cid, msg); err != nil {
+			t.Errorf("%v", err)
+		}
+		mux.channelRemove(cid, sid)
+		mux.socketRemove(sid, true)
+	})
+}

--- a/sockets/main.go
+++ b/sockets/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"crypto/tls"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"path/filepath"
+
+	"github.com/Zarel/Pokemon-Showdown/sockets/lib"
+
+	"github.com/gorilla/mux"
+	"github.com/igm/sockjs-go/sockjs"
+)
+
+func main() {
+	// Parse our config settings passed through the $PS_CONFIG environment
+	// variable by the parent process.
+	config, err := sockets.NewConfig("PS_CONFIG")
+	if err != nil {
+		log.Fatalf("Sockets: failed to read parent's config settings from environment: %v")
+	}
+
+	// Instantiate the socket multiplexer and IPC struct.
+	smux := sockets.NewMultiplexer()
+	conn, err := sockets.NewConnection("PS_IPC_PORT")
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	// Begin listening for incoming messages from sockets and the TCP
+	// connection to the parent process. For now, they'll just get enqueued
+	// for workers to manage later.
+	smux.Listen(conn)
+	conn.Listen(smux)
+
+	// Set up routing.
+	r := mux.NewRouter()
+
+	opts := sockjs.Options{
+		SockJSURL:       "//play.pokemonshowdown.com/js/lib/sockjs-1.1.1-nwjsfix.min.js",
+		Websocket:       true,
+		RawWebsocket:    true,
+		HeartbeatDelay:  sockjs.DefaultOptions.HeartbeatDelay,
+		DisconnectDelay: sockjs.DefaultOptions.DisconnectDelay,
+		JSessionID:      sockjs.DefaultOptions.JSessionID,
+	}
+
+	r.PathPrefix("/showdown").
+		Handler(sockjs.NewHandler("/showdown", opts, smux.Handler))
+
+	customCssDir, _ := filepath.Abs("./config")
+	r.Handle("/custom.css", http.FileServer(http.Dir(customCssDir)))
+
+	avatarDir, _ := filepath.Abs("./config/avatars")
+	r.PathPrefix("/avatars/").
+		Handler(http.StripPrefix("/avatars/", http.FileServer(http.Dir(avatarDir))))
+
+	indexPath, _ := filepath.Abs("./static/index.html")
+	r.PathPrefix("/{roomid:[A-Za-z0-9][A-Za-z0-9-]*}").
+		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFile(w, r, indexPath)
+		})
+
+	notFoundPath, _ := filepath.Abs("./static/404.html")
+	notFoundPage, _ := ioutil.ReadFile(notFoundPath)
+	r.NotFoundHandler =
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write(notFoundPage)
+		})
+
+	staticDir, _ := filepath.Abs("./static")
+	r.Handle("/", http.FileServer(http.Dir(staticDir)))
+
+	// Begin serving over HTTP.
+	go func(ba string, port string) {
+		addr, err := net.ResolveTCPAddr("tcp4", ba+port)
+		if err != nil {
+			log.Fatalf("Sockets: failed to resolve the TCP address of the parent's server: %v", err)
+		}
+
+		ln, err := net.ListenTCP("tcp4", addr)
+		defer ln.Close()
+		if err != nil {
+			log.Fatalf("Sockets: failed to listen over HTTP: %v", err)
+		}
+
+		err = http.Serve(ln, r)
+		log.Fatalf("Sockets: HTTP server failed: %v", err)
+	}(config.BindAddress, config.Port)
+
+	// Begin serving over HTTPS if configured to do so.
+	if config.SSL.Options.Cert != "" && config.SSL.Options.Key != "" {
+		go func(ba string, port string, cert string, key string) {
+			certs, err := tls.LoadX509KeyPair(cert, key)
+			if err != nil {
+				log.Fatalf("Sockets: failed to load certificate and key files for TLS: %v", err)
+			}
+
+			srv := &http.Server{
+				Handler:   r,
+				Addr:      ba + port,
+				TLSConfig: &tls.Config{Certificates: []tls.Certificate{certs}},
+			}
+
+			var ln net.Listener
+			ln, err = tls.Listen("tcp4", srv.Addr, srv.TLSConfig)
+			if err != nil {
+				log.Fatalf("Sockets: failed to listen over HTTPS: %v", err)
+			}
+
+			defer ln.Close()
+			err = http.Serve(ln, r)
+			log.Fatalf("Sockets: HTTPS server failed: %v", err)
+		}(config.BindAddress, config.SSL.Port, config.SSL.Options.Cert, config.SSL.Options.Key)
+	}
+
+	// Finally, spawn workers.to pipe messages received at the multiplexer or
+	// IPC connection to each other concurrently.
+	master := sockets.NewMaster(config.Workers)
+	master.Spawn()
+	master.Listen()
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,13 @@
         "./sim/prng.js",
         "./crashlogger.js",
         "./dnsbl.js",
+        "./fs.js",
         "./ladders-matchmaker.js",
         "./monitor.js",
-        "./repl.js",
-        "./fs.js",
         "./process-manager.js",
+        "./repl.js",
+        "./sockets.js",
+        "./sockets-workers.js",
         "./verifier.js"
     ]
 }


### PR DESCRIPTION
WIP

This turned into a pretty substantial refactor of the Node version of
sockets-related code to not only make using Go child processes
possible, but to optimize it and make unit testing of it and any code
dependent on it possible to write entirely synchronously. `sockets.js`
and `sockets-workers.js` are now written in Typescript, though they won't
be able to be transpiled until after `repl.js`, `crashmonitor.js`, `Config`, `Users`, `Dnsbl`, and `Monitor`
work with it as well.

**Breaking changes:** 
- this changes the requirements for the values of Config.ssl.options.cert and Config.ssl.options.key; they must be absolute paths to their corresponding files, not a buffer of their files' contents**

Fixes #2943