### PR TITLE
 Fix choice lock for the combined Pledge move

### DIFF
--- a/data/statuses.js
+++ b/data/statuses.js
@@ -283,7 +283,7 @@ exports.BattleStatuses = {
 	},
 	choicelock: {
 		onStart: function (pokemon) {
-			if (!this.activeMove.id || this.activeMove.sourceEffect && this.activeMove.sourceEffect !== this.activeMove.id) return false;
+			if (!this.activeMove.id || this.activeMove.hasBounced) return false;
 			this.effectData.move = this.activeMove.id;
 		},
 		onBeforeMove: function (pokemon, target, move) {


### PR DESCRIPTION
The original problem with choice lock was that it locked you in to a move that your Magic Bounce bounced. This was hacked around in 08792b1 by checking whether the move had a source effect. (Pursuit has a source effect when it triggers on the foe switching, so an additional hack was added to cope with that case.) Pledge moves also get a source effect when they combine, so this is why they currently don't get choice locked. Instead, we can just directly check whether the move has bounced in the first place.