### PR TITLE
Fix breakage with node-static 0.7.9 and mime 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "optionalDependencies": {
     "cloud-env": "0.2.2",
-    "node-static": "0.7.9"
+    "node-static": "0.7.10"
   },
   "nonDefaultDependencies": {
     "nodemailer": "4.0.1",


### PR DESCRIPTION
mime 2 broke node-static 0.7.9, update to 0.7.10 fixes this