### PR TITLE
/itemsearch: Fix using the 'all' parameter

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -1247,7 +1247,8 @@ function runItemsearch(target, cmd, canAll, message) {
 	let showAll = false;
 
 	target = target.trim();
-	if (target.substr(target.length - 5) === ', all' || target.substr(target.length - 4) === ',all') {
+	if (target.substr(target.length - 5) === ', all') {
+		if (!canAll) return {reply: "A search ending in ', all' cannot be broadcast."};
 		showAll = true;
 		target = target.substr(0, target.length - 5);
 	}


### PR DESCRIPTION
Previously, the command allowed users to broadcast commands ending with` ', all'`. I removed the `',all'` option because it was still stripping off the last 5 characters of `target` even when the space was omitted, and the command doesn't support separating any other words with just a comma anyway.