### PR TITLE
Editorconfig: Increase indent size to 3 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,14 +7,14 @@ root = true
 [*]
 charset = utf-8
 indent_style = tab
-indent_size = 2
+indent_size = 3
 trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.{json,yml,webapp}]
 # npm style
 indent_style = space
-indent_size = 2
+indent_size = 3
 
 [*.md]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ insert_final_newline = true
 [*.{json,yml,webapp}]
 # npm style
 indent_style = space
-indent_size = 3
+indent_size = 2
 
 [*.md]
 indent_style = space


### PR DESCRIPTION
As based on discussion on https://github.com/Zarel/Pokemon-Showdown/commit/9435848c16e4fb3aefa903953d0a545de404d5d3 and the poll in Dev