### PR TITLE
Clear intersect sources if we're only using sources before

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -1114,7 +1114,8 @@ class Validator {
 			if (lsetData.sources) {
 				let sourcesSet = new Set(sources);
 				let intersectSources = lsetData.sources.filter(source => sourcesSet.has(source));
-				if (!intersectSources.length && !(sourcesBefore && lsetData.sourcesBefore)) {
+				if (!intersectSources.length) intersectSources = null;
+				if (!intersectSources && !(sourcesBefore && lsetData.sourcesBefore)) {
 					return {type:'incompatible'};
 				}
 				lsetData.sources = intersectSources;


### PR DESCRIPTION
Reported [here](http://www.smogon.com/forums/posts/7563613).

When validating against Gen 6 PU, Trick and Magic Coat have no `sources` or `sourcesBefore` because they are learned by tutor in ORAS.

When validating against Gen 7 PU, Trick can be learned by Espurr as an Egg move. There is therefore a `sources` of `['7E']` and a `sourcesBefore` of 6.

When the validator tries to combine that with Magic Coat which still has no `sources` but now has a `sourcesBefore` of 6 it arrives at an empty array for `sources` with a `sourcesBefore` of 6. This causes it to fail validation later as it has no compatible source.

The error arises because it's legal for there to be no specific `sources` when both moves have a `sourcesBefore`, but in this case the `sources` should be null instead of empty.

Always assuming I've understood this behaviour of the validator correctly, of course...