### PR TITLE
Remove bogus Illusion check from Gen2

### DIFF
--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -500,11 +500,6 @@ exports.BattleScripts = {
 				this.debug('damage event failed');
 				return damage;
 			}
-			if (target.illusion && effect && effect.effectType === 'Move') {
-				this.debug('illusion cleared');
-				target.illusion = null;
-				this.add('replace', target, target.getDetails);
-			}
 		}
 		if (damage !== 0) damage = this.clampIntRange(damage, 1);
 		damage = target.damage(damage, source, effect);


### PR DESCRIPTION
Spotted by @QuiteQuiet, this code was obviously unused in Gen2 even before Illusion-ending got moved to `ability.js`.