### PR TITLE
Parental Bond damage should reset for Instruct

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2290,6 +2290,9 @@ exports.BattleAbilities = {
 					return secondaries.filter(effect => effect.volatileStatus === 'flinch');
 				}
 			},
+			onAnyAfterMove: function () {
+				this.effectData.target.removeVolatile("parentalbond");
+			},
 		},
 		id: "parentalbond",
 		name: "Parental Bond",

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2291,7 +2291,7 @@ exports.BattleAbilities = {
 				}
 			},
 			onAnyAfterMove: function () {
-				this.effectData.target.removeVolatile("parentalbond");
+				this.effectData.target.removeVolatile('parentalbond');
 			},
 		},
 		id: "parentalbond",


### PR DESCRIPTION
Currently if Oranguru instructs Kangaskhan-Mega, then only its first hit is at full power, but I'm assuming that both the Instruct first hit and the natural first hit (in whichever order depending on Trick Room etc.) should be at full power.