### PR TITLE
Gen 4 Random Battle improvements

### DIFF
--- a/mods/gen4/formats-data.js
+++ b/mods/gen4/formats-data.js
@@ -660,7 +660,7 @@ exports.BattleFormatsData = {
 		tier: "UU",
 	},
 	glaceon: {
-		randomBattleMoves: ["icebeam", "hiddenpowerground", "hiddenpowerfire", "shadowball", "batonpass", "wish", "substitute", "toxic", "protect"],
+		randomBattleMoves: ["icebeam", "hiddenpowerground", "hiddenpowerfire", "shadowball", "wish", "toxic", "protect"],
 		tier: "NU",
 	},
 	porygon: {

--- a/mods/gen4/formats-data.js
+++ b/mods/gen4/formats-data.js
@@ -136,7 +136,7 @@ exports.BattleFormatsData = {
 		tier: "NFE",
 	},
 	nidoking: {
-		randomBattleMoves: ["fireblast", "thunderbolt", "icebeam", "earthquake", "superpower", "stealthrock"],
+		randomBattleMoves: ["fireblast", "thunderbolt", "icebeam", "earthquake", "megahorn", "suckerpunch", "stealthrock"],
 		tier: "UU",
 	},
 	cleffa: {
@@ -165,7 +165,7 @@ exports.BattleFormatsData = {
 		tier: "NFE",
 	},
 	wigglytuff: {
-		randomBattleMoves: ["wish", "protect", "thunderwave", "reflect", "lightscreen", "healbell", "seismictoss", "toxic", "stealthrock"],
+		randomBattleMoves: ["wish", "protect", "thunderwave", "doubleedge", "bodyslam", "fireblast", "healbell", "seismictoss", "toxic", "stealthrock"],
 		tier: "NU",
 	},
 	zubat: {
@@ -235,7 +235,7 @@ exports.BattleFormatsData = {
 	},
 	golduck: {
 		inherit: true,
-		randomBattleMoves: ["hydropump", "surf", "icebeam", "hiddenpowergrass", "encore", "calmmind", "crosschop"],
+		randomBattleMoves: ["hydropump", "surf", "icebeam", "hiddenpowergrass", "encore", "calmmind", "psychic"],
 		tier: "NU",
 	},
 	mankey: {
@@ -358,7 +358,7 @@ exports.BattleFormatsData = {
 	},
 	farfetchd: {
 		inherit: true,
-		randomBattleMoves: ["aerialace", "swordsdance", "slash", "leafblade", "roost"],
+		randomBattleMoves: ["return", "swordsdance", "slash", "leafblade", "nightslash", "batonpass", "uturn"],
 		tier: "NU",
 	},
 	doduo: {
@@ -418,7 +418,7 @@ exports.BattleFormatsData = {
 	},
 	hypno: {
 		inherit: true,
-		randomBattleMoves: ["wish", "protect", "psychic", "seismictoss", "thunderwave", "nastyplot", "batonpass", "calmmind", "grassknot"],
+		randomBattleMoves: ["wish", "protect", "psychic", "seismictoss", "thunderwave", "toxic", "batonpass", "calmmind"],
 		tier: "NU",
 	},
 	krabby: {
@@ -599,7 +599,7 @@ exports.BattleFormatsData = {
 	},
 	magmortar: {
 		inherit: true,
-		randomBattleMoves: ["fireblast", "substitute", "crosschop", "focusblast", "hiddenpowergrass", "hiddenpowerice", "thunderbolt"],
+		randomBattleMoves: ["fireblast", "substitute", "focusblast", "hiddenpowergrass", "hiddenpowerice", "thunderbolt"],
 		tier: "NU",
 	},
 	pinsir: {
@@ -642,7 +642,7 @@ exports.BattleFormatsData = {
 		tier: "OU",
 	},
 	flareon: {
-		randomBattleMoves: ["rest", "sleeptalk", "lavaplume", "roar"],
+		randomBattleMoves: ["lavaplume", "fireblast", "wish", "protect", "hiddenpowergrass", "superpower", "toxic"],
 		tier: "NU",
 	},
 	espeon: {
@@ -660,7 +660,7 @@ exports.BattleFormatsData = {
 		tier: "UU",
 	},
 	glaceon: {
-		randomBattleMoves: ["icebeam", "hiddenpowerground", "shadowball", "batonpass", "wish"],
+		randomBattleMoves: ["icebeam", "hiddenpowerground", "hiddenpowerfire", "shadowball", "batonpass", "wish", "substitute", "toxic", "protect"],
 		tier: "NU",
 	},
 	porygon: {
@@ -838,7 +838,7 @@ exports.BattleFormatsData = {
 		tier: "NFE",
 	},
 	ampharos: {
-		randomBattleMoves: ["substitute", "hiddenpowerice", "focuspunch", "thunderbolt", "focusblast", "signalbeam"],
+		randomBattleMoves: ["substitute", "hiddenpowerice", "discharge", "thunderbolt", "focusblast", "signalbeam"],
 		tier: "NU",
 	},
 	azurill: {
@@ -1026,7 +1026,7 @@ exports.BattleFormatsData = {
 	},
 	octillery: {
 		inherit: true,
-		randomBattleMoves: ["waterspout", "surf", "icebeam", "energyball", "fireblast", "waterfall", "gunkshot", "seedbomb", "rockblast"],
+		randomBattleMoves: ["surf", "icebeam", "energyball", "fireblast", "substitute"],
 		tier: "NU",
 	},
 	delibird: {
@@ -1082,7 +1082,7 @@ exports.BattleFormatsData = {
 	},
 	entei: {
 		inherit: true,
-		randomBattleMoves: ["extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge", "calmmind", "fireblast"],
+		randomBattleMoves: ["extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge", "ironhead"],
 		tier: "BL2",
 	},
 	suicune: {
@@ -1148,7 +1148,7 @@ exports.BattleFormatsData = {
 		tier: "NFE",
 	},
 	swampert: {
-		randomBattleMoves: ["stealthrock", "earthquake", "icebeam", "roar", "surf", "waterfall", "stoneedge", "icepunch"],
+		randomBattleMoves: ["stealthrock", "earthquake", "icebeam", "roar", "waterfall", "stoneedge", "icepunch"],
 		tier: "OU",
 	},
 	poochyena: {
@@ -1156,7 +1156,7 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	mightyena: {
-		randomBattleMoves: ["suckerpunch", "crunch", "facade", "taunt", "howl", "superfang", "toxic"],
+		randomBattleMoves: ["suckerpunch", "return", "firefang", "taunt", "superfang", "toxic"],
 		tier: "NU",
 	},
 	zigzagoon: {
@@ -1203,7 +1203,7 @@ exports.BattleFormatsData = {
 		tier: "NFE",
 	},
 	shiftry: {
-		randomBattleMoves: ["swordsdance", "seedbomb", "suckerpunch", "lowkick", "nastyplot", "grassknot", "darkpulse", "hiddenpowerfire", "leafstorm"],
+		randomBattleMoves: ["swordsdance", "seedbomb", "suckerpunch", "lowkick", "explosion", "sunnyday", "solarbeam", "darkpulse", "hiddenpowerfire", "leafstorm"],
 		tier: "NU",
 	},
 	taillow: {
@@ -1262,7 +1262,7 @@ exports.BattleFormatsData = {
 	},
 	slaking: {
 		inherit: true,
-		randomBattleMoves: ["return", "earthquake", "pursuit", "firepunch", "suckerpunch", "icepunch", "doubleedge", "shadowclaw"],
+		randomBattleMoves: ["return", "earthquake", "pursuit", "firepunch", "icepunch", "doubleedge", "nightslash"],
 		tier: "NU",
 	},
 	nincada: {
@@ -1410,7 +1410,7 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	camerupt: {
-		randomBattleMoves: ["rockpolish", "fireblast", "earthpower", "stoneedge", "lavaplume", "explosion", "earthquake"],
+		randomBattleMoves: ["rockpolish", "fireblast", "earthpower", "stoneedge", "lavaplume", "explosion", "earthquake", "stealthrock"],
 		tier: "NU",
 	},
 	torkoal: {
@@ -1493,7 +1493,7 @@ exports.BattleFormatsData = {
 	},
 	crawdaunt: {
 		inherit: true,
-		randomBattleMoves: ["dragondance", "waterfall", "crunch", "superpower", "xscissor", "swordsdance"],
+		randomBattleMoves: ["dragondance", "waterfall", "crunch", "superpower", "xscissor"],
 		tier: "NU",
 	},
 	baltoy: {
@@ -1550,7 +1550,7 @@ exports.BattleFormatsData = {
 	},
 	banette: {
 		inherit: true,
-		randomBattleMoves: ["trickroom", "destinybond", "taunt", "shadowclaw", "willowisp"],
+		randomBattleMoves: ["shadowsneak", "destinybond", "taunt", "shadowclaw", "willowisp"],
 		tier: "NU",
 	},
 	duskull: {
@@ -1575,7 +1575,7 @@ exports.BattleFormatsData = {
 	},
 	chimecho: {
 		inherit: true,
-		randomBattleMoves: ["wish", "psychic", "thunderwave", "recover", "calmmind", "shadowball", "yawn"],
+		randomBattleMoves: ["psychic", "thunderwave", "recover", "calmmind", "signalbeam", "hiddenpowerfire", "yawn"],
 		tier: "NU",
 	},
 	absol: {
@@ -1588,7 +1588,7 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	glalie: {
-		randomBattleMoves: ["spikes", "icebeam", "iceshard", "crunch", "explosion", "taunt"],
+		randomBattleMoves: ["spikes", "icebeam", "iceshard", "earthquake", "explosion", "taunt"],
 		tier: "NU",
 	},
 	froslass: {
@@ -1603,7 +1603,7 @@ exports.BattleFormatsData = {
 		tier: "NFE",
 	},
 	walrein: {
-		randomBattleMoves: ["substitute", "protect", "toxic", "surf", "icebeam", "superfang", "roar"],
+		randomBattleMoves: ["protect", "toxic", "surf", "icebeam", "roar", "encore", "rest", "sleeptalk"],
 		tier: "NU",
 	},
 	clamperl: {
@@ -1611,7 +1611,7 @@ exports.BattleFormatsData = {
 		tier: "NU",
 	},
 	huntail: {
-		randomBattleMoves: ["hiddenpowergrass", "hydropump", "doubleedge", "icebeam", "suckerpunch"],
+		randomBattleMoves: ["raindance", "surf", "hiddenpowergrass", "hydropump", "doubleedge", "icebeam", "suckerpunch"],
 		tier: "NU",
 	},
 	gorebyss: {
@@ -1708,12 +1708,12 @@ exports.BattleFormatsData = {
 		tier: "Uber",
 	},
 	deoxysdefense: {
-		randomBattleMoves: ["spikes", "stealthrock", "recover", "taunt", "toxic", "psychoboost"],
+		randomBattleMoves: ["spikes", "stealthrock", "recover", "taunt", "toxic", "seismictoss"],
 		eventOnly: true,
 		tier: "Uber",
 	},
 	deoxysspeed: {
-		randomBattleMoves: ["spikes", "stealthrock", "icebeam", "psychoboost", "taunt", "lightscreen", "reflect", "superpower", "extremespeed"],
+		randomBattleMoves: ["spikes", "stealthrock", "psychoboost", "taunt", "lightscreen", "reflect", "superpower"],
 		eventOnly: true,
 		tier: "Uber",
 	},
@@ -1765,7 +1765,7 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	bibarel: {
-		randomBattleMoves: ["return", "waterfall", "superfang", "quickattack", "toxic", "stealthrock", "thunderwave"],
+		randomBattleMoves: ["return", "waterfall", "quickattack", "curse", "rest"],
 		tier: "NU",
 	},
 	kricketot: {
@@ -1976,11 +1976,11 @@ exports.BattleFormatsData = {
 		tier: "OU",
 	},
 	rotomfan: {
-		randomBattleMoves: ["discharge", "substitute", "painsplit", "rest", "sleeptalk", "airslash", "confuseray"],
+		randomBattleMoves: ["discharge", "substitute", "painsplit", "rest", "sleeptalk", "airslash", "willowisp", "hiddenpowerice"],
 		tier: "OU",
 	},
 	rotommow: {
-		randomBattleMoves: ["thunderbolt", "discharge", "substitute", "painsplit", "hiddenpowerice", "willowisp", "rest", "sleeptalk", "trick", "leafstorm"],
+		randomBattleMoves: ["thunderbolt", "discharge", "substitute", "painsplit", "hiddenpowerice", "willowisp", "shadowball", "trick", "leafstorm"],
 		tier: "OU",
 	},
 	uxie: {
@@ -2000,12 +2000,12 @@ exports.BattleFormatsData = {
 	},
 	dialga: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "dracometeor", "toxic", "thunderbolt", "outrage", "fireblast", "aurasphere", "dragonclaw", "bulkup"],
+		randomBattleMoves: ["stealthrock", "dracometeor", "toxic", "thunderbolt", "outrage", "fireblast", "aurasphere", "dragonclaw", "bulkup", "earthquake"],
 		tier: "Uber",
 	},
 	palkia: {
 		inherit: true,
-		randomBattleMoves: ["spacialrend", "dracometeor", "surf", "hydropump", "thunderbolt", "outrage", "fireblast", "aquatail", "earthquake", "stoneedge", "dragonclaw"],
+		randomBattleMoves: ["spacialrend", "dracometeor", "surf", "hydropump", "thunderbolt", "fireblast", "aurasphere"],
 		tier: "Uber",
 	},
 	heatran: {

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -214,6 +214,9 @@ exports.BattleScripts = {
 				case 'sunnyday':
 					if (!hasMove['solarbeam']) rejected = true;
 					break;
+				case 'weatherball':
+					if (!hasMove['raindance'] && !hasMove['sunnyday']) rejected = true;
+					break;
 
 				// Set up once and only if we have the moves for it
 				case 'bellydrum': case 'bulkup': case 'curse': case 'dragondance': case 'swordsdance':
@@ -329,9 +332,6 @@ exports.BattleScripts = {
 				case 'solarbeam':
 					if (counter.setupType === 'Physical' || !hasMove['sunnyday']) rejected = true;
 					break;
-				case 'weatherball':
-					if (!hasMove['raindance'] && !hasMove['sunnyday']) rejected = true;
-					break;
 				case 'icepunch':
 					if (!counter.setupType && hasMove['icebeam']) rejected = true;
 					break;
@@ -376,6 +376,9 @@ exports.BattleScripts = {
 					break;
 
 				// Status:
+				case 'encore':
+					if (hasMove['roar'] || hasMove['taunt'] || hasMove['whirlwind'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					break;
 				case 'leechseed': case 'painsplit':
 					if (hasMove['moonlight'] || hasMove['rest'] || hasMove['rockpolish'] || hasMove['synthesis']) rejected = true;
 					break;
@@ -384,9 +387,6 @@ exports.BattleScripts = {
 					break;
 				case 'thunderwave':
 					if (hasMove['toxic'] || hasMove['trickroom']) rejected = true;
-					break;
-				case 'encore':
-					if (hasMove['roar'] || hasMove['taunt'] || hasMove['whirlwind'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
 					break;
 				}
 

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -198,16 +198,21 @@ exports.BattleScripts = {
 					if (!hasMove['substitute'] || counter.damagingMoves.length < 2) rejected = true;
 					if (hasMove['hammerarm']) rejected = true;
 					break;
-				case 'rest': {
+				case 'raindance':
+					if (counter.Physical + counter.Special < 2 && !(hasAbility['Hydration'] && hasMove['rest'])) rejected = true;
+					break;
+				case 'rest':
 					if (movePool.includes('sleeptalk')) rejected = true;
 					break;
-				}
 				case 'sleeptalk':
 					if (!hasMove['rest']) rejected = true;
 					if (movePool.length > 1) {
 						let rest = movePool.indexOf('rest');
 						if (rest >= 0) this.fastPop(movePool, rest);
 					}
+					break;
+				case 'sunnyday':
+					if (!hasMove['solarbeam']) rejected = true;
 					break;
 
 				// Set up once and only if we have the moves for it
@@ -237,7 +242,7 @@ exports.BattleScripts = {
 					if (counter.setupType && !hasAbility['Speed Boost']) rejected = true;
 					break;
 				case 'protect':
-					if (!(hasAbility['Speed Boost'] || hasAbility['Guts'] || hasAbility['Quick Feet'] || hasMove['Wish'] || hasMove['Toxic'])) rejected = true;
+					if (!(hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Speed Boost'] || hasMove['Toxic'] || hasMove['Wish'])) rejected = true;
 					break;
 				case 'wish':
 					if (!(hasMove['Protect'] || hasMove['U-turn'] || hasMove['Baton Pass'])) rejected = true;
@@ -272,18 +277,10 @@ exports.BattleScripts = {
 				// Bit redundant to have both
 				// Attacks:
 				case 'bodyslam': case 'slash':
-					if (hasMove['return']) rejected = true;
-					if (hasMove['facade'] && (hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Poison Heal'])) rejected = true;
+					if (hasMove['facade'] || hasMove['return']) rejected = true;
 					break;
 				case 'doubleedge':
-					if (hasMove['return'] || hasMove['bodyslam']) rejected = true;
-					if (hasMove['facade'] && (hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Poison Heal'])) rejected = true;
-					break;
-				case 'return':
-					if (hasMove['facade'] && (hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Poison Heal'])) rejected = true;
-					break;
-				case 'facade':
-					if (!(hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Poison Heal'])) rejected = true;
+					if (hasMove['bodyslam'] || hasMove['facade'] || hasMove['return']) rejected = true;
 					break;
 				case 'judgment':
 					if (counter.setupType !== 'Special' && counter.stab > 1) rejected = true;
@@ -292,8 +289,7 @@ exports.BattleScripts = {
 					if (hasMove['thunderwave']) rejected = true;
 					break;
 				case 'firepunch': case 'flamethrower':
-					if (hasMove['fireblast']) rejected = true;
-					if (hasMove['overheat'] && !counter.setupType) rejected = true;
+					if (hasMove['fireblast'] || hasMove['overheat'] && !counter.setupType) rejected = true;
 					break;
 				case 'lavaplume':
 					if (hasMove['fireblast'] && !!counter['speedsetup']) rejected = true;
@@ -306,6 +302,9 @@ exports.BattleScripts = {
 				case 'overheat':
 					if (counter.setupType === 'Special' || hasMove['batonpass'] || hasMove['fireblast'] || hasMove['flareblitz']) rejected = true;
 					break;
+				case 'aquajet':
+					if (hasMove['waterfall'] && counter.Physical < 3) rejected = true;
+					break;
 				case 'hydropump':
 					if (hasMove['surf']) rejected = true;
 					break;
@@ -313,14 +312,11 @@ exports.BattleScripts = {
 					if (hasMove['aquatail']) rejected = true;
 					if ((hasMove['hydropump'] || hasMove['surf']) && counter.setupType !== 'Physical') rejected = true;
 					break;
-				case 'aqua jet':
-					if (hasMove['waterfall'] && counter.Physical < 3) rejected = true;
+				case 'chargebeam':
+					if (hasMove['thunderbolt'] && counter.Special < 3) rejected = true;
 					break;
 				case 'discharge':
 					if (hasMove['thunderbolt']) rejected = true;
-					break;
-				case 'chargebeam':
-					if (hasMove['thunderbolt'] && counter.Special < 3) rejected = true;
 					break;
 				case 'energyball': case 'seedbomb':
 					if (hasMove['grassknot'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
@@ -330,12 +326,6 @@ exports.BattleScripts = {
 					break;
 				case 'solarbeam':
 					if (counter.setupType === 'Physical' || !hasMove['sunnyday']) rejected = true;
-					break;
-				case 'sunnyday':
-					if (!hasMove['solarbeam']) rejected = true;
-					break;
-				case 'raindance':
-					if (counter.Physical + counter.Special < 2 && !(hasAbility['Hydration'] && hasMove['rest'])) rejected = true;
 					break;
 				case 'weatherball':
 					if (!hasMove['raindance'] && !hasMove['sunnyday']) rejected = true;
@@ -355,11 +345,11 @@ exports.BattleScripts = {
 				case 'gunkshot':
 					if (hasMove['poisonjab']) rejected = true;
 					break;
-				case 'zenheadbutt':
-					if (hasMove['psychocut']) rejected = true;
-					break;
 				case 'earthpower':
 					if (hasMove['earthquake']) rejected = true;
+					break;
+				case 'zenheadbutt':
+					if (hasMove['psychocut']) rejected = true;
 					break;
 				case 'rockslide':
 					if (hasMove['stoneedge']) rejected = true;
@@ -394,8 +384,7 @@ exports.BattleScripts = {
 					if (hasMove['toxic'] || hasMove['trickroom']) rejected = true;
 					break;
 				case 'encore':
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					if (hasMove['whirlwind'] || hasMove['roar'] || hasMove['taunt']) rejected = true;
+					if (hasMove['roar'] || hasMove['taunt'] || hasMove['whirlwind'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
 					break;
 				}
 

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -245,12 +245,11 @@ exports.BattleScripts = {
 					if (!(hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Speed Boost'] || hasMove['Toxic'] || hasMove['Wish'])) rejected = true;
 					break;
 				case 'wish':
-					if (!(hasMove['Protect'] || hasMove['U-turn'] || hasMove['Baton Pass'])) rejected = true;
+					if (!(hasMove['batonpass'] || hasMove['protect'] || hasMove['uturn'])) rejected = true;
 					if (hasMove['rest'] || !!counter['speedsetup']) rejected = true;
 					break;
 				case 'rapidspin':
-					if (teamDetails.rapidSpin) rejected = true;
-					if (counter.setupType && counter.Physical + counter.Special < 2) rejected = true;
+					if (teamDetails.rapidSpin || counter.setupType && counter.Physical + counter.Special < 2) rejected = true;
 					break;
 				case 'stealthrock':
 					if (counter.setupType || !!counter['speedsetup'] || hasMove['rest'] || teamDetails.stealthRock) rejected = true;

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -255,15 +255,15 @@ exports.BattleScripts = {
 				case 'stealthrock':
 					if (counter.setupType || !!counter['speedsetup'] || hasMove['rest'] || teamDetails.stealthRock) rejected = true;
 					break;
-				case 'reflect': case 'lightscreen':
-					if (counter.setupType) rejected = true;
+				case 'reflect': case 'lightscreen': case 'fakeout':
+					if (counter.setupType || !!counter['speedsetup'] || hasMove['substitute']) rejected = true;
 					break;
 				case 'switcheroo': case 'trick':
 					if (counter.Physical + counter.Special < 3 || counter.setupType) rejected = true;
 					if (hasMove['lightscreen'] || hasMove['reflect'] || hasMove['suckerpunch'] || hasMove['trickroom']) rejected = true;
 					break;
 				case 'toxic': case 'toxicspikes':
-					if (isSetup || counter.setupType || teamDetails.toxicSpikes) rejected = true;
+					if (counter.setupType || teamDetails.toxicSpikes) rejected = true;
 					break;
 				case 'trickroom':
 					if (counter.setupType || !!counter['speedsetup'] || counter.damagingMoves.length < 2) rejected = true;
@@ -319,7 +319,10 @@ exports.BattleScripts = {
 					if (hasMove['thunderbolt']) rejected = true;
 					break;
 				case 'energyball': case 'seedbomb':
-					if (hasMove['grassknot'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
+					if (hasMove['grassknot'] || hasMove['woodhammer'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
+					break;
+				case 'grassknot':
+					if (hasMove['woodhammer'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
 					break;
 				case 'leafstorm':
 					if (counter.setupType || hasMove['batonpass'] || hasMove['powerwhip'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -233,21 +233,32 @@ exports.BattleScripts = {
 				case 'explosion': case 'selfdestruct':
 					if (counter.stab < 2 || counter.setupType || !!counter['recovery'] || hasMove['rest'] || hasMove['substitute']) rejected = true;
 					break;
-				case 'foresight': case 'protect': case 'roar':
+				case 'foresight': case 'roar':
 					if (counter.setupType && !hasAbility['Speed Boost']) rejected = true;
+					break;
+				case 'protect':
+					if (!(hasAbility['Speed Boost'] || hasAbility['Guts'] || hasAbility['Quick Feet'] || hasMove['Wish'] || hasMove['Toxic'])) rejected = true;
+					break;
+				case 'wish':
+					if (!(hasMove['Protect'] || hasMove['U-turn'] || hasMove['Baton Pass'])) rejected = true;
+					if (hasMove['rest'] || !!counter['speedsetup']) rejected = true;
 					break;
 				case 'rapidspin':
 					if (teamDetails.rapidSpin) rejected = true;
+					if (counter.setupType && counter.Physical + counter.Special < 2) rejected = true;
 					break;
 				case 'stealthrock':
 					if (counter.setupType || !!counter['speedsetup'] || hasMove['rest'] || teamDetails.stealthRock) rejected = true;
+					break;
+				case 'reflect': case 'lightscreen':
+					if (counter.setupType) rejected = true;
 					break;
 				case 'switcheroo': case 'trick':
 					if (counter.Physical + counter.Special < 3 || counter.setupType) rejected = true;
 					if (hasMove['lightscreen'] || hasMove['reflect'] || hasMove['suckerpunch'] || hasMove['trickroom']) rejected = true;
 					break;
 				case 'toxic': case 'toxicspikes':
-					if (counter.setupType || teamDetails.toxicSpikes) rejected = true;
+					if (isSetup || counter.setupType || teamDetails.toxicSpikes) rejected = true;
 					break;
 				case 'trickroom':
 					if (counter.setupType || !!counter['speedsetup'] || counter.damagingMoves.length < 2) rejected = true;
@@ -260,8 +271,19 @@ exports.BattleScripts = {
 
 				// Bit redundant to have both
 				// Attacks:
-				case 'bodyslam': case 'doubleedge':
+				case 'bodyslam': case 'slash':
 					if (hasMove['return']) rejected = true;
+					if (hasMove['facade'] && (hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Poison Heal'])) rejected = true;
+					break;
+				case 'doubleedge':
+					if (hasMove['return'] || hasMove['bodyslam']) rejected = true;
+					if (hasMove['facade'] && (hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Poison Heal'])) rejected = true;
+					break;
+				case 'return':
+					if (hasMove['facade'] && (hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Poison Heal'])) rejected = true;
+					break;
+				case 'facade':
+					if (!(hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Poison Heal'])) rejected = true;
 					break;
 				case 'judgment':
 					if (counter.setupType !== 'Special' && counter.stab > 1) rejected = true;
@@ -271,24 +293,52 @@ exports.BattleScripts = {
 					break;
 				case 'firepunch': case 'flamethrower':
 					if (hasMove['fireblast']) rejected = true;
+					if (hasMove['overheat'] && !counter.setupType) rejected = true;
+					break;
+				case 'lavaplume':
+					if (hasMove['fireblast'] && !!counter['speedsetup']) rejected = true;
+					if (hasMove['flareblitz'] && counter.setupType !== 'Special') rejected = true;
+					break;
+				case 'fireblast':
+					if (hasMove['lavaplume'] && !counter['speedsetup']) rejected = true;
+					if (hasMove['flareblitz'] && counter.setupType !== 'Special') rejected = true;
+					break;
+				case 'overheat':
+					if (counter.setupType === 'Special' || hasMove['batonpass'] || hasMove['fireblast'] || hasMove['flareblitz']) rejected = true;
 					break;
 				case 'hydropump':
 					if (hasMove['surf']) rejected = true;
 					break;
 				case 'waterfall':
 					if (hasMove['aquatail']) rejected = true;
+					if ((hasMove['hydropump'] || hasMove['surf']) && counter.setupType !== 'Physical') rejected = true;
+					break;
+				case 'aqua jet':
+					if (hasMove['waterfall'] && counter.Physical < 3) rejected = true;
 					break;
 				case 'discharge':
 					if (hasMove['thunderbolt']) rejected = true;
 					break;
-				case 'energyball':
-					if (hasMove['grassknot']) rejected = true;
+				case 'chargebeam':
+					if (hasMove['thunderbolt'] && counter.Special < 3) rejected = true;
+					break;
+				case 'energyball': case 'seedbomb':
+					if (hasMove['grassknot'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
 					break;
 				case 'leafstorm':
-					if (counter.setupType || hasMove['batonpass'] || hasMove['powerwhip']) rejected = true;
+					if (counter.setupType || hasMove['batonpass'] || hasMove['powerwhip'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
 					break;
 				case 'solarbeam':
-					if (counter.setupType === 'Physical' || !hasMove['sunnyday'] && !movePool.includes('sunnyday')) rejected = true;
+					if (counter.setupType === 'Physical' || !hasMove['sunnyday']) rejected = true;
+					break;
+				case 'sunnyday':
+					if (!hasMove['solarbeam']) rejected = true;
+					break;
+				case 'raindance':
+					if (counter.Physical + counter.Special < 2 && !(hasAbility['Hydration'] && hasMove['rest'])) rejected = true;
+					break;
+				case 'weatherball':
+					if (!hasMove['raindance'] && !hasMove['sunnyday']) rejected = true;
 					break;
 				case 'icepunch':
 					if (!counter.setupType && hasMove['icebeam']) rejected = true;
@@ -307,6 +357,9 @@ exports.BattleScripts = {
 					break;
 				case 'zenheadbutt':
 					if (hasMove['psychocut']) rejected = true;
+					break;
+				case 'earthpower':
+					if (hasMove['earthquake']) rejected = true;
 					break;
 				case 'rockslide':
 					if (hasMove['stoneedge']) rejected = true;
@@ -331,7 +384,7 @@ exports.BattleScripts = {
 					break;
 
 				// Status:
-				case 'leechseed': case 'painsplit': case 'wish':
+				case 'leechseed': case 'painsplit':
 					if (hasMove['moonlight'] || hasMove['rest'] || hasMove['rockpolish'] || hasMove['synthesis']) rejected = true;
 					break;
 				case 'substitute':
@@ -339,6 +392,10 @@ exports.BattleScripts = {
 					break;
 				case 'thunderwave':
 					if (hasMove['toxic'] || hasMove['trickroom']) rejected = true;
+					break;
+				case 'encore':
+					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['whirlwind'] || hasMove['roar'] || hasMove['taunt']) rejected = true;
 					break;
 				}
 
@@ -556,26 +613,28 @@ exports.BattleScripts = {
 			item = 'Sitrus Berry';
 
 		// Medium priority
-		} else if (counter.Physical >= 4 && !hasMove['bodyslam'] && !hasMove['fakeout'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.random(3) ? 'Choice Scarf' : 'Choice Band';
+		} else if (counter.Physical >= 4 && !hasMove['fakeout'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
+			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !hasMove['bodyslam'] && this.random(3) ? 'Choice Scarf' : 'Choice Band';
 		} else if ((counter.Special >= 4 || (counter.Special >= 3 && (hasMove['batonpass'] || hasMove['uturn']))) && !hasMove['chargebeam']) {
 			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && ability !== 'Speed Boost' && !counter['priority'] && this.random(3) ? 'Choice Scarf' : 'Choice Specs';
 		} else if (hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal']) {
 			item = 'Focus Sash';
-		} else if (hasMove['outrage'] && counter.setupType) {
-			item = 'Lum Berry';
 		} else if (ability === 'Slow Start' || hasMove['curse'] || hasMove['detect'] || hasMove['protect'] || hasMove['sleeptalk']) {
 			item = 'Leftovers';
+		} else if (hasMove['outrage'] && counter.setupType) {
+			item = 'Lum Berry';
 		} else if (hasMove['substitute']) {
 			item = !counter['drain'] || counter.damagingMoves.length < 2 ? 'Leftovers' : 'Life Orb';
 		} else if (hasMove['lightscreen'] || hasMove['reflect']) {
 			item = 'Light Clay';
+		} else if (template.species === 'Palkia' && !!counter['Dragon'] && !!counter['Water']) {
+			item = 'Lustrous Orb';
 		} else if (counter.damagingMoves.length >= 4) {
 			item = (!!counter['Normal'] || hasMove['chargebeam'] || (hasMove['suckerpunch'] && !hasType['Dark'])) ? 'Life Orb' : 'Expert Belt';
 		} else if (counter.damagingMoves.length >= 3 && !hasMove['superfang']) {
-			item = (template.baseStats.hp + template.baseStats.def + template.baseStats.spd < 285 || !!counter['speedsetup'] || hasMove['trickroom']) ? 'Life Orb' : 'Leftovers';
-		} else if (template.species === 'Palkia' && (hasMove['dracometeor'] || hasMove['spacialrend']) && hasMove['hydropump']) {
-			item = 'Lustrous Orb';
+			let totalBulk = template.baseStats.hp + template.baseStats.def + template.baseStats.spd;
+			item = (!!counter['speedsetup'] || !!counter['priority'] || hasMove['dragondance'] || hasMove['trickroom'] ||
+				totalBulk < 235 || (template.baseStats.spe >= 70 && (totalBulk < 260 || (!!counter['recovery'] && totalBulk < 285)))) ? 'Life Orb' : 'Leftovers';
 		} else if (slot === 0 && !counter['recoil'] && !counter['recovery'] && template.baseStats.hp + template.baseStats.def + template.baseStats.spd < 285) {
 			item = 'Focus Sash';
 


### PR DESCRIPTION
I relaxed the bulk requirements for Leftovers on 3-attack sets because DPP has
a lot of defensive-oriented Pokemon that don't want a Life Orb but didn't meet
the 285 cutoff, like Weezing, Quagsire, and Nidoqueen. The extra check for fast
bulky Pokemon with recovery is to avoid taking Life Orb away from stuff like
Roost Zapdos that has good bulk but doesn't mind the recoil nearly as much.