### PR TITLE
Require minimum IVs for Hidden Power 70 in Gen 5

### DIFF
--- a/mods/gen5/scripts.js
+++ b/mods/gen5/scripts.js
@@ -596,12 +596,12 @@ exports.BattleScripts = {
 		// Minimize confusion damage
 		if (!counter['Physical']) {
 			evs.atk = 0;
-			ivs.atk = hasMove['hiddenpower'] ? ivs.atk - 30 : 0;
+			ivs.atk = hasMove['hiddenpower'] ? ivs.atk - 28 : 0;
 		}
 
 		if (hasMove['gyroball'] || hasMove['trickroom']) {
 			evs.spe = 0;
-			ivs.spe = 0;
+			ivs.spe = hasMove['hiddenpower'] ? ivs.spe - 28 : 0;
 		}
 
 		return {

--- a/mods/gen6/scripts.js
+++ b/mods/gen6/scripts.js
@@ -942,7 +942,7 @@ exports.BattleScripts = {
 
 		if (hasMove['gyroball'] || hasMove['trickroom']) {
 			evs.spe = 0;
-			ivs.spe = 0;
+			ivs.spe = hasMove['hiddenpower'] ? ivs.spe - 30 : 0;
 		}
 
 		return {


### PR DESCRIPTION
As described [here](http://www.smogon.com/forums/posts/7382966/) the randbat generator doesn't take the Gen 5 hidden power BP calculation into account, so it will happily reduce the BP of hidden power by 2 to save a couple of points on the Attack stat. Indeed, for those Pokémon which get both Hidden Power and Trick Room, it will happily reduce the BP by 6 or 7, or potentially even change its type entirely. The latter applies to Gen 6 as well; it should also apply to Gen 7, but the server cheats and pretends that reverse bottle caps exist, and I can't be bothered to fix it.