### PR TITLE
Fix gen 2 Hidden Power base power formula

### DIFF
--- a/sim/dex.js
+++ b/sim/dex.js
@@ -686,7 +686,7 @@ class ModdedDex {
 			const spcDV = Math.floor(ivs.spa / 2);
 			return {
 				type: hpTypes[4 * (atkDV % 4) + (defDV % 4)],
-				power: Math.floor((5 * ((spcDV >> 3) + (2 * (speDV >> 3)) + (4 * (defDV >> 3)) + (8 * (atkDV >> 3))) + (spcDV > 2 ? 3 : spcDV)) / 2 + 31),
+				power: Math.floor((5 * ((spcDV >> 3) + (2 * (speDV >> 3)) + (4 * (defDV >> 3)) + (8 * (atkDV >> 3))) + (spcDV % 4)) / 2 + 31),
 			};
 		} else {
 			// Hidden Power check for gen 3 onwards


### PR DESCRIPTION
Before : HP_Power=(5*(v+2w+4x+8y)+min(Z, 3))/2 + 31 
After: HP_Power=(5*(v+2w+4x+8y)+(Z % 4))/2 + 31 

where 
* v is 1 if SpcIV>=8; otherwise 0, 
* w is 1 if SpeIV>=8; otherwise 0, 
* x is 1 if DefIV>=8; otherwise 0, 
* y is 1 if AtkIV>=8; otherwise 0, 
* Z = SpcIV

See: 
http://tasvideos.org/forum/viewtopic.php?p=361950#361950
https://github.com/pret/pokecrystal/blob/master/battle/hidden_power.asm#L52