### PR TITLE
Gen 2: Fix items like Thick Club on nicknamed Pokemon

### DIFF
--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -51,9 +51,9 @@ exports.BattleScripts = {
 			}
 
 			// Treat here the items.
-			if ((this.name in {'Cubone':1, 'Marowak':1} && this.item === 'thickclub' && statName === 'atk') || (this.name === 'Pikachu' && this.item === 'lightball' && statName === 'spa')) {
+			if ((this.species in {'Cubone':1, 'Marowak':1} && this.item === 'thickclub' && statName === 'atk') || (this.species === 'Pikachu' && this.item === 'lightball' && statName === 'spa')) {
 				stat *= 2;
-			} else if (this.name === 'Ditto' && this.item === 'metalpowder' && statName in {'def':1, 'spd':1}) {
+			} else if (this.species === 'Ditto' && this.item === 'metalpowder' && statName in {'def':1, 'spd':1}) {
 				// what. the. fuck. stop playing pokémon
 				stat *= 1.5;
 			}
@@ -795,7 +795,7 @@ exports.BattleScripts = {
 
 		return {
 			moveset: {
-				name: template.name,
+				species: template.name,
 				moves: moves,
 				ability: 'None',
 				evs: {hp: 255, atk: 255, def: 255, spa: 255, spd: 255, spe: 255},


### PR DESCRIPTION
This is a bug I introduced in my Gen 2 randbats update. It was making nicknamed Cubone, Marowak, Pikachu and Ditto not to receive boosts from their signature items. With this fix boosts are properly handled both in randbats and in other Gen 2 tiers. Sorry for the inconvenience.

Thanks to @urkerab for bringing this to my attention.