### PR TITLE
DNSBL: Typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         "./sim/dex.js",
         "./sim/prng.js",
         "./crashlogger.js",
+        "./dnsbl.js",
         "./repl.js"
     ]
 }


### PR DESCRIPTION
This is the last module I care about moving over to Typescript before having to write type declarations for sockets.js' dependencies.

I had to use `{function(any): any}` syntax instead of `{(id: any) => any}` for function parametres. I'm not entirely sure why `tsc` is complaining about it.