### PR TITLE
Misty Terrain shouldn't -activate for secondary confusion

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -10558,7 +10558,7 @@ exports.BattleMovedex = {
 			},
 			onSetStatus: function (status, target, source, effect) {
 				if (!target.isGrounded() || target.isSemiInvulnerable()) return;
-				if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
+				if (effect && effect.status) {
 					this.add('-activate', target, 'move: Misty Terrain');
 				}
 				return false;
@@ -10566,7 +10566,7 @@ exports.BattleMovedex = {
 			onTryAddVolatile: function (status, target, source, effect) {
 				if (!target.isGrounded() || target.isSemiInvulnerable()) return;
 				if (status.id === 'confusion') {
-					this.add('-activate', target, 'move: Misty Terrain');
+					if (!effect.secondaries) this.add('-activate', target, 'move: Misty Terrain');
 					return null;
 				}
 			},


### PR DESCRIPTION
For example, if Chatot uses Chatter on a grounded Pokémon, then the confusion secondary should just be silently ignored, as it would be for e.g. Safeguard or the Ability Own Tempo.

I also copied the status check from the Ability Leaf Guard as it's much simpler. (The Ability Synchronize uses a custom effect object when setting status.)