### PR TITLE
Admins are staff too

### DIFF
--- a/users.js
+++ b/users.js
@@ -968,7 +968,7 @@ class User {
 			this.avatar = Config.customavatars[this.userid];
 		}
 
-		this.isStaff = Config.groups[this.group] && Config.groups[this.group].lock;
+		this.isStaff = Config.groups[this.group] && (Config.groups[this.group].lock || Config.groups[this.group].root);
 		if (!this.isStaff) {
 			let staffRoom = Rooms('staff');
 			this.isStaff = (staffRoom && staffRoom.auth && staffRoom.auth[this.userid]);
@@ -998,7 +998,7 @@ class User {
 	setGroup(group, forceTrusted) {
 		if (!group) throw new Error(`Falsy value passed to setGroup`);
 		this.group = group.charAt(0);
-		this.isStaff = (this.group in {'%':1, '@':1, '&':1, '~':1});
+		this.isStaff = Config.groups[this.group] && (Config.groups[this.group].lock || Config.groups[this.group].root);
 		if (!this.isStaff) {
 			let staffRoom = Rooms('staff');
 			this.isStaff = (staffRoom && staffRoom.auth && staffRoom.auth[this.userid]);


### PR DESCRIPTION
Unlike any other rank, the admin rank dosen't inherit anything, but instead has `root: true`. When checking `Config.groups['~'].lock`, this comes out to false because of the lack of said inherit even though root gives full access.

EDIT: Ready to merge