### PR TITLE
Fix priority shorthand parameter in movesearch

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -926,7 +926,7 @@ function runMovesearch(target, cmd, canAll, message) {
 				return {reply: "Priority cannot be set with both shorthand and inequality range."};
 			} else {
 				searches['property']['priority'] = {};
-				searches['property']['priority'][sign] = (sign === 'less' ? -1 : 1);
+				searches['property']['priority'][sign] = 0;
 			}
 			continue;
 		}


### PR DESCRIPTION
'priority+' now includes priority +1, and 'priority-' includes -1
(this was a regression most likely introduced in 8299bcc2bfc1007131df502582f361d4ac22eb8e)