### PR TITLE
Random Battle: Add Pursuit to Alolan Muk

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -939,7 +939,7 @@ exports.BattleFormatsData = {
 		tier: "NU",
 	},
 	mukalola: {
-		randomBattleMoves: ["curse", "gunkshot", "knockoff", "poisonjab", "shadowsneak", "stoneedge"],
+		randomBattleMoves: ["curse", "gunkshot", "knockoff", "poisonjab", "shadowsneak", "stoneedge", "pursuit"],
 		randomDoubleBattleMoves: ["gunkshot", "knockoff", "stoneedge", "snarl", "protect", "poisonjab", "shadowsneak"],
 		tier: "UU",
 	},


### PR DESCRIPTION
It's commonly used on its sets and can help with trapping.