### PR TITLE
[Gen 3] Random Battles

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1177,6 +1177,13 @@ exports.Formats = [
 		banlist: ['Wobbuffet + Leftovers'],
 	},
 	{
+		name: "[Gen 3] Random Battle",
+
+		mod: 'gen3',
+		team: 'random',
+		ruleset: ['Pokemon', 'Sleep Clause Mod', 'Freeze Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+	},
+	{
 		name: "[Gen 3] Custom Game",
 
 		mod: 'gen3',

--- a/mods/gen3/formats-data.js
+++ b/mods/gen3/formats-data.js
@@ -3,658 +3,581 @@
 exports.BattleFormatsData = {
 	bulbasaur: {
 		inherit: true,
-		randomBattleMoves: ["sleeppowder", "gigadrain", "growth", "hiddenpowerfire", "hiddenpowerice", "sludgebomb", "swordsdance", "powerwhip", "leechseed", "synthesis"],
 		tier: "LC",
 	},
 	ivysaur: {
-		randomBattleMoves: ["sleeppowder", "gigadrain", "growth", "hiddenpowerfire", "hiddenpowerice", "sludgebomb", "swordsdance", "powerwhip", "leechseed", "synthesis"],
 		tier: "NFE",
 	},
 	venusaur: {
-		randomBattleMoves: ["sleeppowder", "gigadrain", "growth", "hiddenpowerfire", "hiddenpowerice", "sludgebomb", "swordsdance", "powerwhip", "leechseed", "synthesis", "earthquake"],
+		randomBattleMoves: ["sleeppowder", "sludgebomb", "leechseed", "toxic", "curse", "swordsdance", "synthesis", "hiddenpowerfire"],
 		tier: "BL",
 	},
 	charmander: {
 		inherit: true,
-		randomBattleMoves: ["flamethrower", "overheat", "dragonpulse", "hiddenpowergrass", "fireblast"],
 		tier: "LC",
 	},
 	charmeleon: {
-		randomBattleMoves: ["flamethrower", "overheat", "dragonpulse", "hiddenpowergrass", "fireblast"],
 		tier: "NU",
 	},
 	charizard: {
 		inherit: true,
-		randomBattleMoves: ["flamethrower", "fireblast", "substitute", "airslash", "dragonpulse", "hiddenpowergrass", "roost"],
+		randomBattleMoves: ["substitute", "hiddenpowergrass", "fireblast", "sunnyday", "flamethrower", "earthquake", "overheat", "bellydrum", "focuspunch", "dragondance", "hiddenpowerflying", "irontail", "bodyslam"],
 		tier: "BL",
 	},
 	squirtle: {
 		inherit: true,
-		randomBattleMoves: ["surf", "icebeam", "hydropump", "rapidspin", "scald", "aquajet", "toxic"],
 		tier: "LC",
 	},
 	wartortle: {
-		randomBattleMoves: ["surf", "icebeam", "hydropump", "rapidspin", "scald", "aquajet", "toxic"],
 		tier: "NU",
 	},
 	blastoise: {
 		inherit: true,
-		randomBattleMoves: ["surf", "icebeam", "hydropump", "rapidspin", "scald", "aquajet", "toxic", "dragontail"],
+		randomBattleMoves: ["surf", "icebeam", "earthquake", "rapidspin", "rest", "sleeptalk", "roar", "toxic", "counter", "mirrorcoat"],
 		tier: "UU",
 	},
 	caterpie: {
-		randomBattleMoves: ["bugbite", "snore", "tackle", "electroweb"],
 		tier: "LC",
 	},
 	metapod: {
-		randomBattleMoves: ["irondefense", "bugbite", "tackle", "electroweb"],
 		tier: "NFE",
 	},
 	butterfree: {
 		inherit: true,
-		randomBattleMoves: ["quiverdance", "roost", "bugbuzz", "airslash", "substitute", "sleeppowder", "gigadrain", "stunspore", "uturn"],
+		randomBattleMoves: ["sleeppowder", "stunspore", "morningsun", "substitute", "whirlwind", "nightmare", "psychic", "hiddenpowerfire"],
 		tier: "NU",
 	},
 	weedle: {
-		randomBattleMoves: ["bugbite", "stringshot", "poisonsting", "electroweb"],
 		tier: "LC",
 	},
 	kakuna: {
-		randomBattleMoves: ["electroweb", "bugbite", "irondefense", "poisonsting"],
 		tier: "NFE",
 	},
 	beedrill: {
 		inherit: true,
-		randomBattleMoves: ["toxicspikes", "xscissor", "swordsdance", "uturn", "endeavor", "poisonjab", "drillrun", "nightslash", "brickbreak"],
+		randomBattleMoves: ["sludgebomb", "hiddenpowerbug", "brickbreak", "doubleedge", "swordsdance", "substitute"],
 		tier: "NU",
 	},
 	pidgey: {
-		randomBattleMoves: ["roost", "bravebird", "heatwave", "hurricane", "return", "workup", "uturn"],
 		tier: "LC",
 	},
 	pidgeotto: {
 		inherit: true,
-		randomBattleMoves: ["roost", "bravebird", "heatwave", "hurricane", "return", "workup", "uturn"],
 		tier: "NFE",
 	},
 	pidgeot: {
-		randomBattleMoves: ["roost", "bravebird", "pursuit", "heatwave", "return", "workup", "uturn"],
+		randomBattleMoves: ["hiddenpowerflying", "return", "pursuit", "whirlwind", "rest", "sleeptalk", "toxic"],
 		tier: "NU",
 	},
 	rattata: {
-		randomBattleMoves: ["facade", "flamewheel", "wildcharge", "suckerpunch", "uturn"],
 		tier: "LC",
 	},
 	raticate: {
 		inherit: true,
-		randomBattleMoves: ["facade", "flamewheel", "wildcharge", "suckerpunch", "uturn"],
+		randomBattleMoves: ["facade", "shadowball", "superfang", "taunt", "substitute", "quickattack", "hiddenpowerfighting"],
 		tier: "NU",
 	},
 	spearow: {
 		inherit: true,
-		randomBattleMoves: ["return", "drillpeck", "doubleedge", "uturn", "quickattack", "pursuit"],
 		tier: "LC",
 	},
 	fearow: {
-		randomBattleMoves: ["return", "drillpeck", "doubleedge", "uturn", "quickattack", "pursuit", "drillrun", "roost"],
+		randomBattleMoves: ["return", "doubleedge", "quickattack", "drillpeck", "hiddenpowerground", "hiddenpowerfighting", "agility", "substitute", "batonpass"],
 		tier: "UU",
 	},
 	ekans: {
 		inherit: true,
-		randomBattleMoves: ["coil", "gunkshot", "seedbomb", "glare", "suckerpunch", "aquatail", "crunch", "earthquake", "rest"],
 		tier: "LC",
 	},
 	arbok: {
 		inherit: true,
-		randomBattleMoves: ["coil", "gunkshot", "seedbomb", "glare", "suckerpunch", "aquatail", "crunch", "earthquake", "rest"],
+		randomBattleMoves: ["sludgebomb", "earthquake", "rockslide", "hiddenpowerghost", "hiddenpowerfire", "rest", "sleeptalk"],
 		tier: "NU",
 	},
 	pichu: {
 		inherit: true,
-		randomBattleMoves: ["fakeout", "volttackle", "encore", "irontail", "toxic", "thunderpunch"],
 		tier: "LC",
 	},
 	pikachu: {
 		inherit: true,
-		randomBattleMoves: ["thunderbolt", "volttackle", "grassknot", "hiddenpowerice", "brickbreak", "extremespeed", "encore", "substitute"],
 		tier: "NU",
 	},
 	raichu: {
-		randomBattleMoves: ["nastyplot", "encore", "thunderbolt", "grassknot", "hiddenpowerice", "focusblast", "substitute", "extremespeed"],
+		randomBattleMoves: ["hiddenpowerice", "thunderbolt", "bodyslam", "substitute", "toxic", "thunderwave", "surf"],
 		tier: "UU",
 	},
 	sandshrew: {
 		inherit: true,
-		randomBattleMoves: ["earthquake", "stoneedge", "swordsdance", "rapidspin", "nightslash", "xscissor", "stealthrock", "toxic"],
 		tier: "LC",
 	},
 	sandslash: {
-		randomBattleMoves: ["earthquake", "stoneedge", "swordsdance", "rapidspin", "nightslash", "xscissor", "stealthrock", "toxic"],
+		randomBattleMoves: ["earthquake", "rapidspin", "swordsdance", "rockslide", "counter", "hiddenpowerbug", "hiddenpowerghost", "brickbreak", "toxic", "bodyslam"],
 		tier: "UU",
 	},
 	nidoranf: {
-		randomBattleMoves: ["toxicspikes", "crunch", "poisonjab", "honeclaws", "doublekick"],
 		tier: "LC",
 	},
 	nidorina: {
-		randomBattleMoves: ["toxicspikes", "crunch", "poisonjab", "honeclaws", "doublekick", "icebeam"],
 		tier: "NFE",
 	},
 	nidoqueen: {
-		randomBattleMoves: ["toxicspikes", "stealthrock", "fireblast", "thunderbolt", "icebeam", "earthpower", "sludgewave", "dragontail", "focusblast"],
+		randomBattleMoves: ["earthquake", "icebeam", "fireblast", "thunderbolt", "shadowball", "superpower", "sludgebomb"],
 		tier: "UU",
 	},
 	nidoranm: {
-		randomBattleMoves: ["suckerpunch", "poisonjab", "headsmash", "honeclaws"],
 		tier: "LC",
 	},
 	nidorino: {
-		randomBattleMoves: ["suckerpunch", "poisonjab", "headsmash", "honeclaws"],
 		tier: "NFE",
 	},
 	nidoking: {
-		randomBattleMoves: ["fireblast", "thunderbolt", "icebeam", "earthpower", "sludgewave", "focusblast"],
+		randomBattleMoves: ["earthquake", "sludgebomb", "icebeam", "thunderbolt", "substitute", "megahorn", "focuspunch", "fireblast", "shadowball", "superpower", "sludgebomb"],
 		tier: "UU",
 	},
 	cleffa: {
-		randomBattleMoves: ["reflect", "thunderwave", "lightscreen", "toxic", "fireblast", "encore", "wish", "protect", "softboiled", "aromatherapy"],
 		tier: "LC",
 	},
 	clefairy: {
-		randomBattleMoves: ["healingwish", "reflect", "thunderwave", "lightscreen", "toxic", "fireblast", "encore", "wish", "protect", "softboiled", "aromatherapy", "stealthrock"],
 		tier: "NFE",
 	},
 	clefable: {
-		randomBattleMoves: ["fireblast", "thunderbolt", "icebeam", "seismictoss", "wish", "protect", "softboiled", "healingwish", "doubleedge", "facade", "meteormash", "aromatherapy", "bellydrum", "trick", "calmmind", "stealthrock", "grassknot", "cosmicpower", "storedpower"],
+		randomBattleMoves: ["thunderbolt", "icebeam", "flamethrower", "doubleedge", "return", "meteormash", "shadowball", "calmmind", "bellydrum", "cosmicpower", "softboiled", "wish", "protect", "rest", "encore", "counter"],
 		tier: "UU",
 	},
 	vulpix: {
 		inherit: true,
-		randomBattleMoves: ["flamethrower", "fireblast", "willowisp", "solarbeam", "nastyplot", "substitute", "toxic", "hypnosis", "painsplit"],
 		tier: "LC",
 	},
 	ninetales: {
-		randomBattleMoves: ["flamethrower", "fireblast", "willowisp", "solarbeam", "nastyplot", "substitute", "toxic", "hypnosis", "painsplit"],
+		randomBattleMoves: ["overheat", "fireblast", "sunnyday", "solarbeam", "flamethrower", "swagger", "willowisp", "hypnosis", "heatwave"],
 		tier: "UU",
 	},
 	igglybuff: {
 		inherit: true,
-		randomBattleMoves: ["wish", "thunderwave", "reflect", "lightscreen", "healbell", "seismictoss", "counter", "protect"],
 		tier: "LC",
 	},
 	jigglypuff: {
-		randomBattleMoves: ["wish", "thunderwave", "reflect", "lightscreen", "healbell", "seismictoss", "counter", "stealthrock", "protect"],
 		tier: "NFE",
 	},
 	wigglytuff: {
-		randomBattleMoves: ["wish", "thunderwave", "reflect", "lightscreen", "healbell", "seismictoss", "counter", "stealthrock", "protect"],
+		randomBattleMoves: ["wish", "protect", "seismictoss", "toxic", "doubleedge", "brickbreak", "shadowball", "facade"],
 		tier: "NU",
 	},
 	zubat: {
-		randomBattleMoves: ["bravebird", "roost", "toxic", "taunt", "nastyplot", "gigadrain", "sludgebomb", "airslash", "uturn", "whirlwind", "acrobatics", "heatwave", "superfang"],
 		tier: "LC",
 	},
 	golbat: {
-		randomBattleMoves: ["bravebird", "roost", "toxic", "taunt", "nastyplot", "gigadrain", "sludgebomb", "airslash", "uturn", "whirlwind", "acrobatics", "heatwave", "superfang"],
 		tier: "NU",
 	},
 	crobat: {
-		randomBattleMoves: ["bravebird", "roost", "toxic", "taunt", "nastyplot", "gigadrain", "sludgebomb", "airslash", "uturn", "whirlwind", "acrobatics", "heatwave", "superfang"],
+		randomBattleMoves: ["sludgebomb", "hiddenpowerflying", "aerialace", "hiddenpowerground", "hiddenpowerfighting", "shadowball", "gigadrain", "taunt"],
 		tier: "BL",
 	},
 	oddish: {
 		inherit: true,
-		randomBattleMoves: ["gigadrain", "sludgebomb", "synthesis", "sleeppowder", "stunspore", "toxic", "hiddenpowerfire", "leechseed"],
 		tier: "LC",
 	},
 	gloom: {
 		inherit: true,
-		randomBattleMoves: ["gigadrain", "sludgebomb", "synthesis", "sleeppowder", "stunspore", "toxic", "hiddenpowerfire", "leechseed"],
 		tier: "NFE",
 	},
 	vileplume: {
-		randomBattleMoves: ["gigadrain", "sludgebomb", "synthesis", "sleeppowder", "stunspore", "toxic", "hiddenpowerfire", "leechseed", "aromatherapy"],
+		randomBattleMoves: ["sunnyday", "solarbeam", "synthesis", "sludgebomb", "gigadrain", "hiddenpowerfire", "leechseed", "toxic"],
 		tier: "UU",
 	},
 	bellossom: {
-		randomBattleMoves: ["gigadrain", "sludgebomb", "synthesis", "sleeppowder", "stunspore", "toxic", "hiddenpowerfire", "leechseed", "aromatherapy", "leafstorm"],
+		randomBattleMoves: ["sleeppowder", "stunspore", "leechseed", "moonlight", "gigadrain", "sludgebomb", "hiddenpowerground"],
 		tier: "NU",
 	},
 	paras: {
 		inherit: true,
-		randomBattleMoves: ["spore", "stunspore", "xscissor", "seedbomb", "synthesis", "leechseed", "aromatherapy"],
 		tier: "LC",
 	},
 	parasect: {
-		randomBattleMoves: ["spore", "stunspore", "xscissor", "seedbomb", "synthesis", "leechseed", "aromatherapy"],
+		randomBattleMoves: ["swordsdance", "spore", "frustration", "hiddenpowerground", "sludgebomb", "aromatherapy", "gigadrain"],
 		tier: "NU",
 	},
 	venonat: {
-		randomBattleMoves: ["sleeppowder", "morningsun", "toxicspikes", "sludgebomb", "signalbeam", "stunspore"],
 		tier: "LC",
 	},
 	venomoth: {
 		inherit: true,
-		randomBattleMoves: ["sleeppowder", "roost", "toxicspikes", "quiverdance", "batonpass", "bugbuzz", "sludgebomb", "gigadrain", "substitute"],
+		randomBattleMoves: ["signalbeam", "sludgebomb", "hiddenpowerground", "substitute", "batonpass", "sleeppowder"],
 		tier: "NU",
 	},
 	diglett: {
-		randomBattleMoves: ["earthquake", "rockslide", "stealthrock", "suckerpunch", "reversal", "substitute"],
 		tier: "LC",
 	},
 	dugtrio: {
 		inherit: true,
-		randomBattleMoves: ["earthquake", "stoneedge", "stealthrock", "suckerpunch", "reversal", "substitute"],
+		randomBattleMoves: ["earthquake", "rockslide", "hiddenpowerbug", "hiddenpowerghost", "aerialace", "substitute"],
 		tier: "OU",
 	},
 	meowth: {
 		inherit: true,
-		randomBattleMoves: ["fakeout", "uturn", "bite", "taunt", "return", "hypnosis", "waterpulse"],
 		tier: "LC",
 	},
 	persian: {
-		randomBattleMoves: ["fakeout", "uturn", "bite", "taunt", "return", "hypnosis", "waterpulse", "switcheroo"],
+		randomBattleMoves: ["fakeout", "return", "shadowball", "hiddenpowerfighting", "hiddenpowerground", "waterpulse", "thunderbolt", "hiddenpowerice", "taunt", "toxic", "screech", "substitute", "hypnosis", "bodyslam", "roar", "rest", "sleeptalk"],
 		tier: "UU",
 	},
 	psyduck: {
 		inherit: true,
-		randomBattleMoves: ["hydropump", "surf", "icebeam", "hiddenpowergrass", "crosschop", "encore"],
 		tier: "LC",
 	},
 	golduck: {
 		inherit: true,
-		randomBattleMoves: ["hydropump", "surf", "icebeam", "hiddenpowergrass", "encore", "focusblast"],
+		randomBattleMoves: ["surf", "hydropump", "icebeam", "hiddenpowergrass", "calmmind", "hypnosis", "substitute"],
 		tier: "UU",
 	},
 	mankey: {
-		randomBattleMoves: ["closecombat", "uturn", "icepunch", "rockslide", "punishment"],
 		tier: "LC",
 	},
 	primeape: {
 		inherit: true,
-		randomBattleMoves: ["closecombat", "uturn", "icepunch", "stoneedge", "punishment", "encore"],
+		randomBattleMoves: ["crosschop", "earthquake", "overheat", "taunt", "toxic", "rockslide", "return"],
 		tier: "UU",
 	},
 	growlithe: {
 		inherit: true,
-		randomBattleMoves: ["flareblitz", "wildcharge", "hiddenpowergrass", "hiddenpowerice", "closecombat", "morningsun", "willowisp", "toxic"],
 		tier: "LC",
 	},
 	arcanine: {
-		randomBattleMoves: ["flareblitz", "wildcharge", "hiddenpowergrass", "hiddenpowerice", "extremespeed", "closecombat", "morningsun", "willowisp", "toxic"],
+		randomBattleMoves: ["fireblast", "extremespeed", "hiddenpowergrass", "rest", "sleeptalk", "toxic", "roar"],
 		tier: "BL",
 	},
 	poliwag: {
 		inherit: true,
-		randomBattleMoves: ["hydropump", "icebeam", "encore", "bellydrum", "hypnosis", "waterfall", "return"],
 		tier: "LC",
 	},
 	poliwhirl: {
-		randomBattleMoves: ["hydropump", "icebeam", "encore", "bellydrum", "hypnosis", "waterfall", "return"],
 		tier: "NU",
 	},
 	poliwrath: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "circlethrow", "focuspunch", "bulkup", "encore", "waterfall", "toxic", "rest", "sleeptalk", "icepunch"],
+		randomBattleMoves: ["earthquake", "hydropump", "icebeam", "bulkup", "brickbreak", "hiddenpowerghost", "toxic"],
 		tier: "UU",
 	},
 	politoed: {
-		randomBattleMoves: ["scald", "hypnosis", "toxic", "encore", "perishsong", "protect", "icebeam", "focusblast", "surf", "hydropump", "hiddenpowergrass"],
+		randomBattleMoves: ["hydropump", "surf", "icebeam", "hiddenpowergrass", "toxic", "hypnosis", "counter"],
 		tier: "UU",
 	},
 	abra: {
-		randomBattleMoves: ["calmmind", "psychic", "psyshock", "hiddenpowerfighting", "shadowball", "encore", "substitute"],
 		tier: "LC",
 	},
 	kadabra: {
-		randomBattleMoves: ["calmmind", "psychic", "psyshock", "hiddenpowerfighting", "shadowball", "encore", "substitute"],
 		tier: "BL",
 	},
 	alakazam: {
 		inherit: true,
-		randomBattleMoves: ["calmmind", "psychic", "psyshock", "focusblast", "shadowball", "encore", "substitute"],
+		randomBattleMoves: ["firepunch", "icepunch", "thunderpunch", "psychic", "calmmind", "encore", "thunderwave", "substitute", "recover"],
 		tier: "BL",
 	},
 	machop: {
-		randomBattleMoves: ["dynamicpunch", "payback", "bulkup", "icepunch", "rockslide", "bulletpunch"],
 		tier: "LC",
 	},
 	machoke: {
-		randomBattleMoves: ["dynamicpunch", "payback", "bulkup", "icepunch", "rockslide", "bulletpunch"],
 		tier: "NU",
 	},
 	machamp: {
 		inherit: true,
-		randomBattleMoves: ["dynamicpunch", "payback", "bulkup", "icepunch", "stoneedge", "bulletpunch"],
+		randomBattleMoves: ["crosschop", "earthquake", "bulkup", "bodyslam", "rockslide", "rest", "sleeptalk"],
 		tier: "BL",
 	},
 	bellsprout: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "sleeppowder", "sunnyday", "growth", "solarbeam", "gigadrain", "sludgebomb", "weatherball", "suckerpunch", "seedbomb"],
 		tier: "LC",
 	},
 	weepinbell: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "sleeppowder", "sunnyday", "growth", "solarbeam", "gigadrain", "sludgebomb", "weatherball", "suckerpunch", "seedbomb"],
 		tier: "NU",
 	},
 	victreebel: {
-		randomBattleMoves: ["swordsdance", "sleeppowder", "sunnyday", "growth", "solarbeam", "gigadrain", "sludgebomb", "weatherball", "suckerpunch", "powerwhip"],
+		randomBattleMoves: ["sleeppowder", "sludgebomb", "synthesis", "sunnyday", "hiddenpowerfighting", "bodyslam", "swordsdance"],
 		tier: "UU",
 	},
 	tentacool: {
-		randomBattleMoves: ["toxicspikes", "rapidspin", "scald", "sludgebomb", "icebeam", "knockoff", "gigadrain", "toxic"],
 		tier: "LC",
 	},
 	tentacruel: {
-		randomBattleMoves: ["toxicspikes", "rapidspin", "scald", "sludgebomb", "icebeam", "knockoff", "gigadrain", "toxic"],
+		randomBattleMoves: ["icebeam", "rapidspin", "hydropump", "gigadrain", "toxic", "hiddenpowerelectric", "haze"],
 		tier: "UU",
 	},
 	geodude: {
-		randomBattleMoves: ["stealthrock", "earthquake", "stoneedge", "suckerpunch", "hammerarm", "firepunch"],
 		tier: "LC",
 	},
 	graveler: {
-		randomBattleMoves: ["stealthrock", "earthquake", "stoneedge", "suckerpunch", "hammerarm", "firepunch"],
 		tier: "NU",
 	},
 	golem: {
-		randomBattleMoves: ["stealthrock", "earthquake", "stoneedge", "suckerpunch", "hammerarm", "firepunch"],
+		randomBattleMoves: ["earthquake", "rockslide", "hiddenpowerbug", "doubleedge", "explosion", "counter"],
 		tier: "UU",
 	},
 	ponyta: {
-		randomBattleMoves: ["flareblitz", "wildcharge", "morningsun", "hypnosis", "flamecharge"],
 		tier: "LC",
 	},
 	rapidash: {
 		inherit: true,
-		randomBattleMoves: ["flareblitz", "wildcharge", "morningsun", "hypnosis", "flamecharge", "megahorn", "drillrun"],
+		randomBattleMoves: ["fireblast", "agility", "substitute", "batonpass", "toxic", "hiddenpowergrass", "rest", "sleeptalk"],
 		tier: "UU",
 	},
 	slowpoke: {
 		inherit: true,
-		randomBattleMoves: ["scald", "aquatail", "zenheadbutt", "thunderwave", "toxic", "slackoff", "trickroom", "trick"],
 		tier: "LC",
 	},
 	slowbro: {
-		randomBattleMoves: ["scald", "surf", "fireblast", "icebeam", "psychic", "grassknot", "calmmind", "thunderwave", "toxic", "slackoff", "trickroom", "trick"],
+		randomBattleMoves: ["calmmind", "disable", "fireblast", "icebeam", "surf", "rest", "sleeptalk", "psychic"],
 		tier: "BL",
 	},
 	slowking: {
-		randomBattleMoves: ["scald", "surf", "fireblast", "icebeam", "psychic", "grassknot", "calmmind", "thunderwave", "toxic", "slackoff", "trickroom", "trick", "nastyplot"],
+		randomBattleMoves: ["surf", "psychic", "fireblast", "flamethrower", "icebeam", "calmmind", "thunderwave", "counter", "rest", "sleeptalk"],
 		tier: "UU",
 	},
 	magnemite: {
-		randomBattleMoves: ["thunderbolt", "thunderwave", "magnetrise", "substitute", "flashcannon", "hiddenpowerice", "voltswitch"],
 		tier: "LC",
 	},
 	magneton: {
 		inherit: true,
-		randomBattleMoves: ["thunderbolt", "thunderwave", "magnetrise", "substitute", "flashcannon", "hiddenpowerice", "voltswitch"],
+		randomBattleMoves: ["thunderbolt", "hiddenpowergrass", "hiddenpowerice", "rest", "sleeptalk", "thunderwave", "toxic"],
 		tier: "OU",
 	},
 	farfetchd: {
 		inherit: true,
-		randomBattleMoves: ["bravebird", "swordsdance", "return", "leafblade", "roost"],
+		randomBattleMoves: ["swordsdance", "agility", "slash", "hiddenpowerground", "shadowball", "substitute", "flail"],
 		tier: "NU",
 	},
 	doduo: {
-		randomBattleMoves: ["bravebird", "return", "doubleedge", "roost", "quickattack", "pursuit"],
 		tier: "LC",
 	},
 	dodrio: {
 		inherit: true,
-		randomBattleMoves: ["bravebird", "return", "doubleedge", "roost", "quickattack", "pursuit"],
+		randomBattleMoves: ["doubleedge", "return", "drillpeck", "quickattack", "flail", "hiddenpowerground", "agility", "substitute", "endure", "batonpass", "taunt", "rest"],
 		tier: "BL",
 	},
 	seel: {
 		inherit: true,
-		randomBattleMoves: ["surf", "icebeam", "aquajet", "iceshard", "raindance", "protect", "rest", "toxic", "drillrun"],
 		tier: "LC",
 	},
 	dewgong: {
-		randomBattleMoves: ["surf", "icebeam", "aquajet", "iceshard", "raindance", "protect", "rest", "toxic", "drillrun"],
+		randomBattleMoves: ["rest", "sleeptalk", "icebeam", "surf", "perishsong", "toxic", "hiddenpowerfire", "fakeout"],
 		tier: "NU",
 	},
 	grimer: {
 		inherit: true,
-		randomBattleMoves: ["curse", "gunkshot", "poisonjab", "shadowsneak", "payback", "brickbreak", "rest", "icepunch", "firepunch", "sleeptalk"],
 		tier: "LC",
 	},
 	muk: {
-		randomBattleMoves: ["curse", "gunkshot", "poisonjab", "shadowsneak", "payback", "brickbreak", "rest", "icepunch", "firepunch", "sleeptalk"],
+		randomBattleMoves: ["sludgebomb", "hiddenpowerground", "curse", "fireblast", "icepunch", "bodyslam", "rest", "sleeptalk", "toxic", "shadowpunch", "memento", "taunt"],
 		tier: "UU",
 	},
 	shellder: {
 		inherit: true,
-		randomBattleMoves: ["shellsmash", "hydropump", "razorshell", "rockblast", "iciclespear", "rapidspin"],
 		tier: "LC",
 	},
 	cloyster: {
-		randomBattleMoves: ["shellsmash", "hydropump", "razorshell", "rockblast", "iciclespear", "iceshard", "rapidspin", "spikes", "toxicspikes"],
+		randomBattleMoves: ["surf", "icebeam", "spikes", "rapidspin", "explosion", "toxic"],
 		tier: "OU",
 	},
 	gastly: {
-		randomBattleMoves: ["shadowball", "sludgebomb", "hiddenpowerfighting", "thunderbolt", "substitute", "disable", "painsplit", "hypnosis", "gigadrain", "trick"],
 		tier: "LC",
 	},
 	haunter: {
-		randomBattleMoves: ["shadowball", "sludgebomb", "hiddenpowerfighting", "thunderbolt", "substitute", "disable", "painsplit", "hypnosis", "gigadrain", "trick"],
 		tier: "NU",
 	},
 	gengar: {
 		inherit: true,
-		randomBattleMoves: ["shadowball", "sludgebomb", "focusblast", "thunderbolt", "substitute", "disable", "painsplit", "hypnosis", "gigadrain", "trick"],
+		randomBattleMoves: ["thunderbolt", "icepunch", "firepunch", "explosion", "willowisp", "destinybond", "taunt", "substitute", "meanlook", "perishsong"],
 		tier: "OU",
 	},
 	onix: {
-		randomBattleMoves: ["stealthrock", "earthquake", "stoneedge", "dragontail", "curse"],
 		tier: "LC",
 	},
 	steelix: {
-		randomBattleMoves: ["stealthrock", "earthquake", "ironhead", "curse", "dragontail", "roar", "toxic", "stoneedge", "icefang", "firefang"],
+		randomBattleMoves: ["earthquake", "rockslide", "hiddenpowerrock", "hiddenpowersteel", "irontail", "roar", "toxic", "rest", "explosion", "doubleedge"],
 		tier: "BL",
 	},
 	drowzee: {
 		inherit: true,
-		randomBattleMoves: ["psychic", "seismictoss", "thunderwave", "wish", "protect", "healbell", "toxic", "nastyplot", "shadowball", "trickroom", "calmmind", "barrier"],
 		tier: "LC",
 	},
 	hypno: {
 		inherit: true,
-		randomBattleMoves: ["psychic", "seismictoss", "thunderwave", "wish", "protect", "healbell", "toxic", "nastyplot", "shadowball", "trickroom", "batonpass", "calmmind", "barrier", "bellydrum", "zenheadbutt", "firepunch"],
+		randomBattleMoves: ["psychic", "hypnosis", "firepunch", "icepunch", "thunderpunch", "calmmind"],
 		tier: "UU",
 	},
 	krabby: {
-		randomBattleMoves: ["crabhammer", "return", "swordsdance", "agility", "rockslide", "substitute", "xscissor", "superpower"],
 		tier: "LC",
 	},
 	kingler: {
-		randomBattleMoves: ["crabhammer", "return", "swordsdance", "agility", "rockslide", "substitute", "xscissor", "superpower"],
+		randomBattleMoves: ["doubleedge", "return", "bodyslam", "hiddenpowerground", "mudshot", "hiddenpowerghost", "swordsdance", "crabhammer", "knockoff", "toxic", "rest", "sleeptalk", "haze", "surf"],
 		tier: "NU",
 	},
 	voltorb: {
 		inherit: true,
-		randomBattleMoves: ["voltswitch", "thunderbolt", "taunt", "foulplay", "hiddenpowerice"],
 		tier: "LC",
 	},
 	electrode: {
-		randomBattleMoves: ["voltswitch", "thunderbolt", "taunt", "foulplay", "hiddenpowerice"],
+		randomBattleMoves: ["thunderbolt", "thunder", "hiddenpowergrass", "hiddenpowerice", "explosion", "raindance", "lightscreen", "taunt", "thunderwave", "substitute"],
 		tier: "UU",
 	},
 	exeggcute: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "leechseed", "gigadrain", "psychic", "sleeppowder", "stunspore", "hiddenpowerfire", "synthesis"],
 		tier: "LC",
 	},
 	exeggutor: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "leechseed", "gigadrain", "leafstorm", "psychic", "sleeppowder", "stunspore", "hiddenpowerfire", "synthesis"],
