### PR TITLE
Really ban Meditite from Gen 4

### DIFF
--- a/mods/gen4/formats-data.js
+++ b/mods/gen4/formats-data.js
@@ -1482,7 +1482,7 @@ exports.BattleFormatsData = {
 	meditite: {
 		inherit: true,
 		randomBattleMoves: ["highjumpkick", "psychocut", "icepunch", "thunderpunch", "trick", "fakeout", "bulletpunch", "drainpunch"],
-		tier: "NU",
+		tier: "LC Uber",
 	},
 	medicham: {
 		randomBattleMoves: ["highjumpkick", "drainpunch", "psychocut", "icepunch", "thunderpunch", "trick", "fakeout", "bulletpunch"],


### PR DESCRIPTION
The way LC bans work is that anything that's naturally tiered by usage has to be explicitly banned but otherwise bans use the LC Uber tier.