### PR TITLE
Fix Reflect Type vs. Pokemon with the "???" type

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -13038,13 +13038,16 @@ exports.BattleMovedex = {
 		flags: {protect: 1, authentic: 1, mystery: 1},
 		onHit: function (target, source) {
 			if (source.template && (source.template.num === 493 || source.template.num === 773)) return false;
-			if (target.getTypes() === ['???']) return false;
 			this.add('-start', source, 'typechange', '[from] move: Reflect Type', '[of] ' + target);
-			if (target.addedType) {
-				source.types = target.getTypes(true).map(type => type === '???' ? 'Normal' : type);
-			} else {
-				source.types = target.getTypes(true).filter(type => type !== '???');
+			let newBaseTypes = target.getTypes(true).filter(type => type !== '???');
+			if (!newBaseTypes.length) {
+				if (target.addedType) {
+					newBaseTypes = ['Normal'];
+				} else {
+					return false;
+				}
 			}
+			source.types = newBaseTypes;
 			source.addedType = target.addedType;
 			source.knownType = target.side === source.side && target.knownType;
 		},

--- a/data/moves.js
+++ b/data/moves.js
@@ -13038,8 +13038,13 @@ exports.BattleMovedex = {
 		flags: {protect: 1, authentic: 1, mystery: 1},
 		onHit: function (target, source) {
 			if (source.template && (source.template.num === 493 || source.template.num === 773)) return false;
+			if (target.getTypes() === ['???']) return false;
 			this.add('-start', source, 'typechange', '[from] move: Reflect Type', '[of] ' + target);
-			source.types = target.getTypes(true);
+			if (target.addedType) {
+				source.types = target.getTypes(true).map(type => type === '???' ? 'Normal' : type);
+			} else {
+				source.types = target.getTypes(true).filter(type => type !== '???');
+			}
 			source.addedType = target.addedType;
 			source.knownType = target.side === source.side && target.knownType;
 		},

--- a/test/simulator/moves/reflecttype.js
+++ b/test/simulator/moves/reflecttype.js
@@ -22,8 +22,7 @@ describe('Reflect Type', function () {
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Moltres', ability: 'intimidate', moves: ['burnup']}]);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].getTypes().length, 1);
-		assert.strictEqual(battle.p1.active[0].getTypes()[0], 'Flying');
+		assert.strictEqual(battle.p1.active[0].getTypes().join('/'), 'Flying');
 		p1.chooseMove(2, 1).foe.chooseDefault();
 		battle.commitDecisions();
 		assert.strictEqual(battle.p1.active[0].getTypes().join('/'), 'Flying/Ghost');

--- a/test/simulator/moves/reflecttype.js
+++ b/test/simulator/moves/reflecttype.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Reflect Type', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should fail when used against a Pokemon whose type is "???"', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Arcanine', ability: 'intimidate', moves: ['burnup']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype']}]);
+		assert.constant(() => battle.p2.active[0].getTypes(), () => battle.commitDecisions());
+	});
+
+	it('should ignore the "???" type when used against a Pokemon whose type contains "???" and a non-added type', function () {
+		battle = common.createBattle();
+		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Moltres', ability: 'intimidate', moves: ['burnup']}]);
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].getTypes().length, 1);
+		assert.strictEqual(battle.p1.active[0].getTypes()[0], 'Flying');
+		p1.chooseMove(2, 1).foe.chooseDefault();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].getTypes().length, 2);
+		assert.strictEqual(battle.p1.active[0].getTypes()[0], 'Flying');
+		assert.strictEqual(battle.p1.active[0].getTypes()[1], 'Ghost');
+	});
+
+	it('should turn the "???" type into "Normal" when used against a Pokemon whose type is only "???" and an added type', function () {
+		battle = common.createBattle();
+		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Arcanine', ability: 'intimidate', moves: ['burnup']}]);
+		p1.chooseMove(2, 1).foe.chooseDefault();
+		battle.commitDecisions();
+		assert.strictEqual(battle.p1.active[0].getTypes().length, 2);
+		assert.strictEqual(battle.p1.active[0].getTypes()[0], 'Normal');
+		assert.strictEqual(battle.p1.active[0].getTypes()[1], 'Ghost');
+	});
+});

--- a/test/simulator/moves/reflecttype.js
+++ b/test/simulator/moves/reflecttype.js
@@ -26,9 +26,7 @@ describe('Reflect Type', function () {
 		assert.strictEqual(battle.p1.active[0].getTypes()[0], 'Flying');
 		p1.chooseMove(2, 1).foe.chooseDefault();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].getTypes().length, 2);
-		assert.strictEqual(battle.p1.active[0].getTypes()[0], 'Flying');
-		assert.strictEqual(battle.p1.active[0].getTypes()[1], 'Ghost');
+		assert.strictEqual(battle.p1.active[0].getTypes().join('/'), 'Flying/Ghost');
 	});
 
 	it('should turn the "???" type into "Normal" when used against a Pokemon whose type is only "???" and an added type', function () {
@@ -37,8 +35,6 @@ describe('Reflect Type', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Arcanine', ability: 'intimidate', moves: ['burnup']}]);
 		p1.chooseMove(2, 1).foe.chooseDefault();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].getTypes().length, 2);
-		assert.strictEqual(battle.p1.active[0].getTypes()[0], 'Normal');
-		assert.strictEqual(battle.p1.active[0].getTypes()[1], 'Ghost');
+		assert.strictEqual(battle.p1.active[0].getTypes().join('/'), 'Normal/Ghost');
 	});
 });


### PR DESCRIPTION
Previously, Reflect Type didn't treat the "???" type differently than any other type, unlike what its [description](https://dex.pokemonshowdown.com/moves/reflecttype) said it did.