### PR TITLE
Gen 4 Random Battle updates

### DIFF
--- a/mods/gen4/formats-data.js
+++ b/mods/gen4/formats-data.js
@@ -104,7 +104,6 @@ exports.BattleFormatsData = {
 	},
 	pikachu: {
 		inherit: true,
-		randomBattleMoves: ["nastyplot", "thunderbolt", "hiddenpowerice", "grassknot", "encore", "substitute", "focuspunch"],
 		tier: "NU",
 	},
 	raichu: {
@@ -172,7 +171,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	golbat: {
-		randomBattleMoves: ["bravebird", "roost", "taunt", "uturn", "nastyplot", "gigadrain", "sludgebomb", "airslash", "heatwave"],
 		tier: "NU",
 	},
 	crobat: {
@@ -213,7 +211,6 @@ exports.BattleFormatsData = {
 		tier: "NU",
 	},
 	diglett: {
-		randomBattleMoves: ["earthquake", "rockslide", "substitute", "nightslash", "suckerpunch"],
 		tier: "NU",
 	},
 	dugtrio: {
@@ -275,7 +272,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	kadabra: {
-		randomBattleMoves: ["calmmind", "psychic", "hiddenpowerfighting", "shadowball", "encore", "substitute"],
 		tier: "NU",
 	},
 	alakazam: {
@@ -287,7 +283,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	machoke: {
-		randomBattleMoves: ["closecombat", "payback", "icepunch", "thunderpunch", "bulletpunch"],
 		tier: "NU",
 	},
 	machamp: {
@@ -349,7 +344,6 @@ exports.BattleFormatsData = {
 	},
 	magneton: {
 		inherit: true,
-		randomBattleMoves: ["thunderbolt", "hiddenpowerfire", "chargebeam", "substitute", "flashcannon", "hiddenpowerice", "explosion"],
 		tier: "NU",
 	},
 	magnezone: {
@@ -397,7 +391,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	haunter: {
-		randomBattleMoves: ["shadowball", "sludgebomb", "hiddenpowerground", "thunderbolt", "substitute", "painsplit", "hypnosis", "explosion"],
 		tier: "NU",
 	},
 	gengar: {
@@ -501,7 +494,6 @@ exports.BattleFormatsData = {
 	},
 	chansey: {
 		inherit: true,
-		randomBattleMoves: ["wish", "softboiled", "protect", "toxic", "aromatherapy", "seismictoss", "thunderwave", "stealthrock"],
 		tier: "UU",
 	},
 	blissey: {
@@ -510,7 +502,6 @@ exports.BattleFormatsData = {
 	},
 	tangela: {
 		inherit: true,
-		randomBattleMoves: ["sunnyday", "sleeppowder", "endeavor", "leafstorm", "solarbeam", "hiddenpowerfire"],
 		tier: "NU",
 	},
 	tangrowth: {
@@ -582,7 +573,6 @@ exports.BattleFormatsData = {
 	},
 	electabuzz: {
 		inherit: true,
-		randomBattleMoves: ["thunderbolt", "substitute", "hiddenpowerice", "hiddenpowergrass", "crosschop", "focusblast", "psychic"],
 		tier: "NU",
 	},
 	electivire: {
@@ -720,7 +710,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	dragonair: {
-		randomBattleMoves: ["dragondance", "outrage", "fireblast", "extremespeed", "dracometeor", "aquatail"],
 		tier: "NU",
 	},
 	dragonite: {
@@ -815,7 +804,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	togetic: {
-		randomBattleMoves: ["nastyplot", "batonpass", "hiddenpowerflying", "roost"],
 		tier: "NU",
 	},
 	togekiss: {
@@ -885,7 +873,6 @@ exports.BattleFormatsData = {
 		tier: "NU",
 	},
 	yanma: {
-		randomBattleMoves: ["bugbuzz", "airslash", "hiddenpowerground", "hypnosis", "protect"],
 		tier: "NU",
 	},
 	yanmega: {
@@ -901,7 +888,6 @@ exports.BattleFormatsData = {
 	},
 	murkrow: {
 		inherit: true,
-		randomBattleMoves: ["suckerpunch", "bravebird", "heatwave", "hiddenpowergrass"],
 		tier: "NU",
 	},
 	honchkrow: {
@@ -910,7 +896,6 @@ exports.BattleFormatsData = {
 	},
 	misdreavus: {
 		inherit: true,
-		randomBattleMoves: ["rest", "sleeptalk", "calmmind", "willowisp", "shadowball"],
 		tier: "NU",
 	},
 	mismagius: {
@@ -923,7 +908,6 @@ exports.BattleFormatsData = {
 	},
 	wynaut: {
 		inherit: true,
-		randomBattleMoves: ["destinybond", "counter", "mirrorcoat", "encore"],
 		tier: "Uber",
 	},
 	wobbuffet: {
@@ -949,7 +933,6 @@ exports.BattleFormatsData = {
 	},
 	gligar: {
 		inherit: true,
-		randomBattleMoves: ["substitute", "toxic", "roost", "taunt", "earthquake", "aerialace"],
 		tier: "NU",
 	},
 	gliscor: {
@@ -980,7 +963,6 @@ exports.BattleFormatsData = {
 	},
 	sneasel: {
 		inherit: true,
-		randomBattleMoves: ["iceshard", "brickbreak", "lowkick", "pursuit", "punishment"],
 		tier: "NU",
 	},
 	weavile: {
@@ -1009,7 +991,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	piloswine: {
-		randomBattleMoves: ["earthquake", "iceshard", "stoneedge", "substitute", "icefang"],
 		tier: "NU",
 	},
 	mamoswine: {
@@ -1114,7 +1095,7 @@ exports.BattleFormatsData = {
 	},
 	celebi: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "thunderwave", "leafstorm", "hiddenpowerfire", "psychic", "uturn", "recover", "nastyplot", "grassknot", "earthpower", "substitute", "leechseed", "batonpass"],
+		randomBattleMoves: ["stealthrock", "thunderwave", "leafstorm", "hiddenpowerfire", "psychic", "uturn", "recover", "nastyplot", "energyball", "earthpower", "substitute", "leechseed", "batonpass"],
 		tier: "OU",
 	},
 	treecko: {
@@ -1125,7 +1106,7 @@ exports.BattleFormatsData = {
 		tier: "NFE",
 	},
 	sceptile: {
-		randomBattleMoves: ["substitute", "leechseed", "grassknot", "hiddenpowerice", "hiddenpowerfire", "leafstorm", "earthquake", "focusblast"],
+		randomBattleMoves: ["substitute", "leechseed", "energyball", "hiddenpowerice", "hiddenpowerfire", "leafstorm", "earthquake", "focusblast"],
 		tier: "UU",
 	},
 	torchic: {
@@ -1192,7 +1173,7 @@ exports.BattleFormatsData = {
 		tier: "NFE",
 	},
 	ludicolo: {
-		randomBattleMoves: ["raindance", "surf", "energyball", "icebeam", "grassknot", "substitute", "leechseed"],
+		randomBattleMoves: ["raindance", "surf", "energyball", "icebeam", "substitute", "leechseed"],
 		tier: "UU",
 	},
 	seedot: {
@@ -1374,7 +1355,6 @@ exports.BattleFormatsData = {
 	},
 	roselia: {
 		inherit: true,
-		randomBattleMoves: ["spikes", "toxicspikes", "sleeppowder", "gigadrain", "stunspore", "rest"],
 		tier: "NU",
 	},
 	roserade: {
@@ -1558,7 +1538,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	dusclops: {
-		randomBattleMoves: ["willowisp", "sleeptalk", "rest", "painsplit", "seismictoss", "shadowpunch"],
 		tier: "NU",
 	},
 	dusknoir: {
@@ -1607,7 +1586,6 @@ exports.BattleFormatsData = {
 		tier: "NU",
 	},
 	clamperl: {
-		randomBattleMoves: ["icebeam", "surf", "hiddenpowergrass", "brine"],
 		tier: "NU",
 	},
 	huntail: {
@@ -1631,7 +1609,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	shelgon: {
-		randomBattleMoves: ["outrage", "brickbreak", "dragonclaw", "dragondance"],
 		tier: "NU",
 	},
 	salamence: {
@@ -1644,7 +1621,6 @@ exports.BattleFormatsData = {
 	},
 	metang: {
 		inherit: true,
-		randomBattleMoves: ["stealthrock", "meteormash", "explosion", "toxic", "lightscreen", "reflect"],
 		tier: "NU",
 	},
 	metagross: {
@@ -1732,7 +1708,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	monferno: {
-		randomBattleMoves: ["stealthrock", "endeavor", "fireblast", "taunt", "vacuumwave"],
 		tier: "NU",
 	},
 	infernape: {
@@ -1902,7 +1877,6 @@ exports.BattleFormatsData = {
 		tier: "LC",
 	},
 	gabite: {
-		randomBattleMoves: ["outrage", "dragonclaw", "earthquake", "stoneedge"],
 		tier: "NU",
 	},
 	garchomp: {
@@ -1919,7 +1893,6 @@ exports.BattleFormatsData = {
 		tier: "OU",
 	},
 	hippopotas: {
-		randomBattleMoves: ["earthquake", "slackoff", "roar", "stealthrock", "protect", "toxic", "yawn"],
 		tier: "BL2",
 	},
 	hippowdon: {
@@ -1952,11 +1925,10 @@ exports.BattleFormatsData = {
 		tier: "NU",
 	},
 	snover: {
-		randomBattleMoves: ["blizzard", "iceshard", "protect", "leechseed", "substitute", "swordsdance", "seedbomb"],
 		tier: "BL2",
 	},
 	abomasnow: {
-		randomBattleMoves: ["blizzard", "iceshard", "woodhammer", "leechseed", "substitute", "earthquake", "hiddenpowerfire", "grassknot"],
+		randomBattleMoves: ["blizzard", "iceshard", "woodhammer", "leechseed", "substitute", "earthquake", "hiddenpowerfire", "energyball"],
 		tier: "BL",
 	},
 	rotom: {
@@ -2041,7 +2013,7 @@ exports.BattleFormatsData = {
 	},
 	manaphy: {
 		inherit: true,
-		randomBattleMoves: ["tailglow", "surf", "icebeam", "grassknot"],
+		randomBattleMoves: ["tailglow", "surf", "icebeam", "energyball"],
 		tier: "Uber",
 	},
 	darkrai: {

--- a/mods/gen4/random-teams.js
+++ b/mods/gen4/random-teams.js
@@ -254,10 +254,10 @@ class RandomGen4Teams extends RandomGen5Teams {
 					if (hasMove['thunderbolt']) rejected = true;
 					break;
 				case 'energyball':
-					if (hasMove['grassknot'] || hasMove['leafblade'] || hasMove['woodhammer'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
+					if (hasMove['leafblade'] || hasMove['woodhammer'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
 					break;
 				case 'grassknot': case 'seedbomb':
-					if (hasMove['energyball'] || hasMove['woodhammer'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
+					if (hasMove['woodhammer'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
 					break;
 				case 'leafstorm':
 					if (counter.setupType || hasMove['batonpass'] || hasMove['powerwhip'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
@@ -282,7 +282,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 					if (hasMove['nightshade'] || counter.Physical + counter.Special >= 1) rejected = true;
 					break;
 				case 'superpower':
-					if (hasMove['dragondance']) rejected = true;
+					if (hasMove['dragondance'] || !!counter['speedsetup']) rejected = true;
 					break;
 				case 'gunkshot':
 					if (hasMove['poisonjab']) rejected = true;
@@ -540,8 +540,6 @@ class RandomGen4Teams extends RandomGen5Teams {
 			item = 'Stick';
 		} else if (template.species === 'Marowak') {
 			item = 'Thick Club';
-		} else if (template.species === 'Pikachu') {
-			item = 'Light Ball';
 		} else if (template.species === 'Shedinja' || template.species === 'Smeargle') {
 			item = 'Focus Sash';
 		} else if (template.species === 'Unown') {
@@ -629,8 +627,12 @@ class RandomGen4Teams extends RandomGen5Teams {
 			OU: 75,
 			Uber: 71,
 		};
+		let customScale = {
+			Ditto: 99, Unown: 99,
+		};
 		let tier = template.tier;
 		let level = levelScale[tier] || 75;
+		if (customScale[template.name]) level = customScale[template.name];
 
 		// Prepare optimal HP
 		let hp = Math.floor(Math.floor(2 * template.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);


### PR DESCRIPTION
* Remove unused NFE movepools
* Favor Energy Ball over Grass Knot in movepools
* Reject Agility + Superpower
* Boost Unown and Ditto to level 99