### PR TITLE
Remove some ability effects to improve compatibility with Instruct

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -71,12 +71,12 @@ exports.BattleAbilities = {
 		onModifyMove: function (move, pokemon) {
 			if (move.type === 'Normal' && !(move.id in {naturalgift:1, revelationdance:1}) && !(move.isZ && move.category !== 'Status')) {
 				move.type = 'Flying';
-				move.aerilate = true;
+				move.aerilateBoosted = true;
 			}
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.aerilate) return this.chainModify([0x1333, 0x1000]);
+			if (move.aerilateBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
 		id: "aerilate",
 		name: "Aerilate",
@@ -200,7 +200,7 @@ exports.BattleAbilities = {
 		},
 		onAnyTryPrimaryHit: function (target, source, move) {
 			if (target === source || move.category === 'Status') return;
-			move.aurabreak = true;
+			move.hasAuraBreak = true;
 		},
 		id: "aurabreak",
 		name: "Aura Break",
@@ -581,7 +581,7 @@ exports.BattleAbilities = {
 		},
 		onAnyBasePower: function (target, source, move) {
 			if (target === source || move.category === 'Status' || move.type !== 'Dark') return;
-			return this.chainModify([move.aurabreak ? 0x0C00 : 0x1547, 0x1000]);
+			return this.chainModify([move.hasAuraBreak ? 0x0C00 : 0x1547, 0x1000]);
 		},
 		isUnbreakable: true,
 		id: "darkaura",
@@ -886,7 +886,7 @@ exports.BattleAbilities = {
 		},
 		onAnyBasePower: function (target, source, move) {
 			if (target === source || move.category === 'Status' || move.type !== 'Fairy') return;
-			return this.chainModify([move.aurabreak ? 0x0C00 : 0x1547, 0x1000]);
+			return this.chainModify([move.hasAuraBreak ? 0x0C00 : 0x1547, 0x1000]);
 		},
 		isUnbreakable: true,
 		id: "fairyaura",
@@ -1199,12 +1199,12 @@ exports.BattleAbilities = {
 		onModifyMove: function (move, pokemon) {
 			if (move.type === 'Normal' && !(move.id in {naturalgift:1, revelationdance:1}) && !(move.isZ && move.category !== 'Status')) {
 				move.type = 'Electric';
-				move.galvanize = true;
+				move.galvanizeBoosted = true;
 			}
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.galvanize) return this.chainModify([0x1333, 0x1000]);
+			if (move.galvanizeBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
 		id: "galvanize",
 		name: "Galvanize",
@@ -2148,12 +2148,12 @@ exports.BattleAbilities = {
 		onModifyMove: function (move, pokemon) {
 			if (!(move.isZ && move.category !== 'Status') && !(move.id in {hiddenpower:1, judgment:1, multiattack:1, naturalgift:1, revelationdance:1, struggle:1, technoblast:1, weatherball:1})) {
 				move.type = 'Normal';
-				move.normalize = true;
+				move.normalizeBoosted = true;
 			}
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.normalize) return this.chainModify([0x1333, 0x1000]);
+			if (move.normalizeBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
 		id: "normalize",
 		name: "Normalize",
@@ -2256,16 +2256,16 @@ exports.BattleAbilities = {
 			if (move.id in {iceball: 1, rollout: 1}) return;
 			if (move.category !== 'Status' && !move.selfdestruct && !move.multihit && !move.flags['charge'] && !move.spreadHit && !move.isZ) {
 				move.multihit = 2;
-				move.parentalbond = true;
+				move.hasParentalBond = true;
 				move.hit = 0;
 			}
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.parentalbond && ++move.hit > 1) return this.chainModify(0.25);
+			if (move.hasParentalBond && ++move.hit > 1) return this.chainModify(0.25);
 		},
 		onSourceModifySecondaries: function (secondaries, target, source, move) {
-			if (move.parentalbond && move.id === 'secretpower' && move.hit < 2) {
+			if (move.hasParentalBond && move.id === 'secretpower' && move.hit < 2) {
 				// hack to prevent accidentally suppressing King's Rock/Razor Fang
 				return secondaries.filter(effect => effect.volatileStatus === 'flinch');
 			}
@@ -2332,12 +2332,12 @@ exports.BattleAbilities = {
 		onModifyMove: function (move, pokemon) {
 			if (move.type === 'Normal' && !(move.id in {naturalgift:1, revelationdance:1}) && !(move.isZ && move.category !== 'Status')) {
 				move.type = 'Fairy';
-				move.pixilate = true;
+				move.pixilateBoosted = true;
 			}
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.pixilate) return this.chainModify([0x1333, 0x1000]);
+			if (move.pixilateBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
 		id: "pixilate",
 		name: "Pixilate",
@@ -2656,12 +2656,12 @@ exports.BattleAbilities = {
 		onModifyMove: function (move, pokemon) {
 			if (move.type === 'Normal' && !(move.id in {naturalgift:1, revelationdance:1}) && !(move.isZ && move.category !== 'Status')) {
 				move.type = 'Ice';
-				move.refrigerate = true;
+				move.refrigerateBoosted = true;
 			}
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.refrigerate) return this.chainModify([0x1333, 0x1000]);
+			if (move.refrigerateBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
 		id: "refrigerate",
 		name: "Refrigerate",
@@ -2951,12 +2951,12 @@ exports.BattleAbilities = {
 			if (move.secondaries) {
 				delete move.secondaries;
 				// Actual negation of `AfterMoveSecondary` effects implemented in scripts.js
-				move.sheerforce = true;
+				move.hasSheerForce = true;
 			}
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.sheerforce) return this.chainModify([0x14CD, 0x1000]);
+			if (move.hasSheerForce) return this.chainModify([0x14CD, 0x1000]);
 		},
 		id: "sheerforce",
 		name: "Sheer Force",

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -275,7 +275,7 @@ exports.BattleScripts = {
 			return true;
 		}
 
-		if (!move.negateSecondary && !(pokemon.hasAbility('sheerforce') && pokemon.volatiles['sheerforce'])) {
+		if (!move.negateSecondary && !(move.sheerforce && pokemon.hasAbility('sheerforce'))) {
 			this.singleEvent('AfterMoveSecondarySelf', move, null, pokemon, target, move);
 			this.runEvent('AfterMoveSecondarySelf', pokemon, target, move);
 		}
@@ -518,7 +518,7 @@ exports.BattleScripts = {
 
 		this.eachEvent('Update');
 
-		if (target && !move.negateSecondary && !(pokemon.hasAbility('sheerforce') && pokemon.volatiles['sheerforce'])) {
+		if (target && !move.negateSecondary && !(move.sheerforce && pokemon.hasAbility('sheerforce'))) {
 			this.singleEvent('AfterMoveSecondary', move, null, target, pokemon, move);
 			this.runEvent('AfterMoveSecondary', target, pokemon, move);
 		}

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -275,7 +275,7 @@ exports.BattleScripts = {
 			return true;
 		}
 
-		if (!move.negateSecondary && !(move.sheerforce && pokemon.hasAbility('sheerforce'))) {
+		if (!move.negateSecondary && !(move.hasSheerForce && pokemon.hasAbility('sheerforce'))) {
 			this.singleEvent('AfterMoveSecondarySelf', move, null, pokemon, target, move);
 			this.runEvent('AfterMoveSecondarySelf', pokemon, target, move);
 		}
@@ -518,7 +518,7 @@ exports.BattleScripts = {
 
 		this.eachEvent('Update');
 
-		if (target && !move.negateSecondary && !(move.sheerforce && pokemon.hasAbility('sheerforce'))) {
+		if (target && !move.negateSecondary && !(move.hasSheerForce && pokemon.hasAbility('sheerforce'))) {
 			this.singleEvent('AfterMoveSecondary', move, null, target, pokemon, move);
 			this.runEvent('AfterMoveSecondary', target, pokemon, move);
 		}

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -417,19 +417,6 @@ exports.BattleStatuses = {
 			return this.chainModify([0x14CD, 0x1000]);
 		},
 	},
-	aura: {
-		duration: 1,
-		onBasePowerPriority: 8,
-		onBasePower: function (basePower, user, target, move) {
-			let modifier = 0x1547;
-			this.debug('Aura Boost');
-			if (user.volatiles['aurabreak']) {
-				modifier = 0x0C00;
-				this.debug('Aura Boost reverted by Aura Break');
-			}
-			return this.chainModify([modifier, 0x1000]);
-		},
-	},
 
 	// weather is implemented here since it's so important to the game
 

--- a/mods/gen6/abilities.js
+++ b/mods/gen6/abilities.js
@@ -5,12 +5,8 @@ exports.BattleAbilities = {
 		inherit: true,
 		desc: "This Pokemon's Normal-type moves become Flying-type moves and have their power multiplied by 1.3. This effect comes after other effects that change a move's type, but before Ion Deluge and Electrify's effects.",
 		shortDesc: "This Pokemon's Normal-type moves become Flying type and have 1.3x power.",
-		effect: {
-			duration: 1,
-			onBasePowerPriority: 8,
-			onBasePower: function (basePower, pokemon, target, move) {
-				return this.chainModify([0x14CD, 0x1000]);
-			},
+		onBasePower: function (basePower, pokemon, target, move) {
+			if (move.aerilate) return this.chainModify([0x14CD, 0x1000]);
 		},
 	},
 	"aftermath": {
@@ -68,35 +64,16 @@ exports.BattleAbilities = {
 		inherit: true,
 		desc: "This Pokemon's damaging moves become multi-hit moves that hit twice. The second hit has its damage halved. Does not affect multi-hit moves or moves that have multiple targets.",
 		shortDesc: "This Pokemon's damaging moves hit twice. The second hit has its damage halved.",
-		effect: {
-			duration: 1,
-			onBasePowerPriority: 8,
-			onBasePower: function (basePower) {
-				if (this.effectData.hit) {
-					this.effectData.hit++;
-					return this.chainModify(0.5);
-				} else {
-					this.effectData.hit = 1;
-				}
-			},
-			onSourceModifySecondaries: function (secondaries, target, source, move) {
-				if (move.id === 'secretpower' && this.effectData.hit < 2) {
-					// hack to prevent accidentally suppressing King's Rock/Razor Fang
-					return secondaries.filter(effect => effect.volatileStatus === 'flinch');
-				}
-			},
+		onBasePower: function (basePower, pokemon, target, move) {
+			if (move.parentalbond && ++move.hits > 1) return this.chainModify(0.5);
 		},
 	},
 	"pixilate": {
 		inherit: true,
 		desc: "This Pokemon's Normal-type moves become Fairy-type moves and have their power multiplied by 1.3. This effect comes after other effects that change a move's type, but before Ion Deluge and Electrify's effects.",
 		shortDesc: "This Pokemon's Normal-type moves become Fairy type and have 1.3x power.",
-		effect: {
-			duration: 1,
-			onBasePowerPriority: 8,
-			onBasePower: function (basePower, pokemon, target, move) {
-				return this.chainModify([0x14CD, 0x1000]);
-			},
+		onBasePower: function (basePower, pokemon, target, move) {
+			if (move.pixilate) return this.chainModify([0x14CD, 0x1000]);
 		},
 	},
 	"prankster": {
@@ -108,12 +85,8 @@ exports.BattleAbilities = {
 		inherit: true,
 		desc: "This Pokemon's Normal-type moves become Ice-type moves and have their power multiplied by 1.3. This effect comes after other effects that change a move's type, but before Ion Deluge and Electrify's effects.",
 		shortDesc: "This Pokemon's Normal-type moves become Ice type and have 1.3x power.",
-		effect: {
-			duration: 1,
-			onBasePowerPriority: 8,
-			onBasePower: function (basePower, pokemon, target, move) {
-				return this.chainModify([0x14CD, 0x1000]);
-			},
+		onBasePower: function (basePower, pokemon, target, move) {
+			if (move.refrigerate) return this.chainModify([0x14CD, 0x1000]);
 		},
 	},
 	"roughskin": {

--- a/mods/gen6/abilities.js
+++ b/mods/gen6/abilities.js
@@ -6,7 +6,7 @@ exports.BattleAbilities = {
 		desc: "This Pokemon's Normal-type moves become Flying-type moves and have their power multiplied by 1.3. This effect comes after other effects that change a move's type, but before Ion Deluge and Electrify's effects.",
 		shortDesc: "This Pokemon's Normal-type moves become Flying type and have 1.3x power.",
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.aerilate) return this.chainModify([0x14CD, 0x1000]);
+			if (move.aerilateBoosted) return this.chainModify([0x14CD, 0x1000]);
 		},
 	},
 	"aftermath": {
@@ -65,7 +65,7 @@ exports.BattleAbilities = {
 		desc: "This Pokemon's damaging moves become multi-hit moves that hit twice. The second hit has its damage halved. Does not affect multi-hit moves or moves that have multiple targets.",
 		shortDesc: "This Pokemon's damaging moves hit twice. The second hit has its damage halved.",
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.parentalbond && ++move.hits > 1) return this.chainModify(0.5);
+			if (move.hasParentalBond && ++move.hits > 1) return this.chainModify(0.5);
 		},
 	},
 	"pixilate": {
@@ -73,7 +73,7 @@ exports.BattleAbilities = {
 		desc: "This Pokemon's Normal-type moves become Fairy-type moves and have their power multiplied by 1.3. This effect comes after other effects that change a move's type, but before Ion Deluge and Electrify's effects.",
 		shortDesc: "This Pokemon's Normal-type moves become Fairy type and have 1.3x power.",
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.pixilate) return this.chainModify([0x14CD, 0x1000]);
+			if (move.pixilateBoosted) return this.chainModify([0x14CD, 0x1000]);
 		},
 	},
 	"prankster": {
@@ -86,7 +86,7 @@ exports.BattleAbilities = {
 		desc: "This Pokemon's Normal-type moves become Ice-type moves and have their power multiplied by 1.3. This effect comes after other effects that change a move's type, but before Ion Deluge and Electrify's effects.",
 		shortDesc: "This Pokemon's Normal-type moves become Ice type and have 1.3x power.",
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.refrigerate) return this.chainModify([0x14CD, 0x1000]);
+			if (move.refrigerateBoosted) return this.chainModify([0x14CD, 0x1000]);
 		},
 	},
 	"roughskin": {


### PR DESCRIPTION
Instruct means that a Pokémon is now capable of making more than one move in a given turn, and not even the same move at that (if the Instruct happens before the Pokémon's own move then the previous move gets repeated).

This means that several effects that used to be per-turn need to be replaced with per-move flags instead, otherwise they could end up affecting both moves.

This PR deals with abilities which used to use effects but should be using per-move flags. (The other effects set by abilities all already have multiple turn duration.)

Note that Dark Aura and Fairy Aura used to be effectively unbreakable because Mold Breaker doesn't ignore the TryPrimaryHit event, and the aura effect isn't affected by Mold Breaker of course.