### PR TITLE
Process Manager: fix memory leak in ProcessManager#unspawn

### DIFF
--- a/process-manager.js
+++ b/process-manager.js
@@ -39,6 +39,8 @@ class ProcessWrapper extends EventEmitter {
 
 	release() {
 		if (this.load || this.active) return;
+		this.PM = null;
+		this.removeAllListeners('message');
 		this.process.disconnect();
 	}
 


### PR DESCRIPTION
Doesn't break hotpatching anything related to battles this time!

`ProcessWrapper`was holding on to references to `ProcessManager` after its
process had been killed and it had been removed from `ProcessManager`'s
list of processes, keeping it on the heap. Not good. This removes all
references to the wrapper's manager when disconnecting its process,
allowing it to be GCed.