+		randomBattleMoves: ["solarbeam", "gigadrain", "psychic", "hiddenpowerice", "hiddenpowerfire", "explosion", "sunnyday", "sleeppowder", "stunspore", "synthesis", "leechseed"],
 		tier: "BL",
 	},
 	cubone: {
-		randomBattleMoves: ["substitute", "bonemerang", "doubleedge", "stoneedge", "firepunch", "earthquake"],
 		tier: "LC",
 	},
 	marowak: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "bonemerang", "doubleedge", "stoneedge", "swordsdance", "firepunch", "earthquake"],
+		randomBattleMoves: ["earthquake", "bonemerang", "rockslide", "doubleedge", "hiddenpowerbug", "swordsdance"],
 		tier: "BL",
 	},
 	tyrogue: {
-		randomBattleMoves: ["highjumpkick", "rapidspin", "fakeout", "bulletpunch", "machpunch", "toxic", "counter"],
 		tier: "LC",
 	},
 	hitmonlee: {
 		inherit: true,
-		randomBattleMoves: ["highjumpkick", "suckerpunch", "stoneedge", "machpunch", "substitute", "fakeout", "closecombat", "earthquake", "blazekick"],
+		randomBattleMoves: ["brickbreak", "highjumpkick", "hiddenpowerghost", "rockslide", "earthquake", "machpunch", "focuspunch", "reversal", "substitute", "endure", "bulkup"],
 		tier: "UU",
 	},
 	hitmonchan: {
 		inherit: true,
-		randomBattleMoves: ["bulkup", "drainpunch", "icepunch", "machpunch", "substitute", "closecombat", "stoneedge", "rapidspin"],
+		randomBattleMoves: ["bulkup", "highjumpkick", "rapidspin", "machpunch", "return", "earthquake", "rockslide"],
 		tier: "NU",
 	},
 	hitmontop: {
-		randomBattleMoves: ["fakeout", "suckerpunch", "machpunch", "bulkup", "rapidspin", "closecombat", "stoneedge", "toxic", "bulletpunch"],
+		randomBattleMoves: ["brickbreak", "highjumpkick", "hiddenpowerghost", "rockslide", "earthquake", "machpunch", "endeavor", "substitute", "endure", "bulkup", "rapidspin", "counter"],
 		tier: "UU",
 	},
 	lickitung: {
 		inherit: true,
-		randomBattleMoves: ["wish", "protect", "dragontail", "curse", "bodyslam", "return", "powerwhip", "swordsdance", "earthquake", "toxic", "healbell"],
+		randomBattleMoves: ["wish", "protect", "healbell", "seismictoss", "knockoff", "earthquake"],
 		tier: "NU",
 	},
 	koffing: {
-		randomBattleMoves: ["painsplit", "sludgebomb", "willowisp", "fireblast", "toxic", "clearsmog", "rest", "sleeptalk", "thunderbolt"],
 		tier: "LC",
 	},
 	weezing: {
-		randomBattleMoves: ["painsplit", "sludgebomb", "willowisp", "fireblast", "toxic", "clearsmog", "rest", "sleeptalk", "thunderbolt"],
+		randomBattleMoves: ["sludgebomb", "haze", "flamethrower", "explosion", "painsplit", "willowisp", "thunderbolt", "shadowball", "toxic"],
 		tier: "BL",
 	},
 	rhyhorn: {
-		randomBattleMoves: ["stoneedge", "earthquake", "aquatail", "megahorn", "stealthrock", "rockblast"],
 		tier: "LC",
 	},
 	rhydon: {
 		inherit: true,
-		randomBattleMoves: ["stoneedge", "earthquake", "aquatail", "megahorn", "stealthrock", "rockblast"],
+		randomBattleMoves: ["earthquake", "rockslide", "hiddenpowerrock", "megahorn", "doubleedge", "focuspunch", "substitute", "toxic"],
 		tier: "BL",
 	},
 	chansey: {
 		inherit: true,
-		randomBattleMoves: ["wish", "softboiled", "protect", "toxic", "aromatherapy", "seismictoss", "counter", "thunderwave", "stealthrock"],
 		tier: "BL",
 	},
 	blissey: {
-		randomBattleMoves: ["wish", "softboiled", "protect", "toxic", "aromatherapy", "seismictoss", "counter", "thunderwave", "stealthrock", "flamethrower", "icebeam"],
+		randomBattleMoves: ["icebeam", "thunderbolt", "flamethrower", "hiddenpowergrass", "seismictoss", "toxic", "thunderwave", "wish", "protect", "softboiled", "calmmind", "counter"],
 		tier: "OU",
 	},
 	tangela: {
 		inherit: true,
-		randomBattleMoves: ["gigadrain", "sleeppowder", "hiddenpowerrock", "hiddenpowerice", "leechseed", "knockoff", "leafstorm", "stunspore", "synthesis"],
+		randomBattleMoves: ["sunnyday", "solarbeam", "hiddenpowerfire", "sleeppowder", "gigadrain", "stunspore", "leechseed"],
 		tier: "NU",
 	},
 	kangaskhan: {
 		inherit: true,
-		randomBattleMoves: ["fakeout", "return", "hammerarm", "doubleedge", "suckerpunch", "earthquake", "substitute", "focuspunch", "circlethrow", "wish"],
+		randomBattleMoves: ["fakeout", "bodyslam", "doubleedge", "earthquake", "rockslide", "brickbreak", "shadowball", "wish"],
 		tier: "UU",
 	},
 	horsea: {
-		randomBattleMoves: ["hydropump", "icebeam", "substitute", "hiddenpowergrass", "raindance"],
 		tier: "LC",
 	},
 	seadra: {
 		inherit: true,
-		randomBattleMoves: ["hydropump", "icebeam", "agility", "substitute", "hiddenpowergrass"],
 		tier: "NU",
 	},
 	kingdra: {
 		inherit: true,
-		randomBattleMoves: ["hydropump", "icebeam", "dragondance", "substitute", "outrage", "dracometeor", "waterfall", "rest", "sleeptalk"],
+		randomBattleMoves: ["hydropump", "surf", "icebeam", "hiddenpowergrass", "dragonbreath", "doubleedge", "return", "dragondance", "raindance", "rest", "sleeptalk"],
 		tier: "BL",
 	},
 	goldeen: {
-		randomBattleMoves: ["raindance", "waterfall", "megahorn", "return", "drillrun"],
 		tier: "LC",
 	},
 	seaking: {
-		randomBattleMoves: ["raindance", "waterfall", "megahorn", "return", "drillrun"],
+		randomBattleMoves: ["hydropump", "icebeam", "hiddenpowergrass", "megahorn", "raindance"],
 		tier: "NU",
 	},
 	staryu: {
 		inherit: true,
-		randomBattleMoves: ["surf", "thunderbolt", "icebeam", "rapidspin", "recover"],
 		tier: "LC",
 	},
 	starmie: {
 		inherit: true,
-		randomBattleMoves: ["surf", "thunderbolt", "icebeam", "rapidspin", "recover", "psychic", "trick"],
+		randomBattleMoves: ["surf", "thunderbolt", "icebeam", "psychic", "rapidspin", "recover", "thunderwave", "toxic"],
 		tier: "OU",
 	},
 	mrmime: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "calmmind", "batonpass", "barrier", "psychic", "hiddenpowerfighting", "healingwish", "nastyplot", "shadowball", "thunderbolt", "encore"],
