### PR TITLE
Fix inconsistent indentation

### DIFF
--- a/chat-plugins/scavengers.js
+++ b/chat-plugins/scavengers.js
@@ -640,8 +640,8 @@ let commands = {
 	 * --------------
 	 * Individual game commands for each Scavenger Game
 	 */
-	 game: 'games',
-	 games: {
+	game: 'games',
+	games: {
 		knockoutgames: 'kogames',
 		kogames: function (target, room, user) {
 			if (room.id !== 'scavengers') return this.errorReply("Scavenger games can only be created in the scavengers room.");

--- a/punishments.js
+++ b/punishments.js
@@ -1248,13 +1248,13 @@ Punishments.isRoomBanned = function (user, roomid) {
 	for (let ip in user.ips) {
 		punishment = Punishments.roomIps.nestedGet(roomid, ip);
 		if (punishment) {
-			 if (punishment[0] === 'ROOMBAN') {
+			if (punishment[0] === 'ROOMBAN') {
 				return punishment;
-			 } else if (punishment[0] === 'BLACKLIST') {
+			} else if (punishment[0] === 'BLACKLIST') {
 				if (Punishments.sharedIps.has(ip) && user.autoconfirmed) return;
 
 				return punishment;
-			 }
+			}
 		}
 	}
 };


### PR DESCRIPTION
This is really not that important in of itself, but it seems right to highlight this in general. It seems as if Travis indentation rules aren't being entirely enforced since these are getting a pass in current pullreqs (https://github.com/Zarel/Pokemon-Showdown/pull/4055). Since the errors do get detected by the rules on other platforms, this doesn't seem to be a problem with the rules themselves but rather the environment its tested in.
```
>npm test

> pokemon-showdown@0.11.2 test .
> eslint --rulesdir=dev-tools/eslint --cache *.js chat-plugins/ config/ data/ dev-tools/ mods/ sim/ tournaments/ test/ && mocha


punishments.js
  1251:5  error  Expected indentation of 3 tabs but found 1 space and 3 tabs  indent
  1253:5  error  Expected indentation of 3 tabs but found 1 space and 3 tabs  indent
  1257:5  error  Expected indentation of 3 tabs but found 1 space and 3 tabs  indent

chat-plugins/scavengers.js
  643:3  error  Expected indentation of 1 tab but found 1 space and 1 tab  indent
  644:3  error  Expected indentation of 1 tab but found 1 space and 1 tab  indent

✖ 5 problems (5 errors, 0 warnings)

npm ERR! Test failed.  See above for more details.
```