### PR TITLE
Fix /modlog all when using ripgrep

### DIFF
--- a/chat-plugins/modlog.js
+++ b/chat-plugins/modlog.js
@@ -120,7 +120,7 @@ class SortedLimitedLengthList {
 function checkRipgrepAvailability() {
 	if (Config.ripgrepmodlog === undefined) {
 		try {
-			execFileSync('rg', ['--version'], {cwd: path.normalize(`${__dirname}/../${LOG_PATH}`)});
+			execFileSync('rg', ['--version'], {cwd: path.normalize(`${__dirname}/../`)});
 			Config.ripgrepmodlog = true;
 		} catch (error) {
 			Config.ripgrepmodlog = false;
@@ -144,6 +144,7 @@ async function runModlog(rooms, searchString, exactSearch, maxLines) {
 			fileNameList.push(`modlog_${rooms[i]}.txt`);
 		}
 	}
+	fileNameList = fileNameList.map(filename => `${LOG_PATH}${filename}`);
 
 	let regexString;
 	if (!searchString) {
@@ -161,7 +162,6 @@ async function runModlog(rooms, searchString, exactSearch, maxLines) {
 		if (checkAllRooms) fileNameList = [LOG_PATH];
 		runRipgrepModlog(fileNameList, regexString, results);
 	} else {
-		fileNameList = fileNameList.map(filename => `${LOG_PATH}${filename}`);
 		const searchStringRegex = new RegExp(regexString, 'i');
 		for (let i = 0; i < fileNameList.length; i++) {
 			await checkRoomModlog(fileNameList[i], searchStringRegex, results);
@@ -185,7 +185,7 @@ async function checkRoomModlog(path, regex, results) {
 function runRipgrepModlog(paths, regexString, results) {
 	let stdout;
 	try {
-		stdout = execFileSync('rg', ['-i', '-e', regexString, '--no-filename', '--no-line-number', ...paths], {cwd: path.normalize(`${__dirname}/../${LOG_PATH}`)});
+		stdout = execFileSync('rg', ['-i', '-e', regexString, '--no-filename', '--no-line-number', ...paths], {cwd: path.normalize(`${__dirname}/../`)});
 	} catch (error) {
 		return results;
 	}


### PR DESCRIPTION
Non-rg modlog uses FS while rg modlog uses its own cwd setting, and they were running off different working directories, making use of relative paths difficult, This changes rg modlog to also use PS' main dir as working directory, so we can use the same paths for both.