+		randomBattleMoves: ["taunt", "thunderbolt", "psychic", "firepunch", "icepunch", "lightscreen", "reflect", "calmmind", "encore", "batonpass"],
 		tier: "UU",
 	},
 	scyther: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "roost", "bugbite", "quickattack", "brickbreak", "aerialace", "batonpass", "uturn"],
 		tier: "UU",
 	},
 	scizor: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "roost", "bulletpunch", "bugbite", "superpower", "uturn", "batonpass", "pursuit"],
+		randomBattleMoves: ["steelwing", "silverwind", "hiddenpowerground", "hiddenpowerrock", "morningsun", "swordsdance", "agility", "batonpass"],
 		tier: "BL",
 	},
 	smoochum: {
-		randomBattleMoves: ["icebeam", "psychic", "hiddenpowerfighting", "trick", "shadowball", "grassknot"],
 		tier: "LC",
 	},
 	jynx: {
-		randomBattleMoves: ["icebeam", "psychic", "focusblast", "trick", "shadowball", "nastyplot", "lovelykiss", "substitute", "energyball"],
+		randomBattleMoves: ["icebeam", "psychic", "hiddenpowerfire", "lovelykiss", "calmmind", "substitute", "meanlook", "perishsong"],
 		tier: "BL",
 	},
 	elekid: {
 		inherit: true,
-		randomBattleMoves: ["thunderbolt", "crosschop", "voltswitch", "substitute", "hiddenpowerice", "psychic"],
 		tier: "LC",
 	},
 	electabuzz: {
 		inherit: true,
-		randomBattleMoves: ["thunderbolt", "voltswitch", "substitute", "hiddenpowerice", "focusblast", "psychic"],
+		randomBattleMoves: ["thunderbolt", "icepunch", "firepunch", "hiddenpowergrass", "crosschop", "focuspunch", "substitute", "toxic", "thunderwave"],
 		tier: "UU",
 	},
 	magby: {
-		randomBattleMoves: ["flareblitz", "substitute", "fireblast", "hiddenpowergrass", "crosschop", "thunderpunch", "overheat"],
 		tier: "NU",
 	},
 	magmar: {
 		inherit: true,
-		randomBattleMoves: ["flareblitz", "substitute", "fireblast", "hiddenpowergrass", "crosschop", "thunderpunch", "overheat", "focusblast"],
+		randomBattleMoves: ["crosschop", "fireblast", "psychic", "thunderpunch", "hiddenpowerice", "toxic"],
 		tier: "UU",
 	},
 	pinsir: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "xscissor", "earthquake", "closecombat", "stealthrock", "substitute", "stoneedge", "quickattack"],
