### PR TITLE
Add a /requesttie command

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -3033,6 +3033,14 @@ exports.commands = {
 		room.game.choose(user, 'team ' + target);
 	},
 
+	offerdraw: 'requesttie',
+	requesttie: function (target, room, user) {
+		if (!room.game) return this.errorReply("This room doesn't have an active game.");
+		if (!room.game.requestTie) return this.errorReply("This game doesn't support /requesttie");
+
+		room.game.requestTie(user, room);
+	},
+
 	undo: function (target, room, user) {
 		if (!room.game) return this.errorReply("This room doesn't have an active game.");
 		if (!room.game.undo) return this.errorReply("This game doesn't support /undo");

--- a/room-game.js
+++ b/room-game.js
@@ -123,6 +123,9 @@ class RoomGame {
 	// undo(user, text)
 	//   Called when a user uses /undo [text]
 
+	// requestTie(user, room)
+	//   Called when a user uses /requesttie
+
 	// joinGame(user, text)
 	//   Called when a user uses /joingame [text]
 


### PR DESCRIPTION
[DO NOT MERGE... YET]
### TODO:
- [ ] Fix making ties per-format and figure out how to send that to the client
- [ ] Make tie requests expire the next turn
- [ ] Limit of tie requests per battle? Maybe?

This is in tandem with https://github.com/Zarel/Pokemon-Showdown-Client/pull/966