### PR TITLE
Add /hidealtstext command

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2186,7 +2186,9 @@ exports.commands = {
 	},
 	unnamelockhelp: ["/unnamelock [username] - Unnamelocks the user. Requires: % @ * & ~"],
 
-	hidetext: function (target, room, user) {
+	hidetextalts: 'hidetext',
+	hidealtstext: 'hidetext',
+	hidetext: function (target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help hidetext');
 
 		this.splitTarget(target);
@@ -2203,11 +2205,22 @@ exports.commands = {
 			return this.errorReply("User '" + name + "' is not banned from this room or locked.");
 		}
 
-		this.addModCommand("" + targetUser.name + "'s messages were cleared from  " + room.title + " by " + user.name + ".");
-		this.add('|unlink|' + hidetype + userid);
-		if (userid !== toId(this.inputUsername)) this.add('|unlink|' + hidetype + toId(this.inputUsername));
+		if (cmd === 'hidealtstext' || cmd === 'hidetextalts') {
+			this.addModCommand(`${targetUser.name}'s alts' messages were cleared from ${room.title} by ${user.name}.`);
+			this.add(`|unlink|${hidetype}${userid}`);
+			for (let i in targetUser.prevNames) {
+				this.add(`|unlink|${hidetype}${targetUser.prevNames[i]}`);
+			}
+		} else {
+			this.addModCommand("" + targetUser.name + "'s messages were cleared from  " + room.title + " by " + user.name + ".");
+			this.add('|unlink|' + hidetype + userid);
+			if (userid !== toId(this.inputUsername)) this.add('|unlink|' + hidetype + toId(this.inputUsername));
+		}
 	},
-	hidetexthelp: ["/hidetext [username] - Removes a locked or banned user's messages from chat (includes users banned from the room). Requires: % (global only), @ * # & ~"],
+	hidetexthelp: [
+		"/hidetext [username] - Removes a locked or banned user's messages from chat (includes users banned from the room). Requires: % (global only), @ * # & ~",
+		"/hidealtstext OR /hidetextalts [username] - Removes a locked or banned user's messages, and their alternate account's messages from the chat (includes users banned from the room).  Requires: % (global only), @ * # & ~",
+	],
 
 	ab: 'blacklist',
 	blacklist: function (target, room, user) {


### PR DESCRIPTION
When a user is spamming, often times they are doing so under several accounts.  When this happens, a staff member has to manually hide each alts messages in the room, which takes up one line of the chat for each alt.  By doing this, it automatically does it on the same line as the lock  message at the same time, which both clutters up the chat less and makes it easier on the staff

PREVIEW:
<img src="https://image.prntscr.com/image/7VRfMjXUQli9vK0odjbyRg.png">