### PR TITLE
Locked symbol: Use unicode code point

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -405,7 +405,7 @@ exports.grouplist = [
 	{
 		name: 'Locked',
 		id: 'locked',
-		symbol: '‽',
+		symbol: '\u203d',
 		punishgroup: 'LOCK',
 	},
 	{

--- a/users.js
+++ b/users.js
@@ -246,7 +246,7 @@ function cacheGroupData() {
 		punishgroups.locked = {
 			name: 'Locked',
 			id: 'locked',
-			symbol: '‽',
+			symbol: '\u203d',
 		};
 	}
 	if (!punishgroups.muted) {
@@ -448,7 +448,7 @@ class User {
 	}
 	getIdentity(roomid) {
 		if (this.locked || this.namelocked) {
-			const lockedSymbol = (Config.punishgroups && Config.punishgroups.locked ? Config.punishgroups.locked.symbol : '‽');
+			const lockedSymbol = (Config.punishgroups && Config.punishgroups.locked ? Config.punishgroups.locked.symbol : '\u203d');
 			return lockedSymbol + this.name;
 		}
 		if (roomid && roomid !== 'global') {


### PR DESCRIPTION
This should use the unicode instead of the actual character itself for the same reason the player rank does - some text editors don't like unicode and will override this with an actual question mark.