### PR TITLE
Move Illusion-breaking out of the battle engine

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1450,8 +1450,11 @@ exports.BattleAbilities = {
 			if (pokemon === pokemon.side.pokemon[i]) return;
 			pokemon.illusion = pokemon.side.pokemon[i];
 		},
-		// illusion clearing for damage is hardcoded in the damage
-		// function because mold breaker inhibits the damage event
+		onAfterDamage: function (damage, target, source, effect) {
+			if (target.illusion && effect && effect.effectType === 'Move' && effect.id !== 'confused') {
+				this.singleEvent('End', this.getAbility('Illusion'), target.abilityData, target, source, effect);
+			}
+		},
 		onEnd: function (pokemon) {
 			if (pokemon.illusion) {
 				this.debug('illusion cleared');
@@ -1464,6 +1467,7 @@ exports.BattleAbilities = {
 		onFaint: function (pokemon) {
 			pokemon.illusion = null;
 		},
+		isUnbreakable: true,
 		id: "illusion",
 		name: "Illusion",
 		rating: 4,

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1511,9 +1511,6 @@ class Battle extends Dex.ModdedDex {
 				this.debug('damage event failed');
 				return damage;
 			}
-			if (target.illusion && target.hasAbility('Illusion') && effect && effect.effectType === 'Move' && effect.id !== 'confused') {
-				this.singleEvent('End', this.getAbility('Illusion'), target.abilityData, target, source, effect);
-			}
 		}
 		if (damage !== 0) damage = this.clampIntRange(damage, 1);
 		damage = target.damage(damage, source, effect);


### PR DESCRIPTION
This is mainly on the off-chance that [Dancerability ](https://www.smogon.com/forums/threads/3600658/) wins LC/OMotM, in which case it will want to be able to extend the illusion-breaking event.

This works because we can make the ability Unbreakable which means that it gets the AfterDamage event even when the attacker has a Mold Breaker clone.