### PR TITLE
Add a check for Room only ranks

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1944,6 +1944,7 @@ exports.commands = {
 			let groupid = Config.groups[nextGroup].id;
 			if (!groupid && nextGroup === Config.groupsranking[0]) groupid = 'deauth';
 			if (Config.groups[nextGroup].globalonly) return this.errorReply(`Did you mean "/global${groupid}"?`);
+			if (Config.groups[nextGroup].roomonly) return this.errorReply(`Did you mean "/room${groupid}"?`);
 			return this.errorReply(`Did you mean "/room${groupid}" or "/global${groupid}"?`);
 		}
 		if (Config.groups[nextGroup].roomonly || Config.groups[nextGroup].battleonly) {


### PR DESCRIPTION
Normally when you do /owner it gives 'did you mean /roomowner or /globalowner?' However global room owner doesn't exist as owner is a room only rank. This PR fixes this issue.

Sorry for the bad pr name, I'm still kinda new to contributing here.