+		randomBattleMoves: ["swordsdance", "hiddenpowerghost", "rockslide", "brickbreak", "return", "earthquake"],
 		tier: "UU",
 	},
 	tauros: {
 		inherit: true,
-		randomBattleMoves: ["return", "earthquake", "zenheadbutt", "rockslide", "pursuit"],
+		randomBattleMoves: ["bodyslam", "doubleedge", "return", "earthquake", "hiddenpowerghost", "hiddenpowerrock"],
 		tier: "BL",
 	},
 	magikarp: {
-		randomBattleMoves: ["bounce", "flail", "tackle", "splash"],
 		tier: "LC",
 	},
 	gyarados: {
-		randomBattleMoves: ["dragondance", "waterfall", "earthquake", "bounce", "rest", "sleeptalk", "dragontail", "stoneedge", "substitute", "thunderwave", "icefang"],
+		randomBattleMoves: ["hiddenpowerflying", "hiddenpowerrock", "earthquake", "doubleedge", "hydropump", "blizzard", "dragondance", "taunt", "thunderwave"],
 		tier: "OU",
 	},
 	lapras: {
 		inherit: true,
-		randomBattleMoves: ["icebeam", "thunderbolt", "healbell", "toxic", "surf", "dragondance", "substitute", "waterfall", "return", "avalanche", "rest", "sleeptalk", "curse", "iceshard", "drillrun"],
+		randomBattleMoves: ["dragondance", "hiddenpowerghost", "return", "icebeam", "hydropump", "thunderbolt", "healbell", "psychic"],
 		tier: "BL",
 	},
 	ditto: {
@@ -662,1084 +585,998 @@ exports.BattleFormatsData = {
 		tier: "NU",
 	},
 	eevee: {
-		randomBattleMoves: ["quickattack", "return", "bite", "batonpass", "irontail", "yawn", "protect", "wish"],
 		tier: "LC",
 	},
 	vaporeon: {
-		randomBattleMoves: ["wish", "protect", "scald", "roar", "icebeam", "toxic", "batonpass", "substitute", "acidarmor", "hydropump", "hiddenpowergrass", "rest", "raindance"],
+		randomBattleMoves: ["hydropump", "surf", "icebeam", "wish", "toxic", "protect", "roar"],
 		tier: "BL",
 	},
 	jolteon: {
-		randomBattleMoves: ["thunderbolt", "voltswitch", "hiddenpowergrass", "hiddenpowerice", "chargebeam", "batonpass", "substitute"],
+		randomBattleMoves: ["thunderbolt", "hiddenpowerice", "hiddenpowergrass", "substitute", "agility", "batonpass", "toxic", "thunderwave", "wish"],
 		tier: "OU",
 	},
 	flareon: {
-		randomBattleMoves: ["rest", "sleeptalk", "flamecharge", "facade"],
+		randomBattleMoves: ["return", "bodyslam", "quickattack", "shadowball", "fireblast", "overheat", "hiddenpowergrass"],
 		tier: "NU",
 	},
 	espeon: {
 		inherit: true,
-		randomBattleMoves: ["psychic", "psyshock", "substitute", "wish", "shadowball", "hiddenpowerfighting", "calmmind", "morningsun", "storedpower", "batonpass"],
+		randomBattleMoves: ["psychic", "hiddenpowerfire", "morningsun", "calmmind", "substitute", "wish", "protect", "batonpass", "reflect", "lightscreen"],
 		tier: "BL",
 	},
 	umbreon: {
 		inherit: true,
-		randomBattleMoves: ["curse", "payback", "moonlight", "wish", "protect", "healbell", "toxic", "batonpass"],
+		randomBattleMoves: ["psychic", "meanlook", "charm", "curse", "substitute", "wish", "protect", "batonpass", "taunt", "toxic", "moonlight"],
 		tier: "BL",
 	},
 	porygon: {
-		randomBattleMoves: ["triattack", "icebeam", "recover", "toxic", "thunderwave", "discharge", "trick"],
 		tier: "LC",
 	},
 	porygon2: {
-		randomBattleMoves: ["triattack", "icebeam", "recover", "toxic", "thunderwave", "discharge", "trick"],
+		randomBattleMoves: ["thunderbolt", "icebeam", "return", "shadowball", "sharpen", "recover", "toxic", "thunderwave"],
 		tier: "OU",
 	},
 	omanyte: {
-		randomBattleMoves: ["shellsmash", "surf", "icebeam", "earthpower", "hiddenpowerelectric", "spikes", "toxicspikes", "stealthrock", "hydropump"],
 		tier: "LC",
 	},
 	omastar: {
-		randomBattleMoves: ["shellsmash", "surf", "icebeam", "earthpower", "hiddenpowerelectric", "spikes", "toxicspikes", "stealthrock", "hydropump"],
+		randomBattleMoves: ["raindance", "hydropump", "icebeam", "spikes", "toxic", "hiddenpowergrass", "haze"],
 		tier: "UU",
 	},
 	kabuto: {
-		randomBattleMoves: ["aquajet", "rockslide", "rapidspin", "stealthrock", "honeclaws", "waterfall", "toxic"],
 		tier: "LC",
 	},
 	kabutops: {
-		randomBattleMoves: ["aquajet", "stoneedge", "rapidspin", "stealthrock", "swordsdance", "waterfall", "toxic", "superpower"],
+		randomBattleMoves: ["return", "hiddenpowerghost", "brickbreak", "rockslide", "swordsdance", "rapidspin", "toxic"],
 		tier: "UU",
 	},
 	aerodactyl: {
-		randomBattleMoves: ["stealthrock", "taunt", "stoneedge", "rockslide", "earthquake", "aquatail", "roost", "firefang"],
+		randomBattleMoves: ["rockslide", "earthquake", "hiddenpowerflying", "doubleedge", "substitute", "taunt", "toxic"],
 		tier: "OU",
 	},
 	snorlax: {
 		inherit: true,
-		randomBattleMoves: ["rest", "curse", "sleeptalk", "bodyslam", "earthquake", "return", "firepunch", "icepunch", "crunch", "selfdestruct", "pursuit", "whirlwind"],
+		randomBattleMoves: ["earthquake", "brickbreak", "shadowball", "return", "selfdestruct", "rockslide", "rest", "sleeptalk"],
 		tier: "OU",
 	},
 	articuno: {
 		inherit: true,
-		randomBattleMoves: ["icebeam", "roost", "roar", "healbell", "toxic", "substitute", "hurricane"],
+		randomBattleMoves: ["icebeam", "toxic", "roar", "hiddenpowerfire", "reflect", "healbell", "rest", "sleeptalk", "haze", "extrasensory", "substitute", "agility"],
 		tier: "BL",
 	},
 	zapdos: {
 		inherit: true,
-		randomBattleMoves: ["thunderbolt", "heatwave", "hiddenpowergrass", "hiddenpowerice", "roost", "toxic", "substitute", "batonpass", "agility", "discharge"],
+		randomBattleMoves: ["agility", "batonpass", "thunderbolt", "hiddenpowerice", "toxic", "substitute", "thunderwave"],
 		tier: "OU",
 	},
 	moltres: {
 		inherit: true,
-		randomBattleMoves: ["fireblast", "hiddenpowergrass", "airslash", "roost", "substitute", "toxic", "overheat", "uturn", "willowisp", "hurricane"],
+		randomBattleMoves: ["fireblast", "flamethrower", "hiddenpowergrass", "doubleedge", "morningsun", "toxic", "agility", "willowisp", "substitute"],
 		tier: "BL",
 	},
 	dratini: {
-		randomBattleMoves: ["dragondance", "outrage", "waterfall", "fireblast", "extremespeed", "dracometeor", "substitute", "aquatail"],
 		tier: "LC",
 	},
 	dragonair: {
-		randomBattleMoves: ["dragondance", "outrage", "waterfall", "fireblast", "extremespeed", "dracometeor", "substitute", "aquatail"],
 		tier: "NU",
 	},
 	dragonite: {
 		inherit: true,
-		randomBattleMoves: ["dragondance", "outrage", "firepunch", "extremespeed", "dragonclaw", "earthquake", "roost", "waterfall", "substitute", "thunderwave", "dragontail", "hurricane", "superpower", "dracometeor"],
+		randomBattleMoves: ["hiddenpowerflying", "earthquake", "dragondance", "fireblast", "flamethrower", "icebeam", "thunderbolt", "thunderwave", "healbell", "substitute", "focuspunch"],
 		tier: "BL",
 	},
 	mewtwo: {
 		inherit: true,
-		randomBattleMoves: ["psystrike", "aurasphere", "fireblast", "icebeam", "calmmind", "substitute", "recover", "thunderbolt"],
+		randomBattleMoves: ["calmmind", "psychic", "icebeam", "thunderbolt", "flamethrower", "bulkup", "shadowball", "earthquake", "brickbreak", "recover", "taunt", "selfdestruct"],
 		tier: "Uber",
 	},
 	mew: {
 		inherit: true,
-		randomBattleMoves: ["taunt", "willowisp", "roost", "psychic", "nastyplot", "aurasphere", "shadowball", "fireblast", "swordsdance", "superpower", "zenheadbutt", "calmmind", "batonpass", "rockpolish", "substitute", "toxic", "explosion", "icebeam", "thunderbolt", "earthquake", "uturn", "stealthrock", "transform"],
+		randomBattleMoves: ["softboiled", "calmmind", "psychic", "icebeam", "thunderbolt", "flamethrower", "swordsdance", "shadowball", "earthquake", "focuspunch", "substitute", "taunt", "hypnosis", "toxic", "transform", "roar", "reflect", "counter", "explosion"],
 		tier: "Uber",
 	},
 	chikorita: {
 		inherit: true,
-		randomBattleMoves: ["reflect", "lightscreen", "safeguard", "aromatherapy", "grasswhistle", "leechseed", "toxic", "gigadrain", "synthesis"],
 		tier: "LC",
 	},
 	bayleef: {
-		randomBattleMoves: ["reflect", "lightscreen", "safeguard", "aromatherapy", "grasswhistle", "leechseed", "toxic", "gigadrain", "synthesis"],
 		tier: "NFE",
 	},
 	meganium: {
-		randomBattleMoves: ["reflect", "lightscreen", "safeguard", "aromatherapy", "grasswhistle", "leechseed", "toxic", "gigadrain", "synthesis", "dragontail"],
+		randomBattleMoves: ["hiddenpowergrass", "razorleaf", "hiddenpowerfire", "bodyslam", "return", "earthquake", "swordsdance", "counter", "synthesis", "leechseed", "toxic", "reflect", "lightscreen"],
 		tier: "UU",
 	},
 	cyndaquil: {
 		inherit: true,
-		randomBattleMoves: ["eruption", "fireblast", "flamethrower", "hiddenpowergrass", "naturepower"],
 		tier: "LC",
 	},
 	quilava: {
-		randomBattleMoves: ["eruption", "fireblast", "flamethrower", "hiddenpowergrass", "naturepower"],
 		tier: "NU",
 	},
 	typhlosion: {
 		inherit: true,
-		randomBattleMoves: ["eruption", "fireblast", "flamethrower", "hiddenpowergrass", "naturepower", "focusblast"],
+		randomBattleMoves: ["fireblast", "flamethrower", "earthquake", "thunderpunch", "hiddenpowerice", "hiddenpowergrass", "substitute"],
 		tier: "BL",
 	},
 	totodile: {
 		inherit: true,
-		randomBattleMoves: ["aquajet", "waterfall", "crunch", "icepunch", "superpower", "dragondance", "swordsdance", "return"],
 		tier: "LC",
 	},
 	croconaw: {
-		randomBattleMoves: ["aquajet", "waterfall", "crunch", "icepunch", "superpower", "dragondance", "swordsdance", "return"],
 		tier: "NFE",
 	},
 	feraligatr: {
-		randomBattleMoves: ["aquajet", "waterfall", "crunch", "icepunch", "dragondance", "swordsdance", "return", "earthquake", "superpower"],
+		randomBattleMoves: ["earthquake", "rockslide", "hiddenpowerflying", "icebeam", "focuspunch", "substitute", "swordsdance"],
 		tier: "UU",
 	},
 	sentret: {
-		randomBattleMoves: ["superfang", "trick", "toxic", "uturn", "knockoff"],
 		tier: "LC",
 	},
 	furret: {
-		randomBattleMoves: ["return", "uturn", "suckerpunch", "trick", "icepunch", "firepunch", "thunderpunch"],
+		randomBattleMoves: ["return", "doubleedge", "shadowball", "brickbreak", "hiddenpowerground", "quickattack", "surf", "flamethrower", "trick"],
 		tier: "NU",
 	},
 	hoothoot: {
 		inherit: true,
-		randomBattleMoves: ["reflect", "toxic", "roost", "lightscreen", "whirlwind", "nightshade", "magiccoat"],
 		tier: "LC",
 	},
 	noctowl: {
-		randomBattleMoves: ["roost", "whirlwind", "airslash", "nightshade", "toxic", "reflect", "lightscreen", "magiccoat"],
+		randomBattleMoves: ["psychic", "rest", "sleeptalk", "toxic", "whirlwind", "reflect", "hypnosis"],
 		tier: "NU",
 	},
 	ledyba: {
 		inherit: true,
-		randomBattleMoves: ["roost", "agility", "lightscreen", "encore", "reflect", "knockoff", "swordsdance", "batonpass", "toxic"],
 		tier: "LC",
 	},
 	ledian: {
-		randomBattleMoves: ["roost", "agility", "lightscreen", "encore", "reflect", "knockoff", "swordsdance", "batonpass", "toxic"],
+		randomBattleMoves: ["swordsdance", "substitute", "batonpass", "lightscreen", "reflect", "return"],
 		tier: "NU",
 	},
 	spinarak: {
 		inherit: true,
-		randomBattleMoves: ["agility", "toxic", "xscissor", "toxicspikes", "poisonjab", "batonpass", "swordsdance"],
 		tier: "LC",
 	},
 	ariados: {
-		randomBattleMoves: ["agility", "toxic", "xscissor", "toxicspikes", "poisonjab", "batonpass", "swordsdance"],
+		randomBattleMoves: ["nightshade", "sludgebomb", "signalbeam", "spiderweb", "batonpass", "substitute", "agility"],
 		tier: "NU",
 	},
 	chinchou: {
-		randomBattleMoves: ["voltswitch", "thunderbolt", "hiddenpowergrass", "hydropump", "icebeam", "surf", "thunderwave", "scald", "discharge"],
 		tier: "LC",
 	},
 	lanturn: {
-		randomBattleMoves: ["voltswitch", "thunderbolt", "hiddenpowergrass", "hydropump", "icebeam", "surf", "thunderwave", "scald", "discharge"],
+		randomBattleMoves: ["surf", "hydropump", "thunderbolt", "icebeam", "thunderwave", "toxic", "rest", "sleeptalk"],
 		tier: "UU",
 	},
 	togepi: {
 		inherit: true,
-		randomBattleMoves: ["wish", "protect", "fireblast", "toxic", "thunderwave", "softboiled"],
 		tier: "LC",
 	},
 	togetic: {
-		randomBattleMoves: ["wish", "protect", "fireblast", "toxic", "thunderwave", "roost"],
+		randomBattleMoves: ["seismictoss", "toxic", "softboiled", "batonpass", "encore", "wish", "flamethrower", "aerialace", "doubleedge", "focuspunch", "shadowball"],
 		tier: "NU",
 	},
 	natu: {
 		inherit: true,
-		randomBattleMoves: ["thunderwave", "roost", "toxic", "reflect", "lightscreen", "uturn", "wish", "psychic", "nightshade"],
 		tier: "LC",
 	},
 	xatu: {
-		randomBattleMoves: ["thunderwave", "toxic", "roost", "psychic", "nightshade", "uturn", "reflect", "lightscreen", "wish", "calmmind"],
+		randomBattleMoves: ["psychic", "nightshade", "calmmind", "wish", "protect", "batonpass", "reflect", "lightscreen", "thunderwave", "toxic"],
 		tier: "UU",
 	},
 	mareep: {
 		inherit: true,
-		randomBattleMoves: ["reflect", "lightscreen", "thunderbolt", "discharge", "thunderwave", "toxic", "hiddenpowerice", "cottonguard"],
 		tier: "LC",
 	},
 	flaaffy: {
-		randomBattleMoves: ["reflect", "lightscreen", "thunderbolt", "discharge", "thunderwave", "toxic", "hiddenpowerice", "cottonguard"],
 		tier: "NFE",
 	},
 	ampharos: {
-		randomBattleMoves: ["voltswitch", "focusblast", "hiddenpowerice", "hiddenpowergrass", "thunderbolt", "healbell"],
+		randomBattleMoves: ["thunderbolt", "hiddenpowerice", "hiddenpowergrass", "firepunch", "focuspunch", "substitute", "thunderwave", "healbell", "reflect", "lightscreen"],
 		tier: "UU",
 	},
 	azurill: {
-		randomBattleMoves: ["scald", "return", "doubleedge", "encore", "toxic", "protect"],
 		tier: "LC",
 	},
 	marill: {
-		randomBattleMoves: ["waterfall", "return", "doubleedge", "encore", "toxic", "aquajet", "superpower", "icepunch", "protect"],
 		tier: "NFE",
 	},
 	azumarill: {
-		randomBattleMoves: ["waterfall", "aquajet", "return", "doubleedge", "icepunch", "superpower"],
+		randomBattleMoves: ["focuspunch", "hiddenpowerghost", "bodyslam", "hydropump", "surf", "substitute", "encore", "sing"],
 		tier: "UU",
 	},
 	sudowoodo: {
-		randomBattleMoves: ["hammerarm", "stoneedge", "earthquake", "suckerpunch", "woodhammer", "explosion", "stealthrock"],
+		randomBattleMoves: ["hiddenpowerrock", "rockslide", "earthquake", "explosion", "doubleedge", "brickbreak", "focuspunch", "rest", "sleeptalk"],
 		tier: "NU",
 	},
 	hoppip: {
-		randomBattleMoves: ["encore", "sleeppowder", "uturn", "toxic", "leechseed", "substitute", "protect"],
 		tier: "LC",
 	},
 	skiploom: {
-		randomBattleMoves: ["encore", "sleeppowder", "uturn", "toxic", "leechseed", "substitute", "protect"],
 		tier: "NFE",
 	},
 	jumpluff: {
-		randomBattleMoves: ["encore", "sleeppowder", "uturn", "toxic", "leechseed", "substitute", "gigadrain", "acrobatics", "synthesis"],
+		randomBattleMoves: ["hiddenpowerflying", "leechseed", "encore", "sleeppowder", "synthesis", "toxic", "substitute"],
 		tier: "BL",
 	},
 	aipom: {
 		inherit: true,
-		randomBattleMoves: ["fakeout", "return", "brickbreak", "seedbomb", "shadowclaw", "uturn"],
+		randomBattleMoves: ["taunt", "doubleedge", "shadowball", "batonpass", "focuspunch", "thunderwave"],
 		tier: "NU",
 	},
 	sunkern: {
 		inherit: true,
-		randomBattleMoves: ["sunnyday", "gigadrain", "solarbeam", "hiddenpowerfire", "toxic", "earthpower"],
 		tier: "LC",
 	},
 	sunflora: {
-		randomBattleMoves: ["sunnyday", "leafstorm", "gigadrain", "solarbeam", "hiddenpowerfire", "earthpower"],
+		randomBattleMoves: ["synthesis", "growth", "gigadrain", "razorleaf", "hiddenpowerice", "leechseed", "hiddenpowerfire", "sunnyday", "solarbeam"],
 		tier: "NU",
 	},
 	yanma: {
-		randomBattleMoves: ["bugbuzz", "airslash", "hiddenpowerground", "uturn", "protect", "gigadrain"],
+		randomBattleMoves: ["aerialace", "signalbeam", "hiddenpowerground", "hypnosis", "substitute", "reversal"],
 		tier: "NU",
 	},
 	wooper: {
-		randomBattleMoves: ["recover", "earthquake", "scald", "toxic", "stockpile", "yawn", "protect"],
 		tier: "LC",
 	},
 	quagsire: {
-		randomBattleMoves: ["recover", "earthquake", "waterfall", "scald", "toxic", "curse", "stoneedge", "stockpile", "yawn"],
+		randomBattleMoves: ["earthquake", "surf", "icebeam", "toxic", "rest", "sleeptalk", "curse", "counter"],
 		tier: "UU",
 	},
 	murkrow: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "suckerpunch", "bravebird", "heatwave", "hiddenpowergrass", "roost", "darkpulse", "thunderwave"],
+		randomBattleMoves: ["drillpeck", "shadowball", "hiddenpowerground", "hiddenpowerfighting", "feintattack", "meanlook", "perishsong", "substitute", "protect", "taunt"],
 		tier: "NU",
 	},
 	misdreavus: {
 		inherit: true,
-		randomBattleMoves: ["nastyplot", "substitute", "calmmind", "willowisp", "shadowball", "thunderbolt", "hiddenpowerfighting"],
+		randomBattleMoves: ["calmmind", "thunderbolt", "hiddenpowerice", "psychic", "meanlook", "perishsong", "substitute", "protect", "taunt", "thunderwave"],
 		tier: "UU",
 	},
 	unown: {
-		randomBattleMoves: ["hiddenpowerpsychic"],
+		randomBattleMoves: ["hiddenpowerpsychic", "hiddenpowerfighting"],
 		tier: "NU",
 	},
 	wynaut: {
 		inherit: true,
-		randomBattleMoves: ["destinybond", "counter", "mirrorcoat", "encore"],
 		tier: "Uber",
 	},
 	wobbuffet: {
 		inherit: true,
-		randomBattleMoves: ["destinybond", "counter", "mirrorcoat", "encore"],
+		randomBattleMoves: ["counter", "mirrorcoat", "encore", "safeguard", "tickle"],
 		tier: "Uber",
 	},
 	girafarig: {
-		randomBattleMoves: ["psychic", "thunderbolt", "calmmind", "batonpass", "agility", "hypervoice", "thunderwave"],
+		randomBattleMoves: ["psychic", "thunderbolt", "calmmind", "agility", "substitute", "batonpass", "thunderwave", "wish", "reflect", "lightscreen"],
 		tier: "UU",
 	},
 	pineco: {
 		inherit: true,
-		randomBattleMoves: ["rapidspin", "toxicspikes", "spikes", "bugbite", "stealthrock"],
 		tier: "LC",
 	},
 	forretress: {
-		randomBattleMoves: ["rapidspin", "toxicspikes", "spikes", "bugbite", "earthquake", "voltswitch", "stealthrock"],
+		randomBattleMoves: ["hiddenpowerbug", "earthquake", "counter", "explosion", "rapidspin", "spikes", "toxic", "lightscreen"],
 		tier: "OU",
 	},
 	dunsparce: {
-		randomBattleMoves: ["coil", "rockslide", "bite", "headbutt", "glare", "thunderwave", "bodyslam", "roost"],
+		randomBattleMoves: ["headbutt", "thunderwave", "rockslide", "shadowball", "curse", "rest", "sleeptalk", "bodyslam"],
 		tier: "NU",
 	},
 	gligar: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "toxic", "roost", "taunt", "swordsdance", "earthquake", "uturn", "stoneedge", "acrobatics"],
