### PR TITLE
Typescript: crashlogger.js

### DIFF
--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -1,4 +1,5 @@
 interface AnyObject {[k: string]: any}
 
-var Dex = require('./sim/dex');
-// var Sim = require('./sim');
+let Config = require('./config/config');
+let Dex = require('./sim/dex');
+// let Sim = require('./sim');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         "./sim/dex-data.js",
         "./sim/dex.js",
         "./sim/prng.js",
+        "./crashlogger.js",
         "./repl.js"
     ]
 }


### PR DESCRIPTION
Depended on by numerous other modules to be moved over to Typescript
before they can.

This also adds `Config` to `dev-tools/globals.ts`. I left all of its exports as being `any` type for now. Later, I could add a namespace to `dev-tools/globals.ts` to properly type its exports, since I'd rather not make the types and interfaces local to `config.js` needed for `Config.ssl`, `Config.nodemailer`, and `Config.groups` global by handling the types in `config.js` and adding the interfaces I can't put in the file to `dev-tools/globals.ts`. Alternatively, I could write a type declaration file for it, but it might be too soon to start thinking about those.