### PR TITLE
Added link to another chatbot implementation

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -17,6 +17,8 @@ Client implementations you might want to look at for reference include:
     https://github.com/pickdenis/ps-chatbot
 - Quinella and TalkTakesTime's chat bot (Node.js) -
     https://github.com/TalkTakesTime/Pokemon-Showdown-Bot
+- Nixola's chat bot (Lua) -
+    https://github.com/Nixola/NixPSbot
 - the official client (HTML5 + JavaScript) -
     https://github.com/Zarel/Pokemon-Showdown-Client
 


### PR DESCRIPTION
I added a link to my chatbot in protocol.md. I just started commenting the code, so it isn't well documented yet, and I still have to clean some stuff up, but it can still serve as a guide or a base for anyone who wishes to create their bot, learn with an actual example how PS works, and more. Since it's written in Lua, which none of the examples yet use, I thought it could be a nice addition to the list. I plan on making battles available in the future, but I'm afraid that's a feature worth of a summer.