+		randomBattleMoves: ["earthquake", "hiddenpowerflying", "rockslide", "irontail", "steelwing", "swordsdance", "counter", "endure"],
 		tier: "UU",
 	},
 	snubbull: {
 		inherit: true,
-		randomBattleMoves: ["thunderwave", "return", "crunch", "closecombat"],
 		tier: "LC",
 	},
 	granbull: {
-		randomBattleMoves: ["thunderwave", "return", "crunch", "closecombat", "healbell", "icepunch"],
+		randomBattleMoves: ["return", "doubleedge", "bodyslam", "earthquake", "shadowball", "focuspunch", "overheat", "fireblast", "substitute", "healbell", "thunderwave", "counter"],
 		tier: "UU",
 	},
 	qwilfish: {
 		inherit: true,
-		randomBattleMoves: ["toxicspikes", "waterfall", "spikes", "swordsdance", "poisonjab", "painsplit", "thunderwave", "taunt", "destinybond"],
+		randomBattleMoves: ["spikes", "surf", "hydropump", "sludgebomb", "selfdestruct", "destinybond", "sworddance", "thunderwave", "shadowball", "return"],
 		tier: "UU",
 	},
 	shuckle: {
 		inherit: true,
-		randomBattleMoves: ["rollout", "acupressure", "powersplit", "rest"],
+		randomBattleMoves: ["toxic", "protect", "encore", "rest", "sleeptalk", "wrap"],
 		tier: "NU",
 	},
 	heracross: {
-		randomBattleMoves: ["closecombat", "megahorn", "stoneedge", "swordsdance", "facade"],
+		randomBattleMoves: ["megahorn", "brickbreak", "rockslide", "swordsdance", "substitute", "focuspunch", "endure", "reversal", "rest", "sleeptalk"],
 		tier: "OU",
 	},
 	sneasel: {
 		inherit: true,
-		randomBattleMoves: ["iceshard", "icepunch", "nightslash", "lowkick", "pursuit", "swordsdance"],
+		randomBattleMoves: ["brickbreak", "shadowball", "hiddenpowerflying", "doubleedge", "return", "quickattack", "focuspunch", "substitute", "swordsdance", "taunt"],
 		tier: "UU",
 	},
 	teddiursa: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "protect", "facade", "closecombat", "firepunch", "crunch"],
 		tier: "LC",
 	},
 	ursaring: {
-		randomBattleMoves: ["swordsdance", "protect", "facade", "closecombat", "firepunch", "crunch"],
+		randomBattleMoves: ["return", "bodyslam", "earthquake", "hiddenpowerghost", "focuspunch", "swordsdance", "sleeptalk"],
 		tier: "BL",
 	},
 	slugma: {
-		randomBattleMoves: ["stockpile", "recover", "lavaplume", "willowisp", "toxic", "hiddenpowergrass"],
 		tier: "LC",
 	},
 	magcargo: {
 		inherit: true,
-		randomBattleMoves: ["stockpile", "recover", "lavaplume", "willowisp", "toxic", "hiddenpowergrass", "hiddenpowerrock", "stealthrock", "shellsmash", "fireblast", "earthpower"],
+		randomBattleMoves: ["rest", "sleeptalk", "flamethrower", "hiddenpowerelectric", "toxic"],
 		tier: "NU",
 	},
 	swinub: {
 		inherit: true,
-		randomBattleMoves: ["earthquake", "iciclecrash", "iceshard", "stealthrock", "superpower", "endeavor"],
 		tier: "LC",
 	},
 	piloswine: {
-		randomBattleMoves: ["earthquake", "iciclecrash", "iceshard", "stealthrock", "superpower", "endeavor"],
+		randomBattleMoves: ["earthquake", "rockslide", "toxic", "icebeam", "icywind", "rest", "sleeptalk"],
 		tier: "NU",
 	},
 	corsola: {
 		inherit: true,
-		randomBattleMoves: ["recover", "toxic", "powergem", "scald", "stealthrock"],
+		randomBattleMoves: ["calmmind", "recover", "surf", "toxic", "refresh"],
 		tier: "NU",
 	},
 	remoraid: {
-		randomBattleMoves: ["waterspout", "hydropump", "fireblast", "hiddenpowerground", "icebeam", "seedbomb", "rockblast"],
 		tier: "LC",
 	},
 	octillery: {
-		randomBattleMoves: ["hydropump", "fireblast", "icebeam", "energyball", "rockblast", "thunderwave"],
+		randomBattleMoves: ["sludgebomb", "icebeam", "rockblast", "surf", "hiddenpowerground", "thunderwave", "flamethrower", "fireblast", "psychic"],
 		tier: "NU",
 	},
 	delibird: {
 		inherit: true,
-		randomBattleMoves: ["rapidspin", "iceshard", "icepunch", "aerialace"],
+		randomBattleMoves: ["aerialace", "focuspunch", "icebeam", "quickattack"],
 		tier: "NU",
 	},
 	mantine: {
 		inherit: true,
-		randomBattleMoves: ["raindance", "hydropump", "surf", "airslash", "icebeam", "rest", "sleeptalk", "toxic"],
+		randomBattleMoves: ["surf", "hydropump", "icebeam", "hiddenpowergrass", "toxic", "haze", "raindance", "rest", "sleeptalk"],
 		tier: "UU",
 	},
 	skarmory: {
-		randomBattleMoves: ["whirlwind", "bravebird", "roost", "spikes", "stealthrock"],
+		randomBattleMoves: ["drillpeck", "whirlwind", "spikes", "toxic", "protect", "rest", "taunt", "substitute"],
 		tier: "OU",
 	},
 	houndour: {
 		inherit: true,
-		randomBattleMoves: ["pursuit", "suckerpunch", "fireblast", "darkpulse", "hiddenpowerfighting", "nastyplot"],
 		tier: "LC",
 	},
 	houndoom: {
-		randomBattleMoves: ["nastyplot", "pursuit", "darkpulse", "suckerpunch", "fireblast", "hiddenpowerfighting"],
+		randomBattleMoves: ["pursuit", "fireblast", "flamethrower", "willowisp", "crunch", "hiddenpowerice", "hiddenpowergrass"],
 		tier: "BL",
 	},
 	phanpy: {
-		randomBattleMoves: ["stealthrock", "earthquake", "iceshard", "headsmash", "knockoff", "seedbomb", "superpower"],
 		tier: "LC",
 	},
 	donphan: {
-		randomBattleMoves: ["stealthrock", "rapidspin", "iceshard", "earthquake", "headsmash", "seedbomb", "superpower"],
+		randomBattleMoves: ["earthquake", "rockslide", "bodyslam", "hiddenpowerbug", "rapidspin", "counter", "toxic", "roar", "rest", "sleeptalk"],
 		tier: "BL",
 	},
 	stantler: {
 		inherit: true,
-		randomBattleMoves: ["return", "megahorn", "jumpkick", "earthquake", "thunderwave", "suckerpunch"],
+		randomBattleMoves: ["return", "earthquake", "doubleedge", "hypnosis", "shadowball", "thunderbolt", "calmmind"],
 		tier: "UU",
 	},
 	smeargle: {
 		inherit: true,
-		randomBattleMoves: ["spore", "spikes", "stealthrock", "uturn", "destinybond", "whirlwind"],
+		randomBattleMoves: ["extremespeed", "explosion", "spore", "spikes", "transform", "perishsong", "bellydrum", "tailglow", "agility", "ingrain", "spiderweb", "substitute", "batonpass"],
 		tier: "BL",
 	},
 	miltank: {
-		randomBattleMoves: ["milkdrink", "stealthrock", "bodyslam", "healbell", "curse", "earthquake"],
+		randomBattleMoves: ["return", "bodyslam", "earthquake", "shadowball", "counter", "curse", "milkdrink", "healbell", "toxic", "thunderwave"],
 		tier: "BL",
 	},
 	raikou: {
 		inherit: true,
-		randomBattleMoves: ["thunderbolt", "hiddenpowerice", "aurasphere", "calmmind", "substitute"],
+		randomBattleMoves: ["thunderbolt", "hiddenpowerice", "calmmind", "hiddenpowergrass", "crunch", "substitute", "roar", "rest", "sleeptalk"],
 		tier: "OU",
 	},
 	entei: {
 		inherit: true,
-		randomBattleMoves: ["extremespeed", "flareblitz", "ironhead", "flamecharge", "stoneedge"],
+		randomBattleMoves: ["calmmind", "fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "doubleedge", "return", "sunnyday", "solarbeam", "substitute"],
 		tier: "BL",
 	},
 	suicune: {
 		inherit: true,
-		randomBattleMoves: ["hydropump", "icebeam", "scald", "hiddenpowergrass", "hiddenpowerelectric", "rest", "sleeptalk", "roar", "calmmind"],
+		randomBattleMoves: ["hydropump", "surf", "icebeam", "hiddenpowergrass", "calmmind", "toxic", "roar", "substitute", "rest", "sleeptalk"],
 		tier: "OU",
 	},
 	larvitar: {
 		inherit: true,
-		randomBattleMoves: ["earthquake", "stoneedge", "rockpolish", "dragondance", "superpower"],
 		tier: "LC",
 	},
 	pupitar: {
-		randomBattleMoves: ["earthquake", "stoneedge", "rockpolish", "dragondance", "superpower"],
 		tier: "NU",
 	},
 	tyranitar: {
 		inherit: true,
-		randomBattleMoves: ["crunch", "stoneedge", "pursuit", "superpower", "fireblast", "icebeam", "stealthrock", "aquatail", "dragondance"],
+		randomBattleMoves: ["rockslide", "earthquake", "hiddenpowerbug", "hiddenpowerflying", "pursuit", "fireblast", "icebeam", "hiddenpowergrass", "dragondance", "taunt", "toxic"],
 		tier: "OU",
 	},
 	lugia: {
 		inherit: true,
-		randomBattleMoves: ["toxic", "dragontail", "roost", "substitute", "whirlwind", "icebeam"],
+		randomBattleMoves: ["recover", "icebeam", "calmmind", "aeroblast", "earthquake", "toxic", "whirlwind", "reflect", "lightscreen"],
 		tier: "Uber",
 	},
 	hooh: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "sacredfire", "bravebird", "earthquake", "roost", "flamecharge"],
+		randomBattleMoves: ["sacredfire", "hiddenpowerflying", "thunderbolt", "earthquake", "recover", "whirlwind", "reflect", "substitute"],
 		tier: "Uber",
 	},
 	celebi: {
 		inherit: true,
-		randomBattleMoves: ["nastyplot", "psychic", "gigadrain", "recover", "healbell", "batonpass", "stealthrock", "earthpower", "hiddenpowerfire", "hiddenpowerice", "calmmind"],
+		randomBattleMoves: ["psychic", "hiddenpowergrass", "shadowball", "hiddenpowerfighting", "recover", "calmmind", "swordsdance", "batonpass", "reflect", "healbell", "toxic", "leechseed"],
 		tier: "OU",
 	},
 	treecko: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "leechseed", "gigadrain", "leafstorm", "hiddenpowerice", "hiddenpowerrock", "endeavor"],
 		tier: "LC",
 	},
 	grovyle: {
-		randomBattleMoves: ["substitute", "leechseed", "gigadrain", "leafstorm", "hiddenpowerice", "hiddenpowerrock", "endeavor"],
 		tier: "NU",
 	},
 	sceptile: {
-		randomBattleMoves: ["substitute", "leechseed", "gigadrain", "leafstorm", "hiddenpowerice", "focusblast", "synthesis", "hiddenpowerrock"],
+		randomBattleMoves: ["leafblade", "dragonclaw", "hiddenpowerfire", "hiddenpowerice", "crunch", "thunderpunch", "leechseed", "substitute"],
 		tier: "BL",
 	},
 	torchic: {
 		inherit: true,
-		randomBattleMoves: ["fireblast", "protect", "batonpass", "substitute", "hiddenpowergrass"],
 		tier: "LC",
 	},
 	combusken: {
-		randomBattleMoves: ["flareblitz", "skyuppercut", "protect", "swordsdance", "substitute", "batonpass"],
 		tier: "NFE",
 	},
 	blaziken: {
 		inherit: true,
-		randomBattleMoves: ["flareblitz", "highjumpkick", "protect", "swordsdance", "substitute", "batonpass", "bravebird"],
+		randomBattleMoves: ["flamethrower", "fireblast", "brickbreak", "earthquake", "rockslide", "skyuppercut", "swordsdance", "hiddenpowergrass", "substitute", "focuspunch"],
 		tier: "BL",
 	},
 	mudkip: {
 		inherit: true,
-		randomBattleMoves: ["waterfall", "earthpower", "superpower", "icebeam"],
 		tier: "LC",
 	},
 	marshtomp: {
-		randomBattleMoves: ["waterfall", "earthquake", "superpower", "icepunch", "rockslide", "stealthrock"],
 		tier: "NFE",
 	},
 	swampert: {
-		randomBattleMoves: ["waterfall", "earthquake", "icepunch", "stealthrock", "roar", "superpower", "stoneedge", "rest", "sleeptalk", "curse"],
+		randomBattleMoves: ["earthquake", "hydropump", "icebeam", "rockslide", "toxic", "protect", "surf", "rest", "sleeptalk", "curse"],
 		tier: "OU",
 	},
 	poochyena: {
 		inherit: true,
-		randomBattleMoves: ["superfang", "foulplay", "suckerpunch", "toxic"],
 		tier: "LC",
 	},
 	mightyena: {
-		randomBattleMoves: ["suckerpunch", "crunch", "icefang", "firefang", "howl"],
+		randomBattleMoves: ["shadowball", "hiddenpowerfighting", "bodyslam", "irontail", "taunt", "healbell"],
 		tier: "NU",
 	},
 	zigzagoon: {
 		inherit: true,
-		randomBattleMoves: ["bellydrum", "extremespeed", "seedbomb", "substitute"],
 		tier: "LC",
 	},
 	linoone: {
-		randomBattleMoves: ["bellydrum", "extremespeed", "seedbomb", "substitute", "shadowclaw"],
+		randomBattleMoves: ["bellydrum", "extremespeed", "return", "shadowball", "flail", "subsitute", "hiddenpowerfighting"],
 		tier: "UU",
 	},
 	wurmple: {
-		randomBattleMoves: ["bugbite", "poisonsting", "tackle", "electroweb"],
 		tier: "LC",
 	},
 	silcoon: {
-		randomBattleMoves: ["bugbite", "poisonsting", "tackle", "electroweb"],
 		tier: "NFE",
 	},
 	beautifly: {
-		randomBattleMoves: ["quiverdance", "bugbuzz", "psychic", "hiddenpowerfighting", "hiddenpowerrock", "substitute", "roost"],
+		randomBattleMoves: ["toxic", "stunspore", "morningsun", "whirlwind", "gigadrain", "hiddenpowerbug"],
 		tier: "NU",
 	},
 	cascoon: {
-		randomBattleMoves: ["bugbite", "poisonsting", "tackle", "electroweb"],
 		tier: "NFE",
 	},
 	dustox: {
-		randomBattleMoves: ["toxic", "roost", "whirlwind", "bugbuzz", "protect", "sludgebomb", "quiverdance"],
+		randomBattleMoves: ["sludgebomb", "hiddenpowerfire", "moonlight", "toxic", "lightscreen", "whirlwind"],
 		tier: "NU",
 	},
 	lotad: {
 		inherit: true,
-		randomBattleMoves: ["gigadrain", "icebeam", "scald", "substitute", "leechseed"],
 		tier: "LC",
 	},
 	lombre: {
-		randomBattleMoves: ["gigadrain", "icebeam", "scald", "substitute", "leechseed"],
 		tier: "NFE",
 	},
 	ludicolo: {
-		randomBattleMoves: ["raindance", "hydropump", "surf", "gigadrain", "icebeam", "scald", "leechseed", "substitute", "toxic"],
+		randomBattleMoves: ["hydropump", "surf", "leechseed", "icebeam", "raindance", "thunderpunch", "gigadrain", "fakeout"],
 		tier: "BL",
 	},
 	seedot: {
 		inherit: true,
-		randomBattleMoves: ["leechseed", "naturepower", "seedbomb", "explosion", "foulplay"],
 		tier: "LC",
 	},
 	nuzleaf: {
-		randomBattleMoves: ["foulplay", "naturepower", "seedbomb", "explosion", "swordsdance"],
 		tier: "NFE",
 	},
 	shiftry: {
-		randomBattleMoves: ["hiddenpowerfire", "swordsdance", "seedbomb", "suckerpunch", "naturepower", "nastyplot", "gigadrain", "darkpulse"],
+		randomBattleMoves: ["swordsdance", "shadowball", "brickbreak", "explosion", "fakeout", "sunnyday", "solarbeam", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerdark"],
 		tier: "UU",
 	},
 	taillow: {
 		inherit: true,
-		randomBattleMoves: ["bravebird", "facade", "quickattack", "uturn", "protect"],
 		tier: "LC",
 	},
 	swellow: {
 		inherit: true,
-		randomBattleMoves: ["bravebird", "facade", "quickattack", "uturn", "protect"],
+		randomBattleMoves: ["doubleedge", "return", "facade", "hiddenpowerflying", "aerialace", "hiddenpowerground", "hiddenpowerfighting", "quickattack", "steelwing"],
 		tier: "BL",
 	},
 	wingull: {
-		randomBattleMoves: ["scald", "icebeam", "hiddenpowergrass", "uturn", "airslash", "hurricane"],
 		tier: "LC",
 	},
 	pelipper: {
-		randomBattleMoves: ["scald", "icebeam", "hiddenpowergrass", "uturn", "airslash", "hurricane", "toxic", "roost"],
+		randomBattleMoves: ["rest", "sleeptalk", "surf", "icebeam", "hiddenpowerelectric", "toxic"],
 		tier: "NU",
 	},
 	ralts: {
 		inherit: true,
-		randomBattleMoves: ["trickroom", "destinybond", "hypnosis", "willowisp"],
 		tier: "LC",
 	},
 	kirlia: {
-		randomBattleMoves: ["trickroom", "destinybond", "hypnosis", "willowisp"],
 		tier: "NFE",
 	},
 	gardevoir: {
-		randomBattleMoves: ["psychic", "focusblast", "shadowball", "trick", "calmmind", "willowisp", "wish", "thunderbolt", "protect", "healingwish"],
+		randomBattleMoves: ["psychic", "thunderbolt", "firepunch", "icepunch", "calmmind", "memento", "taunt", "hypnosis", "thunderwave", "willowisp", "destinybond", "substitute", "reflect", "wish", "protect"],
 		tier: "BL",
 	},
 	surskit: {
 		inherit: true,
-		randomBattleMoves: ["hydropump", "signalbeam", "hiddenpowerfire", "hiddenpowerfighting", "gigadrain"],
 		tier: "LC",
 	},
 	masquerain: {
-		randomBattleMoves: ["hydropump", "bugbuzz", "airslash", "quiverdance", "substitute", "batonpass", "roost"],
+		randomBattleMoves: ["doubleedge", "hydropump", "icebeam", "hiddenpowergrass", "raindance", "stunspore", "toxic", "substitute"],
 		tier: "NU",
 	},
 	shroomish: {
 		inherit: true,
-		randomBattleMoves: ["spore", "substitute", "leechseed", "gigadrain", "protect", "toxic", "stunspore"],
 		tier: "LC",
 	},
 	breloom: {
-		randomBattleMoves: ["spore", "substitute", "leechseed", "focuspunch", "machpunch", "lowsweep", "bulletseed", "stoneedge", "swordsdance", "thunderpunch"],
+		randomBattleMoves: ["swordsdance", "hiddenpowerghost", "hiddenpowerrock", "skyuppercut", "machpunch", "focuspunch", "substitute", "leechseed", "spore", "stunspore"],
 		tier: "BL",
 	},
 	slakoth: {
-		randomBattleMoves: ["return", "hammerarm", "firepunch", "suckerpunch", "gigaimpact", "retaliate", "toxic"],
 		tier: "LC",
 	},
 	vigoroth: {
-		randomBattleMoves: ["bulkup", "return", "earthquake", "firepunch", "suckerpunch", "slackoff"],
 		tier: "NU",
 	},
 	slaking: {
-		randomBattleMoves: ["return", "earthquake", "pursuit", "firepunch", "suckerpunch", "doubleedge", "retaliate", "gigaimpact", "hammerarm"],
+		randomBattleMoves: ["return", "doubleedge", "earthquake", "shadowball", "focuspunch", "fireblast"],
 		tier: "BL",
 	},
 	nincada: {
-		randomBattleMoves: ["xscissor", "toxic", "aerialace", "nightslash"],
 		tier: "LC",
 	},
 	ninjask: {
-		randomBattleMoves: ["batonpass", "swordsdance", "substitute", "protect", "xscissor"],
+		randomBattleMoves: ["silverwind", "hiddenpowerflying", "aerialace", "hiddenpowerrock", "swordsdance", "substitute", "protect", "batonpass"],
 		tier: "BL",
 	},
 	shedinja: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "willowisp", "xscissor", "shadowsneak", "suckerpunch"],
