### PR TITLE
Punishments#checkLockExpiration: Don't show 0 days

### DIFF
--- a/punishments.js
+++ b/punishments.js
@@ -1154,7 +1154,13 @@ Punishments.checkLockExpiration = function (userid) {
 		if (user && user.permalocked) return ` (never expires; you are permalocked)`;
 		let expiresIn = new Date(punishment[2]).getTime() - Date.now();
 		let expiresDays = Math.round(expiresIn / 1000 / 60 / 60 / 24);
-		if (expiresIn > 1) return ` (expires in around ${expiresDays} day${Chat.plural(expiresDays)})`;
+		let expiresText = '';
+		if (expiresDays >= 1) {
+			expiresText = `in around ${expiresDays} day${Chat.plural(expiresDays)}`;
+		} else {
+			expiresText = `soon`;
+		}
+		if (expiresIn > 1) return ` (expires ${expiresText})`;
 	}
 
 	return ``;


### PR DESCRIPTION
If there were less than 12 hours left on a lock, it would display as (expires in around 0 days).

If there are 12 hours or less left on a lock, this will instead display the number of hours remaining rounded