### PR TITLE
Team Validator: Fix typo in comment

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -912,7 +912,7 @@ class Validator {
 						// gen 4-7 level-up moves
 						if (level >= parseInt(learned.substr(2)) || learnedGen >= 7) {
 							// we're past the required level to learn it
-							// gen 7 level-up moves can be relearnered at any level
+							// gen 7 level-up moves can be relearned at any level
 							// fall through to LMT check below
 						} else if (!template.gender || template.gender === 'F') {
 							// available as egg move


### PR DESCRIPTION
even though "relearnered" is technically correct because you go to the move relearner to teach them, relearned is an actual word