### PR TITLE
UNO: Fix endgame

### DIFF
--- a/chat-plugins/uno.js
+++ b/chat-plugins/uno.js
@@ -277,7 +277,7 @@ class UNOgame extends Rooms.RoomGame {
 	}
 
 	onDraw(user) {
-		if (this.currentPlayer !== user.userid || this.state !== 'play') return false;
+		if (this.currentPlayer !== user.userid || this.state !== 'play' || user.userid === this.awaitUno) return false;
 		if (this.players[user.userid].cardLock) return true;
 
 		this.onCheckUno();
@@ -291,7 +291,7 @@ class UNOgame extends Rooms.RoomGame {
 	}
 
 	onPlay(user, cardName) {
-		if (this.currentPlayer !== user.userid || this.state !== 'play') return false;
+		if (this.currentPlayer !== user.userid || this.state !== 'play' || user.userid === this.awaitUno) return false;
 		let player = this.players[user.userid];
 
 		let card = player.hasCard(cardName);


### PR DESCRIPTION
Basically a user gets to play two legal cards at two cards (if played under 750 ms I believe) which ends the game.
What this basically does is  prevents a user to play or draw a card when needs to call UNO.