### PR TITLE
Datasearch: Allow using "all" as only perameter

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -549,7 +549,7 @@ function runDexsearch(target, cmd, canAll, message) {
 			searches.push(orGroup);
 		}
 	}
-	if (showAll && searches.length === 0 && megaSearch === null) return {reply: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command."};
+	// if (showAll && searches.length === 0 && megaSearch === null) return {reply: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command."};
 
 	let dex = {};
 	for (let pokemon in Dex.data.Pokedex) {

--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -949,9 +949,9 @@ function runMovesearch(target, cmd, canAll, message) {
 		return {reply: "'" + escapeHTML(oldTarget) + "' could not be found in any of the search categories."};
 	}
 
-	if (showAll && !Object.keys(searches).length && !targetMon) {
-		return {reply: "No search parameters other than 'all' were found. Try '/help movesearch' for more information on this command."};
-	}
+	//if (showAll && !Object.keys(searches).length && !targetMon) {
+	//	return {reply: "No search parameters other than 'all' were found. Try '/help movesearch' for more information on this command."};
+	//}
 
 	let dex = {};
 	if (targetMon) {


### PR DESCRIPTION
[17:59:51] +The(Who+Doctor)²: Is there a way to change the code for /ds to allow "/ds all" to continue working?
[18:29:26] @HoeenHero: oh it got blocked, as the only paramater, maybe thats what twid meant
[19:55:10] +The(Who+Doctor)²: Yeah that is what I meant Hoeen
[19:55:22] +The(Who+Doctor)²: Doing /ds all provides no result where it used to list all Pokemon