### PR TITLE
Datacenters: remove reassigned IP range

### DIFF
--- a/config/datacenters.csv
+++ b/config/datacenters.csv
@@ -2235,7 +2235,6 @@
 188.138.0.0,188.138.127.255,plusserver.de,http://plusserver.de/
 188.165.0.0,188.165.255.255,OVH,http://www.ovh.co.uk/
 188.166.0.0,188.166.255.255,DigitalOcean Europe,https://www.digitalocean.com/
-188.172.0.0,188.172.255.255,xservers.ro,http://www.xservers.ro/
 188.190.96.0,188.190.127.255,infiumhost.com,http://infiumhost.com/
 188.214.128.0,188.214.135.255,Duomenu Centras Lithuania,http://www.duomenucentras.lt/lt/
 188.226.128.0,188.226.191.255,DigitalOcean Netherlands,https://www.digitalocean.com/


### PR DESCRIPTION
188.172.* is no longer owned by xservers, according to RIPE's database. It now seems to be used by a bunch of different companies and ISPs.