+		randomBattleMoves: ["shadowball", "hiddenpowerbug", "silverwind", "hiddenpowerground", "hiddenpowerfighting", "hiddenpowerrock", "protect", "toxic", "agility", "batonpass"],
 		tier: "NU",
 	},
 	whismur: {
 		inherit: true,
-		randomBattleMoves: ["hypervoice", "fireblast", "shadowball", "icebeam"],
 		tier: "LC",
 	},
 	loudred: {
-		randomBattleMoves: ["hypervoice", "fireblast", "shadowball", "icebeam"],
 		tier: "NFE",
 	},
 	exploud: {
 		inherit: true,
-		randomBattleMoves: ["hypervoice", "overheat", "shadowball", "icebeam", "surf", "focusblast"],
+		randomBattleMoves: ["doubleedge", "return", "bodyslam", "earthquake", "shadowball", "fireblast", "flamethrower", "overheat", "icebeam", "toxic"],
 		tier: "UU",
 	},
 	makuhita: {
 		inherit: true,
-		randomBattleMoves: ["crosschop", "bulletpunch", "closecombat", "icepunch", "bulkup"],
 		tier: "LC",
 	},
 	hariyama: {
-		randomBattleMoves: ["crosschop", "bulletpunch", "closecombat", "icepunch", "stoneedge", "bulkup"],
+		randomBattleMoves: ["crosschop", "revenge", "rockslide", "hiddenpowerghost", "substitute", "focuspunch", "fakeout", "counter", "bulkup", "knockoff", "whirlwind", "rest", "sleeptalk"],
 		tier: "BL",
 	},
 	nosepass: {
 		inherit: true,
-		randomBattleMoves: ["stoneedge", "toxic", "stealthrock", "thunderwave"],
+		randomBattleMoves: ["thunderbolt", "firepunch", "earthquake", "explosion", "taunt", "thunderwave", "toxic"],
 		tier: "NU",
 	},
 	skitty: {
 		inherit: true,
-		randomBattleMoves: ["return", "suckerpunch", "zenheadbutt", "thunderwave", "fakeout"],
 		tier: "LC",
 	},
 	delcatty: {
 		inherit: true,
-		randomBattleMoves: ["return", "suckerpunch", "zenheadbutt", "thunderwave", "fakeout", "wish"],
+		randomBattleMoves: ["calmmind", "batonpass", "thunderbolt", "icebeam", "substitute"],
 		tier: "NU",
 	},
 	sableye: {
 		inherit: true,
-		randomBattleMoves: ["recover", "willowisp", "taunt", "trick", "toxic", "nightshade", "seismictoss"],
+		randomBattleMoves: ["seismictoss", "shadowball", "knockoff", "toxic", "recover", "fakeout"],
 		tier: "NU",
 	},
 	mawile: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "ironhead", "firefang", "crunch", "batonpass", "substitute"],
+		randomBattleMoves: ["swordsdance", "batonpass", "taunt", "brickbreak", "hiddenpowersteel", "sludgebomb"],
 		tier: "NU",
 	},
 	aron: {
-		randomBattleMoves: ["headsmash", "ironhead", "earthquake", "superpower", "stealthrock"],
 		tier: "LC",
 	},
 	lairon: {
-		randomBattleMoves: ["headsmash", "ironhead", "earthquake", "superpower", "stealthrock"],
 		tier: "NU",
 	},
 	aggron: {
 		inherit: true,
-		randomBattleMoves: ["rockpolish", "headsmash", "earthquake", "superpower", "heavyslam", "aquatail", "icepunch", "stealthrock", "thunderwave"],
+		randomBattleMoves: ["earthquake", "rockslide", "irontail", "focuspunch", "icebeam", "substitute", "thunderwave", "toxic", "counter"],
 		tier: "UU",
 	},
 	meditite: {
 		inherit: true,
-		randomBattleMoves: ["highjumpkick", "psychocut", "icepunch", "thunderpunch", "trick", "fakeout", "bulletpunch", "drainpunch"],
 		tier: "LC",
 	},
 	medicham: {
-		randomBattleMoves: ["highjumpkick", "drainpunch", "psychocut", "icepunch", "thunderpunch", "trick", "fakeout", "bulletpunch"],
+		randomBattleMoves: ["brickbreak", "highjumpkick", "fakeout", "rockslide", "focuspunch", "endure", "substitute", "shadowball", "reversal", "recover"],
 		tier: "BL",
 	},
 	electrike: {
-		randomBattleMoves: ["voltswitch", "thunderbolt", "hiddenpowerice", "overheat", "switcheroo", "flamethrower"],
 		tier: "LC",
 	},
 	manectric: {
 		inherit: true,
-		randomBattleMoves: ["voltswitch", "thunderbolt", "hiddenpowerice", "overheat", "switcheroo", "flamethrower"],
+		randomBattleMoves: ["thunderbolt", "hiddenpowerice", "crunch", "hiddenpowergrass", "substitute", "thunderwave"],
 		tier: "UU",
 	},
 	plusle: {
 		inherit: true,
-		randomBattleMoves: ["nastyplot", "thunderbolt", "substitute", "batonpass", "hiddenpowerice"],
+		randomBattleMoves: ["thunderbolt", "hiddenpowergrass", "encore", "batonpass", "agility", "substitute"],
 		tier: "NU",
 	},
 	minun: {
 		inherit: true,
-		randomBattleMoves: ["nastyplot", "thunderbolt", "substitute", "batonpass", "hiddenpowerice"],
+		randomBattleMoves: ["thunderbolt", "hiddenpowergrass", "encore", "batonpass", "agility", "substitute"],
 		tier: "NU",
 	},
 	volbeat: {
-		randomBattleMoves: ["tailglow", "batonpass", "substitute", "bugbuzz", "thunderwave", "encore"],
+		randomBattleMoves: ["signalbeam", "brickbreak", "shadowball", "batonpass", "moonlight", "seismictoss", "trick"],
 		tier: "NU",
 	},
 	illumise: {
-		randomBattleMoves: ["substitute", "batonpass", "wish", "bugbuzz", "encore", "thunderbolt"],
+		randomBattleMoves: ["thunderbolt", "icebeam", "gigadrain", "substitute", "batonpass", "wish"],
 		tier: "NU",
 	},
 	roselia: {
 		inherit: true,
-		randomBattleMoves: ["spikes", "toxicspikes", "sleeppowder", "gigadrain", "stunspore", "rest"],
+		randomBattleMoves: ["hiddenpowerfire", "gigadrain", "aromatherapy", "leechseed", "synthesis", "spikes"],
 		tier: "NU",
 	},
 	gulpin: {
 		inherit: true,
-		randomBattleMoves: ["stockpile", "sludgebomb", "icebeam", "toxic", "painsplit", "yawn", "encore"],
 		tier: "LC",
 	},
 	swalot: {
-		randomBattleMoves: ["stockpile", "sludgebomb", "icebeam", "toxic", "painsplit", "yawn", "encore", "earthquake"],
+		randomBattleMoves: ["sludgebomb", "explosion", "firepunch", "gigadrain", "thunderpunch", "icebeam", "counter", "yawn"],
 		tier: "NU",
 	},
 	carvanha: {
 		inherit: true,
-		randomBattleMoves: ["protect", "hydropump", "icebeam", "waterfall", "crunch", "hiddenpowergrass", "aquajet"],
 		tier: "LC",
 	},
 	sharpedo: {
-		randomBattleMoves: ["protect", "hydropump", "icebeam", "crunch", "earthquake", "waterfall", "hiddenpowergrass", "aquajet"],
+		randomBattleMoves: ["earthquake", "doubleedge", "hydropump", "crunch", "icebeam", "hiddenpowerelectric", "agility"],
 		tier: "UU",
 	},
 	wailmer: {
-		randomBattleMoves: ["waterspout", "surf", "hydropump", "icebeam", "hiddenpowergrass", "hiddenpowerelectric"],
 		tier: "LC",
 	},
 	wailord: {
 		inherit: true,
-		randomBattleMoves: ["waterspout", "surf", "hydropump", "icebeam", "hiddenpowergrass", "hiddenpowerelectric"],
+		randomBattleMoves: ["rest", "sleeptalk", "bodyslam", "waterspout", "hydropump", "surf", "icebeam", "toxic", "hiddenpowergrass"],
 		tier: "NU",
 	},
 	numel: {
 		inherit: true,
-		randomBattleMoves: ["curse", "earthquake", "rockslide", "fireblast", "flamecharge", "rest", "sleeptalk", "stockpile"],
 		tier: "LC",
 	},
 	camerupt: {
-		randomBattleMoves: ["rockpolish", "fireblast", "earthpower", "stoneedge", "lavaplume", "stealthrock", "earthquake"],
+		randomBattleMoves: ["fireblast", "earthquake", "rockslide", "explosion", "toxic", "rest", "sleeptalk", "roar"],
 		tier: "UU",
 	},
 	torkoal: {
-		randomBattleMoves: ["rapidspin", "stealthrock", "yawn", "lavaplume", "earthquake", "toxic", "willowisp"],
+		randomBattleMoves: ["fireblast", "flamethrower", "hiddenpowergrass", "rockslide", "explosion", "yawn", "rest", "sleeptalk"],
 		tier: "NU",
 	},
 	spoink: {
 		inherit: true,
-		randomBattleMoves: ["psychic", "reflect", "lightscreen", "thunderwave", "trick", "healbell"],
 		tier: "LC",
 	},
 	grumpig: {
-		randomBattleMoves: ["calmmind", "psychic", "focusblast", "shadowball", "thunderwave", "trick", "healbell"],
+		randomBattleMoves: ["psychic", "hiddenpowerdark", "firepunch", "icywind", "calmmind", "taunt", "substitute"],
 		tier: "UU",
 	},
 	spinda: {
 		inherit: true,
-		randomBattleMoves: ["wish", "protect", "return", "superpower", "suckerpunch"],
+		randomBattleMoves: ["doubleedge", "return", "bodyslam", "endure", "flail", "shadowball", "focuspunch", "brickbreak", "firepunch", "icepunch", "icywind", "psychic", "seismictoss", "encore", "hypnosis", "teeterdance", "trick", "calmmind", "batonpass"],
 		tier: "NU",
 	},
 	trapinch: {
-		randomBattleMoves: ["earthquake", "rockslide", "crunch", "quickattack", "superpower"],
 		tier: "NU",
 	},
 	vibrava: {
-		randomBattleMoves: ["substitute", "earthquake", "outrage", "roost", "uturn", "superpower"],
 		tier: "NFE",
 	},
 	flygon: {
 		inherit: true,
-		randomBattleMoves: ["earthquake", "outrage", "dragonclaw", "uturn", "roost", "substitute", "stoneedge", "firepunch", "superpower"],
+		randomBattleMoves: ["earthquake", "rockslide", "hiddenpowerbug", "hiddenpowerflying", "fireblast", "dragonclaw", "toxic"],
 		tier: "OU",
 	},
 	cacnea: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "spikes", "suckerpunch", "seedbomb", "drainpunch"],
 		tier: "LC",
 	},
 	cacturne: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "spikes", "suckerpunch", "seedbomb", "drainpunch"],
+		randomBattleMoves: ["spikes", "gigadrain", "hiddenpowerdark", "thunderpunch", "substitute", "focuspunch", "hiddenpowerice"],
 		tier: "NU",
 	},
 	swablu: {
 		inherit: true,
-		randomBattleMoves: ["roost", "toxic", "cottonguard", "return"],
 		tier: "LC",
 	},
 	altaria: {
 		inherit: true,
-		randomBattleMoves: ["dragondance", "outrage", "dragonclaw", "earthquake", "roost", "fireblast"],
+		randomBattleMoves: ["dragondance", "earthquake", "hiddenpowerflying", "fireblast", "icebeam", "rest", "toxic", "healbell", "haze", "sing"],
 		tier: "UU",
 	},
 	zangoose: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "closecombat", "nightslash", "quickattack", "facade"],
+		randomBattleMoves: ["doubleedge", "return", "shadowball", "brickbreak", "quickattack", "focuspunch", "swordsdance", "taunt", "fireblast"],
 		tier: "BL",
 	},
 	seviper: {
 		inherit: true,
-		randomBattleMoves: ["sludgebomb", "flamethrower", "gigadrain", "switcheroo", "earthquake", "suckerpunch", "aquatail"],
+		randomBattleMoves: ["sludgebomb", "flamethrower", "gigadrain", "earthquake", "taunt"],
 		tier: "NU",
 	},
 	lunatone: {
 		inherit: true,
-		randomBattleMoves: ["psychic", "earthpower", "stealthrock", "rockpolish", "batonpass", "calmmind", "icebeam", "hiddenpowerrock", "moonlight"],
+		randomBattleMoves: ["psychic", "icebeam", "explosion", "calmmind", "batonpass", "hypnosis"],
 		tier: "UU",
 	},
 	solrock: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "explosion", "stoneedge", "zenheadbutt", "earthquake", "batonpass", "willowisp", "rockpolish", "morningsun"],
+		randomBattleMoves: ["rockslide", "earthquake", "shadowball", "bodyslam", "explosion", "overheat", "lightscreen"],
 		tier: "UU",
 	},
 	barboach: {
-		randomBattleMoves: ["dragondance", "waterfall", "earthquake", "return"],
 		tier: "LC",
 	},
 	whiscash: {
-		randomBattleMoves: ["dragondance", "waterfall", "earthquake", "stoneedge"],
+		randomBattleMoves: ["earthquake", "rockslide", "surf", "icebeam", "hiddenpowerbug", "spark", "rest", "sleeptalk", "toxic"],
 		tier: "NU",
 	},
 	corphish: {
 		inherit: true,
-		randomBattleMoves: ["dragondance", "waterfall", "crunch", "superpower", "swordsdance"],
 		tier: "LC",
 	},
 	crawdaunt: {
 		inherit: true,
-		randomBattleMoves: ["dragondance", "waterfall", "crunch", "superpower", "swordsdance"],
+		randomBattleMoves: ["surf", "icebeam", "crunch", "knockoff", "swordsdance", "return", "hiddenpowerghost"],
 		tier: "NU",
 	},
 	baltoy: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "earthquake", "toxic", "psychic", "reflect", "lightscreen", "icebeam", "rapidspin"],
 		tier: "LC",
 	},
 	claydol: {
-		randomBattleMoves: ["stealthrock", "toxic", "psychic", "icebeam", "earthquake", "rapidspin", "reflect", "lightscreen"],
+		randomBattleMoves: ["earthquake", "icebeam", "hiddenpowerfire", "psychic", "explosion", "rapidspin", "toxic", "reflect", "lightscreen"],
 		tier: "OU",
 	},
 	lileep: {
-		randomBattleMoves: ["stealthrock", "recover", "ancientpower", "hiddenpowerfire", "gigadrain", "stockpile"],
 		tier: "LC",
 	},
 	cradily: {
-		randomBattleMoves: ["stealthrock", "recover", "stockpile", "seedbomb", "rockslide", "earthquake", "curse", "swordsdance"],
+		randomBattleMoves: ["earthquake", "rockslide", "gigadrain", "hiddenpowerfire", "barrier", "amnesia", "mirrorcoat", "toxic", "recover", "rest"],
 		tier: "UU",
 	},
 	anorith: {
-		randomBattleMoves: ["stealthrock", "brickbreak", "toxic", "xscissor", "rockslide", "swordsdance", "rockpolish"],
 		tier: "LC",
 	},
 	armaldo: {
-		randomBattleMoves: ["stealthrock", "stoneedge", "toxic", "xscissor", "swordsdance", "earthquake", "superpower"],
+		randomBattleMoves: ["rockslide", "rockblast", "earthquake", "hiddenpowerbug", "knockoff", "rapidspin", "swordsdance"],
 		tier: "BL",
 	},
 	feebas: {
-		randomBattleMoves: ["protect", "confuseray", "hypnosis", "scald", "toxic"],
 		tier: "LC",
 	},
 	milotic: {
 		inherit: true,
-		randomBattleMoves: ["recover", "scald", "hypnosis", "toxic", "icebeam", "dragontail", "rest", "sleeptalk", "hiddenpowergrass"],
+		randomBattleMoves: ["surf", "icebeam", "hiddenpowerelectric", "mirrorcoat", "toxic", "hypnosis", "recover", "rest", "sleeptalk"],
 		tier: "OU",
 	},
 	castform: {
 		tier: "NU",
 	},
+	castformsunny: {
+		randomBattleMoves: ["sunnyday", "thunderbolt", "icebeam", "flamethrower", "weatherball", "solarbeam"],
+	},
+	castformrainy: {
+		randomBattleMoves: ["raindance", "thunderbolt", "thunder", "weatherball", "icebeam"],
+	},
+	castformsnowy: {
+		randomBattleMoves: ["hail", "weatherball", "thunderbolt", "thunderwave", "flamethrower", "blizzard"],
+	},
 	kecleon: {
-		randomBattleMoves: ["stealthrock", "recover", "return", "thunderwave", "suckerpunch"],
+		randomBattleMoves: ["return", "shadowball", "brickbreak", "trick", "irontail", "thunderwave"],
 		tier: "NU",
 	},
 	shuppet: {
 		inherit: true,
-		randomBattleMoves: ["trickroom", "destinybond", "taunt", "shadowsneak", "willowisp"],
 		tier: "LC",
 	},
 	banette: {
 		inherit: true,
-		randomBattleMoves: ["trickroom", "destinybond", "taunt", "shadowclaw", "willowisp"],
+		randomBattleMoves: ["shadowball", "hiddenpowerfighting", "knockoff", "willowisp", "thunderwave", "toxic", "endure", "destinybond"],
 		tier: "UU",
 	},
 	duskull: {
 		inherit: true,
-		randomBattleMoves: ["willowisp", "shadowsneak", "icebeam", "painsplit", "substitute", "nightshade"],
 		tier: "LC",
 	},
 	dusclops: {
-		randomBattleMoves: ["willowisp", "shadowsneak", "icebeam", "painsplit", "substitute", "seismictoss"],
+		randomBattleMoves: ["nightshade", "shadowball", "icebeam", "calmmind", "rest", "painsplit", "willowisp", "sleeptalk"],
 		tier: "BL",
 	},
 	tropius: {
-		randomBattleMoves: ["leechseed", "substitute", "airslash", "gigadrain", "earthquake", "hiddenpowerfire", "roost", "leafstorm"],
+		randomBattleMoves: ["sunnyday", "solarbeam", "synthesis", "hiddenpowerfire", "swordsdance", "hiddenpowerflying", "earthquake"],
 		tier: "NU",
 	},
 	chimecho: {
 		inherit: true,
-		randomBattleMoves: ["hypnosis", "toxic", "wish", "psychic", "thunderwave", "recover", "calmmind", "shadowball", "hiddenpowerfighting", "healingwish"],
+		randomBattleMoves: ["psychic", "hiddenpowerfire", "healbell", "taunt", "toxic", "reflect", "lightscreen", "hypnosis"],
 		tier: "NU",
 	},
 	absol: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "suckerpunch", "nightslash", "psychocut", "superpower", "pursuit", "megahorn"],
