### PR TITLE
Fix Refrigerate Boost

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2687,7 +2687,7 @@ exports.BattleAbilities = {
 			duration: 1,
 			onBasePowerPriority: 8,
 			onBasePower: function (basePower, pokemon, target, move) {
-				return this.chainModify([0x14CD, 0x1000]);
+				return this.chainModify([0x1333, 0x1000]);
 			},
 		},
 		id: "refrigerate",

--- a/mods/gen6/abilities.js
+++ b/mods/gen6/abilities.js
@@ -112,7 +112,7 @@ exports.BattleAbilities = {
 			duration: 1,
 			onBasePowerPriority: 8,
 			onBasePower: function (basePower, pokemon, target, move) {
-				return this.chainModify([0x1333, 0x1000]);
+				return this.chainModify([0x14CD, 0x1000]);
 			},
 		},
 	},


### PR DESCRIPTION
The description for Refrigerate claims it has been updated to the 1.2x boost applied in Gen 7, however the value is still set to the 1.3x from previous generations