### PR TITLE
Prevent rooms from being named "all" or "public"

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -517,7 +517,7 @@ class GlobalRoom {
 	}
 	addChatRoom(title) {
 		let id = toId(title);
-		if (id === 'battles' || id === 'rooms' || id === 'ladder' || id === 'teambuilder' || id === 'home') return false;
+		if (id === 'battles' || id === 'rooms' || id === 'ladder' || id === 'teambuilder' || id === 'home' || id === 'all' || id === 'public') return false;
 		if (Rooms.rooms.has(id)) return false;
 
 		let chatRoomData = {


### PR DESCRIPTION
As this would make the modlog permission checking overly complicated.