### PR TITLE
Replace fs module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
 	"root": true,
 	"parserOptions": {
-		"ecmaVersion": 6,
+		"ecmaVersion": 8,
 		"sourceType": "script",
 		"ecmaFeatures": {
 			"globalReturn": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
+  - "7.7"
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Installing
 
     ./pokemon-showdown
 
-(Requires Node.js 6+)
+(Requires Node.js 8+)
 
 
 Detailed installation instructions
 ------------------------------------------------------------------------
 
-Pokémon Showdown requires you to have [Node.js][6] installed, 6.x or later.
+Pokémon Showdown requires you to have [Node.js][6] installed, 8.x or later (7.7 or later can work, but you might as well be on the latest stable).
 
 Next, obtain a copy of Pokémon Showdown. If you're reading this outside of GitHub, you've probably already done this. If you're reading this in GitHub, there's a "Clone or download" button near the top right (it's green). I recommend the "Open in Desktop" method - you need to install GitHub Desktop which is more work than "Download ZIP", but it makes it much easier to update in the long run (it lets you use the `/updateserver` command).
 

--- a/app.js
+++ b/app.js
@@ -44,11 +44,18 @@
 
 const FS = require('./fs');
 
-// Check for dependencies
+// Check for version and dependencies
+try {
+	// I've gotten enough reports by people who don't use the launch
+	// script that this is worth repeating here
+	eval('{ let a = async () => {}; }');
+} catch (e) {
+	throw new Error("We require Node.js version 8 or later; you're using " + process.version);
+}
 try {
 	require.resolve('sockjs');
 } catch (e) {
-	throw new Error('Dependencies are unmet; run node pokemon-showdown before launching Pokemon Showdown again.');
+	throw new Error("Dependencies are unmet; run node pokemon-showdown before launching Pokemon Showdown again.");
 }
 
 /*********************************************************

--- a/app.js
+++ b/app.js
@@ -42,7 +42,7 @@
 
 'use strict';
 
-const fs = require('fs');
+const FS = require('./fs');
 
 // Check for dependencies
 try {
@@ -66,8 +66,7 @@ global.Config = require('./config/config');
 
 if (Config.watchconfig) {
 	let configPath = require.resolve('./config/config');
-	fs.watchFile(configPath, (curr, prev) => {
-		if (curr.mtime <= prev.mtime) return;
+	FS(configPath).onModify(() => {
 		try {
 			delete require.cache[configPath];
 			global.Config = require('./config/config');

--- a/dnsbl.js
+++ b/dnsbl.js
@@ -19,8 +19,7 @@
 const BLOCKLISTS = ['sbl.spamhaus.org', 'rbl.efnetrbl.org'];
 
 const dns = require('dns');
-const fs = require('fs');
-const path = require('path');
+const FS = require('./fs');
 
 let Dnsbl = module.exports;
 
@@ -217,23 +216,21 @@ Dnsbl.urlToHost = function (url) {
 };
 
 Dnsbl.datacenters = [];
-Dnsbl.loadDatacenters = function () {
-	fs.readFile(path.resolve(__dirname, 'config/datacenters.csv'), 'utf8', (err, data) => {
-		if (err) return;
-		let rows = data.split('\n');
-		let datacenters = [];
-		for (let row of rows) {
-			if (!row) continue;
-			let rowSplit = row.split(',');
-			let rowData = [
-				Dnsbl.ipToNumber(rowSplit[0]),
-				Dnsbl.ipToNumber(rowSplit[1]),
-				Dnsbl.urlToHost(rowSplit[3]),
-			];
-			datacenters.push(rowData);
-		}
-		Dnsbl.datacenters = datacenters;
-	});
+Dnsbl.loadDatacenters = async function () {
+	const data = await FS('config/datacenters.csv').readTextIfExists();
+	const rows = data.split('\n');
+	let datacenters = [];
+	for (const row of rows) {
+		if (!row) continue;
+		const rowSplit = row.split(',');
+		const rowData = [
+			Dnsbl.ipToNumber(rowSplit[0]),
+			Dnsbl.ipToNumber(rowSplit[1]),
+			Dnsbl.urlToHost(rowSplit[3]),
+		];
+		datacenters.push(rowData);
+	}
+	Dnsbl.datacenters = datacenters;
 };
 
 let rangeTmobile = Dnsbl.cidrToPattern('172.32.0.0/11');

--- a/fs.js
+++ b/fs.js
@@ -5,7 +5,7 @@
  * An abstraction layer around Node's filesystem.
  *
  * Advantages:
- * - TODO: write() etc do nothing in unit tests
+ * - write() etc do nothing in unit tests
  * - paths are always relative to PS's base directory
  * - Promises (seriously wtf Node Core what are you thinking)
  * - PS-style API: FS("foo.txt").write("bar") for easier argument order
@@ -68,6 +68,7 @@ class Path {
 	 * @param {Object} options
 	 */
 	write(data, options = {}) {
+		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {
 			fs.writeFile(this.path, data, options, err => {
 				err ? reject(err) : resolve();
@@ -79,6 +80,7 @@ class Path {
 	 * @param {Object} options
 	 */
 	writeSync(data, options = {}) {
+		if (Config.nofswriting) return;
 		return fs.writeFileSync(this.path, data, options);
 	}
 	/**
@@ -86,6 +88,7 @@ class Path {
 	 * @param {Object} options
 	 */
 	append(data, options = {}) {
+		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {
 			fs.appendFile(this.path, data, options, err => {
 				err ? reject(err) : resolve();
@@ -97,12 +100,14 @@ class Path {
 	 * @param {Object} options
 	 */
 	appendSync(data, options = {}) {
+		if (Config.nofswriting) return;
 		return fs.appendFileSync(this.path, data, options);
 	}
 	/**
 	 * @param {string} target
 	 */
 	symlinkTo(target) {
+		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {
 			// @ts-ignore TypeScript bug
 			fs.symlink(target, this.path, err => {
@@ -114,12 +119,14 @@ class Path {
 	 * @param {string} target
 	 */
 	symlinkToSync(target) {
+		if (Config.nofswriting);
 		return fs.symlinkSync(target, this.path);
 	}
 	/**
 	 * @param {string} target
 	 */
 	rename(target) {
+		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {
 			fs.rename(target, this.path, err => {
 				err ? reject(err) : resolve();
@@ -130,6 +137,7 @@ class Path {
 	 * @param {string} target
 	 */
 	renameSync(target) {
+		if (Config.nofswriting) return;
 		return fs.renameSync(target, this.path);
 	}
 	readdir() {
@@ -143,13 +151,22 @@ class Path {
 		return fs.readdirSync(this.path);
 	}
 	createWriteStream(options = {}) {
+		if (Config.nofswriting) {
+			const Writable = require('stream').Writable;
+			return new Writable({write: (chunk, encoding, callback) => callback()});
+		}
 		return fs.createWriteStream(this.path, options);
 	}
 	createAppendStream(options = {}) {
+		if (Config.nofswriting) {
+			const Writable = require('stream').Writable;
+			return new Writable({write: (chunk, encoding, callback) => callback()});
+		}
 		options.mode = options.mode || 'a';
 		return fs.createWriteStream(this.path, options);
 	}
 	unlinkIfExists() {
+		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {
 			fs.unlink(this.path, err => {
 				if (err && err.code === 'ENOENT') return resolve();
@@ -158,6 +175,7 @@ class Path {
 		});
 	}
 	unlinkIfExistsSync() {
+		if (Config.nofswriting) return;
 		try {
 			fs.unlinkSync(this.path);
 		} catch (err) {
@@ -168,6 +186,7 @@ class Path {
 	 * @param {string | number} mode
 	 */
 	mkdir(mode = 0o755) {
+		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {
 			// @ts-ignore
 			fs.mkdir(this.path, mode, err => {
@@ -179,6 +198,7 @@ class Path {
 	 * @param {string | number} mode
 	 */
 	mkdirSync(mode = 0o755) {
+		if (Config.nofswriting) return;
 		// @ts-ignore
 		return fs.mkdirSync(this.path, mode);
 	}
@@ -186,6 +206,7 @@ class Path {
 	 * @param {string | number} mode
 	 */
 	mkdirIfNonexistent(mode = 0o755) {
+		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {
 			// @ts-ignore
 			fs.mkdir(this.path, mode, err => {
@@ -198,6 +219,7 @@ class Path {
 	 * @param {string | number} mode
 	 */
 	mkdirIfNonexistentSync(mode = 0o755) {
+		if (Config.nofswriting) return;
 		try {
 			// @ts-ignore
 			fs.mkdirSync(this.path, mode);

--- a/fs.js
+++ b/fs.js
@@ -1,0 +1,260 @@
+/**
+ * FS
+ * Pokemon Showdown - http://pokemonshowdown.com/
+ *
+ * An abstraction layer around Node's filesystem.
+ *
+ * Advantages:
+ * - TODO: write() etc do nothing in unit tests
+ * - paths are always relative to PS's base directory
+ * - Promises (seriously wtf Node Core what are you thinking)
+ * - PS-style API: FS("foo.txt").write("bar") for easier argument order
+ * - mkdirp
+ *
+ * FS is used nearly everywhere, but exceptions include:
+ * - crashlogger.js - in case the crash is in here
+ * - repl.js - which use Unix sockets out of this file's scope
+ * - launch script - happens before modules are loaded
+ * - sim/ - intended to be self-contained
+ *
+ * @license MIT license
+ */
+
+'use strict';
+
+const pathModule = require('path');
+const fs = require('fs');
+
+/*eslint no-unused-expressions: ["error", { "allowTernary": true }]*/
+
+class Path {
+	/**
+	 * @param {string} path
+	 */
+	constructor(path) {
+		this.path = pathModule.resolve(__dirname, path);
+	}
+	parentDir() {
+		return new Path(pathModule.dirname(this.path));
+	}
+	read(options = {}) {
+		return new Promise((resolve, reject) => {
+			fs.readFile(this.path, options, (err, data) => {
+				err ? reject(err) : resolve(data);
+			});
+		});
+	}
+	readSync(options = {}) {
+		return fs.readFileSync(this.path, options);
+	}
+	readTextIfExists() {
+		return new Promise((resolve, reject) => {
+			fs.readFile(this.path, 'utf8', (err, data) => {
+				if (err && err.code === 'ENOENT') return resolve('');
+				err ? reject(err) : resolve(data);
+			});
+		});
+	}
+	readTextIfExistsSync() {
+		try {
+			return fs.readFileSync(this.path, 'utf8');
+		} catch (err) {
+			if (err.code !== 'ENOENT') throw err;
+		}
+		return '';
+	}
+	/**
+	 * @param {string | Buffer} data
+	 * @param {Object} options
+	 */
+	write(data, options = {}) {
+		return new Promise((resolve, reject) => {
+			fs.writeFile(this.path, data, options, err => {
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+	/**
+	 * @param {string | Buffer} data
+	 * @param {Object} options
+	 */
+	writeSync(data, options = {}) {
+		return fs.writeFileSync(this.path, data, options);
+	}
+	/**
+	 * @param {string | Buffer} data
+	 * @param {Object} options
+	 */
+	append(data, options = {}) {
+		return new Promise((resolve, reject) => {
+			fs.appendFile(this.path, data, options, err => {
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+	/**
+	 * @param {string | Buffer} data
+	 * @param {Object} options
+	 */
+	appendSync(data, options = {}) {
+		return fs.appendFileSync(this.path, data, options);
+	}
+	/**
+	 * @param {string} target
+	 */
+	symlinkTo(target) {
+		return new Promise((resolve, reject) => {
+			// @ts-ignore TypeScript bug
+			fs.symlink(target, this.path, err => {
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+	/**
+	 * @param {string} target
+	 */
+	symlinkToSync(target) {
+		return fs.symlinkSync(target, this.path);
+	}
+	/**
+	 * @param {string} target
+	 */
+	rename(target) {
+		return new Promise((resolve, reject) => {
+			fs.rename(target, this.path, err => {
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+	/**
+	 * @param {string} target
+	 */
+	renameSync(target) {
+		return fs.renameSync(target, this.path);
+	}
+	readdir() {
+		return new Promise((resolve, reject) => {
+			fs.readdir(this.path, (err, data) => {
+				err ? reject(err) : resolve(data);
+			});
+		});
+	}
+	readdirSync() {
+		return fs.readdirSync(this.path);
+	}
+	createWriteStream(options = {}) {
+		return fs.createWriteStream(this.path, options);
+	}
+	createAppendStream(options = {}) {
+		options.mode = options.mode || 'a';
+		return fs.createWriteStream(this.path, options);
+	}
+	unlinkIfExists() {
+		return new Promise((resolve, reject) => {
+			fs.unlink(this.path, err => {
+				if (err && err.code === 'ENOENT') return resolve();
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+	unlinkIfExistsSync() {
+		try {
+			fs.unlinkSync(this.path);
+		} catch (err) {
+			if (err.code !== 'ENOENT') throw err;
+		}
+	}
+	/**
+	 * @param {string | number} mode
+	 */
+	mkdir(mode = 0o755) {
+		return new Promise((resolve, reject) => {
+			// @ts-ignore
+			fs.mkdir(this.path, mode, err => {
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+	/**
+	 * @param {string | number} mode
+	 */
+	mkdirSync(mode = 0o755) {
+		// @ts-ignore
+		return fs.mkdirSync(this.path, mode);
+	}
+	/**
+	 * @param {string | number} mode
+	 */
+	mkdirIfNonexistent(mode = 0o755) {
+		return new Promise((resolve, reject) => {
+			// @ts-ignore
+			fs.mkdir(this.path, mode, err => {
+				if (err && err.code === 'EEXIST') return resolve();
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+	/**
+	 * @param {string | number} mode
+	 */
+	mkdirIfNonexistentSync(mode = 0o755) {
+		try {
+			// @ts-ignore
+			fs.mkdirSync(this.path, mode);
+		} catch (err) {
+			if (err.code !== 'EEXIST') throw err;
+		}
+	}
+	/**
+	 * Creates the directory (and any parent directories if necessary).
+	 * Does not throw if the directory already exists.
+	 * @param {string | number} mode
+	 */
+	async mkdirp(mode = 0o755) {
+		try {
+			await this.mkdirIfNonexistent(mode);
+		} catch (err) {
+			if (err.code !== 'ENOENT') throw err;
+			await this.parentDir().mkdirp(mode);
+			await this.mkdirIfNonexistent(mode);
+		}
+	}
+	/**
+	 * Creates the directory (and any parent directories if necessary).
+	 * Does not throw if the directory already exists. Synchronous.
+	 * @param {string | number} mode
+	 */
+	mkdirpSync(mode = 0o755) {
+		try {
+			this.mkdirIfNonexistentSync(mode);
+		} catch (err) {
+			if (err.code !== 'ENOENT') throw err;
+			this.parentDir().mkdirpSync(mode);
+			this.mkdirIfNonexistentSync(mode);
+		}
+	}
+	/**
+	 * Calls the callback if the file is modified.
+	 * @param {function (): void} callback
+	 */
+	onModify(callback) {
+		fs.watchFile(this.path, (curr, prev) => {
+			if (curr.mtime > prev.mtime) return callback();
+		});
+	}
+	/**
+	 * Clears callbacks added with onModify()
+	 */
+	unwatch() {
+		fs.unwatchFile(this.path);
+	}
+}
+
+/**
+ * @param {string} path
+ */
+function getFs(path) {
+	return new Path(path);
+}
+
+module.exports = getFs;

--- a/loginserver.js
+++ b/loginserver.js
@@ -15,6 +15,8 @@ const LOGIN_SERVER_BATCH_TIME = 1000;
 const http = require("http");
 const url = require('url');
 
+const FS = require('./fs');
+
 let TimeoutError = function (message) {
 	Error.captureStackTrace(this, TimeoutError);
 	this.name = "TimeoutError";
@@ -234,7 +236,7 @@ LoginServer.TimeoutError = TimeoutError;
 if (Config.remoteladder) LoginServer.ladderupdateServer = new LoginServerInstance();
 LoginServer.prepreplayServer = new LoginServerInstance();
 
-require('fs').watchFile('./config/custom.css', (curr, prev) => {
+FS('./config/custom.css').onModify(() => {
 	LoginServer.request('invalidatecss', {}, () => {});
 });
 LoginServer.request('invalidatecss', {}, () => {});

--- a/monitor.js
+++ b/monitor.js
@@ -8,8 +8,7 @@
  */
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const FS = require('./fs');
 
 class TimedCounter extends Map {
 	increment(key, timeLimit) {
@@ -165,7 +164,7 @@ const Monitor = module.exports = {
 		for (let i in this.networkUse) {
 			buf += '' + this.networkUse[i] + '\t' + this.networkCount[i] + '\t' + i + '\n';
 		}
-		fs.writeFile(path.resolve(__dirname, 'logs/networkuse.tsv'), buf, () => {});
+		FS('logs/networkuse.tsv').write(buf);
 	},
 	clearNetworkUse: function () {
 		if (Config.emergency) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,26 @@
   "version": "0.11.0",
   "lockfileVersion": 1,
   "dependencies": {
+    "@types/node": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.1.tgz",
+      "integrity": "sha512-bys2VRs6H7HP8S26aHgPWSiSX7q81TToe5HSSvl5bQjoSElQ2SwbGw2p6/DSDb7Vr0oKhewFao9ZuTn8DSag9Q=="
+    },
+    "@types/nodemailer": {
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-1.3.33.tgz",
+      "integrity": "sha512-PONEJf/LwNcqgU/GpMIAquSBFdq+kCdpYI9TdoeGcTfLCsXzWunKzv4bUQs8zfKGz97CLymgoL0fMLYpOu+/1A=="
+    },
+    "@types/nodemailer-direct-transport": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.29.tgz",
+      "integrity": "sha1-Ake7RzT4u/k5gkGxa0ECLhMD3fE="
+    },
+    "@types/nodemailer-smtp-transport": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz",
+      "integrity": "sha512-sFeTdk87Xk4ADTs7HY32Thr/sD06HJHPbmjuCOGtqVhSnMeVPf3OQAU3d4oW9bhccRLpjCWUds00CrbuU/iLzw=="
+    },
     "acorn": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
@@ -325,12 +345,6 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
-      "optional": true
-    },
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -431,12 +445,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
-    },
-    "http-proxy": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "optional": true
     },
     "ignore": {
       "version": "3.3.3",
@@ -688,6 +696,11 @@
         }
       }
     },
+    "mock-fs": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.4.1.tgz",
+      "integrity": "sha512-C8aapOvl77Bs18WCkejdLuX2kX8DaqaJ7ZmqUmX9U6HD2g31Pd0tZfNBAEVulmJWKyzUIyutrtxiIoNdXLAYsw=="
+    },
     "mock-fs-require-fix": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mock-fs-require-fix/-/mock-fs-require-fix-1.0.1.tgz",
@@ -716,12 +729,6 @@
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.9.tgz",
       "integrity": "sha1-m7afziKB96480fuYPp6g7AzZ/ss=",
-      "optional": true
-    },
-    "nodemailer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.0.1.tgz",
-      "integrity": "sha1-uVhksH+s7oKH6CMu/9bx1W7HWrI=",
       "optional": true
     },
     "number-is-nan": {
@@ -857,12 +864,6 @@
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "optional": true
     },
     "resolve": {
       "version": "1.3.3",
@@ -1026,6 +1027,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "2.5.0-dev.20170622",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.0-dev.20170622.tgz",
+      "integrity": "sha1-usxy/QNWA/W+C2pODT448GJP7P4="
     },
     "user-home": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ofe": "0.5.1"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=7.7.0"
   },
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
   "devDependencies": {
     "eslint": "^4.0.0",
     "mocha": "^3.0.0",
-    "mock-fs-require-fix": "~1.0.0"
+    "mock-fs-require-fix": "~1.0.0",
+    "@types/node": "^8.0.1",
+    "@types/nodemailer": "^1.3.33",
+    "typescript": "^2.5.0-dev.20170622"
   }
 }

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -5,12 +5,12 @@ const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-// Make sure we're Node 6+
+// Make sure we're Node 8+
 
 try {
-	eval('{ let [a] = [1]; }');
+	eval('{ let a = async () => {}; }');
 } catch (e) {
-	console.log("We require Node.js v6 or later; you're using " + process.version);
+	console.log("We require Node.js version 8 or later; you're using " + process.version);
 	process.exit(1);
 }
 

--- a/rooms.js
+++ b/rooms.js
@@ -17,8 +17,7 @@ const REPORT_USER_STATS_INTERVAL = 10 * 60 * 1000;
 
 const CRASH_REPORT_THROTTLE = 60 * 60 * 1000;
 
-const fs = require('fs');
-const path = require('path');
+const FS = require('./fs');
 
 let Rooms = module.exports = getRoom;
 
@@ -316,7 +315,7 @@ class GlobalRoom {
 
 		// init battle room logging
 		if (Config.logladderip) {
-			this.ladderIpLog = fs.createWriteStream('logs/ladderip/ladderip.txt', {encoding: 'utf8', flags: 'a'});
+			this.ladderIpLog = FS('logs/ladderip/ladderip.txt').createAppendStream();
 		} else {
 			// Prevent there from being two possible hidden classes an instance
 			// of GlobalRoom can have.
@@ -325,15 +324,14 @@ class GlobalRoom {
 
 		let lastBattle;
 		try {
-			lastBattle = fs.readFileSync('logs/lastbattle.txt', 'utf8');
+			lastBattle = FS('logs/lastbattle.txt').readSync('utf8');
 		} catch (e) {}
 		this.lastBattle = (!lastBattle || isNaN(lastBattle)) ? 0 : +lastBattle;
-
 
 		this.writeChatRoomData = (() => {
 			let writing = false;
 			let writePending = false;
-			return () => {
+			return async () => {
 				if (writing) {
 					writePending = true;
 					return;
@@ -344,23 +342,22 @@ class GlobalRoom {
 					.replace(/\{"title":/g, '\n{"title":')
 					.replace(/\]$/, '\n]');
 
-				fs.writeFile('config/chatrooms.json.0', data, () => {
-					data = null;
-					fs.rename('config/chatrooms.json.0', 'config/chatrooms.json', () => {
-						writing = false;
-						if (writePending) {
-							writePending = false;
-							setImmediate(() => this.writeChatRoomData());
-						}
-					});
-				});
+				await FS('config/chatrooms.json.0').write(data);
+				data = null;
+				await FS('config/chatrooms.json.0').rename('config/chatrooms.json');
+				writing = false;
+				if (writePending) {
+					writePending = false;
+					setImmediate(() => this.writeChatRoomData());
+				}
 			};
 		})();
+		if (Config.nofswriting) this.writeChatRoomData = () => {};
 
 		this.writeNumRooms = (() => {
 			let writing = false;
 			let lastBattle = -1; // last lastBattle to be written to file
-			return () => {
+			return async () => {
 				if (writing) return;
 
 				// batch writing lastbattle.txt for every 10 battles
@@ -369,18 +366,17 @@ class GlobalRoom {
 
 				let filename = 'logs/lastbattle.txt';
 				writing = true;
-				fs.writeFile(`${filename}.0`, '' + lastBattle, () => {
-					fs.rename(`${filename}.0`, filename, () => {
-						writing = false;
-						lastBattle = null;
-						filename = null;
-						if (lastBattle < this.lastBattle) {
-							setImmediate(() => this.writeNumRooms());
-						}
-					});
-				});
+				await FS(`${filename}.0`).write('' + lastBattle);
+				await FS(`${filename}.0`).rename(filename);
+				writing = false;
+				lastBattle = null;
+				filename = null;
+				if (lastBattle < this.lastBattle) {
+					setImmediate(() => this.writeNumRooms());
+				}
 			};
 		})();
+		if (Config.nofswriting) this.writeNumRooms = () => {};
 
 		// init users
 		this.users = Object.create(null);
@@ -394,7 +390,7 @@ class GlobalRoom {
 		);
 
 		// Create writestream for modlog
-		this.modlogStream = fs.createWriteStream(path.resolve(__dirname, 'logs/modlog/modlog_global.txt'), {flags:'a+'});
+		this.modlogStream = FS('logs/modlog/modlog_global.txt').createAppendStream();
 	}
 
 	reportUserStats() {
@@ -945,7 +941,7 @@ class BattleRoom extends Room {
 			this.expireTimer = setTimeout(() => this.tryExpire(), TIMEOUT_INACTIVE_DEALLOCATE);
 		}
 	}
-	logBattle(p1score, p1rating, p2rating) {
+	async logBattle(p1score, p1rating, p2rating) {
 		if (this.battle.supplementaryBanlist) return;
 		let logData = this.battle.logData;
 		if (!logData) return;
@@ -974,20 +970,13 @@ class BattleRoom extends Room {
 		logData.timestamp = '' + date;
 		logData.id = this.id;
 		logData.format = this.format;
+
 		const logsubfolder = Chat.toTimestamp(date).split(' ')[0];
 		const logfolder = logsubfolder.split('-', 2).join('-');
-
-		let curpath = 'logs/' + logfolder;
-		fs.mkdir(curpath, '0755', () => {
-			let tier = this.format.toLowerCase().replace(/[^a-z0-9]+/g, '');
-			curpath += '/' + tier;
-			fs.mkdir(curpath, '0755', () => {
-				curpath += '/' + logsubfolder;
-				fs.mkdir(curpath, '0755', () => {
-					fs.writeFile(curpath + '/' + this.id + '.log.json', JSON.stringify(logData), () => {});
-				});
-			});
-		}); // asychronicity
+		const tier = this.format.toLowerCase().replace(/[^a-z0-9]+/g, '');
+		const logpath = `logs/${logfolder}/${tier}/${logsubfolder}/`;
+		await FS(logpath).mkdirp();
+		await FS(logpath + '/' + this.id + '.log.json').write(JSON.stringify(logData));
 		//console.log(JSON.stringify(logData));
 	}
 	tryExpire() {
@@ -1157,7 +1146,7 @@ class ChatRoom extends Room {
 		if (this.isPersonal) {
 			this.modlogStream = Rooms.groupchatModlogStream;
 		} else {
-			this.modlogStream = fs.createWriteStream(path.resolve(__dirname, 'logs/modlog/modlog_' + roomid + '.txt'), {flags:'a+'});
+			this.modlogStream = FS('logs/modlog/modlog_' + roomid + '.txt').createAppendStream();
 		}
 	}
 
@@ -1172,52 +1161,48 @@ class ChatRoom extends Room {
 		this.reportJoinsQueue.length = 0;
 	}
 
-	rollLogFile(sync) {
-		let mkdir = sync ? (path, mode, callback) => {
-			try {
-				fs.mkdirSync(path, mode);
-			} catch (e) {}	// directory already exists
-			callback();
-		} : fs.mkdir;
-		let date = new Date();
-		let basepath = 'logs/chat/' + this.id + '/';
-		mkdir(basepath, '0755', () => {
-			const dateString = Chat.toTimestamp(date).split(' ')[0];
-			let path = dateString.split('-', 2).join('-');
-			mkdir(basepath + path, '0755', () => {
-				if (this.destroyingLog) return;
-				path += '/' + dateString + '.txt';
-				if (path !== this.logFilename) {
-					this.logFilename = path;
-					if (this.logFile) this.logFile.destroySoon();
-					this.logFile = fs.createWriteStream(basepath + path, {flags: 'a'});
-					// Create a symlink to today's lobby log.
-					// These operations need to be synchronous, but it's okay
-					// because this code is only executed once every 24 hours.
-					let link0 = basepath + 'today.txt.0';
-					try {
-						fs.unlinkSync(link0);
-					} catch (e) {} // file doesn't exist
-					try {
-						fs.symlinkSync(path, link0); // `basepath` intentionally not included
-						try {
-							fs.renameSync(link0, basepath + 'today.txt');
-						} catch (e) {} // OS doesn't support atomic rename
-					} catch (e) {} // OS doesn't support symlinks
-				}
-				let currentTime = date.getTime();
-				let nextHour = new Date(date.setMinutes(60)).setSeconds(1);
-				setTimeout(() => this.rollLogFile(), nextHour - currentTime);
-			});
-		});
+	async rollLogFile(sync) {
+		const date = new Date();
+		const dateString = Chat.toTimestamp(date).split(' ')[0];
+		const monthString = dateString.split('-', 2).join('-');
+		const basepath = `logs/chat/${this.id}/`;
+		const relpath = `${monthString}/`;
+		const filename = dateString + '.txt';
+
+		const currentTime = date.getTime();
+		const nextHour = new Date(date.setMinutes(60)).setSeconds(1);
+
+		// This could cause problems if the previous rollLogFile from an
+		// hour ago isn't done yet. But if that's the case, we have bigger
+		// problems anyway.
+		if (!sync) setTimeout(() => this.rollLogFile(), nextHour - currentTime);
+
+		if (relpath + filename === this.logFilename) return;
+
+		if (sync) {
+			FS(basepath + relpath).mkdirpSync();
+		} else {
+			await FS(basepath + relpath).mkdirp();
+		}
+		if (this.destroyingLog) return;
+		this.logFilename = relpath + filename;
+		if (this.logFile) this.logFile.end();
+		this.logFile = FS(basepath + relpath + filename).createAppendStream();
+		// Create a symlink to today's lobby log.
+		// These operations need to be synchronous, but it's okay
+		// because this code is only executed once every 24 hours.
+		let link0 = basepath + 'today.txt.0';
+		FS(link0).unlinkIfExistsSync();
+		try {
+			FS(link0).symlinkToSync(relpath + filename); // intentionally a relative link
+			FS(link0).renameSync(basepath + 'today.txt');
+		} catch (e) {} // OS might not support symlinks or atomic rename
 	}
-	destroyLog(initialCallback, finalCallback) {
+	destroyLog(finalCallback) {
 		this.destroyingLog = true;
-		initialCallback();
 		if (this.logFile) {
 			this.logEntry = function () { };
-			this.logFile.on('close', finalCallback);
-			this.logFile.destroySoon();
+			this.logFile.end(finalCallback);
 		} else {
 			finalCallback();
 		}
@@ -1420,8 +1405,8 @@ class ChatRoom extends Room {
 		this.logUserStatsInterval = null;
 
 		if (!this.isPersonal) {
-			this.modlogStream.destroySoon();
 			this.modlogStream.removeAllListeners('finish');
+			this.modlogStream.end();
 		}
 		this.modlogStream = null;
 
@@ -1462,8 +1447,8 @@ Rooms.createChatRoom = function (roomid, title, data) {
 	return room;
 };
 
-Rooms.battleModlogStream = fs.createWriteStream(path.resolve(__dirname, 'logs/modlog/modlog_battle.txt'), {flags:'a+'});
-Rooms.groupchatModlogStream = fs.createWriteStream(path.resolve(__dirname, 'logs/modlog/modlog_groupchat.txt'), {flags:'a+'});
+Rooms.battleModlogStream = FS('logs/modlog/modlog_battle.txt').createAppendStream();
+Rooms.groupchatModlogStream = FS('logs/modlog/modlog_groupchat.txt').createAppendStream();
 
 Rooms.global = null;
 Rooms.lobby = null;

--- a/test/main.js
+++ b/test/main.js
@@ -2,19 +2,8 @@
 
 const path = require('path');
 const fs = require('fs');
-const Module = require('module');
-const mock = require('mock-fs-require-fix');
 
 const noop = () => {};
-
-function getDirTypedContentsSync(dir, forceType) {
-	// Return value can be fed to mock-fs
-	if (forceType !== 'dir' && forceType !== 'file') throw new Error("Not implemented");
-	return fs.readdirSync(dir).reduce((dict, elem) => {
-		dict[elem] = forceType === 'dir' ? {} : '';
-		return dict;
-	}, {});
-}
 
 before('initialization', function () {
 	// Load and override configuration before starting the server
@@ -34,40 +23,13 @@ before('initialization', function () {
 
 	// Actually crash if we crash
 	config.crashguard = false;
+	// Don't allow config to be overridden while test is running
+	config.watchconfig = false;
 	// Don't try to write to file system
-	config.logladderip = false;
-	config.logchallenges = false;
-	config.logchat = false;
 	config.nofswriting = true;
-
-	try {
-		let chatRoomsPath = require.resolve('../config/chatrooms.json');
-		let chatRoomsData = require.cache[chatRoomsPath] = new Module(chatRoomsPath, module);
-		chatRoomsData.filename = chatRoomsData.id;
-		chatRoomsData.exports = []; // empty chatrooms list
-		chatRoomsData.loaded = true;
-	} catch (e) {}
 
 	// Don't create a REPL
 	require('../repl').start = noop;
-
-	// `watchFile` is unsupported and throws with mock-fs
-	Object.defineProperty(fs, 'watchFile', {
-		get: function () {return noop;},
-		set: noop,
-	});
-
-	// Sandbox file system: it's possible for a production server to be running in the same directory.
-	// And using a sandbox is safer anyway.
-	mock({
-		'config': {},
-		'chat-plugins': getDirTypedContentsSync('chat-plugins', 'file'),
-		'mods': getDirTypedContentsSync('mods', 'dir'),
-		'logs': {
-			'chat': {}, 'ladderip': {}, 'modlog': {}, 'repl': {},
-			'lastbattle.txt': '0',
-		},
-	});
 
 	// Start the server.
 	require('../app');
@@ -80,7 +42,4 @@ before('initialization', function () {
 	}
 
 	LoginServer.disabled = true;
-
-	// Disable writing to modlog
-	Rooms.Room.prototype.modlog = noop;
 });

--- a/test/main.js
+++ b/test/main.js
@@ -38,6 +38,7 @@ before('initialization', function () {
 	config.logladderip = false;
 	config.logchallenges = false;
 	config.logchat = false;
+	config.nofswriting = true;
 
 	try {
 		let chatRoomsPath = require.resolve('../config/chatrooms.json');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "./sim/prng.js",
         "./crashlogger.js",
         "./dnsbl.js",
-        "./repl.js"
+        "./repl.js",
+        "./fs.js"
     ]
 }

--- a/users.js
+++ b/users.js
@@ -32,7 +32,7 @@ const THROTTLE_MULTILINE_WARN_STAFF = 6;
 
 const PERMALOCK_CACHE_TIME = 30 * 24 * 60 * 60 * 1000;
 
-const fs = require('fs');
+const FS = require('./fs');
 
 const Matchmaker = require('./ladders-matchmaker').matchmaker;
 
@@ -138,13 +138,11 @@ function importUsergroups() {
 	// can't just say usergroups = {} because it's exported
 	for (let i in usergroups) delete usergroups[i];
 
-	fs.readFile('config/usergroups.csv', (err, data) => {
-		if (err) return;
-		data = ('' + data).split("\n");
-		for (let i = 0; i < data.length; i++) {
-			if (!data[i]) continue;
-			let row = data[i].split(",");
-			usergroups[toId(row[0])] = (row[1] || Config.groupsranking[0]) + row[0];
+	FS('config/usergroups.csv').readTextIfExists().then(data => {
+		for (const row of data.split("\n")) {
+			if (!row) continue;
+			let cells = row.split(",");
+			usergroups[toId(cells[0])] = (cells[1] || Config.groupsranking[0]) + cells[0];
 		}
 	});
 }
@@ -153,7 +151,7 @@ function exportUsergroups() {
 	for (let i in usergroups) {
 		buffer += usergroups[i].substr(1).replace(/,/g, '') + ',' + usergroups[i].charAt(0) + "\n";
 	}
-	fs.writeFile('config/usergroups.csv', buffer, () => {});
+	FS('config/usergroups.csv').write(buffer);
 }
 importUsergroups();
 
@@ -1536,12 +1534,7 @@ Users.socketConnect = function (worker, workerid, socketid, ip, protocol) {
 	}
 	// Emergency mode connections logging
 	if (Config.emergency) {
-		fs.appendFile('logs/cons.emergency.log', '[' + ip + ']\n', err => {
-			if (err) {
-				console.log('!! Error in emergency conns log !!');
-				throw err;
-			}
-		});
+		FS('logs/cons.emergency.log').append('[' + ip + ']\n');
 	}
 
 	let user = new User(connection);
@@ -1615,12 +1608,7 @@ Users.socketReceive = function (worker, workerid, socketid, message) {
 	}
 	// Emergency logging
 	if (Config.emergency) {
-		fs.appendFile('logs/emergency.log', `[${user} (${connection.ip})] ${roomId}|${message}\n`, err => {
-			if (err) {
-				console.log(`!! Error in emergency log !!`);
-				throw err;
-			}
-		});
+		FS('logs/emergency.log').append(`[${user} (${connection.ip})] ${roomId}|${message}\n`);
 	}
 
 	let startTime = Date.now();


### PR DESCRIPTION
This replaces the fs module with a new abstraction layer.

The new abstraction layer looks slightly different:

```js
// new
const data = await FS("package.json").read();

// old
fs.readFile(path.resolve(__dirname, "package.json"), (err, data) => {
  ...
});
```

as you can see:

 - PS-style API: FS("foo.txt").write("bar") for easier argument order
 - Promises (seriously wtf Node Core what are you thinking)

but also:

 - ability to turn off all filesystem writing (for unit tests)
 - paths are always relative to PS's base directory
 - `mkdirp` - make a directory and all the parent directories necessary to make it
 - `readTextIfExists` - suppress "file not found" errors and read as string
 - `onModify` - like `watchFile` but only calls callback for modifications
 - `rmdirIfExists` - suppress "directory not found" errors

Most importantly, though, the ability to turn off writes is important, because currently our tests don't work on Node 8, because `mock-fs-require-fix` doesn't support Node 8. This module is a lot easier to support than a `mock-fs` fork.