### PR TITLE
Implement DPP damage formula

### DIFF
--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -28,6 +28,24 @@ exports.BattleAbilities = {
 			}
 		},
 	},
+	"flashfire": {
+		inherit: true,
+		effect: {
+			noCopy: true, // doesn't get copied by Baton Pass
+			onStart: function (target) {
+				this.add('-start', target, 'ability: Flash Fire');
+			},
+			onModifyDamagePhase1: function (atk, attacker, defender, move) {
+				if (move.type === 'Fire') {
+					this.debug('Flash Fire boost');
+					return this.chainModify(1.5);
+				}
+			},
+			onEnd: function (target) {
+				this.add('-end', target, 'ability: Flash Fire', '[silent]');
+			},
+		},
+	},
 	"flowergift": {
 		inherit: true,
 		onAllyModifyAtk: function (atk) {

--- a/mods/gen4/items.js
+++ b/mods/gen4/items.js
@@ -135,7 +135,10 @@ exports.BattleItems = {
 			if (!target.volatiles['substitute']) {
 				user.addVolatile('lifeorb');
 			}
-			return basePower * 1.3;
+			return basePower;
+		},
+		onModifyDamagePhase2: function (damage, source, target, move) {
+			return damage * 1.3;
 		},
 		effect: {
 			duration: 1,
@@ -197,18 +200,24 @@ exports.BattleItems = {
 	"metronome": {
 		inherit: true,
 		effect: {
-			onBasePower: function (basePower, pokemon, target, move) {
-				if (pokemon.item !== 'metronome') {
+			onStart: function (pokemon) {
+				this.effectData.numConsecutive = 0;
+				this.effectData.lastMove = '';
+			},
+			onBeforeMove: function (pokemon, target, move) {
+				if (!pokemon.hasItem('metronome')) {
 					pokemon.removeVolatile('metronome');
 					return;
 				}
-				if (!this.effectData.move || this.effectData.move !== move.id) {
-					this.effectData.move = move.id;
-					this.effectData.numConsecutive = 0;
-				} else if (this.effectData.numConsecutive < 10) {
+				if (this.effectData.lastMove === move.id) {
 					this.effectData.numConsecutive++;
+				} else {
+					this.effectData.numConsecutive = 0;
 				}
-				return basePower * (1 + (this.effectData.numConsecutive / 10));
+				this.effectData.lastMove = move.id;
+			},
+			onModifyDamagePhase2: function (damage, source, target, move) {
+				return damage * (1 + (this.effectData.numConsecutive / 10));
 			},
 		},
 	},

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -719,6 +719,34 @@ exports.BattleMovedex = {
 		inherit: true,
 		basePower: 130,
 	},
+	lightscreen: {
+		inherit: true,
+		effect: {
+			duration: 5,
+			durationCallback: function (target, source, effect) {
+				if (source && source.hasItem('lightclay')) {
+					return 8;
+				}
+				return 5;
+			},
+			onAnyModifyDamagePhase1: function (damage, source, target, move) {
+				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
+					if (!move.crit && !move.infiltrates) {
+						this.debug('Light Screen weaken');
+						if (target.side.active.length > 1) return this.chainModify([0xAAC, 0x1000]);
+						return this.chainModify(0.5);
+					}
+				}
+			},
+			onStart: function (side) {
+				this.add('-sidestart', side, 'Light Screen');
+			},
+			onResidualOrder: 21,
+			onEnd: function (side) {
+				this.add('-sideend', side, 'Light Screen');
+			},
+		},
+	},
 	luckychant: {
 		inherit: true,
 		flags: {},
@@ -792,6 +820,15 @@ exports.BattleMovedex = {
 			onResidualSubOrder: 9,
 			onEnd: function (target) {
 				this.add('-end', target, 'Magnet Rise');
+			},
+		},
+	},
+	mefirst: {
+		inherit: true,
+		effect: {
+			duration: 1,
+			onModifyDamagePhase2: function (damage) {
+				return damage * 1.5;
 			},
 		},
 	},
@@ -949,6 +986,34 @@ exports.BattleMovedex = {
 	recycle: {
 		inherit: true,
 		flags: {},
+	},
+	reflect: {
+		inherit: true,
+		effect: {
+			duration: 5,
+			durationCallback: function (target, source, effect) {
+				if (source && source.hasItem('lightclay')) {
+					return 8;
+				}
+				return 5;
+			},
+			onAnyModifyDamagePhase1: function (damage, source, target, move) {
+				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
+					if (!move.crit && !move.infiltrates) {
+						this.debug('Reflect weaken');
+						if (target.side.active.length > 1) return this.chainModify([0xAAC, 0x1000]);
+						return this.chainModify(0.5);
+					}
+				}
+			},
+			onStart: function (side) {
+				this.add('-sidestart', side, 'Reflect');
+			},
+			onResidualOrder: 21,
+			onEnd: function (side) {
+				this.add('-sideend', side, 'Reflect');
+			},
+		},
 	},
 	reversal: {
 		inherit: true,

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -9,6 +9,82 @@ exports.BattleScripts = {
 		}
 	},
 
+	modifyDamage: function (baseDamage, pokemon, target, move, suppressMessages) {
+		// DPP divides modifiers into several mathematically important stages
+		// The modifiers run earlier than other generations are called with ModifyDamagePhase1 and ModifyDamagePhase2
+
+		if (!move.type) move.type = '???';
+		let type = move.type;
+
+		// Burn
+		if (pokemon.status === 'brn' && baseDamage && move.category === 'Physical' && !pokemon.hasAbility('guts')) {
+			baseDamage = this.modify(baseDamage, 0.5);
+		}
+
+		// Other modifiers (Reflect/Light Screen/etc)
+		baseDamage = this.runEvent('ModifyDamagePhase1', pokemon, target, move, baseDamage);
+
+		// Double battle multi-hit
+		if (move.spreadHit) {
+			let spreadModifier = move.spreadModifier || 0.75;
+			this.debug('Spread modifier: ' + spreadModifier);
+			baseDamage = this.modify(baseDamage, spreadModifier);
+		}
+
+		// Weather
+		baseDamage = this.runEvent('WeatherModifyDamage', pokemon, target, move, baseDamage);
+
+		baseDamage += 2;
+
+		if (move.crit) {
+			baseDamage = this.modify(baseDamage, move.critModifier || 2);
+		}
+
+		// Mod 2 (Damage is floored after all multipliers are in)
+		baseDamage = Math.floor(this.runEvent('ModifyDamagePhase2', pokemon, target, move, baseDamage));
+
+		// this is not a modifier
+		baseDamage = this.randomizer(baseDamage);
+
+		// STAB
+		if (move.hasSTAB || type !== '???' && pokemon.hasType(type)) {
+			// The "???" type never gets STAB
+			// Not even if you Roost in Gen 4 and somehow manage to use
+			// Struggle in the same turn.
+			// (On second thought, it might be easier to get a Missingno.)
+			baseDamage = this.modify(baseDamage, move.stab || 1.5);
+		}
+		// types
+		move.typeMod = target.runEffectiveness(move);
+
+		move.typeMod = this.clampIntRange(move.typeMod, -6, 6);
+		if (move.typeMod > 0) {
+			if (!suppressMessages) this.add('-supereffective', target);
+
+			for (let i = 0; i < move.typeMod; i++) {
+				baseDamage *= 2;
+			}
+		}
+		if (move.typeMod < 0) {
+			if (!suppressMessages) this.add('-resisted', target);
+
+			for (let i = 0; i > move.typeMod; i--) {
+				baseDamage = Math.floor(baseDamage / 2);
+			}
+		}
+
+		if (move.crit && !suppressMessages) this.add('-crit', target);
+
+		// Final modifier.
+		baseDamage = this.runEvent('ModifyDamage', pokemon, target, move, baseDamage);
+
+		if (!Math.floor(baseDamage)) {
+			return 1;
+		}
+
+		return Math.floor(baseDamage);
+	},
+
 	calcRecoilDamage: function (damageDealt, move) {
 		return this.clampIntRange(Math.floor(damageDealt * move.recoil[0] / move.recoil[1]), 1);
 	},


### PR DESCRIPTION
Inspired by the chain of events in this thread: http://www.smogon.com/forums/threads/bugs-that-directly-influence-the-outcome-of-a-game.3603259/#post-7347664

Basically, while later generations implement most of their modifiers on damage (such as boosts by items, abilities, etc) in one place in the damage calculation, Gen 4 does this in several steps. This creates small discrepancies between expected damage output and PS damage at Level 100, and these become more significant as levels decrease, becoming potentially game-determining at Level 5.

I based the code on http://www.smogon.com/dp/articles/damage_formula which is what the PS damage calc is based on. I made the changes within the context of PS's event system, basically just adding clones of ModifyDamage (ModifyDamageOne and ModifyDamageTwo) for modifiers at different stages in the calculation. The third modifier is still named ModifyDamage so that if modifiers that didn't exist in Gen 4 appear (in a custom game maybe?) they will still have an effect on the damage rolls.

In every test I've done, the damage has been equal to both what I've calculated by hand and what the damage calculator shows. Obviously, that doesn't mean the code is perfect, and because this is such an important function, I will work to implement any and all feedback ASAP.

Tagging @Marty-D because I think he does mechanics stuff.