### PR TITLE
Fix mixup between moves and ids in Metronome

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -10201,7 +10201,7 @@ exports.BattleMovedex = {
 				if (move.isZ || move.isNonstandard) continue;
 				if (effect.noMetronome[move.id]) continue;
 				if (this.getMove(i).gen > this.gen) continue;
-				moves.push(i);
+				moves.push(move);
 			}
 			let randomMove = '';
 			if (moves.length) {


### PR DESCRIPTION
Because I had the past gen Metronome code in `data/moves.js` which expected ids, and didn't notice the subtle difference when I copied the generation-testing code for PR #3781.