### PR TITLE
Default to battle room's data

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -381,6 +381,8 @@ exports.commands = {
 			mod = Dex.mod(toId(sep[1]));
 		} else if (sep[1] && Dex.getFormat(sep[1]).mod) {
 			mod = Dex.mod(Dex.getFormat(sep[1]).mod);
+		} else if (room && room.battle) {
+			mod = Dex.forFormat(room.battle.format);
 		}
 		let newTargets = mod.dataSearch(target);
 		let showDetails = (cmd === 'dt' || cmd === 'details');


### PR DESCRIPTION
So for instance if you use `/data` in a Gen 1 battle you get Gen 1 data by default.