### PR TITLE
Hide Gen 4 abilities when giving details for Gen 3

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1151,7 +1151,7 @@ Chat.getDataPokemonHTML = function (template, gen = 7) {
 	buf += '</span> ';
 	if (gen >= 3) {
 		buf += '<span style="float:left;min-height:26px">';
-		if (template.abilities['1']) {
+		if (template.abilities['1'] && (gen >= 4 || Dex.getAbility(template.abilities['1']).gen === 3)) {
 			buf += '<span class="col twoabilitycol">' + template.abilities['0'] + '<br />' + template.abilities['1'] + '</span>';
 		} else {
 			buf += '<span class="col abilitycol">' + template.abilities['0'] + '</span>';


### PR DESCRIPTION
Apparently according to https://github.com/Zarel/Pokemon-Showdown/commit/54f957875ee7f2e2c4a6fb3db9da2ef5c96f72af#diff-0b2efe2973c1ca6e59a67d6ffe5516daR9 the teambuilder needs Gen 3 templates to include Gen 4 abilities, but we don't want e.g. `/dt Machamp, Gen3` to show it having the No Guard Ability, which it didn't get until Gen 4.