### PR TITLE
Users: isStaff compatibility with custom ranks

### DIFF
--- a/users.js
+++ b/users.js
@@ -968,7 +968,7 @@ class User {
 			this.avatar = Config.customavatars[this.userid];
 		}
 
-		this.isStaff = (this.group in {'%':1, '@':1, '&':1, '~':1});
+		this.isStaff = Config.groups[this.group] && Config.groups[this.group].lock;
 		if (!this.isStaff) {
 			let staffRoom = Rooms('staff');
 			this.isStaff = (staffRoom && staffRoom.auth && staffRoom.auth[this.userid]);


### PR DESCRIPTION
check via permissions instead of symbols 
- compared to before, this allows bots to enter the staff room - @Zarel if you do not desire this, I can add ``&& !Config.groups[this.group].addhtml`` to keep them out

