### PR TITLE
Gen 4 Random Battle improvements

### DIFF
--- a/mods/gen4/formats-data.js
+++ b/mods/gen4/formats-data.js
@@ -827,7 +827,7 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	xatu: {
-		randomBattleMoves: ["reflect", "lightscreen", "wish", "uturn", "calmmind", "psychic", "heatwave", "roost"],
+		randomBattleMoves: ["reflect", "lightscreen", "wish", "uturn", "calmmind", "psychic", "heatwave", "airslash", "hiddenpowerfighting", "batonpass", "trick", "roost"],
 		tier: "NU",
 	},
 	mareep: {
@@ -1736,7 +1736,7 @@ exports.BattleFormatsData = {
 		tier: "NU",
 	},
 	infernape: {
-		randomBattleMoves: ["stealthrock", "fireblast", "closecombat", "uturn", "grassknot", "stoneedge", "machpunch", "fakeout", "nastyplot", "hiddenpowerice", "flareblitz", "vacuumwave"],
+		randomBattleMoves: ["stealthrock", "fireblast", "closecombat", "uturn", "grassknot", "stoneedge", "machpunch", "focusblast", "swordsdance", "nastyplot", "hiddenpowerice", "flareblitz", "vacuumwave"],
 		tier: "OU",
 	},
 	piplup: {
@@ -1915,7 +1915,7 @@ exports.BattleFormatsData = {
 	},
 	lucario: {
 		inherit: true,
-		randomBattleMoves: ["swordsdance", "closecombat", "crunch", "extremespeed", "icepunch", "bulletpunch", "nastyplot", "aurasphere", "shadowball", "vacuumwave"],
+		randomBattleMoves: ["swordsdance", "closecombat", "crunch", "extremespeed", "icepunch", "bulletpunch", "agility", "vacuumwave"],
 		tier: "OU",
 	},
 	hippopotas: {

--- a/mods/gen4/random-teams.js
+++ b/mods/gen4/random-teams.js
@@ -208,6 +208,9 @@ class RandomGen4Teams extends RandomGen5Teams {
 				case 'doubleedge':
 					if (hasMove['bodyslam'] || hasMove['facade'] || hasMove['return']) rejected = true;
 					break;
+				case 'headbutt':
+					if (!hasMove['bodyslam'] && !hasMove['thunderwave']) rejected = true;
+					break;
 				case 'judgment':
 					if (counter.setupType !== 'Special' && counter.stab > 1) rejected = true;
 					break;
@@ -259,17 +262,15 @@ class RandomGen4Teams extends RandomGen5Teams {
 				case 'icepunch':
 					if (!counter.setupType && hasMove['icebeam']) rejected = true;
 					break;
-				case 'aurasphere': case 'drainpunch':
+				case 'aurasphere': case 'drainpunch': case 'focusblast':
 					if (hasMove['closecombat'] && counter.setupType !== 'Special') rejected = true;
 					break;
 				case 'brickbreak': case 'closecombat': case 'crosschop':
 					if (hasMove['substitute'] && hasMove['focuspunch']) rejected = true;
 					break;
-				case 'focusblast':
-					if (hasMove['crosschop']) rejected = true;
-					break;
 				case 'machpunch':
 					if (hasType['Fighting'] && counter.stab < 2 && !hasAbility['Technician']) rejected = true;
+					if (hasMove['vacuumwave'] && counter.setupType !== 'Physical') rejected = true;
 					break;
 				case 'seismictoss':
 					if (hasMove['nightshade'] || counter.Physical + counter.Special >= 1) rejected = true;
@@ -318,6 +319,9 @@ class RandomGen4Teams extends RandomGen5Teams {
 				case 'leechseed': case 'painsplit':
 					if (counter.setupType || !!counter['speedsetup'] || hasMove['moonlight'] || hasMove['rest'] || hasMove['synthesis']) rejected = true;
 					break;
+				case 'recover': case 'slackoff':
+					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					break;
 				case 'stunspore':
 					if (movePool.includes('sleeppowder') || movePool.includes('spore')) rejected = true;
 					break;
@@ -325,7 +329,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 					if (hasMove['pursuit'] || hasMove['rest'] || hasMove['taunt']) rejected = true;
 					break;
 				case 'thunderwave':
-					if (hasMove['toxic'] || hasMove['trickroom']) rejected = true;
+					if (hasMove['toxic'] || hasMove['trickroom'] || hasMove['bodyslam'] && hasAbility['Serene Grace']) rejected = true;
 					break;
 				}
 
@@ -350,8 +354,9 @@ class RandomGen4Teams extends RandomGen5Teams {
 				}
 
 				// Reject defensive status moves if a reliable recovery move is available but not selected.
-				// Toxic is only defensive if used with another status move (Toxic + 3 attacks is ok).
-				if ((!!defensiveStatusMoves[moveid] || moveid === 'toxic' && counter.Status > 1) && !moves.some(id => !!recoveryMoves[id]) && movePool.some(id => !!recoveryMoves[id])) {
+				// Toxic is only defensive if used with another status move other than Protect (Toxic + 3 attacks and Toxic + Protect are ok).
+				if ((!!defensiveStatusMoves[moveid] || moveid === 'toxic' && ((counter.Status > 1 && !hasMove['protect']) || counter.Status > 2)) &&
+					!moves.some(id => !!recoveryMoves[id]) && movePool.some(id => !!recoveryMoves[id])) {
 					rejected = true;
 				}
 
@@ -360,6 +365,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 					(hasType['Electric'] && !counter['Electric']) ||
 					(hasType['Fighting'] && !counter['Fighting'] && (counter.setupType || !counter['Status'])) ||
 					(hasType['Fire'] && !counter['Fire']) ||
+					(hasType['Flying'] && !counter['Flying'] && movePool.includes('bravebird')) ||
 					(hasType['Ground'] && !counter['Ground']) ||
 					(hasType['Ice'] && !counter['Ice'] && (!hasType['Water'] || !counter['Water'])) ||
 					(hasType['Psychic'] && !!counter['Psychic'] && !hasType['Flying'] && template.types.length > 1 && counter.stab < 2) ||
@@ -568,7 +574,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 			item = 'Lum Berry';
 		} else if (hasMove['substitute']) {
 			item = counter.damagingMoves.length < 2 ||
-				!counter['drain'] && (counter.damagingMoves.length < 3 || template.baseStats.hp < 60 && template.baseStats.def + template.baseStats.spd < 180) ? 'Leftovers' : 'Life Orb';
+				!counter['drain'] && (counter.damagingMoves.length < 3 || template.baseStats.hp >= 60 || template.baseStats.def + template.baseStats.spd >= 180) ? 'Leftovers' : 'Life Orb';
 		} else if (hasMove['lightscreen'] || hasMove['reflect']) {
 			item = 'Light Clay';
 		} else if (template.species === 'Palkia' && !!counter['Dragon'] && !!counter['Water']) {


### PR DESCRIPTION
* Fix my Substitute item check
* Relax recovery move check to allow Toxic + Protect to avoid overly aggressive rejecting
* Fix Lucario's movepool (it cannot learn Nasty Plot in Gen 4)
* Various other minor improvements