### PR TITLE
Pokedex: Update Tsareena Evolution Conditions

### DIFF
--- a/data/pokedex.js
+++ b/data/pokedex.js
@@ -12139,7 +12139,8 @@ exports.BattlePokedex = {
 		weightkg: 21.4,
 		color: "Purple",
 		prevo: "steenee",
-		evoLevel: 29,
+		evoLevel: 19,
+		evoMove: "Stomp",
 		eggGroups: ["Grass"],
 	},
 	comfey: {


### PR DESCRIPTION
Seeing as this generation in the games, you can learn moves with the relearn tutor without actually needing to reach that level it is possible to reach Level 19 and evolve a Tsareena.