### PR TITLE
UNO: fix playing 2 cards during UNO

### DIFF
--- a/chat-plugins/uno.js
+++ b/chat-plugins/uno.js
@@ -225,6 +225,7 @@ class UNOgame extends Rooms.RoomGame {
 		return new Promise((resolve, reject) => {
 			if (!this.awaitUno) return resolve();
 
+			this.state = "uno";
 			// the throttle for sending messages is at 600ms for non-authed users,
 			// wait 750ms before sending the next person's turn.
 			// this allows games to be fairer, so the next player would not spam the pass command blindly


### PR DESCRIPTION
Add a new "uno" state (that does absolutely nothing except define what is going on), so that the previous player can't play their last card during the 750ms grace period for the player to slap the UNO button.

Credits to PS user "Java SE Runtime" for catching this