### PR TITLE
/ds<N> single result details should be for gen<N>

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -110,6 +110,7 @@ exports.commands = {
 			} else if (response.reply) {
 				this.sendReplyBox(response.reply);
 			} else if (response.dt) {
+				if (targetGen) response.dt += `, gen${targetGen}`;
 				Chat.commands.data.call(this, response.dt, room, user, connection, 'dt');
 			}
 			this.update();


### PR DESCRIPTION
For example, compare `/ds hp=65, atk=40` with `/ds3 hp=65, atk=40`. Reported [here](https://www.smogon.com/forums/posts/7541421).