### PR TITLE
Gen 3: Implement correct damage flooring

### DIFF
--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -34,6 +34,10 @@ exports.BattleScripts = {
 		// Weather
 		baseDamage = this.runEvent('WeatherModifyDamage', pokemon, target, move, baseDamage);
 
+		if (this.gen === 3 && move.category === 'Physical' && !Math.floor(baseDamage)) {
+			baseDamage = 1;
+		}
+
 		baseDamage += 2;
 
 		if (move.crit) {


### PR DESCRIPTION
So after going through various sources on the Gen 3 damage formula, I've realized that this small check is basically the only difference between damage calculation in gens 3 and 4. The only other difference is that a small group of moves which double in power in certain situations have that x2 modifier calculated in a different place than in Gen 4, but that change can be made within the context of the gen 4 formula, so I don't see a reason to write a different ``modifyDamage`` for Gen 3. Hooray for old gen implementation.

Sources:
http://upcarchive.playker.info/0/upokecenter/content/pokemon-ruby-version-sapphire-version-and-emerald-version-damage-calculation.html
https://github.com/pret/pokeruby/blob/9640df02dd8651d5b05cf3767f6c7e16a697db3b/src/calculate_base_damage.c