### PR TITLE
Don't allow Power Construct with another Uber

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -297,7 +297,7 @@ exports.Formats = [
 
 		mod: 'gen7',
 		ruleset: ['[Gen 7] Ubers'],
-		banlist: ['Blissey', 'Chansey', 'Uber > 1', 'AG + Uber > 1', 'Huge Power', 'Pure Power', 'Shadow Tag', 'Gengarite', 'Mawilite', 'Medichamite', 'Baton Pass'],
+		banlist: ['Blissey', 'Chansey', 'Uber > 1', 'Uber ++ Power Construct', 'Huge Power', 'Pure Power', 'Shadow Tag', 'Gengarite', 'Mawilite', 'Medichamite', 'Baton Pass'],
 		onModifyTemplate: function (template, target, source, effect) {
 			if (source || !target.side) return;
 			let uber = target.side.team.find(set => {


### PR DESCRIPTION
We were already copying Zygarde's stats if it had Power Construct and was before the Uber in the team, although this is unlikely as Zygarde would probably have been put last.

While I'm here I noticed ROM now seems to count Rayquaza + Dragon Ascent as Uber rather than AG, so if it's buggy, you'll probably want to use `Uber + AG + Power Construct > 1` instead.