### PR TITLE
Fix mismatch between Z moves and base moves

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -819,7 +819,10 @@ exports.BattleScripts = {
 		let atLeastOne = false;
 		let zMoves = [];
 		for (let i = 0; i < pokemon.moves.length; i++) {
-			if (pokemon.moveset[i].pp <= 0) continue;
+			if (pokemon.moveset[i].pp <= 0) {
+				zMoves.push(null);
+				continue;
+			}
 			let move = this.getMove(pokemon.moves[i]);
 			let zMoveName = this.getZMove(move, pokemon, true) || '';
 			if (zMoveName) {


### PR DESCRIPTION
Moves without PP would be skipped entirely, making the canZMove array come up short in those cases, causing the button positions to not match up in the client, making the client send invalid Z move choices.