### PR TITLE
Chat: Refactor chat filter out of Config

### DIFF
--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -1286,7 +1286,7 @@ let commands = {
 	},
 };
 
-Chat.loadCommands();
+Chat.loadPlugins();
 Chat.commands.tour = 'tournament';
 Chat.commands.tours = 'tournament';
 Chat.commands.tournaments = 'tournament';


### PR DESCRIPTION
This turns Config.chatfilter into Chat.filter.

Also, each chat-plugin can potentially alter the chat filter by exporting 'chatfilter', just as they can export 'commands'.

Note:
1. returning a string in a chatfilter will make that be a user's message sent to the room
2. returning false will make a user's message not send to the room
3. returning undefined will send a user's original message to the room