### PR TITLE
Random Doubles: Fix Persian-Alola Typo

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -648,7 +648,7 @@ exports.BattleFormatsData = {
 	},
 	persianalola: {
 		randomBattleMoves: ["nastyplot", "darkpulse", "powergem", "hypnosis", "hiddenpowerfighting"],
-		randomDoublesBattleMoves: ["fakeout", "foulplay", "darkpulse", "powergem", "snarl", "hiddenpowerfighting", "partingshot", "protect"],
+		randomDoubleBattleMoves: ["fakeout", "foulplay", "darkpulse", "powergem", "snarl", "hiddenpowerfighting", "partingshot", "protect"],
 		tier: "PU",
 	},
 	psyduck: {


### PR DESCRIPTION
I saw Persian-Alola had randomDoublesBattleMoves rather than randomDoubleBattleMoves