### PR TITLE
Modlog: fix result count display being off by one

### DIFF
--- a/chat-plugins/modlog.js
+++ b/chat-plugins/modlog.js
@@ -218,7 +218,7 @@ function runRipgrepModlog(paths, regexString, results) {
 	}
 	const fileResults = stdout.toString().split('\n').reverse();
 	for (let i = 0; i < fileResults.length; i++) {
-		results.tryInsert(fileResults[i]);
+		if (fileResults[i]) results.tryInsert(fileResults[i]);
 	}
 	return results;
 }


### PR DESCRIPTION
There's a newline at the end of ripgrep's output, which led to an additional empty result element being added.