### PR TITLE
Prevent weak Punishments from overriding stronger ones 

### DIFF
--- a/punishments.js
+++ b/punishments.js
@@ -394,6 +394,20 @@ setImmediate(() => {
  * @param {?Set<string>} recursionKeys
  */
 Punishments.punish = function (user, punishment, recursionKeys) {
+	let existingPunishment = Punishments.userids.get(toId(user.name));
+	if (existingPunishment) {
+		// don't reduce the duration of an existing punishment
+		if (existingPunishment[2] > punishment[2]) {
+			punishment[2] = existingPunishment[2];
+		}
+
+		// don't override stronger punishment types
+		const types = ['LOCK', 'NAMELOCK', 'BAN'];
+		if (types.indexOf(existingPunishment[0]) > types.indexOf(punishment[0])) {
+			punishment[0] = existingPunishment[0];
+		}
+	}
+
 	let keys = recursionKeys || new Set();
 
 	if (!recursionKeys) {


### PR DESCRIPTION
This fixes the following problems:
- Users frequently get locked and weeklocked in two different places.
What punishment they end up getting depends on which is applied first
- Namelocking weeklocked users reduces the duration
- Autolocks could potentially reduce punishments