+		randomBattleMoves: ["swordsdance", "shadowball", "hiddenpowerfighting", "aerialace", "calmmind", "icebeam", "thunderbolt", "flamethrower", "substitute", "taunt", "batonpass", "thunderwave"],
 		tier: "UU",
 	},
 	snorunt: {
 		inherit: true,
-		randomBattleMoves: ["spikes", "icebeam", "hiddenpowerground", "iceshard", "crunch"],
 		tier: "LC",
 	},
 	glalie: {
-		randomBattleMoves: ["spikes", "icebeam", "iceshard", "crunch", "explosion", "earthquake"],
+		randomBattleMoves: ["icebeam", "hiddenpowergrass", "earthquake", "explosion", "taunt", "toxic", "spikes"],
 		tier: "NU",
 	},
 	spheal: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "protect", "toxic", "surf", "icebeam"],
 		tier: "LC",
 	},
 	sealeo: {
-		randomBattleMoves: ["substitute", "protect", "toxic", "surf", "icebeam"],
 		tier: "NU",
 	},
 	walrein: {
-		randomBattleMoves: ["substitute", "protect", "toxic", "surf", "icebeam", "roar"],
+		randomBattleMoves: ["icebeam", "surf", "earthquake", "hiddenpowergrass", "toxic", "rest", "sleeptalk", "encore", "roar", "yawn", "icywind"],
 		tier: "UU",
 	},
 	clamperl: {
-		randomBattleMoves: ["shellsmash", "icebeam", "surf", "hiddenpowergrass", "hiddenpowerelectric", "substitute"],
 		tier: "NU",
 	},
 	huntail: {
-		randomBattleMoves: ["shellsmash", "return", "hydropump", "batonpass", "suckerpunch"],
+		randomBattleMoves: ["doubleedge", "bodyslam", "surf", "hydropump", "icebeam", "crunch", "hiddenpowergrass", "hiddenpowerground", "raindance"],
 		tier: "NU",
 	},
 	gorebyss: {
-		randomBattleMoves: ["shellsmash", "batonpass", "hydropump", "icebeam", "hiddenpowergrass", "substitute"],
+		randomBattleMoves: ["surf", "hydropump", "icebeam", "hiddenpowergrass", "raindance", "agility", "amnesia", "irondefense", "substitute", "batonpass"],
 		tier: "UU",
 	},
 	relicanth: {
-		randomBattleMoves: ["headsmash", "waterfall", "earthquake", "doubleedge", "stealthrock"],
+		randomBattleMoves: ["rockslide", "earthquake", "doubleedge", "bodyslam", "hiddenpowerbug", "yawn", "rest", "sleeptalk"],
 		tier: "NU",
 	},
 	luvdisc: {
-		randomBattleMoves: ["surf", "icebeam", "toxic", "sweetkiss", "protect"],
+		randomBattleMoves: ["raindance", "surf", "icebeam", "sweetkiss"],
 		tier: "NU",
 	},
 	bagon: {
 		inherit: true,
-		randomBattleMoves: ["outrage", "dragondance", "firefang", "rockslide", "dragonclaw"],
 		tier: "LC",
 	},
 	shelgon: {
-		randomBattleMoves: ["outrage", "brickbreak", "dragonclaw", "dragondance"],
 		tier: "NU",
 	},
 	salamence: {
 		inherit: true,
-		randomBattleMoves: ["outrage", "fireblast", "earthquake", "dracometeor", "roost", "dragondance", "dragonclaw"],
+		randomBattleMoves: ["dragondance", "hiddenpowerflying", "earthquake", "brickbreak", "rockslide", "fireblast", "hydropump", "dragonclaw", "wish", "protect", "roar"],
 		tier: "OU",
 	},
 	beldum: {
-		randomBattleMoves: ["ironhead", "zenheadbutt", "headbutt", "irondefense"],
 		tier: "LC",
 	},
 	metang: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "meteormash", "toxic", "earthquake", "bulletpunch"],
 		tier: "NU",
 	},
 	metagross: {
-		randomBattleMoves: ["meteormash", "earthquake", "agility", "stealthrock", "zenheadbutt", "bulletpunch", "trick"],
+		randomBattleMoves: ["meteormash", "earthquake", "rockslide", "bodyslam", "explosion", "psychic", "icepunch", "agility", "rest", "sleeptalk"],
 		tier: "OU",
 	},
 	regirock: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "thunderwave", "stoneedge", "earthquake", "curse", "rest", "sleeptalk", "rockslide", "toxic"],
+		randomBattleMoves: ["rockslide", "earthquake", "explosion", "hiddenpowerbug", "substitute", "focuspunch", "thunderwave", "counter", "curse", "rest", "sleeptalk"],
 		tier: "BL",
 	},
 	regice: {
 		inherit: true,
-		randomBattleMoves: ["thunderwave", "icebeam", "thunderbolt", "rest", "sleeptalk", "focusblast"],
+		randomBattleMoves: ["icebeam", "thunderbolt", "hiddenpowerfire", "explosion", "rest", "sleeptalk", "psychup", "curse", "thunderwave"],
 		tier: "OU",
 	},
 	registeel: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "ironhead", "curse", "rest", "thunderwave", "toxic"],
+		randomBattleMoves: ["earthquake", "rockslide", "hiddenpowersteel", "seismictoss", "explosion", "counter", "curse", "rest", "sleeptalk", "toxic", "thunderwave"],
 		tier: "BL",
 	},
 	latias: {
 		inherit: true,
-		randomBattleMoves: ["dragonpulse", "surf", "hiddenpowerfire", "roost", "calmmind", "wish", "healingwish"],
+		randomBattleMoves: ["dragonclaw", "icebeam", "thunderbolt", "recover", "calmmind", "toxic", "refresh", "safeguard", "roar"],
 		tier: "Uber",
 	},
 	latios: {
 		inherit: true,
-		randomBattleMoves: ["dracometeor", "dragonpulse", "surf", "hiddenpowerfire", "psyshock", "roost"],
+		randomBattleMoves: ["dragonclaw", "icebeam", "thunderbolt", "hiddenpowerfire", "recover", "calmmind", "roar"],
 		tier: "Uber",
 	},
 	kyogre: {
 		inherit: true,
-		randomBattleMoves: ["waterspout", "surf", "thunder", "icebeam", "calmmind", "rest", "sleeptalk"],
+		randomBattleMoves: ["surf", "hydropump", "icebeam", "thunder", "waterspout", "sleeptalk", "calmmind", "rest"],
 		tier: "Uber",
 	},
 	groudon: {
 		inherit: true,
-		randomBattleMoves: ["earthquake", "dragontail", "stealthrock", "stoneedge", "swordsdance", "rockpolish", "thunderwave", "firepunch"],
+		randomBattleMoves: ["earthquake", "rockslide", "hiddenpowerbug", "swordsdance", "overheat", "roar"],
 		tier: "Uber",
 	},
 	rayquaza: {
 		inherit: true,
-		randomBattleMoves: ["outrage", "vcreate", "extremespeed", "dragondance", "swordsdance", "dracometeor", "dragonclaw"],
+		randomBattleMoves: ["dragondance", "earthquake", "extremespeed", "rockslide", "hiddenpowerflying", "hiddenpowerbug", "dragonclaw", "icebeam", "fireblast", "thunderbolt", "surf"],
 		tier: "Uber",
 	},
 	jirachi: {
 		inherit: true,
-		randomBattleMoves: ["ironhead", "firepunch", "thunderwave", "stealthrock", "wish", "uturn", "calmmind", "psychic", "thunder", "icepunch", "flashcannon"],
+		randomBattleMoves: ["psychic", "thunderbolt", "firepunch", "icepunch", "calmmind", "thunderwave", "toxic", "reflect", "lightscreen", "wish", "protect"],
 		tier: "OU",
 	},
 	deoxys: {
 		inherit: true,
-		randomBattleMoves: ["psychoboost", "superpower", "extremespeed", "icebeam", "thunderbolt", "firepunch", "spikes", "stealthrock"],
+		randomBattleMoves: ["superpower", "shadowball", "psychoboost", "extremespeed", "firepunch", "thunderbolt", "icebeam"],
 		tier: "Uber",
 	},
 	deoxysattack: {
 		inherit: true,
-		randomBattleMoves: ["psychoboost", "superpower", "extremespeed", "icebeam", "thunderbolt", "firepunch", "spikes", "stealthrock"],
+		randomBattleMoves: ["superpower", "shadowball", "psychoboost", "extremespeed", "firepunch", "thunderbolt", "icebeam"],
 		tier: "Uber",
 	},
 	deoxysdefense: {
 		inherit: true,
-		randomBattleMoves: ["spikes", "stealthrock", "recover", "taunt", "toxic", "agility", "seismictoss", "magiccoat"],
+		randomBattleMoves: ["recover", "rest", "spikes", "taunt", "substitute", "toxic", "thunderwave", "nightshade", "counter", "mirrorcoat", "reflect", "lightscreen", "knockoff"],
 		tier: "Uber",
 	},
 	deoxysspeed: {
 		inherit: true,
-		randomBattleMoves: ["spikes", "stealthrock", "superpower", "icebeam", "psychoboost", "taunt", "lightscreen", "reflect", "magiccoat", "trick"],
+		randomBattleMoves: ["shadowball", "superpower", "icebeam", "thunderbolt", "firepunch", "psychic", "knockoff", "spikes", "taunt", "toxic", "recover", "calmmind", "reflect", "lightscreen", "substitute"],
 		tier: "Uber",
 	},
 };

