### PR TITLE
Confusion self-hit doesn't trigger Sitrus + super sitrus Berries

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1270,8 +1270,8 @@ exports.BattleAbilities = {
 		onResidual: function (pokemon) {
 			if (this.isWeather(['sunnyday', 'desolateland']) || this.random(2) === 0) {
 				if (pokemon.hp && !pokemon.item && this.getItem(pokemon.lastItem).isBerry) {
+					this.add('-item', pokemon, pokemon.lastItem, '[from] ability: Harvest');
 					pokemon.setItem(pokemon.lastItem);
-					this.add('-item', pokemon, pokemon.getItem(), '[from] ability: Harvest');
 				}
 			}
 		},
@@ -1629,6 +1629,11 @@ exports.BattleAbilities = {
 		desc: "This Pokemon's held item has no effect. This Pokemon cannot use Fling successfully. Macho Brace, Power Anklet, Power Band, Power Belt, Power Bracer, Power Lens, and Power Weight still have their effects.",
 		shortDesc: "This Pokemon's held item has no effect, except Macho Brace. Fling cannot be used.",
 		// Item suppression implemented in Pokemon.ignoringItem() within sim/pokemon.js
+		onAfterEnd: function (pokemon) {
+			let item = pokemon.getItem();
+			if ((!item.isBerry && item.id !== 'berryjuice') || pokemon.ignoringItem()) return;
+			this.singleEvent('Start', item, pokemon.itemData, pokemon, pokemon, item);
+		},
 		id: "klutz",
 		name: "Klutz",
 		rating: -1,

--- a/data/items.js
+++ b/data/items.js
@@ -115,7 +115,13 @@ exports.BattleItems = {
 			basePower: 80,
 			type: "Dragon",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -231,7 +237,13 @@ exports.BattleItems = {
 			basePower: 100,
 			type: "Ground",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -395,7 +407,13 @@ exports.BattleItems = {
 		fling: {
 			basePower: 30,
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 2) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				if (this.runEvent('TryHeal', pokemon) && pokemon.useItem()) {
 					this.heal(20);
@@ -1669,7 +1687,13 @@ exports.BattleItems = {
 			basePower: 80,
 			type: "Bug",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -1938,7 +1962,13 @@ exports.BattleItems = {
 			basePower: 100,
 			type: "Ice",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -2367,7 +2397,13 @@ exports.BattleItems = {
 			basePower: 80,
 			type: "Dark",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -2706,7 +2742,13 @@ exports.BattleItems = {
 			basePower: 100,
 			type: "Flying",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -2848,7 +2890,13 @@ exports.BattleItems = {
 			basePower: 100,
 			type: "Grass",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -3080,7 +3128,13 @@ exports.BattleItems = {
 			basePower: 80,
 			type: "Ghost",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -3405,7 +3459,13 @@ exports.BattleItems = {
 			basePower: 100,
 			type: "Rock",
 		},
-		onResidual: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -3676,7 +3736,13 @@ exports.BattleItems = {
 			basePower: 80,
 			type: "Poison",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
 			}
@@ -3813,7 +3879,13 @@ exports.BattleItems = {
 			basePower: 100,
 			type: "Poison",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -4678,7 +4750,13 @@ exports.BattleItems = {
 			basePower: 100,
 			type: "Fighting",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -4908,7 +4986,13 @@ exports.BattleItems = {
 			basePower: 80,
 			type: "Psychic",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 2) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
 			}
@@ -5136,7 +5220,13 @@ exports.BattleItems = {
 			basePower: 100,
 			type: "Psychic",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}
@@ -5672,7 +5762,13 @@ exports.BattleItems = {
 			basePower: 80,
 			type: "Rock",
 		},
-		onUpdate: function (pokemon) {
+		onStart: function (pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage: function (damage, pokemon, source, effect) {
+			if (effect.id === 'confused') return;
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				pokemon.eatItem();
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -4330,6 +4330,11 @@ exports.BattleMovedex = {
 			onEnd: function (pokemon) {
 				this.add('-end', pokemon, 'Embargo');
 			},
+			onAfterEnd: function (pokemon) {
+				let item = pokemon.getItem();
+				if ((!item.isBerry && item.id !== 'berryjuice') || pokemon.ignoringItem()) return;
+				this.singleEvent('Start', item, pokemon.itemData, pokemon, pokemon, item);
+			},
 		},
 		secondary: false,
 		target: "normal",
@@ -6137,6 +6142,7 @@ exports.BattleMovedex = {
 			onStart: function (pokemon) {
 				this.add('-endability', pokemon);
 				this.singleEvent('End', this.getAbility(pokemon.ability), pokemon.abilityData, pokemon, pokemon, 'gastroacid');
+				this.singleEvent('AfterEnd', this.getAbility(pokemon.ability), pokemon.abilityData, pokemon, pokemon, 'gastroacid');
 			},
 		},
 		secondary: false,
@@ -9596,6 +9602,15 @@ exports.BattleMovedex = {
 			onEnd: function () {
 				this.add('-fieldend', 'move: Magic Room', '[of] ' + this.effectData.source);
 			},
+			onAfterEnd: function () {
+				for (const side of this.sides) {
+					for (const pokemon of side.active) {
+						let item = pokemon.getItem();
+						if ((!item.isBerry && item.id !== 'berryjuice') || pokemon.ignoringItem()) continue;
+						this.singleEvent('Start', item, pokemon.itemData, pokemon, pokemon, item);
+					}
+				}
+			},
 		},
 		secondary: false,
 		target: "all",
@@ -12970,8 +12985,8 @@ exports.BattleMovedex = {
 		flags: {snatch: 1},
 		onHit: function (pokemon) {
 			if (pokemon.item || !pokemon.lastItem) return false;
+			this.add('-item', pokemon, pokemon.lastItem, '[from] move: Recycle');
 			pokemon.setItem(pokemon.lastItem);
-			this.add('-item', pokemon, pokemon.getItem(), '[from] move: Recycle');
 		},
 		secondary: false,
 		target: "self",

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -255,6 +255,7 @@ class Battle extends Dex.ModdedDex {
 		if (!this.pseudoWeather[status.id]) return false;
 		this.singleEvent('End', status, this.pseudoWeather[status.id], this);
 		delete this.pseudoWeather[status.id];
+		this.singleEvent('AfterEnd', status, null, this);
 		return true;
 	}
 	suppressingAttackEvents() {
@@ -420,7 +421,7 @@ class Battle extends Dex.ModdedDex {
 			this.debug(eventid + ' handler suppressed by Embargo, Klutz or Magic Room');
 			return relayVar;
 		}
-		if (eventid !== 'End' && effect.effectType === 'Ability' && (target instanceof Sim.Pokemon) && target.ignoringAbility()) {
+		if (eventid !== 'End' && eventid !== 'AfterEnd' && effect.effectType === 'Ability' && (target instanceof Sim.Pokemon) && target.ignoringAbility()) {
 			this.debug(eventid + ' handler suppressed by Gastro Acid');
 			return relayVar;
 		}
@@ -638,7 +639,7 @@ class Battle extends Dex.ModdedDex {
 					this.debug(eventid + ' handler suppressed by Embargo, Klutz or Magic Room');
 				}
 				continue;
-			} else if (eventid !== 'End' && status.effectType === 'Ability' && (thing instanceof Sim.Pokemon) && thing.ignoringAbility()) {
+			} else if (eventid !== 'End' && eventid !== 'AfterEnd' && status.effectType === 'Ability' && (thing instanceof Sim.Pokemon) && thing.ignoringAbility()) {
 				if (eventid !== 'Update') {
 					this.debug(eventid + ' handler suppressed by Gastro Acid');
 				}
@@ -1098,6 +1099,7 @@ class Battle extends Dex.ModdedDex {
 		this.runEvent('BeforeSwitchIn', pokemon);
 		if (side.active[pos]) {
 			let oldActive = side.active[pos];
+			let unnerveEnded = oldActive.hasAbility('unnerve');
 			oldActive.isActive = false;
 			oldActive.isStarted = false;
 			oldActive.usedItemThisTurn = false;
@@ -1107,6 +1109,13 @@ class Battle extends Dex.ModdedDex {
 			side.pokemon[oldActive.position] = oldActive;
 			this.cancelMove(oldActive);
 			oldActive.clearVolatile();
+			if (unnerveEnded) {
+				for (const foe of side.foe.active) {
+					let item = foe.getItem();
+					if ((!item.isBerry && item.id !== 'berryjuice') || foe.ignoringItem()) continue;
+					this.singleEvent('Start', item, foe.itemData, foe, foe, item);
+				}
+			}
 		}
 		side.active[pos] = pokemon;
 		pokemon.activeTurns = 0;
@@ -1157,6 +1166,7 @@ class Battle extends Dex.ModdedDex {
 			this.runEvent('SwitchOut', oldActive);
 			oldActive.illusion = null;
 			this.singleEvent('End', this.getAbility(oldActive.ability), oldActive.abilityData, oldActive);
+			let unnerveEnded = oldActive.hasAbility('unnerve');
 			oldActive.isActive = false;
 			oldActive.isStarted = false;
 			oldActive.usedItemThisTurn = false;
@@ -1174,6 +1184,13 @@ class Battle extends Dex.ModdedDex {
 				}
 			}
 			oldActive.clearVolatile();
+			if (unnerveEnded) {
+				for (const foe of side.foe.active) {
+					let item = foe.getItem();
+					if ((!item.isBerry && item.id !== 'berryjuice') || foe.ignoringItem()) continue;
+					this.singleEvent('Start', item, foe.itemData, foe, foe, item);
+				}
+			}
 		}
 		side.active[pos] = pokemon;
 		pokemon.isActive = true;
@@ -1618,7 +1635,11 @@ class Battle extends Dex.ModdedDex {
 			this.add('-damage', target, target.getHealth);
 			break;
 		}
-		if (target.fainted) this.faint(target);
+		if (target.fainted) {
+			this.faint(target);
+		} else {
+			damage = this.runEvent('AfterDamage', target, source, effect, damage);
+		}
 		return damage;
 	}
 	heal(damage, target, source, effect) {

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1112,7 +1112,7 @@ class Battle extends Dex.ModdedDex {
 			if (unnerveEnded) {
 				for (const foe of side.foe.active) {
 					let item = foe.getItem();
-					if ((!item.isBerry && item.id !== 'berryjuice') || foe.ignoringItem()) continue;
+					if (!item.isBerry || foe.ignoringItem()) continue;
 					this.singleEvent('Start', item, foe.itemData, foe, foe, item);
 				}
 			}
@@ -1187,7 +1187,7 @@ class Battle extends Dex.ModdedDex {
 			if (unnerveEnded) {
 				for (const foe of side.foe.active) {
 					let item = foe.getItem();
-					if ((!item.isBerry && item.id !== 'berryjuice') || foe.ignoringItem()) continue;
+					if (!item.isBerry || foe.ignoringItem()) continue;
 					this.singleEvent('Start', item, foe.itemData, foe, foe, item);
 				}
 			}

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -1025,12 +1025,14 @@ class Pokemon {
 			if (ability.id in {illusion:1, multitype:1, stancechange:1}) return false;
 			if (oldAbility in {multitype:1, stancechange:1}) return false;
 		}
+
 		this.battle.singleEvent('End', this.battle.getAbility(oldAbility), this.abilityData, this, source, effect);
 		if (!effect && this.battle.effect && this.battle.effect.effectType === 'Move') {
 			this.battle.add('-endability', this, this.battle.getAbility(oldAbility), '[from] move: ' + this.battle.getMove(this.battle.effect.id));
 		}
 		this.ability = ability.id;
 		this.abilityData = {id: ability.id, target: this};
+		this.battle.singleEvent('AfterEnd', this.battle.getAbility(oldAbility), null, this);
 		if (ability.id && this.battle.gen > 3) {
 			this.battle.singleEvent('Start', ability, this.abilityData, this, source, effect);
 		}
@@ -1122,6 +1124,7 @@ class Pokemon {
 		let linkedPokemon = this.volatiles[status.id].linkedPokemon;
 		let linkedStatus = this.volatiles[status.id].linkedStatus;
 		delete this.volatiles[status.id];
+		this.battle.singleEvent('AfterEnd', status, null, this);
 		if (linkedPokemon && linkedPokemon.volatiles[linkedStatus]) {
 			linkedPokemon.removeVolatile(linkedStatus);
 		}

--- a/test/simulator/items/sitrusberry.js
+++ b/test/simulator/items/sitrusberry.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Sitrus Berry', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should heal 25% hp when consumed', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Aggron', ability: 'sturdy', item: 'sitrusberry', moves: ['sleeptalk']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Lucario', ability: 'adaptability', moves: ['aurasphere']}]);
+		const holder = battle.p1.active[0];
+		battle.commitDecisions();
+		assert.false.holdsItem(holder);
+		assert.strictEqual(holder.hp, Math.floor(holder.maxhp / 4) + 1);
+	});
+
+	it('should be eaten immediately if (re)gained on low hp', function () {
+		battle = common.createBattle([
+			[{species: 'Magnemite', ability: 'sturdy', item: 'sitrusberry', moves: ['recycle']}],
+			[{species: 'Garchomp', ability: 'roughskin', moves: ['earthquake']}],
+		]);
+		const holder = battle.p1.active[0];
+		const hpgain = Math.floor(holder.maxhp / 4);
+		battle.commitDecisions();
+		assert.false.holdsItem(holder);
+		assert.strictEqual(holder.hp, hpgain + hpgain + 1);
+	});
+
+	it('should not heal 25% hp if a confusion self-hit triggers the healing', function () {
+		battle = common.createBattle([
+			[{species: 'Deoxys-Attack', ability: 'pressure', item: 'sitrusberry', moves: ['sleeptalk']}],
+			[{species: 'Sableye', ability: 'prankster', moves: ['confuseray']}],
+		]);
+		const holder = battle.p1.active[0];
+		battle.commitDecisions();
+		assert.holdsItem(holder);
+		assert.false.strictEqual(holder.hp, holder.maxhp);
+	});
+});


### PR DESCRIPTION
Mentioned in https://github.com/Zarel/Pokemon-Showdown/issues/2367#issuecomment-327332860

Not sure if this is the best way to implement this, but I can't think of anything else.

@Marty or @DaWoblefet can either of you confirm if Oran Berry/Berry Juice/Stat-boosting berries also does this or if it's only the healing berries. Also is this new in Gen 7, or was this also the case before?