### PR TITLE
Matchmaker: Typescript, fix crash in Matchmaker#cancelSearch on hotpatch

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2467,6 +2467,7 @@ exports.commands = {
 					}
 				}
 
+				let searches = new Map(require('./ladders-matchmaker').matchmaker.searches);
 				Chat.uncacheTree('./chat');
 				delete require.cache[require.resolve('./chat-commands')];
 				delete require.cache[require.resolve('./chat-plugins/info')];
@@ -2476,14 +2477,17 @@ exports.commands = {
 				Chat.uncacheTree('./tournaments');
 				global.Tournaments = require('./tournaments');
 				Tournaments.tournaments = runningTournaments;
+				require('./ladders-matchmaker').matchmaker.searches = searches;
 				this.sendReply("Chat commands have been hot-patched.");
 			} else if (target === 'tournaments') {
 				if (lock['tournaments']) return this.errorReply(`Hot-patching tournaments has been disabled by ${lock['tournaments'].by} (${lock['tournaments'].reason})`);
 
+				let searches = new Map(require('./ladders-matchmaker').matchmaker.searches);
 				let runningTournaments = Tournaments.tournaments;
 				Chat.uncacheTree('./tournaments');
 				global.Tournaments = require('./tournaments');
 				Tournaments.tournaments = runningTournaments;
+				require('./ladders-matchmaker').matchmaker.searches = searches;
 				this.sendReply("Tournaments have been hot-patched.");
 			} else if (target === 'battles') {
 				if (lock['battles']) return this.errorReply(`Hot-patching battles has been disabled by ${lock['battles'].by} (${lock['battles'].reason})`);

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -9,7 +9,7 @@ let toId = Dex.toId;
 // let Sim = require('../sim');
 
 let LoginServer = require('../loginserver');
-let Ladders = (Config.remoteladder ? '../ladders-remote' : '../ladders');
+let Ladders = require(Config.remoteladder ? '../ladders-remote' : '../ladders');
 let Users = require('../users');
 type Connection = any;
 type User = any;

--- a/test/application/ladders-matchmaker.js
+++ b/test/application/ladders-matchmaker.js
@@ -149,13 +149,13 @@ describe('Matchmaker', function () {
 		it('should prevent battles from starting if either player is no longer a user', function () {
 			this.p2 = destroyPlayer(this.p2);
 			let room = matchmaker.startBattle(this.p1, this.p2, FORMATID, this.s1.team, this.s2.team, {rated: 1000});
-			assert.strictEqual(room, undefined);
+			assert.strictEqual(room, null);
 		});
 
 		it('should prevent battles from starting if both players are identical', function () {
 			Object.assign(this.s2, this.s1);
 			let room = matchmaker.startBattle(this.p1, this.p2, FORMATID, this.s1.team, this.s2.team, {rated: 1000});
-			assert.strictEqual(room, undefined);
+			assert.strictEqual(room, null);
 		});
 
 		before(function () {
@@ -170,7 +170,7 @@ describe('Matchmaker', function () {
 
 		it('should prevent battles from starting if the server is in lockdown', function () {
 			let room = matchmaker.startBattle(this.p1, this.p2, FORMATID, this.s1.team, this.s2.team, {rated: 1000});
-			assert.strictEqual(room, undefined);
+			assert.strictEqual(room, null);
 		});
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "./sim/prng.js",
         "./crashlogger.js",
         "./dnsbl.js",
+        "./ladders-matchmaker.js",
         "./monitor.js",
         "./repl.js",
         "./fs.js",


### PR DESCRIPTION
Hotpatching chat and tournaments would clear the matchmaker's searches
map, causing Matchmaker#cancelSearch to crash, since the users would
still appear as searching for a battle according to user.searching.
This keeps a cache of matchmaker.searches and replaces the map after
hotpatching to prevent the crash from happening.

Matchmaker#searchBattle is also an async method now to make it wait for
Promise.all to have fulfilled before returning.