### PR TITLE
REPL: add Config.repl, refactor, Typescript

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -205,8 +205,10 @@ exports.ratedtours = false;
 // which case users won't be given any information on how to appeal.
 exports.appealurl = '';
 
+// repl - whether repl sockets are enabled or not
 // replsocketprefix - the prefix for the repl sockets to be listening on
 // replsocketmode - the file mode bits to use for the repl sockets
+exports.repl = true;
 exports.replsocketprefix = './logs/repl/';
 exports.replsocketmode = 0o600;
 

--- a/repl.js
+++ b/repl.js
@@ -1,65 +1,77 @@
 'use strict';
 
-const REPL_ENABLED = true;
-
 const fs = require('fs');
 const path = require('path');
 const net = require('net');
+const repl = require('repl');
 
-let sockets = [];
+/**
+ * Contains the pathnames of all active REPL sockets.
+ * @type {Set<string>}
+ */
+const socketPathnames = new Set();
 
-function cleanup() {
-	for (let s = 0; s < sockets.length; ++s) {
+process.once("exit", () => {
+	socketPathnames.forEach(s => {
 		try {
-			fs.unlinkSync(sockets[s]);
+			fs.unlinkSync(s);
 		} catch (e) {}
-	}
-}
-process.on("exit", cleanup);
+	});
+});
 
 // exit handlers aren't called by the default handler
 if (process.listeners('SIGHUP').length === 0) {
-	process.on('SIGHUP', () => process.exit(128 + 1));
+	process.once('SIGHUP', () => process.exit(128 + 1));
 }
 if (process.listeners('SIGINT').length === 0) {
-	process.on('SIGINT', () => process.exit(128 + 2));
+	process.once('SIGINT', () => process.exit(128 + 2));
 }
 
