### PR TITLE
Add CAP LC and NFE to the Allow CAP clause

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -112,7 +112,7 @@ exports.BattleFormats = {
 				problems.push((set.name || set.species) + ' is higher than level 100.');
 			}
 
-			if (!allowCAP || template.tier !== 'CAP' || template.tier !== 'CAP NFE' || template.tier !== 'CAP LC') {
+			if (!allowCAP || !template.tier.startsWith('CAP')) {
 				if (template.isNonstandard) {
 					problems.push(set.species + ' does not exist.');
 				}

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -112,7 +112,7 @@ exports.BattleFormats = {
 				problems.push((set.name || set.species) + ' is higher than level 100.');
 			}
 
-			if (!allowCAP || template.tier !== 'CAP') {
+			if (!allowCAP || template.tier !== 'CAP' || template.tier !== 'CAP NFE' || template.tier !== 'CAP LC') {
 				if (template.isNonstandard) {
 					problems.push(set.species + ' does not exist.');
 				}


### PR DESCRIPTION
Seeing as Allow CAP clause is built in the Pokemon Clause I had to add it there, but this should make it where they are considered Illegal in all tiers Allow CAP is not legal.
Thanks to Marty for pointing this out to me.