### PR TITLE
Gen 2 Random battles: Push format to ladder

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1255,7 +1255,6 @@ exports.Formats = [
 		name: "[Gen 2] Random Battle",
 
 		mod: 'gen2',
-		searchShow: false,
 		team: 'random',
 		ruleset: ['Pokemon', 'Standard'],
 	},


### PR DESCRIPTION
It's been a while since I updated the format, and from the few tournament games we've played in Ruins of Alph, everything looks balanced and stable to me. In fact, I'm confident to say that it's more stable than Gen 3 RB right now. I think Gen 2 RB is the only RB format that is not in the ladder already, so I see no reason it shouldn't be there.