### PR TITLE
Inform the client when format's level is 50

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -430,6 +430,8 @@ class GlobalRoom {
 			if (format.searchShow) displayCode |= 2;
 			if (format.challengeShow) displayCode |= 4;
 			if (format.tournamentShow) displayCode |= 8;
+			const level = format.maxLevel || format.maxForcedLevel || format.forcedLevel;
+			if (level === 50) displayCode |= 16;
 			this.formatList += ',' + displayCode.toString(16);
 		}
 		return this.formatList;


### PR DESCRIPTION
Game Freak releases new formats quite often, and updating client is somewhat problematic. This introduces backward compatible way for the client (clients unaware of this functionality will just ignore this flag) to know whether teambuilder should set Pokemon levels to 50.

The reason to not have a generic solution is that's unlikely there will be need for different levels than 50, and level 5 formats are usually called LC, so it isn't really an issue for them either.