### PR TITLE
Add "CAP NFE's"

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -6574,7 +6574,7 @@ exports.BattleFormatsData = {
 	},
 	flarelm: {
 		isNonstandard: true,
-		tier: "CAP LC",
+		tier: "CAP NFE",
 	},
 	breezi: {
 		isNonstandard: true,
@@ -6594,7 +6594,7 @@ exports.BattleFormatsData = {
 	},
 	argalis: {
 		isNonstandard: true,
-		tier: "CAP LC",
+		tier: "CAP NFE",
 	},
 	brattler: {
 		isNonstandard: true,
@@ -6618,7 +6618,7 @@ exports.BattleFormatsData = {
 	},
 	caimanoe: {
 		isNonstandard: true,
-		tier: "CAP LC",
+		tier: "CAP NFE",
 	},
 	pluffle: {
 		isNonstandard: true,


### PR DESCRIPTION
Turns out there is indeed some of these that are not LC but indeed CAP NFE's so I will make this a rank to clarify the difference.

In tandem with: https://github.com/Zarel/Pokemon-Showdown-Client/pull/974