### PR TITLE
Dexsearch: fix maxgen parameter

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -127,6 +127,7 @@ exports.commands = {
 		"Parameters can be excluded through the use of '!', e.g., '!water type' excludes all water types.",
 		"The parameter 'mega' can be added to search for Mega Evolutions only, and the parameter 'NFE' can be added to search not-fully evolved Pok\u00e9mon only.",
 		"Parameters separated with '|' will be searched as alternatives for each other, e.g., 'trick | switcheroo' searches for all Pok\u00e9mon that learn either Trick or Switcheroo.",
+		"You can search for info in a specific generation by appending the generation to ds, e.g. '/ds1 normal' searches for all Pok\u00e9mon that were normal type in Generation I",
 		"The order of the parameters does not matter.",
 	],
 

--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -640,7 +640,7 @@ function runDexsearch(target, cmd, canAll, message) {
 	for (let pokemon in mod.data.Pokedex) {
 		let template = mod.getTemplate(pokemon);
 		let megaSearchResult = (megaSearch === null || (megaSearch === true && template.isMega) || (megaSearch === false && !template.isMega));
-		if (template.tier !== 'Unreleased' && template.tier !== 'Illegal' && (!template.tier.startsWith("CAP") || capSearch) && megaSearchResult) {
+		if ((maxGen === 0 || template.gen <= maxGen) && template.tier !== 'Unreleased' && template.tier !== 'Illegal' && (!template.tier.startsWith("CAP") || capSearch) && megaSearchResult) {
 			dex[pokemon] = template;
 		}
 	}


### PR DESCRIPTION
So that searching for gen1 mons doesn't give the rest of the gens too.