### PR TITLE
Automatically detect name of Node.js binary when using ./pokemon-showdown

### DIFF
--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -1,5 +1,22 @@
-#!/usr/bin/env node
-'use strict';
+#!/bin/sh
+
+true /*
+# Shell script will interpret above as a command and execute everything after
+# it, while JavaScript will interpret this as beginning of a comment and skip
+# shell script contents.
+#
+# As shell script parses lines only when they are needed, nothing after exit 1
+# can possibly cause a syntax error.
+
+if command -v node > /dev/null 2>&1; then
+	exec node "$0" "$*"
+fi
+if command -v nodejs > /dev/null 2>&1; then
+	exec nodejs "$0" "$*"
+fi
+echo "We require Node.js version 8 or later; Node.js not found"
+exit 1
+*/;
 
 const child_process = require('child_process');
 const fs = require('fs');

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -9,10 +9,10 @@ true /*
 # can possibly cause a syntax error.
 
 if command -v node > /dev/null 2>&1; then
-	exec node "$0" "$*"
+	exec node "$0" "$@"
 fi
 if command -v nodejs > /dev/null 2>&1; then
-	exec nodejs "$0" "$*"
+	exec nodejs "$0" "$@"
 fi
 echo "We require Node.js version 8 or later; Node.js not found"
 exit 1

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -8,11 +8,8 @@ true /*
 # As shell script parses lines only when they are needed, nothing after exit 1
 # can possibly cause a syntax error.
 
-if command -v node > /dev/null 2>&1; then
-	exec node "$0" "$@"
-fi
-if command -v nodejs > /dev/null 2>&1; then
-	exec nodejs "$0" "$@"
+if nodepath="$(command -v node || command -v nodejs)"; then
+	exec "$nodepath" "$0" "$@"
 fi
 echo "We require Node.js version 8 or later; Node.js not found"
 exit 1


### PR DESCRIPTION
In Ubuntu, the binary is called nodejs. In order to support this possibility, ./pokemon-showdown script was changed into shell/Node.js [polyglot](https://en.wikipedia.org/wiki/Polyglot_(computing)) which calls the correct Node.js binary or informs that Node.js is not installed.

Should fix #3997.