--- a/mods/gen3/scripts.js
+++ b/mods/gen3/scripts.js
@@ -6,6 +6,7 @@ exports.BattleScripts = {
 	init: function () {
 		for (let i in this.data.Pokedex) {
 			delete this.data.Pokedex[i].abilities['H'];
+			if (Dex.getAbility(this.data.Pokedex[i].abilities[1]).gen > 3) delete this.data.Pokedex[i].abilities[1];
 		}
 		let specialTypes = {Fire:1, Water:1, Grass:1, Ice:1, Electric:1, Dark:1, Psychic:1, Dragon:1};
 		let newCategory = '';
@@ -21,5 +22,578 @@ exports.BattleScripts = {
 
 	calcRecoilDamage: function (damageDealt, move) {
 		return this.clampIntRange(Math.floor(damageDealt * move.recoil[0] / move.recoil[1]), 1);
+	},
+
+	randomSet: function (template, slot, teamDetails) {
+		if (slot === undefined) slot = 1;
+		let baseTemplate = (template = this.getTemplate(template));
+		let species = template.species;
+
+		if (!template.exists || (!template.randomBattleMoves && !template.learnset)) {
+			template = this.getTemplate('unown');
+
+			let err = new Error('Template incompatible with random battles: ' + species);
+			require('../crashlogger')(err, 'The gen 3 randbat set generator');
+		}
+
+		if (template.battleOnly) species = template.baseSpecies;
+
+		let movePool = (template.randomBattleMoves ? template.randomBattleMoves.slice() : Object.keys(template.learnset));
+		let moves = [];
+		let ability = '';
+		let item = '';
+		let evs = {
+			hp: 85,
+			atk: 85,
+			def: 85,
+			spa: 85,
+			spd: 85,
+			spe: 85,
+		};
+		let ivs = {
+			hp: 31,
+			atk: 31,
+			def: 31,
+			spa: 31,
+			spd: 31,
+			spe: 31,
+		};
+		let hasType = {};
+		hasType[template.types[0]] = true;
+		if (template.types[1]) {
+			hasType[template.types[1]] = true;
+		}
+		let hasAbility = {};
+		hasAbility[template.abilities[0]] = true;
+		if (template.abilities[1]) {
+			hasAbility[template.abilities[1]] = true;
+		}
+		let availableHP = 0;
+		for (let i = 0, len = movePool.length; i < len; i++) {
+			if (movePool[i].substr(0, 11) === 'hiddenpower') availableHP++;
+		}
+
+		// These moves can be used even if we aren't setting up to use them:
+		let SetupException = {
+			extremespeed:1, superpower:1, overheat:1,
+		};
+
+		let hasMove, counter;
+
+		do {
+			// Keep track of all moves we have:
+			hasMove = {};
+			for (let k = 0; k < moves.length; k++) {
+				if (moves[k].substr(0, 11) === 'hiddenpower') {
+					hasMove['hiddenpower'] = true;
+				} else {
+					hasMove[moves[k]] = true;
+				}
+			}
+
+			// Choose next 4 moves from learnset/viable moves and add them to moves list:
+			while (moves.length < 4 && movePool.length) {
+				let moveid = this.sampleNoReplace(movePool);
+				if (moveid.substr(0, 11) === 'hiddenpower') {
+					availableHP--;
+					if (hasMove['hiddenpower']) continue;
+					hasMove['hiddenpower'] = true;
+				} else {
+					hasMove[moveid] = true;
+				}
+				moves.push(moveid);
+			}
+
+			counter = this.queryMoves(moves, hasType, hasAbility, movePool);
+
+			// Iterate through the moves again, this time to cull them:
+			for (let k = 0; k < moves.length; k++) {
+				let move = this.getMove(moves[k]);
+				let moveid = move.id;
+				let rejected = false;
+				let isSetup = false;
+
+				switch (moveid) {
+				// Not very useful without their supporting moves
+				case 'batonpass':
+					if (!counter.setupType && !counter['speedsetup'] && !hasMove['substitute']) rejected = true;
+					break;
+				case 'eruption': case 'waterspout':
+					if (counter.Physical + counter.Special < 4) rejected = true;
+					break;
+				case 'focuspunch':
+					if (!hasMove['substitute'] || counter.damagingMoves.length < 2) rejected = true;
+					break;
+				case 'perishsong':
+					if (!hasMove['meanlook']) rejected = true;
+					break;
+				case 'rest': {
+					if (movePool.includes('sleeptalk')) rejected = true;
+					break;
+				}
+				case 'sleeptalk':
+					if (!hasMove['rest']) rejected = true;
+					if (movePool.length > 1) {
+						let rest = movePool.indexOf('rest');
+						if (rest >= 0) this.fastPop(movePool, rest);
+					}
+					break;
+
+				// Set up once and only if we have the moves for it
+				case 'bellydrum': case 'bulkup': case 'curse': case 'dragondance': case 'swordsdance':
+					if (counter.setupType !== 'Physical' || counter['physicalsetup'] > 1) rejected = true;
+					if (counter.Physical + counter['physicalpool'] < 2 && !hasMove['batonpass'] && (!hasMove['rest'] || !hasMove['sleeptalk'])) rejected = true;
+					isSetup = true;
+					break;
+				case 'calmmind': case 'growth': case 'nastyplot': case 'tailglow':
+					if (counter.setupType !== 'Special' || counter['specialsetup'] > 1) rejected = true;
+					if (counter.Special + counter['specialpool'] < 2 && !hasMove['batonpass'] && (!hasMove['rest'] || !hasMove['sleeptalk'])) rejected = true;
+					isSetup = true;
+					break;
+				case 'agility': case 'rockpolish':
+					if (counter.damagingMoves.length < 2 && !hasMove['batonpass']) rejected = true;
+					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (!counter.setupType) isSetup = true;
+					break;
+				case 'flail':
+					if (!hasMove['substitute'] && !hasMove['endure']) rejected = true;
+					break;
+
+				// Bad after setup
+				case 'explosion':
+					if (counter.setupType || !!counter['recovery'] || hasMove['rest']) rejected = true;
+					break;
+				case 'foresight': case 'protect': case 'roar':
+					if (counter.setupType && !hasAbility['Speed Boost']) rejected = true;
+					break;
+				case 'rapidspin':
+					if (teamDetails.rapidSpin) rejected = true;
+					break;
+				case 'spikes':
+					if (counter.setupType || teamDetails.spikes) rejected = true;
+					break;
+				case 'switcheroo': case 'trick':
+					if (counter.Physical + counter.Special < 3 || counter.setupType) rejected = true;
+					if (hasMove['lightscreen'] || hasMove['reflect']) rejected = true;
+					break;
+				case 'toxic': case 'toxicspikes':
+					if (counter.setupType || teamDetails.toxicSpikes) rejected = true;
+					break;
+				case 'endure':
+					if (counter.Status >= 3) rejected = true;
+					break;
+				case 'counter':
+					if (hasMove['swordsdance']) rejected = true;
+					break;
+
+				// Bit redundant to have both
+				// Attacks:
+				case 'bodyslam': case 'doubleedge':
+					if (hasMove['return']) rejected = true;
+					break;
+				case 'quickattack':
+					if (hasMove['thunderwave']) rejected = true;
+					break;
+				case 'flamethrower': case 'fireblast': case 'overheat':
+					if ((moves[k] === 'flamethrower' && (hasMove['fireblast'] || hasMove['overheat'])) || (moves[k] === 'fireblast' && (hasMove['flamethrower'] || hasMove['overheat'])) || (moves[k] === 'overheat' && (hasMove['fireblast'] || hasMove['flamethrower']))) rejected = true;
+					break;
+				case 'hydropump':
+					if (hasMove['surf']) rejected = true;
+					break;
+				case 'solarbeam':
+					if (counter.setupType === 'Physical' || !hasMove['sunnyday'] && !movePool.includes('sunnyday')) rejected = true;
+					break;
+				case 'razorleaf':
+					if (hasMove['solarbeam']) rejected = true;
+					break;
+				case 'brickbreak':
+					if (hasMove['substitute'] && hasMove['focuspunch']) rejected = true;
+					break;
+				case 'seismictoss':
+					if (hasMove['nightshade'] || counter.Physical + counter.Special >= 1) rejected = true;
+					break;
+				case 'dragonclaw':
+					if (hasMove['outrage']) rejected = true;
+					break;
+				case 'pursuit':
+					if (counter.setupType) rejected = true;
+					break;
+				case 'aerialace':
+					if (hasMove['hiddenpowerflying']) rejected = true;
+					break;
+				case 'hiddenpowerrock':
+					if (hasMove['rockslide']) rejected = true;
+					break;
+				case 'hiddenpowergrass':
+					if (hasMove['gigadrain']) rejected = true;
+					break;
+				case 'bonemerang':
+					if (hasMove['earthquake']) rejected = true;
+					break;
+
+				// Status:
+				case 'leechseed': case 'painsplit': case 'wish':
+					if (hasMove['moonlight'] || hasMove['morningsun'] || hasMove['rest'] || hasMove['synthesis']) rejected = true;
+					break;
+				case 'substitute':
+					if (hasMove['pursuit'] || hasMove['rest'] || hasMove['taunt']) rejected = true;
+					break;
+				case 'thunderwave':
+					if (hasMove['toxic'] || hasMove['willowisp']) rejected = true;
+					break;
+				}
+
+				// Increased/decreased priority moves are unneeded with moves that boost only speed
+				if (move.priority !== 0 && !!counter['speedsetup']) {
+					rejected = true;
+				}
+
+				// This move doesn't satisfy our setup requirements:
+				if ((move.category === 'Physical' && counter.setupType === 'Special') || (move.category === 'Special' && counter.setupType === 'Physical')) {
+					// Reject STABs last in case the setup type changes later on
+					if (!SetupException[moveid] && (!hasType[move.type] || counter.stab > 1 || counter[move.category] < 2)) rejected = true;
+				}
+				if (counter.setupType && !isSetup && move.category !== counter.setupType && counter[counter.setupType] < 2 && !hasMove['batonpass'] && moveid !== 'rest' && moveid !== 'sleeptalk') {
+					// Mono-attacking with setup and RestTalk is allowed
+					// Reject Status moves only if there is nothing else to reject
+					if (move.category !== 'Status' || counter[counter.setupType] + counter.Status > 3 && counter['physicalsetup'] + counter['specialsetup'] < 2) rejected = true;
+				}
+				if (counter.setupType === 'Special' && moveid === 'hiddenpower' && template.types.length > 1 && counter['Special'] <= 2 && !hasType[move.type] && !counter['Physical'] && counter['specialpool']) {
+					// Hidden Power isn't good enough
+					rejected = true;
+				}
+
+				// Sleep Talk shouldn't be selected without Rest
+				if (moveid === 'rest' && rejected) {
+					let sleeptalk = movePool.indexOf('sleeptalk');
+					if (sleeptalk >= 0) {
+						if (movePool.length < 2) {
+							rejected = false;
+						} else {
+							this.fastPop(movePool, sleeptalk);
+						}
+					}
+				}
+
+				// Remove rejected moves from the move list
+				if (rejected && (movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))) {
+					moves.splice(k, 1);
+					break;
+				}
+			}
+			if (moves.length === 4 && !counter.stab && (counter['physicalpool'] || counter['specialpool'])) {
+				// Move post-processing:
+				if (counter.damagingMoves.length === 0) {
+					// A set shouldn't have zero attacking moves
+					moves.splice(this.random(moves.length), 1);
+				} else if (counter.damagingMoves.length === 1) {
+					// In most cases, a set shouldn't have zero STABs
+					let damagingid = counter.damagingMoves[0].id;
+					if (movePool.length - availableHP || availableHP && (damagingid === 'hiddenpower' || !hasMove['hiddenpower'])) {
+						let replace = false;
+						if (!counter.damagingMoves[0].damage && template.species !== 'Porygon2' && template.species !== 'Unown') {
+							replace = true;
+						}
+						if (replace) moves.splice(counter.damagingMoveIndex[damagingid], 1);
+					}
+				} else if (!counter.damagingMoves[0].damage && !counter.damagingMoves[1].damage && template.species !== 'Porygon2') {
+					// If you have three or more attacks, and none of them are STAB, reject one of them at random.
+					let rejectableMoves = [];
+					let baseDiff = movePool.length - availableHP;
+					for (let l = 0; l < counter.damagingMoves.length; l++) {
+						if (baseDiff || availableHP && (!hasMove['hiddenpower'] || counter.damagingMoves[l].id === 'hiddenpower')) {
+							rejectableMoves.push(counter.damagingMoveIndex[counter.damagingMoves[l].id]);
+						}
+					}
+					if (rejectableMoves.length) {
+						moves.splice(rejectableMoves[this.random(rejectableMoves.length)], 1);
+					}
+				}
+			}
+		} while (moves.length < 4 && movePool.length);
+
+		// If Hidden Power has been removed, reset the IVs
+		if (!hasMove['hiddenpower']) {
+			ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
+		}
+
+		let abilities = Object.values(baseTemplate.abilities);
+		abilities.sort((a, b) => this.getAbility(b).rating - this.getAbility(a).rating);
+		let ability0 = this.getAbility(abilities[0]);
+		let ability1 = this.getAbility(abilities[1]);
+		ability = ability0.name;
+		if (abilities[1]) {
+			if (ability0.rating <= ability1.rating) {
+				if (this.random(2)) ability = ability1.name;
+			} else if (ability0.rating - 0.6 <= ability1.rating) {
+				if (!this.random(3)) ability = ability1.name;
+			}
+
+			let rejectAbility = false;
+			if (ability === 'Hustle') {
+				// Counter ability (hustle)
+				rejectAbility = !counter['hustle'];
+			} else if (ability === 'Blaze') {
+				rejectAbility = !counter['Fire'];
+			} else if (ability === 'Chlorophyll') {
+				rejectAbility = !hasMove['sunnyday'];
+			} else if (ability === 'Compound Eyes') {
+				rejectAbility = !counter['inaccurate'];
+			} else if (ability === 'Lightning Rod') {
+				rejectAbility = template.types.includes('Ground');
+			} else if (ability === 'Limber') {
+				rejectAbility = template.types.includes('Electric');
+			} else if (ability === 'Overgrow') {
+				rejectAbility = !counter['Grass'];
+			} else if (ability === 'Rock Head') {
+				rejectAbility = !counter['recoil'];
+			} else if (ability === 'Sand Veil') {
+				rejectAbility = !teamDetails['sand'];
+			} else if (ability === 'Serene Grace') {
+				rejectAbility = !counter['serenegrace'] || template.id === 'blissey';
+			} else if (ability === 'Sturdy') {
+				rejectAbility = true; // Strudy only blocks OHKO moves in gen3, which arent in our movepools.
+			} else if (ability === 'Swift Swim') {
+				rejectAbility = !hasMove['raindance'] && !teamDetails['rain'];
+			} else if (ability === 'Swarm') {
+				rejectAbility = !counter['Bug'];
+			} else if (ability === 'Synchronize') {
+				rejectAbility = counter.Status < 2;
+			} else if (ability === 'Torrent') {
+				rejectAbility = !counter['Water'];
+			}
+
+			if (rejectAbility) {
+				if (ability === ability1.name) { // or not
+					ability = ability0.name;
+				} else if (ability1.rating > 1) { // only switch if the alternative doesn't suck
+					ability = ability1.name;
+				}
+			}
+			if (abilities.includes('Swift Swim') && hasMove['raindance']) {
+				ability = 'Swift Swim';
+			}
+			if (abilities.includes('Chlorophyll') && hasMove['sunnyday']) {
+				ability = 'Chlorophyll';
+			}
+		}
+
+		item = 'Leftovers';
+		if (template.requiredItems) {
+			item = template.requiredItems[this.random(template.requiredItems.length)];
+
+		// First, the extra high-priority items
+		} else if (template.species === 'Farfetch\'d') {
+			item = 'Stick';
+		} else if (template.species === 'Marowak') {
+			item = 'Thick Club';
+		} else if (template.species === 'Pikachu') {
+			item = 'Light Ball';
+		} else if (template.species === 'Shedinja') {
+			item = 'Lum Berry';
+		} else if (template.species === 'Unown') {
+			item = moves[0] === 'hiddenpowerfighting' ? 'Choice Band' : 'Twisted Spoon';
+		} else if (template.species === 'Wobbuffet') {
+			item = ['Leftovers', 'Sitrus Berry'][this.random(2)];
+		} else if (hasMove['trick']) {
+			item = 'Choice Band';
+		} else if (hasMove['bellydrum']) {
+			item = 'Sitrus Berry';
+		} else if (hasMove['rest'] && !hasMove['sleeptalk'] && ability !== 'Natural Cure' && ability !== 'Shed Skin') {
+			item = 'Chesto Berry';
+
+		// Medium priority
+		} else if (hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal'] || hasMove['endure']) {
+			if (template.baseStats.spe < 108) {
+				item = 'Salac Berry';
+			} else if (counter.Physical > counter.Special) {
+				item = 'Liechi Berry';
+			} else {
+				item = 'Petaya Berry';
+			}
+		} else if (counter.Physical >= 4 && !hasMove['bodyslam'] && !hasMove['fakeout'] && !hasMove['rapidspin']) {
+			if (template.baseStats.spe < 60 && !counter['priority']) {
+				item = 'Liechi Berry';
+			} else {
+				item = template.baseStats.spe <= 108 && !counter['priority'] && this.random(3) ? 'Salac Berry' : 'Choice Band';
+			}
+		} else if (counter.Special >= 4 || (counter.Special >= 3 && hasMove['batonpass'])) {
+			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && ability !== 'Speed Boost' && !counter['priority'] && this.random(3) ? 'Salac Berry' : 'Petaya Berry';
+		} else if (hasMove['outrage'] && counter.setupType) {
+			item = 'Lum Berry';
+		} else if (hasMove['curse'] || hasMove['detect'] || hasMove['protect'] || hasMove['sleeptalk']) {
+			item = 'Leftovers';
+		} else if (hasMove['substitute']) {
+			item = 'Leftovers';
+
+		// This is the "REALLY can't think of a good item" cutoff
+		} else {
+			item = this.random(5) ? 'Leftovers' : ['Bright Powder', 'Quick Claw'][this.random(2)];
+			if (item === 'Quick Claw' && counter.priority) item = 'Bright Powder';
+		}
+
+		let levelScale = {
+			LC: 87,
+			NFE: 85,
+			NU: 83,
+			BL2: 81,
+			UU: 79,
+			BL: 77,
+			OU: 75,
+			Uber: 71,
+		};
+		let tier = template.tier;
+		let level = levelScale[tier] || 75;
+
+		// Prepare optimal HP
+		let hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+		if (hasMove['substitute'] && item === 'Sitrus Berry') {
+			// Two Substitutes should activate Sitrus Berry
+			while (hp % 4 > 0) {
+				evs.hp -= 4;
+				hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+			}
+		} else if (hasMove['bellydrum'] && item === 'Sitrus Berry') {
+			// Belly Drum should activate Sitrus Berry
+			if (hp % 2 > 0) evs.hp -= 4;
+		} else if (hasMove['substitute'] && hasMove['reversal']) {
+			// Reversal users should be able to use four Substitutes
+			if (hp % 4 === 0) evs.hp -= 4;
+		} else if (item === 'Salac Berry' || item === 'Petaya Berry' || item === 'Liechi Berry') {
+			if (hasMove['flail'] || hasMove['reversal']) {
+				while (hp % 4 !== 1) {
+					evs.hp -= 4;
+					hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+				}
+			} else {
+				if (hp % 4 === 0) evs.hp -= 4;
+			}
+		}
+
+		// Minimize confusion damage
+		if (!counter['Physical'] && !hasMove['transform']) {
+			evs.atk = 0;
+			ivs.atk = hasMove['hiddenpower'] ? ivs.atk - 28 : 0;
+		}
+
+		return {
+			name: template.baseSpecies,
+			species: species,
+			moves: moves,
+			ability: ability,
+			evs: evs,
+			ivs: ivs,
+			item: item,
+			level: level,
+			shiny: !this.random(1024),
+		};
+	},
+	randomTeam: function (side) {
+		let pokemon = [];
+
+		let pokemonPool = [];
+		for (let id in this.data.FormatsData) {
+			let template = this.getTemplate(id);
+			if (template.gen > 3 || template.isNonstandard || !template.randomBattleMoves || template.species === 'Unown') continue;
+			if (template.evos) {
+				let invalid = false;
+				for (let i = 0; i < template.evos.length; i++) {
+					if (this.getTemplate(template.evos[i]).gen <= 3) {
+						invalid = true;
+						break;
+					}
+				}
+				if (invalid) continue;
+			}
+			pokemonPool.push(id);
+		}
+
+		let typeCount = {};
+		let typeComboCount = {};
+		let baseFormes = {};
+		let uberCount = 0;
+		let nuCount = 0;
+		let teamDetails = {};
+
+		while (pokemonPool.length && pokemon.length < 6) {
+			let template = this.getTemplate(this.sampleNoReplace(pokemonPool));
+			if (!template.exists) continue;
+
+			// Limit to one of each species (Species Clause)
+			if (baseFormes[template.baseSpecies]) continue;
+
+			let tier = template.tier;
+			switch (tier) {
+			case 'Uber':
+				// Ubers are limited to 2 but have a 20% chance of being added anyway.
+				if (uberCount > 1 && this.random(5) >= 1) continue;
+				break;
+			case 'NU':
+				// NUs are limited to 2 but have a 20% chance of being added anyway.
+				if (nuCount > 1 && this.random(5) >= 1) continue;
+			}
+
+			// Adjust rate for castform
+			if (template.baseSpecies === 'Castform' && this.random(4) >= 1) continue;
+
+			// Limit 2 of any type
+			let types = template.types;
+			let skip = false;
+			for (let t = 0; t < types.length; t++) {
+				if (typeCount[types[t]] > 1 && this.random(5) >= 1) {
+					skip = true;
+					break;
+				}
+			}
+			if (skip) continue;
+
+			let set = this.randomSet(template, pokemon.length, teamDetails);
+
+			// Limit 1 of any type combination
+			let typeCombo = types.slice().sort().join();
+			if (set.ability === 'Drought' || set.ability === 'Drizzle' || set.ability === 'Sand Stream') {
+				// Drought, Drizzle and Sand Stream don't count towards the type combo limit
+				typeCombo = set.ability;
+				if (typeCombo in typeComboCount) continue;
+			} else {
+				if (typeComboCount[typeCombo] >= 1) continue;
+			}
+
+			// Okay, the set passes, add it to our team
+			pokemon.push(set);
+
+			// Now that our Pokemon has passed all checks, we can increment our counters
+			baseFormes[template.baseSpecies] = 1;
+
+			// Increment type counters
+			for (let t = 0; t < types.length; t++) {
+				if (types[t] in typeCount) {
+					typeCount[types[t]]++;
+				} else {
+					typeCount[types[t]] = 1;
+				}
+			}
+			if (typeCombo in typeComboCount) {
+				typeComboCount[typeCombo]++;
+			} else {
+				typeComboCount[typeCombo] = 1;
+			}
+
+			// Increment Uber/NU counters
+			if (tier === 'Uber') {
+				uberCount++;
+			} else if (tier === 'NU') {
+				nuCount++;
+			}
+
+			// Team has
+			if (set.ability === 'Snow Warning') teamDetails['hail'] = 1;
+			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails['rain'] = 1;
+			if (set.ability === 'Sand Stream') teamDetails['sand'] = 1;
+			if (set.moves.includes('spikes')) teamDetails['spikes'] = 1;
+			if (set.moves.includes('toxicspikes')) teamDetails['toxicSpikes'] = 1;
+			if (set.moves.includes('rapidspin')) teamDetails['rapidSpin'] = 1;
+		}
+		return pokemon;
 	},
 };

--- a/test/simulator/misc/random-teams.js
+++ b/test/simulator/misc/random-teams.js
@@ -5,7 +5,7 @@ const common = require('./../../common');
 let battle;
 
 const TOTAL_TEAMS = 100;
-const ALL_GENS = [1, 2/*, 3, 4*/, 5, 6, 7];
+const ALL_GENS = [1, 2, 3, 4, 5, 6, 7];
 
 function isValidSet(gen, set) {
 	const dex = Dex.mod(`gen${gen}`);


### PR DESCRIPTION
Adds scripts and movepools for Gen 3 Random Battles. Only fully evolved pokemon will appear, so only they got movepools. Also activates tests for gen3 and 4 randbats (since 4 was not turned on earlier).

Smogon Thread: http://www.smogon.com/forums/threads/random-battle.3600389/
Testable on http://spacialgaze.psim.us/