### PR TITLE
Modlog: Fix user search for names with certain non-alphanum characters

### DIFF
--- a/chat-plugins/modlog.js
+++ b/chat-plugins/modlog.js
@@ -174,7 +174,7 @@ async function runModlog(rooms, searchString, exactSearch, maxLines) {
 		regexString = searchString.replace(/[\\.+*?()|[\]{}^$]/g, '\\$&');
 	} else {
 		searchString = toId(searchString);
-		regexString = `\\b${searchString.split('').join('[\\W_]*')}\\b`;
+		regexString = `[^a-zA-Z0-9]${searchString.split('').join('[^a-zA-Z0-9]*')}[^a-zA-Z0-9]`;
 	}
 
 	let results = new SortedLimitedLengthList(maxLines);


### PR DESCRIPTION
ripgrep's regular expressions consider ッ to be a word character, for example, so rg modlog's username search for "test" won't find the modlog entry "testッ" despite both being the same userid.
Not sure if this is the best solution, but it should work independently of regex flavor.