### PR TITLE
Work towards making Illusion less confusing for the client

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -60,6 +60,13 @@ exports.BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Pokemon',
 		desc: ["The foundational rules for any and all formats based on in-game mechanics (everything but Custom Game)"],
+		onStart: function () {
+			let ruleTable = this.getRuleTable(this.getFormat());
+			let legality = [];
+			if (!ruleTable.has('speciesclause')) legality.push('nospeciesclause');
+			if (ruleTable.has('ignoreillegalabilities') || !ruleTable.has('-illegal')) legality.push('hackmons');
+			if (legality.length) this.add('legality', legality.join(','));
+		},
 		onValidateTeam: function (team, format) {
 			let problems = [];
 			if (team.length > 6) problems.push('Your team has more than six Pok\u00E9mon.');


### PR DESCRIPTION
This pullreq is in two steps. First is to tell the client what the Illusioned Pokemon was before Illusion broke, so it can deal with that. The second is to tell the client what is legal in the battle.