### PR TITLE
Scavenger games: fix timer

### DIFF
--- a/chat-plugins/scavenger-games.js
+++ b/chat-plugins/scavenger-games.js
@@ -154,7 +154,7 @@ class ScavGame extends Rooms.RoomGame {
 		if (this.childGame && this.childGame.leaveGame) this.childGame.leaveGame(...args);
 	}
 	setTimer(...args) {
-		if (this.childGame && this.childGame.setTimer) this.childGame.setTimer(...args);
+		if (this.childGame && this.childGame.setTimer) return this.childGame.setTimer(...args);
 	}
 	onSendQuestion(...args) {
 		if (this.childGame && this.childGame.onSendQuestion) return this.childGame.onSendQuestion(...args);


### PR DESCRIPTION
- return the value of the timer duration in a scav game so it does not end up as ``undefined``

(NOTE: the timer works as is - it simply does not announce the duration properly to the room)