### PR TITLE
Gen 1 Randbats: Fix Exeggcute getting Mega Drain

### DIFF
--- a/mods/gen1/formats-data.js
+++ b/mods/gen1/formats-data.js
@@ -535,7 +535,7 @@ exports.BattleFormatsData = {
 	exeggcute: {
 		randomBattleMoves: ["sleeppowder", "stunspore"],
 		essentialMove: "psychic",
-		exclusiveMoves: ["megadrain", "explosion"],
+		exclusiveMoves: ["explosion", "explosion", "doubleedge"],
 		tier: "LC",
 	},
 	exeggutor: {


### PR DESCRIPTION
Exeggcute can't learn Mega Drain in RBY. I didn't notice it when I made the randbats movesets. Thanks to Mirabel_ for pointing it out in Smogon: http://www.smogon.com/forums/threads/gen-1-and-tradebacks-dev-post-bugs-here.3524844/page-13#post-7382821