### PR TITLE
Hidetextalts: Make it actually hide alts' messages

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2208,6 +2208,11 @@ exports.commands = {
 		if (cmd === 'hidealtstext' || cmd === 'hidetextalts') {
 			this.addModCommand(`${targetUser.name}'s alts' messages were cleared from ${room.title} by ${user.name}.`);
 			this.add(`|unlink|${hidetype}${userid}`);
+
+			const alts = targetUser.getAltUsers(true);
+			for (let i = 0; i < alts.length; ++i) {
+				this.add(`|unlink|${hidetype}${alts[i].name}`);
+			}
 			for (let i in targetUser.prevNames) {
 				this.add(`|unlink|${hidetype}${targetUser.prevNames[i]}`);
 			}


### PR DESCRIPTION
I guess I didn't realize the difference between prevNames and alts, now I do.