### PR TITLE
Pass the active move when modifying stats

### DIFF
--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -30,7 +30,7 @@ exports.BattleScripts = {
 
 				// On Gen 2 we check modifications here from moves and items
 				let statTable = {atk:'Atk', def:'Def', spa:'SpA', spd:'SpD', spe:'Spe'};
-				stat = this.battle.runEvent('Modify' + statTable[statName], this, null, null, stat);
+				stat = this.battle.runEvent('Modify' + statTable[statName], this, null, this.activeMove, stat);
 			}
 
 			if (!unmodified) {


### PR DESCRIPTION
The new Beat Up code assumes it can access the Move object, but Gen 2 has its own unique stat calculation.