### PR TITLE
ProcessManager: refactor, fix memory leak, use Typescript

### DIFF
--- a/app.js
+++ b/app.js
@@ -107,7 +107,6 @@ global.Chat = require('./chat');
 global.Rooms = require('./rooms');
 
 global.Verifier = require('./verifier');
-Verifier.PM.spawn();
 
 global.Tournaments = require('./tournaments');
 
@@ -153,7 +152,6 @@ if (require.main === module) {
  *********************************************************/
 
 global.TeamValidator = require('./team-validator');
-TeamValidator.PM.spawn();
 
 /*********************************************************
  * Start up the REPL server

--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -21,13 +21,31 @@ function escapeHTML(str) {
 }
 
 class DatasearchManager extends ProcessManager {
+	onFork() {
+		global.Config = require('../config/config');
+		process.on('uncaughtException', err => {
+			if (Config.crashguard) {
+				require('../crashlogger')(err, 'A dexsearch process', true);
+			}
+		});
+
+		global.Dex = require('../sim/dex');
+		global.toId = Dex.getId;
+		Dex.includeData();
+		global.TeamValidator = require('../team-validator');
+
+		process.on('message', message => this.onMessageDownstream(message));
+		process.on('disconnect', () => process.exit(0));
+
+		require('../repl').start('dexsearch', cmd => eval(cmd));
+	}
+
 	onMessageUpstream(message) {
 		// Protocol:
 		// "[id]|JSON"
 		let pipeIndex = message.indexOf('|');
 		let id = +message.substr(0, pipeIndex);
 		let result = JSON.parse(message.slice(pipeIndex + 1));
-
 		if (this.pendingTasks.has(id)) {
 			this.pendingTasks.get(id)(result);
 			this.pendingTasks.delete(id);
@@ -40,9 +58,8 @@ class DatasearchManager extends ProcessManager {
 		// "[id]|{data, sig}"
 		let pipeIndex = message.indexOf('|');
 		let id = message.substr(0, pipeIndex);
-
 		let data = JSON.parse(message.slice(pipeIndex + 1));
-		process.send(id + '|' + JSON.stringify(this.receive(data)));
+		process.send(`${id}|${this.receive(data)}`);
 	}
 
 	receive(data) {
@@ -70,7 +87,7 @@ class DatasearchManager extends ProcessManager {
 			require('./../crashlogger')(err, 'A search query', data);
 			result = {error: "Sorry! Our search engine crashed on your query. We've been automatically notified and will fix this crash."};
 		}
-		return result;
+		return JSON.stringify(result);
 	}
 }
 
@@ -314,28 +331,6 @@ exports.commands = {
 		"/learn can also be prefixed by a generation acronym (e.g.: /dpplearn) to indicate which generation is used. Valid options are: rby gsc adv dpp bw2 oras",
 	],
 };
-
-if (process.send && module === process.mainModule) {
-	// This is a child process!
-
-	global.Config = require('../config/config');
-
-	if (Config.crashguard) {
-		process.on('uncaughtException', err => {
-			require('../crashlogger')(err, 'A dexsearch process', true);
-		});
-	}
-
-	global.Dex = require('../sim/dex');
-	global.toId = Dex.getId;
-	Dex.includeData();
-	global.TeamValidator = require('../team-validator');
-
-	process.on('message', message => PM.onMessageDownstream(message));
-	process.on('disconnect', () => process.exit());
-
-	require('../repl').start('dexsearch', cmd => eval(cmd));
-}
 
 function runDexsearch(target, cmd, canAll, message) {
 	let searches = [];
@@ -1530,8 +1525,4 @@ function runLearn(target, cmd) {
 
 function runSearch(query) {
 	return PM.send(query);
-}
-
-if (!process.send) {
-	PM.spawn();
 }

--- a/process-manager.js
+++ b/process-manager.js
@@ -9,81 +9,142 @@
 
 'use strict';
 
+const child_process = require('child_process');
 const EventEmitter = require('events');
 
+/** @type {Map<any, string>} */
 const processManagers = new Map();
 
+/**
+ * @param {any} str
+ * @return {string}
+ */
 function serialize(str) {
 	if (typeof str === 'string') return str;
 	return JSON.stringify(str);
 }
 
+/**
+ * @class ProcessWrapper
+ * @extends NodeJS.EventEmitter
+ * @property {boolean} active
+ * @property {Map<number, any>} pendingTasks
+ * @property {any} process
+ */
 class ProcessWrapper extends EventEmitter {
-	constructor(PM) {
+	/** @param {string} execFile */
+	constructor(execFile) {
 		super();
 
-		this.PM = PM;
 		this.active = true;
 		this.pendingTasks = new Map();
-		this.process = require('child_process').fork(PM.execFile, {cwd: __dirname});
+		this.process = child_process.fork(execFile, [], {
+			cwd: __dirname,
+			env: {PS_MANAGED_PROCESS: 1},
+		});
 
-		// Allow events to bubble-up to the wrapper
+		// Allow events to bubble up to the wrapper.
 		this.process.on('message', message => this.emit('message', message));
-
-		this.on('message', PM.onMessageUpstream);
+		this.process.once('disconnect', () => this.emit('disconnect'));
 	}
 
+	/**
+	 * @param {string} data
+	 * @return {boolean}
+	 */
 	send(data) {
+		if (!this.active || !this.connected) return false;
 		return this.process.send(data);
 	}
 
+	/** @return {boolean} */
 	release() {
-		if (this.load || this.active) return;
+		if (this.active || this.load || !this.connected) return false;
 		this.process.disconnect();
+		return true;
 	}
 
+	/** @return {boolean} */
+	get connected() {
+		return this.process.connected;
+	}
+
+	/** @return {number} */
 	get load() {
 		return this.pendingTasks.size;
 	}
 }
 
-// execFile - the path to the file to spawn the child process(es) from
-// maxProcesses - the maximum number of child processes to spawn
-// isChatBased - the process manager handles some chat functionality
+/**
+ * @typedef {Object} PMOptions
+ * The path to the module that child process(es) should be forked from.
+ * @property {string} [execFile]
+ * The maximum number of child processes to spawn.
+ * @property {number} [maxProcesses]
+ * Whether or not this manages a chat-commands module.
+ * @property {boolean} [isChatBased]
+ */
+
+/**
+ * @class ProcessManager
+ * @property {Set<ProcessWrapper>} processes
+ * @property {number} taskid
+ * @property {string} execFile
+ * @property {number} maxProcesses
+ * @property {boolean} isChatBased
+ */
 class ProcessManager {
+	/** @param {PMOptions} options */
 	constructor(options) {
-		if (!('execFile' in options)) {
-			Monitor.debug(
-				"No execFile property was missing form the options object to be " +
-				"given to the ProcessManager constructor!"
-			);
-		} else if (!('maxProcesses' in options) || !('isChatBased' in options)) {
-			Monitor.debug(
-				"An options object given to the ProcessManager constructor is " +
-				"missing required properties! The filename given is: " + (options.execFile || '""') + "."
+		if (!('execFile' in options) || !('maxProcesses' in options) || !('isChatBased' in options)) {
+			throw new Error(
+				"An options object given to the ProcessManager constructor is missing required properties! " +
+				`The filename given is: ${options.execFile}`
 			);
 		}
 
-		this.processes = [];
-		this.taskId = 0;
-		this.execFile = options.execFile;
-		this.maxProcesses = (typeof options.maxProcesses === 'number') ? options.maxProcesses : 1;
+		this.processes = new Set();
+		this.taskid = 0;
+		this.execFile = '' + options.execFile;
+		this.maxProcesses = +options.maxProcesses || 1;
 		this.isChatBased = !!options.isChatBased;
 
-		processManagers.set(this, options.execFile);
+		new.target.cache.set(this, this.execFile);
+
+		// @ts-ignore
+		let isParentProcess = !(+process.env.PS_MANAGED_PROCESS);
+		if (isParentProcess) {
+			process.nextTick(() => this.spawn());
+			// @ts-ignore
+		} else if (process.mainModule.filename === this.execFile) {
+			process.nextTick(() => this.onFork());
+		}
 	}
 
+	/**
+	 * Defines any missing global variables, sets up crash logging, etc.
+	 * Child processes call this after being spawned.
+	 */
+	onFork() {}
+
 	spawn() {
-		for (let i = this.processes.length; i < this.maxProcesses; ++i) {
-			this.processes.push(new ProcessWrapper(this));
+		for (let i = this.processes.size; i < this.maxProcesses; i++) {
+			let PW = new ProcessWrapper(this.execFile);
+			PW.on('message', this.onMessageUpstream);
+			this.processes.add(PW);
 		}
 	}
 
 	unspawn() {
-		for (let process of this.processes.splice(0)) {
-			process.active = false;
-			process.release();
+		if (!this.processes.size) return;
+
+		for (let PW of this.processes) {
+			PW.active = false;
+			PW.removeAllListeners('message');
+			PW.release();
 		}
+
+		this.processes.clear();
 	}
 
 	respawn() {
@@ -91,57 +152,80 @@ class ProcessManager {
 		this.spawn();
 	}
 
+	/** @return {?ProcessWrapper} */
 	acquire() {
-		let process = this.processes[0];
-		for (let i = 1; i < this.processes.length; ++i) {
-			if (this.processes[i].load < process.load) {
-				process = this.processes[i];
+		if (!this.processes.size) return null;
+
+		let ret = null;
+		for (let PW of this.processes) {
+			if (!ret || PW.load < ret.load) {
+				ret = PW;
+				if (!PW.load) break;
 			}
 		}
-		return process;
+
+		return ret;
 	}
 
-	release(process) {
-		process.release();
-	}
-
+	/**
+	 * @param {...any} args
+	 * @return {Promise<any>}
+	 */
 	send(...args) {
-		if (!this.processes.length) {
-			return Promise.resolve(this.receive.apply(this, args));
-		}
-
-		let serializedArgs = args.map(serialize).join('|');
 		return new Promise((resolve, reject) => {
-			let process = this.acquire();
-			process.pendingTasks.set(this.taskId, resolve);
-			try {
-				process.process.send(`${this.taskId}|${serializedArgs}`);
-			} catch (e) {}
-			++this.taskId;
+			let PW = this.acquire();
+			if (PW) {
+				let taskid = this.taskid++;
+				let serializedArgs = args.map(serialize).join('|');
+				PW.pendingTasks.set(taskid, resolve);
+				PW.send(`${taskid}|${serializedArgs}`);
+			} else {
+				resolve(this.receive(...args));
+			}
 		});
 	}
 
+	/**
+	 * @param {...any} args
+	 * @return {any}
+	 */
 	sendSync(...args) {
-		// synchronously!
-		return this.receive.apply(this, args);
+		return this.receive(...args);
 	}
 
-	onMessageUpstream() {
-		// Expected to resolve the pending task completed.
+	/**
+	 * Resolves a pending task with its result. This uses ProcessWrapper's
+	 * context.
+	 *
+	 * @param {string} message
+	 */
+	onMessageUpstream(message) {}
+
+	/**
+	 * Parses a message sent by the parent process, passes it to
+	 * ProcessManager#receive, and sends back the result.
+	 *
+	 * @param {string} message
+	 */
+	onMessageDownstream(message) {}
+
+	/**
+	 * Handles processing data sent by the parent process, returning the result.
+	 *
+	 * @param {...any} args
+	 * @return {any}
+	 */
+	receive(...args) {}
+
+	/** @return {Map<ProcessManager, string>} */
+	static get cache() {
+		return processManagers;
 	}
 
-	onMessageDownstream() {
-		// Expected to call `receive()` at some point,
-		// and send the result to the parent process.
-	}
-
-	receive() {
-		// This is where the child process actually does stuff
-		// To be overriden by specific implementations.
-		return '';
+	/** @return {{new(execFile: string): ProcessWrapper}} */
+	static get ProcessWrapper() {
+		return ProcessWrapper;
 	}
 }
 
-ProcessManager.cache = processManagers;
-ProcessManager.ProcessWrapper = ProcessWrapper;
 module.exports = ProcessManager;

--- a/room-battle.js
+++ b/room-battle.js
@@ -13,6 +13,9 @@
 
 'use strict';
 
+const ProcessManager = require('./process-manager');
+let Sim;
+
 /** 10 seconds */
 const TICK_TIME = 10 * 1000;
 
@@ -25,20 +28,122 @@ const MAX_TURN_TICKS_CHALLENGE = 30;
 // time after a player disabling the timer before they can re-enable it
 const TIMER_COOLDOWN = 20 * 1000;
 
-global.Config = require('./config/config');
-
-const ProcessManager = require('./process-manager');
-
 class SimulatorManager extends ProcessManager {
+	constructor(execFile) {
+		super(execFile);
+
+		this.battles = null;
+	}
+
+	onFork() {
+		this.battles = new Map();
+
+		global.Config = require('./config/config');
+		process.on('uncaughtException', err => {
+			if (Config.crashguard) {
+				require('./crashlogger')(err, 'A simulator process');
+			}
+		});
+
+		global.Chat = require('./chat');
+		Sim = require('./sim');
+		global.Dex = require('./sim/dex');
+		global.toId = Dex.getId;
+
+		process.on('message', message => this.onMessageDownstream(message));
+		process.once('disconnect', () => process.exit(0));
+
+		require('./repl').start(`sim-${process.pid}`, cmd => eval(cmd));
+	}
+
 	onMessageUpstream(message) {
 		let lines = message.split('\n');
 		let battle = this.pendingTasks.get(lines[0]);
 		if (battle) battle.receive(lines);
 	}
 
+	onMessageDownstream(message) {
+		//console.log('CHILD MESSAGE RECV: "' + message + '"');
+		let nlIndex = message.indexOf("\n");
+		let more = '';
+		if (nlIndex > 0) {
+			more = message.substr(nlIndex + 1);
+			message = message.substr(0, nlIndex);
+		}
+
+		let data = message.split('|');
+		let id = data[0];
+		switch (data[1]) {
+		case 'init':
+			if (this.battles.has(id)) return;
+
+			try {
+				const battle = Sim.construct(Dex.getFormat(data[2], data[4]), data[3], sendBattleMessage);
+				battle.id = id;
+				this.battles.set(id, battle);
+			} catch (err) {
+				if (require('./crashlogger')(err, 'A battle', {message}) === 'lockdown') {
+					let ministack = Chat.escapeHTML(err.stack).split("\n").slice(0, 2).join("<br />");
+					process.send(id + '\nupdate\n|html|<div class="broadcast-red"><b>A BATTLE PROCESS HAS CRASHED:</b> ' + ministack + '</div>');
+				} else {
+					process.send(id + '\nupdate\n|html|<div class="broadcast-red"><b>The battle crashed!</b><br />Don\'t worry, we\'re working on fixing it.</div>');
+				}
+			}
+
+			break;
+
+		case 'dealloc':
+			if (this.battles.has(id)) {
+				this.battles.get(id).destroy();
+				this.battles.delete(id);
+			} else {
+				require('./crashlogger')(new Error("Invalid dealloc"), 'A battle', {message});
+			}
+
+			break;
+
+		case 'eval':
+			try {
+				eval(message.substr(message.indexOf('|') + 1));
+			} catch (e) {}
+			break;
+
+		default:
+			let battle = this.battles.get(id);
+			if (!battle) return;
+
+			let prevRequest = battle.currentRequest;
+			let prevRequestDetails = battle.currentRequestDetails || '';
+			try {
+				battle.receive(data, more);
+			} catch (err) {
+				require('./crashlogger')(err, 'A battle', {
+					message,
+					currentRequest: prevRequest,
+					log: '\n' + battle.log.join('\n').replace(/\n\|split\n[^\n]*\n[^\n]*\n[^\n]*\n/g, '\n'),
+				});
+
+				let logPos = battle.log.length;
+				battle.add('html', '<div class="broadcast-red"><b>The battle crashed</b><br />You can keep playing but it might crash again.</div>');
+
+				let nestedError;
+				try {
+					battle.makeRequest(prevRequest, prevRequestDetails);
+				} catch (e) {
+					nestedError = e;
+				}
+
+				battle.sendUpdates(logPos);
+				if (nestedError) throw nestedError;
+			}
+
+			break;
+		}
+	}
+
 	eval(code) {
-		for (let process of this.processes) {
-			process.send(`|eval|${code}`);
+		for (let PW of this.processes) {
+			PW.send(`|eval|${code}`);
 		}
 	}
 }
@@ -667,118 +772,17 @@ class Battle {
 	}
 }
 
-exports.RoomBattlePlayer = BattlePlayer;
-exports.RoomBattleTimer = BattleTimer;
-exports.RoomBattle = Battle;
-exports.SimulatorManager = SimulatorManager;
-exports.SimulatorProcess = SimulatorProcess;
-
-if (process.send && module === process.mainModule) {
-	// This is a child process!
-
-	global.Chat = require('./chat');
-	const Sim = require('./sim');
-	global.Dex = require('./sim/dex');
-	global.toId = Dex.getId;
-
-	if (Config.crashguard) {
-		// graceful crash - allow current battles to finish before restarting
-		process.on('uncaughtException', err => {
-			require('./crashlogger')(err, 'A simulator process');
-		});
-	}
-
-	require('./repl').start(`sim-${process.pid}`, cmd => eval(cmd));
-
-	let Battles = new Map();
-
-	// Receive and process a message sent using Simulator.prototype.send in
-	// another process.
-	process.on('message', message => {
-		//console.log('CHILD MESSAGE RECV: "' + message + '"');
-		let nlIndex = message.indexOf("\n");
-		let more = '';
-		if (nlIndex > 0) {
-			more = message.substr(nlIndex + 1);
-			message = message.substr(0, nlIndex);
-		}
-		let data = message.split('|');
-		if (data[1] === 'init') {
-			const id = data[0];
-			if (!Battles.has(id)) {
-				try {
-					const battle = Sim.construct(Dex.getFormat(data[2], data[4]), data[3], sendBattleMessage);
-					battle.id = id;
-					Battles.set(id, battle);
-				} catch (err) {
-					if (require('./crashlogger')(err, 'A battle', {
-						message: message,
-					}) === 'lockdown') {
-						let ministack = Chat.escapeHTML(err.stack).split("\n").slice(0, 2).join("<br />");
-						process.send(id + '\nupdate\n|html|<div class="broadcast-red"><b>A BATTLE PROCESS HAS CRASHED:</b> ' + ministack + '</div>');
-					} else {
-						process.send(id + '\nupdate\n|html|<div class="broadcast-red"><b>The battle crashed!</b><br />Don\'t worry, we\'re working on fixing it.</div>');
-					}
-				}
-			}
-		} else if (data[1] === 'dealloc') {
-			const id = data[0];
-			if (Battles.has(id)) {
-				Battles.get(id).destroy();
-
-				// remove from battle list
-				Battles.delete(id);
-			} else {
-				require('./crashlogger')(new Error("Invalid dealloc"), 'A battle', {
-					message: message,
-				});
-			}
-		} else {
-			let battle = Battles.get(data[0]);
-			if (battle) {
-				let prevRequest = battle.currentRequest;
-				let prevRequestDetails = battle.currentRequestDetails || '';
-				try {
-					battle.receive(data, more);
-				} catch (err) {
-					require('./crashlogger')(err, 'A battle', {
-						message: message,
-						currentRequest: prevRequest,
-						log: '\n' + battle.log.join('\n').replace(/\n\|split\n[^\n]*\n[^\n]*\n[^\n]*\n/g, '\n'),
-					});
-
-					let logPos = battle.log.length;
-					battle.add('html', '<div class="broadcast-red"><b>The battle crashed</b><br />You can keep playing but it might crash again.</div>');
-					let nestedError;
-					try {
-						battle.makeRequest(prevRequest, prevRequestDetails);
-					} catch (e) {
-						nestedError = e;
-					}
-					battle.sendUpdates(logPos);
-					if (nestedError) {
-						throw nestedError;
-					}
-				}
-			} else if (data[1] === 'eval') {
-				try {
-					eval(data[2]);
-				} catch (e) {}
-			}
-		}
-	});
-
-	process.on('disconnect', () => {
-		process.exit();
-	});
-} else {
-	// Create the initial set of simulator processes.
-	SimulatorProcess.spawn();
-}
-
 // Messages sent by this function are received and handled in
 // Battle.prototype.receive in simulator.js (in another process).
 function sendBattleMessage(type, data) {
 	if (Array.isArray(data)) data = data.join("\n");
 	process.send(this.id + "\n" + type + "\n" + data);
 }
+
+module.exports = {
+	RoomBattlePlayer: BattlePlayer,
+	RoomBattleTimer: BattleTimer,
+	RoomBattle: Battle,
+	SimulatorManager,
+	SimulatorProcess,
+};

--- a/test/application/process-manager.js
+++ b/test/application/process-manager.js
@@ -1,61 +1,80 @@
 'use strict';
 
 const assert = require('assert');
-const path = require('path');
 
 const ProcessManager = require('../../process-manager');
-const ProcessWrapper = ProcessManager.ProcessWrapper;
+const {ProcessWrapper} = ProcessManager;
 
-// const DatasearchManager = require('../../chat-plugins/datasearch.js').DatasearchManager;
-// const SimulatorManager = require('../../room-battle.js').SimulatorManager;
-// const TeamValidatorManager = require('../../team-validator.js').TeamValidatorManager;
-// const VerifierManager = require('../../verifier.js').VerifierManager;
-
-// DO NOT CLEAR PROCESSMANAGER'S CACHE DURING THESE TESTS
-// Delete the ProcessManager instances from it manually unless you want to break
-// other tests that rely on what's already there at the beginning of these tests
-// and watch the world burn.
 describe('ProcessManager', function () {
-	it('should construct', function () {
-		let pm;
-		let cacheSize = ProcessManager.cache.size;
-		assert.doesNotThrow(() => {
-			pm = new ProcessManager({
-				execFile: path.resolve('./process-manager'),
-				maxProcesses: 0,
+	const setup = isChild => {
+		before(function () {
+			process.env.PS_MANAGED_PROCESS = '' + +isChild;
+
+			this.PM = new ProcessManager({
+				execFile: require.resolve('../../process-manager'),
+				maxProcesses: 1,
 				isChatBased: false,
 			});
 		});
-		assert.strictEqual(ProcessManager.cache.size, cacheSize + 1);
-		assert.ok(ProcessManager.cache.delete(pm));
+
+		after(function () {
+			this.PM.unspawn();
+			ProcessManager.cache.delete(this.PM);
+			delete process.env.PS_MANAGED_PROCESS;
+		});
+	};
+
+	context('in the parent process', function () {
+		setup(false);
+
+		it('should spawn child processes', function () {
+			assert.strictEqual(this.PM.processes.size, this.PM.maxProcesses);
+		});
+	});
+
+	context('in child processes', function () {
+		setup(true);
+
+		it('should not spawn any child processes', function () {
+			assert.ok(!this.PM.processes.size);
+		});
 	});
 
 	describe('ProcessWrapper', function () {
 		beforeEach(function () {
-			this.pm = new ProcessManager({
-				execFile: path.resolve('./process-manager'),
-				maxProcesses: 0,
-				isChatBased: false,
-			});
+			let execFile = require.resolve('../../process-manager');
+			this.PW = new ProcessWrapper(execFile);
 		});
 
-		afterEach(function () {
-			// Temporary until final process-manager.js refactor
-			this.pm.processes.forEach(pw => {
-				pw.process.removeAllListeners('message');
-				pw.process.disconnect();
-				pw.process = null;
-				pw.removeAllListeners('message');
-				pw.pendingTasks.clear();
-				pw.PM.processes.splice(pw.PM.processes.indexOf(pw), 1);
-				pw.PM = null;
-			});
-
-			ProcessManager.cache.delete(this.pm);
+		afterEach(function (done) {
+			if (!this.PW.connected) return done();
+			this.PW.once('disconnect', done);
+			this.PW.release();
 		});
 
-		it('should construct', function () {
-			assert.doesNotThrow(() => new ProcessWrapper(this.pm));
+		it('should only disconnect while deactivated and connected', function (done) {
+			assert.ok(!this.PW.release());
+			this.PW.active = false;
+			this.PW.once('disconnect', () => {
+				assert.ok(!this.PW.release());
+				this.PW.active = true;
+				assert.ok(!this.PW.release());
+				done();
+			});
+			assert.ok(this.PW.release());
+		});
+
+		it('should only send while activated and connected', function (done) {
+			assert.ok(this.PW.send(''));
+			this.PW.active = false;
+			assert.ok(!this.PW.send(''));
+			this.PW.once('disconnect', () => {
+				assert.ok(!this.PW.send(''));
+				this.PW.active = true;
+				assert.ok(!this.PW.send(''));
+				done();
+			});
+			this.PW.release();
 		});
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,8 @@
         "./crashlogger.js",
         "./dnsbl.js",
         "./repl.js",
-        "./fs.js"
+        "./fs.js",
+        "./process-manager.js",
+        "./verifier.js"
     ]
 }

--- a/verifier.js
+++ b/verifier.js
@@ -15,9 +15,25 @@
 'use strict';
 
 const crypto = require('crypto');
+
 const ProcessManager = require('./process-manager');
 
+/**
+ * @class VerifierManager
+ * @extends ProcessManager
+ */
 class VerifierManager extends ProcessManager {
+	onFork() {
+		// @ts-ignore
+		global.Config = require('./config/config');
+
+		process.on('message', message => this.onMessageDownstream(message));
+		process.once('disconnect', () => process.exit(0));
+
+		require('./repl').start('verifier', /** @param {string} cmd */ cmd => eval(cmd));
+	}
+
+	/** @param {string} message */
 	onMessageUpstream(message) {
 		// Protocol:
 		// success: "[id]|1"
@@ -25,27 +41,35 @@ class VerifierManager extends ProcessManager {
 		let pipeIndex = message.indexOf('|');
 		let id = +message.substr(0, pipeIndex);
 		let result = Boolean(~~message.slice(pipeIndex + 1));
-
+		// @ts-ignore
 		if (this.pendingTasks.has(id)) {
+			// @ts-ignore
 			this.pendingTasks.get(id)(result);
+			// @ts-ignore
 			this.pendingTasks.delete(id);
+			// @ts-ignore
 			this.release();
 		}
 	}
 
+	/** @param {string} message */
 	onMessageDownstream(message) {
 		// protocol:
 		// "[id]|{data, sig}"
 		let pipeIndex = message.indexOf('|');
 		let id = message.substr(0, pipeIndex);
-
 		let data = JSON.parse(message.slice(pipeIndex + 1));
-		process.send(id + '|' + this.receive(data));
+		if (process.send) process.send(`${id}|${this.receive(data)}`);
 	}
 
+	/**
+	 * @param {{data: string, sig: string}} data
+	 * @return {number}
+	 */
 	receive(data) {
 		let verifier = crypto.createVerify(Config.loginserverkeyalgo);
 		verifier.update(data.data);
+
 		let success = false;
 		try {
 			success = verifier.verify(Config.loginserverpublickey, data.sig, 'hex');
@@ -55,25 +79,19 @@ class VerifierManager extends ProcessManager {
 	}
 }
 
-exports.VerifierManager = VerifierManager;
-
-const PM = exports.PM = new VerifierManager({
-	execFile: __filename,
-	maxProcesses: global.Config ? Config.verifierprocesses : 1,
-	isChatBased: false,
-});
-
-if (process.send && module === process.mainModule) {
-	// This is a child process!
-
-	global.Config = require('./config/config');
-
-	require('./repl').start('verifier', cmd => eval(cmd));
-
-	process.on('message', message => PM.onMessageDownstream(message));
-	process.on('disconnect', () => process.exit());
-}
-
-exports.verify = function (data, signature) {
-	return PM.send({data: data, sig: signature});
+module.exports = {
+	VerifierManager,
+	PM: new VerifierManager({
+		execFile: __filename,
+		maxProcesses: ('Config' in global) ? Config.verifierprocesses : 1,
+		isChatBased: false,
+	}),
+	/**
+	 * @param {string} data
+	 * @param {string} sig
+	 * @return {Promise<boolean>}
+	 */
+	verify(data, sig) {
+		return this.PM.send({data, sig});
+	},
 };


### PR DESCRIPTION
- spawning and setting up child processes is now handled by
`ProcessManager#constructor` rather than needing to be done manually for
each module that uses `ProcessManager`
- direct references to `ProcessManager` in `ProcessWrapper` were removed to
prevent dead `ProcessWrapper` instances from being leaked when hotpatching
- `process-manager.js` and `verifier.js` now use Typescript