### PR TITLE
Gen 2: Correctly calculate confusion damage

### DIFF
--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -359,7 +359,13 @@ exports.BattleScripts = {
 
 		// Happens after crit calculation
 		if (basePower) {
-			basePower = this.runEvent('BasePower', pokemon, target, move, basePower, true);
+			if (move.isSelfHit) {
+				move.type = move.baseMoveType;
+				basePower = this.runEvent('BasePower', pokemon, target, move, basePower, true);
+				move.type = '???';
+			} else {
+				basePower = this.runEvent('BasePower', pokemon, target, move, basePower, true);
+			}
 			if (move.basePowerModifier) {
 				basePower *= move.basePowerModifier;
 			}

--- a/mods/gen2/statuses.js
+++ b/mods/gen2/statuses.js
@@ -109,7 +109,7 @@ exports.BattleStatuses = {
 				this.effectData.time = this.random(2, 6);
 			}
 		},
-		onBeforeMove: function (pokemon) {
+		onBeforeMove: function (pokemon, target, move) {
 			pokemon.volatiles.confusion.time--;
 			if (!pokemon.volatiles.confusion.time) {
 				pokemon.removeVolatile('confusion');
@@ -119,7 +119,17 @@ exports.BattleStatuses = {
 			if (this.random(2) === 0) {
 				return;
 			}
-			this.directDamage(this.getDamage(pokemon, pokemon, 40));
+			move = {
+				basePower: 40,
+				type: '???',
+				baseMoveType: move.type,
+				category: 'Physical',
+				willCrit: false,
+				isSelfHit: true,
+				noDamageVariance: true,
+				flags: {},
+			};
+			this.directDamage(this.getDamage(pokemon, pokemon, move));
 			return false;
 		},
 	},


### PR DESCRIPTION
Closes #3229

- Applies item modifiers when relevant
- Gen 2 doesn't have a damage rolls for confusion damage

I double checked this as best as I could with the code from https://github.com/pret/pokecrystal/ so hopefully this should be correct. I don't know if there's someplace else to turn to for this now that Marty stepped down.