### PR TITLE
REPL: fix a couple of Typescript errors I missed

### DIFF
--- a/crashlogger.js
+++ b/crashlogger.js
@@ -25,7 +25,7 @@ let hadException = false;
  *
  * @param {Error} err
  * @param {string} description
- * @param {?Object} data
+ * @param {?Object} [data = null]
  * @return {?string}
  */
 module.exports = function crashLogger(err, description, data = null) {
@@ -41,10 +41,10 @@ module.exports = function crashLogger(err, description, data = null) {
 
 	console.error(`\nCRASH: ${stack}\n`);
 	let out = require('fs').createWriteStream(logPath, {'flags': 'a'});
-	out.on("open", fd => {
+	out.on('open', fd => {
 		out.write(`\n${stack}\n`);
 		out.end();
-	}).on("error", /** @param {Error} err */ err => {
+	}).on('error', /** @param {Error} err */ err => {
 		console.error(`\nSUBCRASH: ${err.stack}\n`);
 	});
 
@@ -60,8 +60,8 @@ module.exports = function crashLogger(err, description, data = null) {
 				from: Config.crashguardemail.from,
 				to: Config.crashguardemail.to,
 				subject: Config.crashguardemail.subject,
-				text: `${description} crashed ${hadException ? "again " : ""}with this stack trace:\n${stack}`,
-			}, /** @param {Error?} err */ err => {
+				text: `${description} crashed ${hadException ? 'again ' : ''}with this stack trace:\n${stack}`,
+			}, /** @param {?Error} err */ err => {
 				if (err) console.error(`Error sending email: ${err}`);
 			});
 		}
@@ -72,5 +72,6 @@ module.exports = function crashLogger(err, description, data = null) {
 		// lock down the server
 		return 'lockdown';
 	}
+
 	return null;
 };

--- a/repl.js
+++ b/repl.js
@@ -11,7 +11,7 @@ const repl = require('repl');
  */
 const socketPathnames = new Set();
 
-process.once("exit", () => {
+process.once('exit', () => {
 	socketPathnames.forEach(s => {
 		try {
 			fs.unlinkSync(s);
@@ -88,11 +88,9 @@ exports.start = function start(filename, evalFunction) {
 		socketPathnames.add(pathname);
 	});
 
-	server.once('error', err => {
-		// @ts-ignore
+	server.once('error', /** @param {NodeJS.ErrnoException} err */ err => {
 		if (err.code === "EADDRINUSE") {
 			fs.unlink(pathname, _err => {
-				// @ts-ignore
 				if (_err && _err.code !== "ENOENT") {
 					require('./crashlogger')(_err, `REPL: ${filename}`);
 				}


### PR DESCRIPTION
`err` is meant to be `NodeJS.ErrnoException` instead of `Error` in this case, but `// @ts-ignore` will have to be used for now