### PR TITLE
Conversion of for...length loops in top-level js files to for...of loops

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -133,7 +133,7 @@ exports.commands = {
 		if (target.includes(separator)) {
 			const params = target.split(separator);
 			let output = [];
-			for (let param of params) {
+			for (const param of params) {
 				output.push(Chat.escapeHTML(param));
 			}
 			let code = `<div class="chat"><code style="white-space: pre-wrap; display: table">${output.join('<br />')}</code></div>`;
@@ -1275,7 +1275,7 @@ exports.commands = {
 		}
 		if (targetId === user.userid || user.can('makeroom')) {
 			innerBuffer = [];
-			for (let chatRoom of Rooms.global.chatRooms) {
+			for (const chatRoom of Rooms.global.chatRooms) {
 				if (!chatRoom.auth || !chatRoom.isPrivate) continue;
 				if (chatRoom.isPrivate !== true) continue;
 				let auth = chatRoom.auth[targetId];
@@ -1375,7 +1375,7 @@ exports.commands = {
 		if (targets.length > 11 || connection.inRooms.size > 1) return;
 		Rooms.global.autojoinRooms(user, connection);
 		let autojoins = [];
-		for (let target of targets) {
+		for (const target of targets) {
 			if (user.tryJoinRoom(target, connection) === null) {
 				autojoins.push(target);
 			}
@@ -1743,8 +1743,8 @@ exports.commands = {
 			affected = affected.slice(1).map(user => user.getLastName()).filter(alt => alt.substr(0, 7) !== '[Guest ');
 			guests -= affected.length;
 			this.privateModCommand("(" + name + "'s " + (acAccount ? " ac account: " + acAccount + ", " : "") + "banned alts: " + affected.join(", ") + (guests ? " [" + guests + " guests]" : "") + ")");
-			for (let i = 0; i < affected.length; ++i) {
-				this.add('|unlink|' + toId(affected[i]));
+			for (const user of affected) {
+				this.add('|unlink|' + toId(user));
 			}
 		} else if (acAccount) {
 			this.privateModCommand("(" + name + "'s ac account: " + acAccount + ")");
@@ -2214,10 +2214,10 @@ exports.commands = {
 			this.add(`|unlink|${hidetype}${userid}`);
 
 			const alts = targetUser.getAltUsers(true);
-			for (let alt of alts) {
+			for (const alt of alts) {
 				this.add(`|unlink|${hidetype}${alt.name}`);
 			}
-			for (let name in targetUser.prevNames) {
+			for (const name in targetUser.prevNames) {
 				this.add(`|unlink|${hidetype}${targetUser.prevNames[name]}`);
 			}
 		} else {
@@ -2313,7 +2313,7 @@ exports.commands = {
 			return this.errorReply(`[${duplicates.join(', ')}] ${Chat.plural(duplicates, "are", "is")} already blacklisted.`);
 		}
 
-		for (let userid of targets) {
+		for (const userid of targets) {
 			Punishments.roomBlacklist(room, null, null, userid, reason);
 
 			let trusted = Users.isTrusted(userid);
@@ -2469,7 +2469,7 @@ exports.commands = {
 				if (lock['all']) return this.errorReply(`Hot-patching all has been disabled by ${lock['all'].by} (${lock['all'].reason})`);
 				if (Config.disablehotpatchall) return this.errorReply("This server does not allow for the use of /hotpatch all");
 
-				for (let hotpatch of hotpatches) {
+				for (const hotpatch of hotpatches) {
 					this.parse(`/hotpatch ${hotpatch}`);
 				}
 			} else if (target === 'chat' || target === 'commands') {
@@ -2951,9 +2951,9 @@ exports.commands = {
 		let memUsage = process.memoryUsage();
 		let results = [memUsage.rss, memUsage.heapUsed, memUsage.heapTotal];
 		let units = ["B", "KiB", "MiB", "GiB", "TiB"];
-		for (let result of results) {
-			let unitIndex = Math.floor(Math.log2(result) / 10); // 2^10 base log
-			result = "" + (result / Math.pow(2, 10 * unitIndex)).toFixed(2) + " " + units[unitIndex];
+		for (let i = 0; i < results.length; i++) {
+			let unitIndex = Math.floor(Math.log2(results[i]) / 10); // 2^10 base log
+			results[i] = "" + (results[i] / Math.pow(2, 10 * unitIndex)).toFixed(2) + " " + units[unitIndex];
 		}
 		this.sendReply("||[Main process] RSS: " + results[0] + ", Heap: " + results[1] + " / " + results[2]);
 	},
@@ -3592,7 +3592,7 @@ exports.commands = {
 				// Handle internal namespace commands
 				let helpCmd = targets.pop() + 'help';
 				let namespace = allCommands[targets.shift()];
-				for (let t of targets) {
+				for (const t of targets) {
 					if (!namespace[t]) return this.errorReply("Help for the command '" + target + "' was not found. Try /help for general help");
 					namespace = namespace[t];
 				}

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -133,8 +133,8 @@ exports.commands = {
 		if (target.includes(separator)) {
 			const params = target.split(separator);
 			let output = [];
-			for (let i = 0; i < params.length; i++) {
-				output.push(Chat.escapeHTML(params[i]));
+			for (let param of params) {
+				output.push(Chat.escapeHTML(param));
 			}
 			let code = `<div class="chat"><code style="white-space: pre-wrap; display: table">${output.join('<br />')}</code></div>`;
 			if (output.length > 3) code = `<details><summary>See code...</summary>${code}</details>`;
@@ -1275,13 +1275,12 @@ exports.commands = {
 		}
 		if (targetId === user.userid || user.can('makeroom')) {
 			innerBuffer = [];
-			for (let i = 0; i < Rooms.global.chatRooms.length; i++) {
-				let curRoom = Rooms.global.chatRooms[i];
-				if (!curRoom.auth || !curRoom.isPrivate) continue;
-				if (curRoom.isPrivate !== true) continue;
-				let auth = curRoom.auth[targetId];
+			for (let chatRoom of Rooms.global.chatRooms) {
+				if (!chatRoom.auth || !chatRoom.isPrivate) continue;
+				if (chatRoom.isPrivate !== true) continue;
+				let auth = chatRoom.auth[targetId];
 				if (!auth) continue;
-				innerBuffer.push(auth + curRoom.id);
+				innerBuffer.push(auth + chatRoom.id);
 			}
 			if (innerBuffer.length) {
 				buffer.push('Private room auth: ' + innerBuffer.join(', '));
@@ -1376,9 +1375,9 @@ exports.commands = {
 		if (targets.length > 11 || connection.inRooms.size > 1) return;
 		Rooms.global.autojoinRooms(user, connection);
 		let autojoins = [];
-		for (let i = 0; i < targets.length; i++) {
-			if (user.tryJoinRoom(targets[i], connection) === null) {
-				autojoins.push(targets[i]);
+		for (let target of targets) {
+			if (user.tryJoinRoom(target, connection) === null) {
+				autojoins.push(target);
 			}
 		}
 		connection.autojoins = autojoins.join(',');
@@ -2215,11 +2214,11 @@ exports.commands = {
 			this.add(`|unlink|${hidetype}${userid}`);
 
 			const alts = targetUser.getAltUsers(true);
-			for (let i = 0; i < alts.length; ++i) {
-				this.add(`|unlink|${hidetype}${alts[i].name}`);
+			for (let alt of alts) {
+				this.add(`|unlink|${hidetype}${alt.name}`);
 			}
-			for (let i in targetUser.prevNames) {
-				this.add(`|unlink|${hidetype}${targetUser.prevNames[i]}`);
+			for (let name in targetUser.prevNames) {
+				this.add(`|unlink|${hidetype}${targetUser.prevNames[name]}`);
 			}
 		} else {
 			this.addModCommand("" + targetUser.name + "'s messages were cleared from  " + room.title + " by " + user.name + ".");
@@ -2314,9 +2313,7 @@ exports.commands = {
 			return this.errorReply(`[${duplicates.join(', ')}] ${Chat.plural(duplicates, "are", "is")} already blacklisted.`);
 		}
 
-		for (let i = 0; i < targets.length; i++) {
-			let userid = targets[i];
-
+		for (let userid of targets) {
 			Punishments.roomBlacklist(room, null, null, userid, reason);
 
 			let trusted = Users.isTrusted(userid);
@@ -2472,8 +2469,8 @@ exports.commands = {
 				if (lock['all']) return this.errorReply(`Hot-patching all has been disabled by ${lock['all'].by} (${lock['all'].reason})`);
 				if (Config.disablehotpatchall) return this.errorReply("This server does not allow for the use of /hotpatch all");
 
-				for (let i = 0; i < hotpatches.length; i++) {
-					this.parse(`/hotpatch ${hotpatches[i]}`);
+				for (let hotpatch of hotpatches) {
+					this.parse(`/hotpatch ${hotpatch}`);
 				}
 			} else if (target === 'chat' || target === 'commands') {
 				if (lock['chat']) return this.errorReply(`Hot-patching chat has been disabled by ${lock['chat'].by} (${lock['chat'].reason})`);
@@ -2954,9 +2951,9 @@ exports.commands = {
 		let memUsage = process.memoryUsage();
 		let results = [memUsage.rss, memUsage.heapUsed, memUsage.heapTotal];
 		let units = ["B", "KiB", "MiB", "GiB", "TiB"];
-		for (let i = 0; i < results.length; i++) {
-			let unitIndex = Math.floor(Math.log2(results[i]) / 10); // 2^10 base log
-			results[i] = "" + (results[i] / Math.pow(2, 10 * unitIndex)).toFixed(2) + " " + units[unitIndex];
+		for (let result of results) {
+			let unitIndex = Math.floor(Math.log2(result) / 10); // 2^10 base log
+			result = "" + (result / Math.pow(2, 10 * unitIndex)).toFixed(2) + " " + units[unitIndex];
 		}
 		this.sendReply("||[Main process] RSS: " + results[0] + ", Heap: " + results[1] + " / " + results[2]);
 	},
@@ -3593,11 +3590,11 @@ exports.commands = {
 				}
 			} else if (targets.length > 1 && typeof allCommands[targets[0]] === 'object') {
 				// Handle internal namespace commands
-				let helpCmd = targets[targets.length - 1] + 'help';
-				let namespace = allCommands[targets[0]];
-				for (let i = 1; i < targets.length - 1; i++) {
-					if (!namespace[targets[i]]) return this.errorReply("Help for the command '" + target + "' was not found. Try /help for general help");
-					namespace = namespace[targets[i]];
+				let helpCmd = targets.pop() + 'help';
+				let namespace = allCommands[targets.shift()];
+				for (let t of targets) {
+					if (!namespace[t]) return this.errorReply("Help for the command '" + target + "' was not found. Try /help for general help");
+					namespace = namespace[t];
 				}
 				if (typeof namespace[helpCmd] === 'object') return this.sendReply(namespace[helpCmd].join('\n'));
 				if (typeof namespace[helpCmd] === 'function') return this.run(namespace[helpCmd]);

--- a/chat.js
+++ b/chat.js
@@ -950,14 +950,14 @@ Chat.uncacheTree = function (root) {
 	let uncache = [require.resolve(root)];
 	do {
 		let newuncache = [];
-		for (const i of uncache) {
-			if (require.cache[i]) {
+		for (let i = 0; i < uncache.length; ++i) {
+			if (require.cache[uncache[i]]) {
 				newuncache.push.apply(newuncache,
-					require.cache[i].children
+					require.cache[uncache[i]].children
 						.filter(cachedModule => !cachedModule.id.endsWith('.node'))
 						.map(cachedModule => cachedModule.id)
 				);
-				delete require.cache[i];
+				delete require.cache[uncache[i]];
 			}
 		}
 		uncache = newuncache;

--- a/chat.js
+++ b/chat.js
@@ -855,8 +855,7 @@ class CommandContext {
 		let tags = html.toLowerCase().match(/<\/?(div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code|table|td|tr)\b/g);
 		if (tags) {
 			let stack = [];
-			for (let i = 0; i < tags.length; i++) {
-				let tag = tags[i];
+			for (let tag of tags) {
 				if (tag.charAt(1) === '/') {
 					if (!stack.length) {
 						this.errorReply("Extraneous </" + tag.substr(2) + "> without an opening tag.");
@@ -951,14 +950,14 @@ Chat.uncacheTree = function (root) {
 	let uncache = [require.resolve(root)];
 	do {
 		let newuncache = [];
-		for (let i = 0; i < uncache.length; ++i) {
-			if (require.cache[uncache[i]]) {
+		for (let i of uncache) {
+			if (require.cache[i]) {
 				newuncache.push.apply(newuncache,
-					require.cache[uncache[i]].children
+					require.cache[i].children
 						.filter(cachedModule => !cachedModule.id.endsWith('.node'))
 						.map(cachedModule => cachedModule.id)
 				);
-				delete require.cache[uncache[i]];
+				delete require.cache[i];
 			}
 		}
 		uncache = newuncache;
@@ -1143,9 +1142,9 @@ Chat.parseText = function (str) {
 			continue;
 		}
 
-		for (let f = 0; f < formattingResolvers.length; f++) {
-			let start = formattingResolvers[f].token;
-			let end = formattingResolvers[f].endToken || start;
+		for (let formattingResolver of formattingResolvers) {
+			let start = formattingResolver.token;
+			let end = formattingResolver.endToken || start;
 
 			if (stack.length && end.startsWith(token) && str.substr(i, end.length) === end && output[stack.length].replace(token, '').length) {
 				for (let j = stack.length - 1; j >= 0; j--) {
@@ -1157,7 +1156,7 @@ Chat.parseText = function (str) {
 						}
 
 						let str = output.pop();
-						let outstr = formattingResolvers[f].resolver(str.trim());
+						let outstr = formattingResolver.resolver(str.trim());
 						if (!outstr) outstr = `${start}${str}${end}`;
 						output[stack.length - 1] += outstr;
 						i += end.length;
@@ -1208,8 +1207,8 @@ Chat.getDataPokemonHTML = function (template, gen = 7) {
 	buf += '<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://pokemonshowdown.com/dex/pokemon/' + template.id + '" target="_blank">' + template.species + '</a></span> ';
 	buf += '<span class="col typecol">';
 	if (template.types) {
-		for (let i = 0; i < template.types.length; i++) {
-			buf += `<img src="https://play.pokemonshowdown.com/sprites/types/${template.types[i]}.png" alt="${template.types[i]}" height="14" width="32">`;
+		for (let type of template.types) {
+			buf += `<img src="https://play.pokemonshowdown.com/sprites/types/${type}.png" alt="${type}" height="14" width="32">`;
 		}
 	}
 	buf += '</span> ';

--- a/chat.js
+++ b/chat.js
@@ -147,7 +147,7 @@ class PatternTester {
 	 * @param {string[]} elems
 	 */
 	register(...elems) {
-		for (let elem of elems) {
+		for (const elem of elems) {
 			this.elements.push(elem);
 			if (/^[^ ^$?|()[\]]+ $/.test(elem)) {
 				this.fastElements.add(this.fastNormalize(elem));
@@ -855,7 +855,7 @@ class CommandContext {
 		let tags = html.toLowerCase().match(/<\/?(div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code|table|td|tr)\b/g);
 		if (tags) {
 			let stack = [];
-			for (let tag of tags) {
+			for (const tag of tags) {
 				if (tag.charAt(1) === '/') {
 					if (!stack.length) {
 						this.errorReply("Extraneous </" + tag.substr(2) + "> without an opening tag.");
@@ -950,7 +950,7 @@ Chat.uncacheTree = function (root) {
 	let uncache = [require.resolve(root)];
 	do {
 		let newuncache = [];
-		for (let i of uncache) {
+		for (const i of uncache) {
 			if (require.cache[i]) {
 				newuncache.push.apply(newuncache,
 					require.cache[i].children
@@ -983,7 +983,7 @@ Chat.loadPlugins = function () {
 	// info always goes first so other plugins can shadow it
 	Object.assign(commands, require('./chat-plugins/info').commands);
 
-	for (let file of FS('chat-plugins/').readdirSync()) {
+	for (const file of FS('chat-plugins/').readdirSync()) {
 		if (file.substr(-3) !== '.js' || file === 'info.js') continue;
 		const plugin = require(`./chat-plugins/${file}`);
 
@@ -1142,7 +1142,7 @@ Chat.parseText = function (str) {
 			continue;
 		}
 
-		for (let formattingResolver of formattingResolvers) {
+		for (const formattingResolver of formattingResolvers) {
 			let start = formattingResolver.token;
 			let end = formattingResolver.endToken || start;
 
@@ -1207,7 +1207,7 @@ Chat.getDataPokemonHTML = function (template, gen = 7) {
 	buf += '<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://pokemonshowdown.com/dex/pokemon/' + template.id + '" target="_blank">' + template.species + '</a></span> ';
 	buf += '<span class="col typecol">';
 	if (template.types) {
-		for (let type of template.types) {
+		for (const type of template.types) {
 			buf += `<img src="https://play.pokemonshowdown.com/sprites/types/${type}.png" alt="${type}" height="14" width="32">`;
 		}
 	}

--- a/dnsbl.js
+++ b/dnsbl.js
@@ -84,9 +84,9 @@ Dnsbl.query = function queryDnsbl(ip) {
 Dnsbl.ipToNumber = function (ip) {
 	let num = 0;
 	let parts = ip.split('.');
-	for (let i = 0, len = parts.length; i < len; i++) {
+	for (let part of parts) {
 		num *= 256;
-		num += parseInt(parts[i]);
+		num += parseInt(part);
 	}
 	return num;
 };
@@ -169,8 +169,7 @@ Dnsbl.rangeToPattern = function (range) {
  * @return {boolean}
  */
 Dnsbl.checkPattern = function (patterns, num) {
-	for (let i = 0; i < patterns.length; ++i) {
-		let pattern = patterns[i];
+	for (let pattern of patterns) {
 		if (num >= pattern[0] && num <= pattern[1]) {
 			return true;
 		}

--- a/dnsbl.js
+++ b/dnsbl.js
@@ -84,7 +84,7 @@ Dnsbl.query = function queryDnsbl(ip) {
 Dnsbl.ipToNumber = function (ip) {
 	let num = 0;
 	let parts = ip.split('.');
-	for (let part of parts) {
+	for (const part of parts) {
 		num *= 256;
 		num += parseInt(part);
 	}
@@ -169,7 +169,7 @@ Dnsbl.rangeToPattern = function (range) {
  * @return {boolean}
  */
 Dnsbl.checkPattern = function (patterns, num) {
-	for (let pattern of patterns) {
+	for (const pattern of patterns) {
 		if (num >= pattern[0] && num <= pattern[1]) {
 			return true;
 		}
@@ -261,7 +261,7 @@ Dnsbl.reverse = function reverseDns(ip) {
 			resolve('ovh.fr.res-nohost');
 			return;
 		}
-		for (let row of Dnsbl.datacenters) {
+		for (const row of Dnsbl.datacenters) {
 			if (ipNumber >= row[0] && ipNumber <= row[1]) {
 				resolve(row[2] + '.proxy-nohost');
 				return;

--- a/ladders.js
+++ b/ladders.js
@@ -59,7 +59,7 @@ class Ladder {
 			const data = await FS('config/ladders/' + this.formatid + '.tsv').read('utf8');
 			let ladder = [];
 			let dataLines = data.split('\n');
-			for (let dataLine of dataLines) {
+			for (const dataLine of dataLines) {
 				let line = dataLine.trim();
 				if (!line) continue;
 				let row = line.split('\t');

--- a/ladders.js
+++ b/ladders.js
@@ -59,8 +59,8 @@ class Ladder {
 			const data = await FS('config/ladders/' + this.formatid + '.tsv').read('utf8');
 			let ladder = [];
 			let dataLines = data.split('\n');
-			for (const dataLine of dataLines) {
-				let line = dataLine.trim();
+			for (let i = 1; i < dataLines.length; i++) {
+				let line = dataLines[i].trim();
 				if (!line) continue;
 				let row = line.split('\t');
 				ladder.push([toId(row[1]), Number(row[0]), row[1], Number(row[2]), Number(row[3]), Number(row[4]), row[5]]);

--- a/ladders.js
+++ b/ladders.js
@@ -59,8 +59,8 @@ class Ladder {
 			const data = await FS('config/ladders/' + this.formatid + '.tsv').read('utf8');
 			let ladder = [];
 			let dataLines = data.split('\n');
-			for (let i = 1; i < dataLines.length; i++) {
-				let line = dataLines[i].trim();
+			for (let dataLine of dataLines) {
+				let line = dataLine.trim();
 				if (!line) continue;
 				let row = line.split('\t');
 				ladder.push([toId(row[1]), Number(row[0]), row[1], Number(row[2]), Number(row[3]), Number(row[4]), row[5]]);
@@ -96,8 +96,7 @@ class Ladder {
 		}
 		let stream = FS(`config/ladders/${this.formatid}.tsv`).createWriteStream();
 		stream.write('Elo\tUsername\tW\tL\tT\tLast update\r\n');
-		for (let i = 0; i < this.loadedLadder.length; i++) {
-			let row = this.loadedLadder[i];
+		for (let row of this.loadedLadder) {
 			stream.write(row.slice(1).join('\t') + '\r\n');
 		}
 		stream.end();

--- a/loginserver.js
+++ b/loginserver.js
@@ -152,8 +152,8 @@ class LoginServerInstance {
 				this.requestTimeoutTimer = null;
 			}
 			req.abort();
-			for (let i = 0, len = requestCallbacks.length; i < len; i++) {
-				setImmediate(requestCallbacks[i], null, null, error);
+			for (const requestCallback of requestCallbacks) {
+				setImmediate(requestCallback, null, null, error);
 			}
 			this.requestEnd(error);
 		};

--- a/process-manager.js
+++ b/process-manager.js
@@ -127,9 +127,9 @@ class ProcessManager {
 	 */
 	acquire() {
 		let process = this.processes[0];
-		for (let i = 1; i < this.processes.length; i++) {
-			if (this.processes[i].load < process.load) {
-				process = this.processes[i];
+		for (const curProcess of this.processes) {
+			if (curProcess.load < process.load) {
+				process = curProcess;
 			}
 		}
 		return process;

--- a/process-manager.js
+++ b/process-manager.js
@@ -126,7 +126,13 @@ class ProcessManager {
 	 * @return {ProcessWrapper}
 	 */
 	acquire() {
-		return this.processes.reduce((best, current) => current.load < best.load ? current : best); // Not sure if this is too obvious...?
+		let process = this.processes[0];
+		for (let i = 1; i < this.processes.length; i++) {
+			if (this.processes[i].load < process.load) {
+				process = this.processes[i];
+			}
+		}
+		return process;
 	}
 
 	/**

--- a/process-manager.js
+++ b/process-manager.js
@@ -126,13 +126,7 @@ class ProcessManager {
 	 * @return {ProcessWrapper}
 	 */
 	acquire() {
-		let process = this.processes[0];
-		for (let i = 1; i < this.processes.length; i++) {
-			if (this.processes[i].load < process.load) {
-				process = this.processes[i];
-			}
-		}
-		return process;
+		return this.processes.reduce((best, current) => current.load < best.load ? current : best); // Not sure if this is too obvious...?
 	}
 
 	/**

--- a/punishments.js
+++ b/punishments.js
@@ -167,8 +167,7 @@ Punishments.loadPunishments = async function () {
 		if (Date.now() >= expireTime) {
 			continue;
 		}
-		for (let j = 0; j < keys.length; j++) {
-			const key = keys[j];
+		for (const key of keys) {
 			if (!USERID_REGEX.test(key)) {
 				Punishments.ips.set(key, punishment);
 			} else {
@@ -1277,8 +1276,7 @@ Punishments.getRoomPunishments = function (user, options) {
 
 	let punishments = [];
 
-	for (let i = 0; i < Rooms.global.chatRooms.length; i++) {
-		const curRoom = Rooms.global.chatRooms[i];
+	for (const curRoom of Rooms.global.chatrooms) {
 		if (!curRoom || curRoom.isPrivate === true || ((options && options.publicOnly) && (curRoom.isPersonal || curRoom.battle))) continue;
 		let punishment = Punishments.roomUserids.nestedGet(curRoom.id, userid);
 		if (punishment) {
@@ -1294,8 +1292,7 @@ Punishments.getRoomPunishments = function (user, options) {
 			}
 		}
 		if (checkMutes && curRoom.muteQueue) {
-			for (let i = 0; i < curRoom.muteQueue.length; i++) {
-				let entry = curRoom.muteQueue[i];
+			for (entry of curRoom.muteQueue) {
 				if (userid === entry.userid ||
 					user.guestNum === entry.guestNum ||
 					(user.autoconfirmed && user.autoconfirmed === entry.autoconfirmed)) {

--- a/punishments.js
+++ b/punishments.js
@@ -1292,11 +1292,11 @@ Punishments.getRoomPunishments = function (user, options) {
 			}
 		}
 		if (checkMutes && curRoom.muteQueue) {
-			for (entry of curRoom.muteQueue) {
+			for (const entry of curRoom.muteQueue) {
 				if (userid === entry.userid ||
 					user.guestNum === entry.guestNum ||
 					(user.autoconfirmed && user.autoconfirmed === entry.autoconfirmed)) {
-					punishments.push([curRoom, ['MUTE', entry.userid, curRoom.muteQueue[i].time]]);
+					punishments.push([curRoom, ['MUTE', entry.userid, entry.time]]);
 				}
 			}
 		}

--- a/room-battle.js
+++ b/room-battle.js
@@ -64,8 +64,7 @@ class BattlePlayer {
 		this.slotNum = Number(slot.charAt(1)) - 1;
 		this.active = true;
 
-		for (let i = 0; i < user.connections.length; i++) {
-			let connection = user.connections[i];
+		for (const connection of user.connections) {
 			if (connection.inRooms.has(game.id)) {
 				Sockets.subchannelMove(connection.worker, this.game.id, this.slotNum + 1, connection.socketid);
 			}
@@ -75,8 +74,7 @@ class BattlePlayer {
 		if (this.active) this.simSend('leave');
 		let user = Users(this.userid);
 		if (user) {
-			for (let j = 0; j < user.connections.length; j++) {
-				let connection = user.connections[j];
+			for (const connection of user.connections) {
 				Sockets.subchannelMove(connection.worker, this.game.id, '0', connection.socketid);
 			}
 			user.games.delete(this.game.id);
@@ -90,8 +88,7 @@ class BattlePlayer {
 			Sockets.subchannelMove(user.worker, this.game.id, this.slotNum + 1, user.socketid);
 			return;
 		}
-		for (let i = 0; i < user.connections.length; i++) {
-			let connection = user.connections[i];
+		for (const connection of user.connections) {
 			Sockets.subchannelMove(connection.worker, this.game.id, this.slotNum + 1, connection.socketid);
 		}
 	}

--- a/rooms.js
+++ b/rooms.js
@@ -123,8 +123,7 @@ class Room {
 	isMuted(user) {
 		if (!user) return;
 		if (this.muteQueue) {
-			for (let i = 0; i < this.muteQueue.length; i++) {
-				let entry = this.muteQueue[i];
+			for (const entry of this.muteQueue) {
 				if (user.userid === entry.userid ||
 					user.guestNum === entry.guestNum ||
 					(user.autoconfirmed && user.autoconfirmed === entry.autoconfirmed)) {

--- a/rooms.js
+++ b/rooms.js
@@ -135,9 +135,9 @@ class Room {
 	getMuteTime(user) {
 		let userid = this.isMuted(user);
 		if (!userid) return;
-		for (let i = 0; i < this.muteQueue.length; i++) {
-			if (userid === this.muteQueue[i].userid) {
-				return this.muteQueue[i].time - Date.now();
+		for (const entry of this.muteQueue) {
+			if (userid === entry.userid) {
+				return entry.time - Date.now();
 			}
 		}
 	}
@@ -224,8 +224,7 @@ class Room {
 			};
 		}
 
-		for (let i = 0; i < this.muteQueue.length; i++) {
-			let entry = this.muteQueue[i];
+		for (const entry of this.muteQueue) {
 			if (entry.userid === user.userid ||
 				entry.guestNum === user.guestNum ||
 				(user.autoconfirmed && entry.autoconfirmed === user.autoconfirmed)) {
@@ -302,8 +301,8 @@ class GlobalRoom {
 			Monitor.notice("NEW CHATROOM: " + id);
 			let room = Rooms.createChatRoom(id, this.chatRoomData[i].title, this.chatRoomData[i]);
 			if (room.aliases) {
-				for (let a = 0; a < room.aliases.length; a++) {
-					Rooms.aliases.set(room.aliases[a], id);
+				for (const alias of aliases) {
+					Rooms.aliases.set(alias, id);
 				}
 			}
 			this.chatRooms.push(room);
@@ -499,8 +498,7 @@ class GlobalRoom {
 	}
 	getRooms(user) {
 		let roomsData = {official:[], pspl:[], chat:[], userCount: this.userCount, battleCount: this.battleCount};
-		for (let i = 0; i < this.chatRooms.length; i++) {
-			let room = this.chatRooms[i];
+		for (const room of this.chatrooms) {
 			if (!room) continue;
 			if (room.isPrivate && !(room.isPrivate === 'voice' && user.group !== ' ')) continue;
 			if (room.isOfficial) {
@@ -641,9 +639,9 @@ class GlobalRoom {
 		// we only autojoin regular rooms if the client requests it with /autojoin
 		// note that this restriction doesn't apply to staffAutojoin
 		let includesLobby = false;
-		for (let i = 0; i < this.autojoin.length; i++) {
-			user.joinRoom(this.autojoin[i], connection);
-			if (this.autojoin[i] === 'lobby') includesLobby = true;
+		for (const roomName of this.autojoin) {
+			user.joinRoom(roomName, connection);
+			if (roomName === 'lobby') includesLobby = true;
 		}
 		if (!includesLobby && Config.serverid !== 'showdown') user.send(`>lobby\n|deinit`);
 	}
@@ -665,12 +663,11 @@ class GlobalRoom {
 				user.joinRoom(room.id, connection);
 			}
 		}
-		for (let i = 0; i < user.connections.length; i++) {
-			connection = user.connections[i];
+		for (const connection of users.connections) {
 			if (connection.autojoins) {
 				let autojoins = connection.autojoins.split(',');
-				for (let j = 0; j < autojoins.length; j++) {
-					user.tryJoinRoom(autojoins[j], connection);
+				for (const roomName of autojoins) {
+					user.tryJoinRoom(roomName, connection);
 				}
 				connection.autojoins = '';
 			}
@@ -913,8 +910,7 @@ class BattleRoom extends Room {
 	// logNum = 3    : debug log (exact HP for all players)
 	getLog(logNum) {
 		let log = [];
-		for (let i = 0; i < this.log.length; ++i) {
-			let line = this.log[i];
+		for (const line of this.log) {
 			if (line === '|split') {
 				log.push(this.log[i + logNum + 1]);
 				i += 4;
@@ -1393,8 +1389,8 @@ class ChatRoom extends Room {
 		Rooms.global.delistChatRoom(this.id);
 
 		if (this.aliases) {
-			for (let i = 0; i < this.aliases.length; i++) {
-				Rooms.aliases.delete(this.aliases[i]);
+			for (const alias of this.aliases) {
+				Rooms.aliases.delete(alias);
 			}
 		}
 

--- a/rooms.js
+++ b/rooms.js
@@ -224,7 +224,8 @@ class Room {
 			};
 		}
 
-		for (const entry of this.muteQueue) {
+		for (let i = 0; i < this.muteQueue.length; i++) {
+			let entry = this.muteQueue[i];
 			if (entry.userid === user.userid ||
 				entry.guestNum === user.guestNum ||
 				(user.autoconfirmed && entry.autoconfirmed === user.autoconfirmed)) {
@@ -301,7 +302,7 @@ class GlobalRoom {
 			Monitor.notice("NEW CHATROOM: " + id);
 			let room = Rooms.createChatRoom(id, this.chatRoomData[i].title, this.chatRoomData[i]);
 			if (room.aliases) {
-				for (const alias of aliases) {
+				for (const alias of room.aliases) {
 					Rooms.aliases.set(alias, id);
 				}
 			}
@@ -663,7 +664,7 @@ class GlobalRoom {
 				user.joinRoom(room.id, connection);
 			}
 		}
-		for (const connection of users.connections) {
+		for (const connection of user.connections) {
 			if (connection.autojoins) {
 				let autojoins = connection.autojoins.split(',');
 				for (const roomName of autojoins) {
@@ -910,7 +911,8 @@ class BattleRoom extends Room {
 	// logNum = 3    : debug log (exact HP for all players)
 	getLog(logNum) {
 		let log = [];
-		for (const line of this.log) {
+		for (let i = 0; i < this.log.length; ++i) {
+			let line = this.log[i];
 			if (line === '|split') {
 				log.push(this.log[i + logNum + 1]);
 				i += 4;

--- a/team-validator.js
+++ b/team-validator.js
@@ -65,13 +65,13 @@ class Validator {
 		}
 
 		let teamHas = {};
-		for (const member of team) {
-			if (!member) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
-			let setProblems = (format.validateSet || this.validateSet).call(this, member, teamHas);
+		for (let i = 0; i < team.length; i++) { // Changing this loop to for-of would require another loop/map statement to do removeNicknames
+			if (!team[i]) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
+			let setProblems = (format.validateSet || this.validateSet).call(this, team[i], teamHas);
 			if (setProblems) {
 				problems = problems.concat(setProblems);
 			}
-			if (removeNicknames) member.name = member.baseSpecies;
+			if (removeNicknames) team[i].name = team[i].baseSpecies;
 		}
 
 		for (const [rule, source, limit, bans] of ruleTable.complexTeamBans) {

--- a/team-validator.js
+++ b/team-validator.js
@@ -408,12 +408,12 @@ class Validator {
 					// one limitedEgg move from another egg.
 					let validFatherExists = false;
 					for (const learned of lsetData.sources) {
-						if (learned.charAt(1) === 'S' || source.charAt(1) === 'D') continue;
-						let eggGen = parseInt(source.charAt(0));
+						if (learned.charAt(1) === 'S' || learned.charAt(1) === 'D') continue;
+						let eggGen = parseInt(learned.charAt(0));
 						if (learned.charAt(1) !== 'E' || eggGen === 6) {
 							// (There is a way to obtain this pokemon without past-gen breeding.)
 							// In theory, limitedEgg should not exist in this case.
-							throw new Error(`invalid limitedEgg on ${name}: ${limitedEgg} with ${source}`);
+							throw new Error(`invalid limitedEgg on ${name}: ${limitedEgg} with ${learned}`);
 						}
 						let potentialFather = dex.getTemplate(learned.slice(learned.charAt(2) === 'T' ? 3 : 2));
 						let restrictedSources = 0;
@@ -500,9 +500,9 @@ class Validator {
 					let eventData = eventPokemon[0];
 					const minPastGen = (format.requirePlus ? 7 : format.requirePentagon ? 6 : 1);
 					let eventNum = 1;
-					for (const curEventData of eventPokemon) {
-						if (curEventData.generation <= dex.gen && curEventData.generation >= minPastGen) {
-							eventData = curEventData;
+					for (let i = 0; i < eventPokemon.length; i++) {
+						if (eventPokemon[i].generation <= dex.gen && eventPokemon[i].generation >= minPastGen) {
+							eventData = eventPokemon[i];
 							eventNum = i + 1;
 							break;
 						}
@@ -872,7 +872,7 @@ class Validator {
 				}
 				if (typeof lset === 'string') lset = [lset];
 
-				for (const learned of lset) {
+				for (let learned of lset) {
 					let learnedGen = parseInt(learned.charAt(0));
 					if (learnedGen < minPastGen) continue;
 					if (noFutureGen && learnedGen > dex.gen) continue;
@@ -1071,7 +1071,8 @@ class Validator {
 			// in sources, so we fill the other array in preparation for intersection
 			if (sourcesBefore && lsetData.sources) {
 				if (!sources) sources = [];
-				for (const learned of lsetData.sources) {
+				for (let i = 0, len = lsetData.sources.length; i < len; i++) {
+					let learned = lsetData.sources[i];
 					if (parseInt(learned.charAt(0)) <= sourcesBefore) {
 						sources.push(learned);
 					}
@@ -1080,7 +1081,8 @@ class Validator {
 			}
 			if (lsetData.sourcesBefore && sources) {
 				if (!lsetData.sources) lsetData.sources = [];
-				for (const learned of sources) {
+				for (let i = 0, len = sources.length; i < len; i++) {
+					let learned = sources[i];
 					let sourceGen = parseInt(learned.charAt(0));
 					if (sourceGen <= lsetData.sourcesBefore && sourceGen > sourcesBefore) {
 						lsetData.sources.push(learned);

--- a/team-validator.js
+++ b/team-validator.js
@@ -407,27 +407,27 @@ class Validator {
 					// They're probably incompatible if all potential fathers learn more than
 					// one limitedEgg move from another egg.
 					let validFatherExists = false;
-					for (const learned of lsetData.sources) {
-						if (learned.charAt(1) === 'S' || learned.charAt(1) === 'D') continue;
-						let eggGen = parseInt(learned.charAt(0));
-						if (learned.charAt(1) !== 'E' || eggGen === 6) {
+					for (const source of lsetData.sources) {
+						if (source.charAt(1) === 'S' || source.charAt(1) === 'D') continue;
+						let eggGen = parseInt(source.charAt(0));
+						if (source.charAt(1) !== 'E' || eggGen === 6) {
 							// (There is a way to obtain this pokemon without past-gen breeding.)
 							// In theory, limitedEgg should not exist in this case.
-							throw new Error(`invalid limitedEgg on ${name}: ${limitedEgg} with ${learned}`);
+							throw new Error(`invalid limitedEgg on ${name}: ${limitedEgg} with ${source}`);
 						}
-						let potentialFather = dex.getTemplate(learned.slice(learned.charAt(2) === 'T' ? 3 : 2));
+						let potentialFather = dex.getTemplate(source.slice(source.charAt(2) === 'T' ? 3 : 2));
 						let restrictedSources = 0;
 						for (const moveid of limitedEgg) {
 							let fatherSources = potentialFather.learnset[moveid] || potentialFather.learnset['sketch'];
 							if (!fatherSources) throw new Error(`Egg move father ${potentialFather.id} can't learn ${moveid}`);
 							let hasUnrestrictedSource = false;
 							let hasSource = false;
-							for (const source of fatherSources) {
+							for (const fatherSource of fatherSources) {
 								// Triply nested loop! Fortunately, all the loops are designed
 								// to be as short as possible.
 								if (source.charAt(0) > eggGen) continue;
 								hasSource = true;
-								if (source.charAt(1) !== 'E' && source.charAt(1) !== 'S') {
+								if (fatherSource.charAt(1) !== 'E' && fatherSource.charAt(1) !== 'S') {
 									hasUnrestrictedSource = true;
 									break;
 								}
@@ -451,9 +451,9 @@ class Validator {
 						// TODO: hardcode false positives for our heuristic
 						// in theory, this heuristic doesn't have false negatives
 						let newSources = [];
-						for (const learned of lsetData.sources) {
-							if (learned.charAt(1) === 'S') {
-								newSources.push(learned);
+						for (const source of lsetData.sources) {
+							if (source.charAt(1) === 'S') {
+								newSources.push(source);
 							}
 						}
 						lsetData.sources = newSources;

--- a/users.js
+++ b/users.js
@@ -282,10 +282,9 @@ Users.isUsernameKnown = function (name) {
 	let userid = toId(name);
 	if (Users(userid)) return true;
 	if (userid in usergroups) return true;
-	for (let i = 0; i < Rooms.global.chatRooms.length; i++) {
-		let curRoom = Rooms.global.chatRooms[i];
-		if (!curRoom.auth) continue;
-		if (userid in curRoom.auth) return true;
+	for (const room of Rooms.global.chatRooms) {
+		if (!room.auth) continue;
+		if (userid in room.auth) return true;
 	}
 	return false;
 };
@@ -294,9 +293,8 @@ Users.isTrusted = function (name) {
 	if (name.trusted) return name.trusted;
 	let userid = toId(name);
 	if (userid in usergroups) return userid;
-	for (let i = 0; i < Rooms.global.chatRooms.length; i++) {
-		let curRoom = Rooms.global.chatRooms[i];
-		if (!curRoom.isPrivate && !curRoom.isPersonal && curRoom.auth && userid in curRoom.auth && curRoom.auth[userid] !== '+') return userid;
+	for (const room of Rooms.global.chatRooms) {
+		if (!room.isPrivate && !room.isPersonal && room.auth && userid in room.auth && room.auth[userid] !== '+') return userid;
 	}
 	return false;
 };
@@ -430,15 +428,15 @@ class User {
 	sendTo(roomid, data) {
 		if (roomid && roomid.id) roomid = roomid.id;
 		if (roomid && roomid !== 'global' && roomid !== 'lobby') data = `>${roomid}\n${data}`;
-		for (let i = 0; i < this.connections.length; i++) {
-			if (roomid && !this.connections[i].inRooms.has(roomid)) continue;
-			this.connections[i].send(data);
+		for (const connection in this.connection) {
+			if (roomid && !connection.inRooms.has(roomid)) continue;
+			connection.send(data);
 			Monitor.countNetworkUse(data.length);
 		}
 	}
 	send(data) {
-		for (let i = 0; i < this.connections.length; i++) {
-			this.connections[i].send(data);
+		for (const connection of this.connections) {
+			connection.send(data);
 			Monitor.countNetworkUse(data.length);
 		}
 	}
@@ -838,10 +836,10 @@ class User {
 
 		if (this.namelocked) this.named = true;
 
-		for (let i = 0; i < this.connections.length; i++) {
+		for (const connection of this.connections) {
 			//console.log('' + name + ' renaming: socket ' + i + ' of ' + this.connections.length);
 			let initdata = `|updateuser|${this.name}|${this.named ? 1 : 0}|${this.avatar}`;
-			this.connections[i].send(initdata);
+			connection.send(initdata);
 		}
 		this.games.forEach(roomid => {
 			const room = Rooms(roomid);
@@ -871,8 +869,8 @@ class User {
 
 		this.updateGroup(this.registered);
 
-		for (let i = 0; i < oldUser.connections.length; i++) {
-			this.mergeConnection(oldUser.connections[i]);
+		for (const connection of oldUser.connections) {
+			this.mergeConnection(connection);
 		}
 		oldUser.inRooms.clear();
 		oldUser.connections = [];
@@ -1045,8 +1043,7 @@ class User {
 		if (usergroups[userid]) {
 			removed.push(usergroups[userid].charAt(0));
 		}
-		for (let i = 0; i < Rooms.global.chatRooms.length; i++) {
-			let room = Rooms.global.chatRooms[i];
+		for (const room of Rooms.global.chatRooms) {
 			if (!room.isPrivate && room.auth && userid in room.auth && room.auth[userid] !== '+') {
 				removed.push(room.auth[userid] + room.id);
 				room.auth[userid] = '+';
@@ -1193,12 +1190,12 @@ class User {
 			}
 		}
 		if (!connection) {
-			for (let i = 0; i < this.connections.length; i++) {
+			for (const curConnection of this.connections) {
 				// only join full clients, not pop-out single-room
 				// clients
 				// (...no, pop-out rooms haven't been implemented yet)
-				if (this.connections[i].inRooms.has('global')) {
-					this.joinRoom(room, this.connections[i]);
+				if (curConnection.inRooms.has('global')) {
+					this.joinRoom(room, curConnection);
 				}
 			}
 			return true;
@@ -1224,11 +1221,11 @@ class User {
 		if (!this.inRooms.has(room.id)) {
 			return false;
 		}
-		for (let i = 0; i < this.connections.length; i++) {
-			if (connection && this.connections[i] !== connection) continue;
-			if (this.connections[i].inRooms.has(room.id)) {
-				this.connections[i].sendTo(room.id, '|deinit');
-				this.connections[i].leaveRoom(room);
+		for (const curConnection of this.connections) {
+			if (connection && curConnection !== connection) continue;
+			if (curConnection.inRooms.has(room.id)) {
+				curConnection.sendTo(room.id, '|deinit');
+				curConnection.leaveRoom(room);
 			}
 			if (connection) break;
 		}
@@ -1634,8 +1631,8 @@ Users.socketReceive = function (worker, workerid, socketid, message) {
 	}
 
 	let startTime = Date.now();
-	for (let i = 0; i < lines.length; i++) {
-		if (user.chat(lines[i], room, connection) === false) break;
+	for (const line of lines) {
+		if (user.chat(line, room, connection) === false) break;
 	}
 	let deltaTime = Date.now() - startTime;
 	if (deltaTime > 1000) {

--- a/users.js
+++ b/users.js
@@ -428,7 +428,7 @@ class User {
 	sendTo(roomid, data) {
 		if (roomid && roomid.id) roomid = roomid.id;
 		if (roomid && roomid !== 'global' && roomid !== 'lobby') data = `>${roomid}\n${data}`;
-		for (const connection in this.connection) {
+		for (const connection of this.connections) {
 			if (roomid && !connection.inRooms.has(roomid)) continue;
 			connection.send(data);
 			Monitor.countNetworkUse(data.length);


### PR DESCRIPTION
*Partially* does the thing in #3918 for top-level `.js` files (I'll do subdirs later...)

I did **NOT** convert:

- Loops where the index was needed (these could be converted using `Array.entries()`, possibly)
- Loops that were iterated backwards
- Other weird loops that didn't simply iterate over all elements

Some of these loops could be converted to `.reduce` statements, I think, but I only refactored one of them in this PR

**EDIT**: Had to change first line to from "resolves" otherwise GitHub would close the issue ...