-// The eval function is passed in because there is no other way to access a file's non-global context
-exports.start = function (prefix, suffix, evalFunction) {
-	if (!REPL_ENABLED) return;
-	if (process.platform === 'win32') return; // Windows doesn't support sockets mounted in the filesystem
+/**
+ * Starts a REPL server, using a UNIX socket for IPC. The eval function
+ * parametre is passed in because there is no other way to access a file's
+ * non-global context.
+ *
+ * @param {string} filename
+ * @param {Function} evalFunction
+ */
+exports.start = function start(filename, evalFunction) {
+	if ('repl' in Config && !Config.repl) return;
 
-	let resolvedPrefix = path.resolve(__dirname, Config.replsocketprefix || 'logs/repl', prefix);
-	if (!evalFunction) {
-		evalFunction = suffix;
-		suffix = "";
-	}
-	let name = resolvedPrefix + suffix;
+	// TODO: Windows does support the REPL when using named pipes. For now,
+	// this only supports UNIX sockets.
+	if (process.platform === 'win32') return;
 
-	if (prefix === 'app') {
-		// Clear out any old sockets
-		let directory = path.dirname(resolvedPrefix);
+	if (filename === 'app') {
+		// Clean up old REPL sockets.
+		let directory = path.dirname(path.resolve(__dirname, Config.replsocketprefix || 'logs/repl', 'app'));
 		for (let file of fs.readdirSync(directory)) {
-			let stat = fs.statSync(directory + '/' + file);
-			if (!stat.isSocket()) {
-				continue;
-			}
+			let pathname = path.resolve(directory, file);
+			let stat = fs.statSync(pathname);
+			if (!stat.isSocket()) continue;
 
-			let socket = net.connect(directory + '/' + file, () => {
+			let socket = net.connect(pathname, () => {
 				socket.end();
 				socket.destroy();
 			}).on('error', () => {
-				fs.unlink(directory + '/' + file, () => {});
+				fs.unlink(pathname, () => {});
 			});
 		}
 	}
 
-	net.createServer(socket => {
-		require('repl').start({
+	let server = net.createServer(socket => {
+		// @ts-ignore
+		repl.start({
 			input: socket,
 			output: socket,
-			eval: (cmd, context, filename, callback) => {
+			/**
+			 * @param {string} cmd
+			 * @param {any} context
+			 * @param {string} filename
+			 * @param {Function} callback
+			 * @return {any}
+			 */
+			eval(cmd, context, filename, callback) {
 				try {
 					return callback(null, evalFunction(cmd));
 				} catch (e) {
@@ -68,22 +80,32 @@ exports.start = function (prefix, suffix, evalFunction) {
 			},
 		}).on('exit', () => socket.end());
 		socket.on('error', () => socket.destroy());
-	}).listen(name, () => {
-		fs.chmodSync(name, Config.replsocketmode || 0o600);
-		sockets.push(name);
-	}).on('error', e => {
-		if (e.code === "EADDRINUSE") {
-			fs.unlink(name, e => {
-				if (e && e.code !== "ENOENT") {
-					require('./crashlogger')(e, 'REPL: ' + name);
-					return;
+	});
+
+	let pathname = path.resolve(__dirname, Config.replsocketprefix || 'logs/repl', filename);
+	server.listen(pathname, () => {
+		fs.chmodSync(pathname, Config.replsocketmode || 0o600);
+		socketPathnames.add(pathname);
+	});
+
+	server.once('error', err => {
+		// @ts-ignore
+		if (err.code === "EADDRINUSE") {
+			fs.unlink(pathname, _err => {
+				// @ts-ignore
+				if (_err && _err.code !== "ENOENT") {
+					require('./crashlogger')(_err, `REPL: ${filename}`);
 				}
-
-				exports.start(prefix, suffix, evalFunction);
+				server.close();
 			});
-			return;
+		} else {
+			require('./crashlogger')(err, `REPL: ${filename}`);
+			server.close();
 		}
+	});
 
-		require('./crashlogger')(e, 'REPL: ' + name);
+	server.once('close', () => {
+		socketPathnames.delete(pathname);
+		start(filename, evalFunction);
 	});
 };

--- a/room-battle.js
+++ b/room-battle.js
@@ -686,7 +686,7 @@ if (process.send && module === process.mainModule) {
 		});
 	}
 
-	require('./repl').start('sim-', process.pid, cmd => eval(cmd));
+	require('./repl').start(`sim-${process.pid}`, cmd => eval(cmd));
 
 	let Battles = new Map();
 

--- a/sockets.js
+++ b/sockets.js
@@ -496,5 +496,5 @@ if (cluster.isMaster) {
 
 	console.log(`Test your server at http://${Config.bindaddress === '0.0.0.0' ? 'localhost' : Config.bindaddress}:${Config.port}`);
 
-	require('./repl').start('sockets-', `${cluster.worker.id}-${process.pid}`, cmd => eval(cmd));
+	require('./repl').start(`sockets-${cluster.worker.id}-${process.pid}`, cmd => eval(cmd));
 }

--- a/team-validator.js
+++ b/team-validator.js
@@ -1279,7 +1279,7 @@ if (process.send && module === process.mainModule) {
 	global.toId = Dex.getId;
 	global.Chat = require('./chat');
 
-	require('./repl').start('team-validator-', process.pid, cmd => eval(cmd));
+	require('./repl').start(`team-validator-${process.pid}`, cmd => eval(cmd));
 
 	process.on('message', message => PM.onMessageDownstream(message));
 	process.on('disconnect', () => process.exit());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "./dev-tools/globals.ts",
         "./sim/dex-data.js",
         "./sim/dex.js",
-        "./sim/prng.js"
+        "./sim/prng.js",
+        "./repl.js"
     ]
 }


### PR DESCRIPTION
- `Config.repl` enables/disables using REPL sockets since it doesn't
make as much sense to configure whether or not it's enabled with the
`REPL_ENABLED` const
- `exports.start` takes a filename parametre rather than a prefix and a
suffix one to avoid having to mutate parametres
- dead REPL sockets are removed from the sockets list when the server
emits an error, and the server closes on error now before respawning
- made the file ready for Typescript

This should be committed after #3605 since this is dependent on `crashlogger.js` being in Typescript.