### PR TITLE
UNO: Fix passing when choosing color

### DIFF
--- a/chat-plugins/uno.js
+++ b/chat-plugins/uno.js
@@ -631,6 +631,7 @@ exports.commands = {
 			if (!room.game || room.game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
 			if (room.game.currentPlayer !== user.userid) return this.errorReply("It is currently not your turn.");
 			if (!room.game.players[user.userid].cardLock) return this.errorReply("You cannot pass until you draw a card.");
+			if (room.game.state === 'color') return this.errorReply("You cannot pass until you choose a color.");
 
 			room.game.sendToRoom(`${user.name} has passed.`);
 			room.game.nextTurn();


### PR DESCRIPTION
The issue was players passing after they played a wild card and did not choose a color. This made the users forced to play wild cards only.