### PR TITLE
Fix order of old and new path when renaming

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -128,7 +128,7 @@ class Path {
 	rename(target) {
 		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {
-			fs.rename(target, this.path, err => {
+			fs.rename(this.path, target, err => {
 				err ? reject(err) : resolve();
 			});
 		});
@@ -138,7 +138,7 @@ class Path {
 	 */
 	renameSync(target) {
 		if (Config.nofswriting) return;
-		return fs.renameSync(target, this.path);
+		return fs.renameSync(this.path, target);
 	}
 	readdir() {
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
Otherwise your server will crash when its log rolls over or a battle starts...