### PR TITLE
Fix remaining custom format issues

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2496,20 +2496,10 @@ exports.commands = {
 				if (lock['battles']) return this.errorReply(`Hot-patching battles has been disabled by ${lock['battles'].by} (${lock['battles'].reason})`);
 				if (lock['validator']) return this.errorReply(`Hot-patching the validator has been disabled by ${lock['validator'].by} (${lock['validator'].reason})`);
 
-				// store custom formats
-				let customFormats = {};
-				for (let i in Dex.data.Formats) {
-					if (!Dex.data.Formats[i].customBanlist) continue;
-					customFormats[i] = {name: Dex.data.Formats[i].name, customBanlist: Dex.data.Formats[i].customBanlist};
-				}
 				// uncache the sim/dex.js dependency tree
 				Chat.uncacheTree('./sim/dex');
 				// reload sim/dex.js
 				global.Dex = require('./sim/dex'); // note: this will lock up the server for a few seconds
-				// rebuild custom formats
-				for (let i in customFormats) {
-					Dex.getFormat(customFormats[i].name, customFormats[i].customBanlist, i);
-				}
 				// rebuild the formats list
 				delete Rooms.global.formatList;
 				// respawn validator processes

--- a/room-battle.js
+++ b/room-battle.js
@@ -322,15 +322,15 @@ class BattleTimer {
 }
 
 class Battle {
-	constructor(room, format, rated) {
-		format = Dex.getFormat(format);
+	constructor(room, formatid, rated) {
+		let format = Dex.getFormat(formatid);
 		this.id = room.id;
 		this.room = room;
 		this.title = format.name;
 		if (!this.title.endsWith(" Battle")) this.title += " Battle";
 		this.allowRenames = !rated;
 
-		this.format = format.id;
+		this.format = formatid;
 		this.rated = rated;
 		this.started = false;
 		this.ended = false;
@@ -353,7 +353,6 @@ class Battle {
 		// data to be logged
 		this.logData = null;
 		this.endType = 'normal';
-		this.customBanlist = !!format.customBanlist;
 
 		this.rqid = 1;
 
@@ -362,7 +361,7 @@ class Battle {
 			throw new Error(`Battle with ID ${room.id} already exists.`);
 		}
 
-		this.send('init', this.format, rated ? '1' : '', format.customBanlist ? format.customBanlist.join(',') : '');
+		this.send('init', this.format, rated ? '1' : '');
 		this.process.pendingTasks.set(room.id, this);
 	}
 
@@ -740,7 +739,7 @@ if (process.send && module === process.mainModule) {
 			const id = data[0];
 			if (!Battles.has(id)) {
 				try {
-					const battle = Sim.construct(Dex.getFormat(data[2], data[4]), data[3], sendBattleMessage);
+					const battle = Sim.construct(data[2], data[3], sendBattleMessage);
 					battle.id = id;
 					Battles.set(id, battle);
 				} catch (err) {

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -12,12 +12,13 @@ const Sim = require('./');
 
 class Battle extends Dex.ModdedDex {
 	/**
-	 * @param {object} format
+	 * @param {string} formatid
 	 * @param {boolean} rated
 	 * @param {Function} send
 	 * @param {PRNG} [maybePrng]
 	 */
-	constructor(format, rated = false, send = (() => {}), prng = new PRNG()) {
+	constructor(formatid, rated = false, send = (() => {}), prng = new PRNG()) {
+		let format = Dex.getFormat(formatid);
 		super(format.mod);
 		Object.assign(this, this.data.Scripts);
 
@@ -29,8 +30,9 @@ class Battle extends Dex.ModdedDex {
 		this.terrainData = {id:''};
 		this.pseudoWeather = {};
 
-		this.format = toId(format);
-		this.formatData = {id:this.format};
+		this.format = format.id;
+		this.formatid = formatid;
+		this.formatData = {id: format.id};
 
 		this.effect = {id:''};
 		this.effectData = {id:''};
@@ -218,7 +220,7 @@ class Battle extends Dex.ModdedDex {
 	}
 
 	getFormat(format) {
-		return super.getFormat(format || this.format);
+		return super.getFormat(format || this.formatid);
 	}
 	addPseudoWeather(status, source, sourceEffect) {
 		status = this.getEffect(status);
@@ -1412,7 +1414,7 @@ class Battle extends Dex.ModdedDex {
 		if (format.onBegin) {
 			format.onBegin.call(this);
 		}
-		this.getRuleTable(this.getFormat()).forEach((v, rule) => {
+		this.getRuleTable(format).forEach((v, rule) => {
 			if (rule.startsWith('+') || rule.startsWith('-') || rule.startsWith('!')) return;
 			if (this.getFormat(rule).exists) this.addPseudoWeather(rule);
 		});

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -460,11 +460,10 @@ class ModdedDex {
 	}
 	/**
 	 * @param {string | Format} name
-	 * @param {string | string[]} [customBanlist]
-	 * @param {string} [customId]
+	 * @param {string | string[]} [customRules]
 	 * @return {Format}
 	 */
-	getFormat(name, customBanlist, customId) {
+	getFormat(name, customRules) {
 		if (name && typeof name !== 'string') {
 			return name;
 		}
@@ -475,38 +474,69 @@ class ModdedDex {
 			id = toId(name);
 		}
 		let effect;
-		if (this.data.Formats.hasOwnProperty(id) || this.data.Formats.hasOwnProperty(name)) {
-			let format = this.data.Formats[this.data.Formats.hasOwnProperty(id) ? id : name];
-			if (customBanlist) {
-				if (typeof customBanlist === 'string') customBanlist = customBanlist.split(',');
-				let customRules = [];
-				for (let ban of customBanlist) {
+		/**@type {string[]} */
+		let sanitizedCustomRules = [];
+		if (name.includes('@@@')) {
+			let parts = name.split('@@@');
+			name = parts[0];
+			id = toId(name);
+			sanitizedCustomRules = parts[1].split(',');
+		}
+		if (this.data.Formats.hasOwnProperty(id)) {
+			let format = this.data.Formats[id];
+			if (customRules) {
+				if (typeof customRules === 'string') customRules = customRules.split(',');
+				const ruleTable = this.getRuleTable(this.getFormat(name));
+				for (let ban of customRules) {
+					ban = ban.trim();
 					let unban = false;
 					if (ban.charAt(0) === '!') {
 						unban = true;
 						ban = ban.substr(1);
 					}
+					let subformat = this.getFormat(ban);
+					if (subformat.effectType === 'ValidatorRule' || subformat.effectType === 'Rule' || subformat.effectType === 'Format') {
+						if (unban) {
+							if (ruleTable.has('!' + subformat.id)) continue;
+						} else {
+							if (ruleTable.has(subformat.id)) continue;
+						}
+						ban = 'Rule:' + subformat.name;
+					} else {
+						ban = ban.toLowerCase();
+						let baseForme = false;
+						if (ban.endsWith('-base')) {
+							baseForme = true;
+							ban = ban.substr(0, ban.length - 5);
+						}
+						let search = this.dataSearch(ban);
+						if (!search || search.length < 1) continue;
+						if (search[0].isInexact || search[0].searchType === 'nature') continue;
+						ban = search[0].name;
+						if (baseForme) ban += '-Base';
+						if (unban) {
+							if (ruleTable.has('+' + ban)) continue;
+						} else {
+							if (ruleTable.has('-' + ban)) continue;
+						}
+					}
 					if (ban.startsWith('Rule:')) {
 						ban = ban.substr(5).trim();
 						if (unban) {
-							customRules.unshift('!' + ban);
+							sanitizedCustomRules.unshift('!' + ban);
 						} else {
-							customRules.push(ban);
+							sanitizedCustomRules.push(ban);
 						}
 					} else {
 						if (unban) {
-							customRules.push('+' + ban);
+							sanitizedCustomRules.push('+' + ban);
 						} else {
-							customRules.push('-' + ban);
+							sanitizedCustomRules.push('-' + ban);
 						}
 					}
 				}
-				effect = new Data.Format({name}, format, {customRules});
-				if (customId === 'pokemon') throw new Error('wtf');
-				if (customId) this.data.Formats[customId] = format;
-			} else {
-				effect = new Data.Format({name}, format);
 			}
+			effect = new Data.Format({name}, format, sanitizedCustomRules.length ? {customRules: sanitizedCustomRules} : null);
 		} else {
 			effect = new Data.Format({name, exists: false});
 		}
@@ -861,7 +891,7 @@ class ModdedDex {
 
 	/**
 	 * @param {string} target
-	 * @param {DataType[] | null=} searchIn
+	 * @param {DataType[] | null} [searchIn]
 	 * @param {boolean=} isInexact
 	 * @return {AnyObject[] | false}
 	 */

--- a/sim/index.js
+++ b/sim/index.js
@@ -19,7 +19,6 @@ const Pokemon = require('./pokemon');
 const PRNG = require('./prng');
 
 exports.construct = function (format, rated, send, prng) {
-	format = Dex.getFormat(format);
 	return new Battle(format, rated, send, prng);
 };
 

--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -46,7 +46,7 @@ class Tournament {
 		this.format = format;
 		this.originalFormat = format;
 		this.teambuilderFormat = format;
-		this.banlist = [];
+		this.customRules = [];
 		this.generator = generator;
 		this.isRated = isRated;
 		this.scouting = true;
@@ -115,35 +115,39 @@ class Tournament {
 		return true;
 	}
 
-	setBanlist(banlist, output) {
+	setCustomRules(rules, output) {
 		let format = Dex.getFormat(this.originalFormat);
 		if (format.team) {
-			output.errorReply(format.name + " does not support custom banlists.");
+			output.errorReply(format.name + " does not support custom rules.");
 			return false;
 		}
-		if (this.teambuilderFormat === this.originalFormat) this.teambuilderFormat = 'customgame-' + this.room.id + '-' + this.room.tourNumber;
-		Dex.getFormat(this.originalFormat, banlist, this.teambuilderFormat);
-		this.banlist = banlist;
+		format = Dex.getFormat(this.originalFormat, rules);
+		if (!format.customRules) {
+			output.errorReply("The specified rules are invalid or already included in " + format.name + ".");
+			return false;
+		}
+		this.teambuilderFormat = this.originalFormat + '@@@' + format.customRules.join(',');
+		this.customRules = format.customRules;
 		return true;
 	}
 
-	getBanlist() {
+	getCustomRules() {
 		let bans = [];
 		let unbans = [];
 		let addedRules = [];
 		let removedRules = [];
-		for (let i = 0; i < this.banlist.length; i++) {
-			let ban = this.banlist[i];
-			let unban = false;
-			if (ban.charAt(0) === '!') {
-				unban = true;
-				ban = ban.substr(1);
-			}
-			if (ban.startsWith('Rule:')) {
-				ban = ban.substr(5);
-				(unban ? removedRules : addedRules).push(ban);
+		for (let i = 0; i < this.customRules.length; i++) {
+			let ban = this.customRules[i];
+			let charAt0 = ban.charAt(0);
+			ban = ban.substr(1);
+			if (charAt0 === '+') {
+				unbans.push(ban);
+			} else if (charAt0 === '-') {
+				bans.push(ban);
+			} else if (charAt0 === '!') {
+				removedRules.push(ban);
 			} else {
-				(unban ? unbans : bans).push(ban);
+				addedRules.push(ban);
 			}
 		}
 		let html = [];
@@ -712,7 +716,7 @@ class Tournament {
 		this.isAvailableMatchesInvalidated = true;
 		this.update();
 
-		user.prepBattle(this.teambuilderFormat, 'tournament', user, this.banlist).then(validTeam => this.finishChallenge(user, to, output, validTeam));
+		user.prepBattle(this.teambuilderFormat, 'tournament', user).then(validTeam => this.finishChallenge(user, to, output, validTeam));
 	}
 	finishChallenge(user, to, output, validTeam) {
 		let from = this.players[user.userid];
@@ -775,7 +779,7 @@ class Tournament {
 		let challenge = this.pendingChallenges.get(player);
 		if (!challenge || !challenge.from) return;
 
-		user.prepBattle(this.teambuilderFormat, 'tournament', user, this.banlist).then(validTeam => this.finishAcceptChallenge(user, challenge, validTeam));
+		user.prepBattle(this.teambuilderFormat, 'tournament', user).then(validTeam => this.finishAcceptChallenge(user, challenge, validTeam));
 	}
 	finishAcceptChallenge(user, challenge, validTeam) {
 		if (validTeam === false) return;
@@ -1010,7 +1014,7 @@ let commands = {
 			if (Monitor.countPrepBattle(connection.ip, connection)) {
 				return;
 			}
-			TeamValidator(tournament.teambuilderFormat, tournament.banlist).prepTeam(user.team).then(result => {
+			TeamValidator(tournament.teambuilderFormat).prepTeam(user.team).then(result => {
 				if (result.charAt(0) === '1') {
 					connection.popup("Your team is valid for this tournament.");
 				} else {
@@ -1019,13 +1023,15 @@ let commands = {
 				}
 			});
 		},
-		viewruleset: 'viewbanlist',
-		viewbanlist: function (tournament) {
+		viewruleset: 'viewcustomrules',
+		viewbanlist: 'viewcustomrules',
+		viewrules: 'viewcustomrules',
+		viewcustomrules: function (tournament) {
 			if (!this.runBroadcast()) return;
-			if (tournament.banlist.length < 1) {
-				return this.errorReply("The tournament's banlist is empty.");
+			if (tournament.customRules.length < 1) {
+				return this.errorReply("The tournament does not have any custom rules.");
 			}
-			this.sendReplyBox("This tournament includes:<br />" + tournament.getBanlist());
+			this.sendReplyBox("This tournament includes:<br />" + tournament.getCustomRules());
 		},
 	},
 	creation: {
@@ -1056,31 +1062,35 @@ let commands = {
 				this.privateModCommand("(" + user.name + " forcibly ended a tournament.)");
 			}
 		},
-		ruleset: 'banlist',
-		banlist: function (tournament, user, params, cmd) {
+		ruleset: 'customrules',
+		banlist: 'customrules',
+		rules: 'customrules',
+		customrules: function (tournament, user, params, cmd) {
 			if (params.length < 1) {
 				return this.sendReply("Usage: " + cmd + " <comma-separated arguments>");
 			}
 			if (tournament.isTournamentStarted) {
-				return this.errorReply("The banlist cannot be changed once the tournament has started.");
+				return this.errorReply("The custom rules cannot be changed once the tournament has started.");
 			}
-			if (tournament.setBanlist(params, this)) {
-				this.room.addRaw("<div class='infobox'>This tournament includes:<br />" + tournament.getBanlist() + "</div>");
-				this.privateModCommand("(" + user.name + " set the tournament's banlist to " + tournament.banlist.join(", ") + ".)");
+			if (tournament.setCustomRules(params, this)) {
+				this.room.addRaw("<div class='infobox'>This tournament includes:<br />" + tournament.getCustomRules() + "</div>");
+				this.privateModCommand("(" + user.name + " set the tournament's custom rules to " + tournament.customRules.join(", ") + ".)");
 			}
 		},
-		clearruleset: 'clearbanlist',
-		clearbanlist: function (tournament, user) {
+		clearruleset: 'clearcustomrules',
+		clearbanlist: 'clearcustomrules',
+		clearrules: 'clearcustomrules',
+		clearcustomrules: function (tournament, user) {
 			if (tournament.isTournamentStarted) {
-				return this.errorReply("The banlist cannot be changed once the tournament has started.");
+				return this.errorReply("The custom rules cannot be changed once the tournament has started.");
 			}
-			if (tournament.banlist.length < 1) {
-				return this.errorReply("The tournament's banlist is already empty.");
+			if (tournament.customRules.length < 1) {
+				return this.errorReply("The tournament does not have any custom rules.");
 			}
-			tournament.banlist = [];
+			tournament.customRules = [];
 			tournament.teambuilderFormat = tournament.originalFormat;
-			this.room.addRaw("<b>The tournament's banlist was cleared.</b>");
-			this.privateModCommand("(" + user.name + " cleared the tournament's banlist.)");
+			this.room.addRaw("<b>The tournament's custom rules were cleared.</b>");
+			this.privateModCommand("(" + user.name + " cleared the tournament's custom rules.)");
 		},
 		name: 'setname',
 		customname: 'setname',
@@ -1436,9 +1446,9 @@ Chat.commands.tournamenthelp = function (target, room, user) {
 	return this.sendReplyBox(
 		"- create/new &lt;format>, &lt;type> [, &lt;comma-separated arguments>]: Creates a new tournament in the current room.<br />" +
 		"- settype &lt;type> [, &lt;comma-separated arguments>]: Modifies the type of tournament after it's been created, but before it has started.<br />" +
-		"- banlist &lt;comma-separated arguments>: Sets the custom banlist for the tournament before it has started.<br />" +
-		"- viewbanlist: Shows the custom banlist for the tournament.<br />" +
-		"- clearbanlist: Clears the custom banlist for the tournament before it has started.<br />" +
+		"- rules/banlist &lt;comma-separated arguments>: Sets the custom rules for the tournament before it has started.<br />" +
+		"- viewrules/viewbanlist: Shows the custom rules for the tournament.<br />" +
+		"- clearrules/clearbanlist: Clears the custom rules for the tournament before it has started.<br />" +
 		"- name &lt;name>: Sets a custom name for the tournament.<br />" +
 		"- clearname: Clears the custom name of the tournament.<br />" +
 		"- end/stop/delete: Forcibly ends the tournament in the current room.<br />" +

--- a/users.js
+++ b/users.js
@@ -1245,7 +1245,7 @@ class User {
 			this.inRooms.delete(room.id);
 		}
 	}
-	prepBattle(formatid, type, connection, customBanlist) {
+	prepBattle(formatid, type, connection) {
 		// all validation for a battle goes through here
 		if (!connection) connection = this;
 		if (!type) type = 'challenge';
@@ -1275,7 +1275,7 @@ class User {
 			connection.popup(`You are already searching a battle in that format.`);
 			return Promise.resolve(false);
 		}
-		return TeamValidator(formatid, customBanlist).prepTeam(this.team, this.locked || this.namelocked).then(result => this.finishPrepBattle(connection, result));
+		return TeamValidator(formatid).prepTeam(this.team, this.locked || this.namelocked).then(result => this.finishPrepBattle(connection, result));
 	}
 
 	/**


### PR DESCRIPTION
Rules for custom formats are once again sanitized and can be passed around more easily by attaching them to the format's id.

Fixes:
- "Rule:" being required to add or remove a rule
- ruleset changes not being shown in battles
- the display of custom rules being affected by user input
- custom formats being broken by /hotpatch formats