### PR TITLE
Gen 4: Fix crash damage interaction with Chople Berry

### DIFF
--- a/mods/gen4/items.js
+++ b/mods/gen4/items.js
@@ -21,6 +21,19 @@ exports.BattleItems = {
 		inherit: true,
 		onStart: function () { },
 	},
+	"chopleberry": {
+		inherit: true,
+		onSourceModifyDamage: function (damage, source, target, move) {
+			if (move.causedCrashDamage) return damage;
+			if (move.type === 'Fighting' && move.typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'])) {
+				if (target.eatItem()) {
+					this.debug('-50% reduction');
+					this.add('-enditem', target, this.effect, '[weaken]');
+					return this.chainModify(0.5);
+				}
+			}
+		},
+	},
 	"custapberry": {
 		id: "custapberry",
 		name: "Custap Berry",

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -679,6 +679,7 @@ exports.BattleMovedex = {
 		shortDesc: "If miss, user takes 1/2 damage it would've dealt.",
 		pp: 20,
 		onMoveFail: function (target, source, move) {
+			move.causedCrashDamage = true;
 			let damage = this.getDamage(source, target, move, true);
 			if (!damage) damage = target.maxhp;
 			this.damage(this.clampIntRange(damage / 2, 1, Math.floor(target.maxhp / 2)), source, source, 'highjumpkick');
@@ -710,6 +711,7 @@ exports.BattleMovedex = {
 		shortDesc: "If miss, user takes 1/2 damage it would've dealt.",
 		pp: 25,
 		onMoveFail: function (target, source, move) {
+			move.causedCrashDamage = true;
 			let damage = this.getDamage(source, target, move, true);
 			if (!damage) damage = target.maxhp;
 			this.damage(this.clampIntRange(damage / 2, 1, Math.floor(target.maxhp / 2)), source, source, 'jumpkick');


### PR DESCRIPTION
Mentioned in #2367 and with the recent damage formula changes, I had hopes this would've been included but apparently it was forgotten after I mentioned it.

This may not be the best way to implement it though, but it's the best I can come up with that isn't even more hardcoded.