### PR TITLE
Fix Unburden/Symbiosis interaction with Air Balloon behind Substitute

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -159,7 +159,9 @@ exports.BattleItems = {
 			this.debug('effect: ' + effect.id);
 			if (effect.effectType === 'Move' && effect.id !== 'confused') {
 				this.add('-enditem', target, 'Air Balloon');
-				target.setItem('');
+				target.item = '';
+				this.itemData = {id: '', target: this};
+				this.runEvent('AfterUseItem', target, null, null, 'airballoon');
 			}
 		},
 		num: 541,


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/7458261/).

This copies the change that @ascriptmaster mde in PR #1560 for regular Air Balloon hits so that it also works when the user is behind a Substitute.