### PR TITLE
App: create default config file in launch script

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,13 +43,12 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 
 // Check for dependencies
 try {
 	require.resolve('sockjs');
 } catch (e) {
-	throw new Error("Dependencies unmet; run npm install");
+	throw new Error('Dependencies are unmet; run node pokemon-showdown before launching Pokemon Showdown again.');
 }
 
 /*********************************************************
@@ -60,15 +59,10 @@ try {
 	require.resolve('./config/config');
 } catch (err) {
 	if (err.code !== 'MODULE_NOT_FOUND') throw err; // should never happen
-
-	// Copy it over synchronously from config-example.js since it's needed before we can start the server
-	console.log("config.js doesn't exist - creating one with default settings...");
-	fs.writeFileSync(path.resolve(__dirname, 'config/config.js'),
-		fs.readFileSync(path.resolve(__dirname, 'config/config-example.js'))
-	);
-} finally {
-	global.Config = require('./config/config');
+	throw new Error('config.js does not exist; run node pokemon-showdown to set up the default config file before launching Pokemon Showdown again.');
 }
+
+global.Config = require('./config/config');
 
 if (Config.watchconfig) {
 	let configPath = require.resolve('./config/config');
@@ -80,7 +74,7 @@ if (Config.watchconfig) {
 			if (global.Users) Users.cacheGroupData();
 			console.log('Reloaded config/config.js');
 		} catch (e) {
-			console.log('Error reloading config/config.js: ' + e.stack);
+			console.error(`Error reloading config/config.js: ${e.stack}`);
 		}
 	});
 }

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -2,6 +2,8 @@
 'use strict';
 
 const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 // Make sure we're Node 6+
 
@@ -9,7 +11,7 @@ try {
 	eval('{ let [a] = [1]; }');
 } catch (e) {
 	console.log("We require Node.js v6 or later; you're using " + process.version);
-	process.exit();
+	process.exit(1);
 }
 
 // Make sure our dependencies are available, and install them if they
@@ -20,6 +22,21 @@ try {
 } catch (e) {
 	console.log('Installing dependencies...');
 	child_process.execSync('npm install --production', {stdio: 'inherit'});
+}
+
+// Make sure config.js exists. If not, copy it over synchronously from
+// config-example.js, since it's needed before we can start the server
+
+try {
+	require.resolve('./config/config');
+} catch (err) {
+	if (err.code !== 'MODULE_NOT_FOUND') throw err; // should never happen
+
+	console.log('config.js does not exist. Creating one with default settings...');
+	fs.writeFileSync(
+		path.resolve(__dirname, 'config/config.js'),
+		fs.readFileSync(path.resolve(__dirname, 'config/config-example.js'))
+	);
 }
 
 // Start the server. We manually load app.js so it can be configured to run as


### PR DESCRIPTION
Brought up in https://github.com/Zarel/Pokemon-Showdown/pull/3536#issuecomment-308049780. I don't think it'd be feasible to install the dependencies and import newly recreated config files from app.js because of how much  of a hassle that caused with the launch script trying to accomplish the same thing.