### PR TITLE
Sockets: prevent creating ghost connections on disconnect

### DIFF
--- a/sockets.js
+++ b/sockets.js
@@ -355,9 +355,9 @@ if (cluster.isMaster) {
 			socketid = data.substr(1);
 			socket = sockets.get(socketid);
 			if (!socket) return;
-			socket.destroy();
 			sockets.delete(socketid);
 			channels.forEach(channel => channel.delete(socketid));
+			socket.destroy();
 			break;
 
 		case '>':
@@ -549,10 +549,8 @@ if (cluster.isMaster) {
 			process.send(`<${socketid}\n${message}`);
 		});
 
-		socket.once('close', () => {
-			process.send(`!${socketid}`);
-			sockets.delete(socketid);
-			channels.forEach(channel => channel.delete(socketid));
+		socket.on('close', () => {
+			if (sockets.has(socketid)) process.send(`!${socketid}`);
 		});
 	});
 	server.installHandlers(app, {});


### PR DESCRIPTION
Socket `'close'` events don't guarantee that their TCP connection has been
closed yet, rather that at some point SockJS sent or received one of its
own close messages. Sockets closed by the client or through errors when
sending/receiving messages didn't always get cleaned up properly because
of this.