### PR TITLE
Fix global bans

### DIFF
--- a/users.js
+++ b/users.js
@@ -792,6 +792,10 @@ class User {
 			}
 			if (this.named) user.prevNames[this.userid] = this.name;
 			this.destroy();
+
+			if (user.named) Punishments.checkName(user, registered);
+			if (user.namelocked) user.named = true;
+
 			Rooms.global.checkAutojoin(user);
 			if (Config.loginfilter) Config.loginfilter(user, this, userType);
 			return true;


### PR DESCRIPTION
Fixes an issue where users can evade global bans on the same name they were banned under.