### PR TITLE
Fix mismatched team complex ban messages

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -83,10 +83,10 @@ class Validator {
 			}
 			if (limit && count > limit) {
 				const clause = source ? ` by ${source}` : ``;
-				problems.push(`Your team has the combination of ${rule}, which is banned${clause}.`);
+				problems.push(`You are limited to ${limit} of ${rule}${clause}.`);
 			} else if (!limit && count >= bans.length) {
 				const clause = source ? ` by ${source}` : ``;
-				problems.push(`You are limited to ${limit} of ${rule}${clause}.`);
+				problems.push(`Your team has the combination of ${rule}, which is banned${clause}.`);
 			}
 		}
 


### PR DESCRIPTION
So instead of saying 

- You are limited to 0 of Drizzle ++ Swift Swim.

it now says

- Your team has the combination of Drizzle ++ Swift Swim, which is banned.

which is slightly closer to what it said before d79e348, which was

- Your team has the combination of Drizzle + Swift Swim, which is banned.