### PR TITLE
Add unique validation messages for Sketchmons

### DIFF
--- a/team-validator.js
+++ b/team-validator.js
@@ -292,8 +292,9 @@ class Validator {
 					let problem = this.checkLearnset(move, template, lsetData);
 					if (problem) {
 						// Sketchmons hack
+						const allowOneSketch = ruleTable.has('allowonesketch');
 						const noSketch = format.noSketch || dex.getFormat('gen7sketchmons').noSketch;
-						if (ruleTable.has('allowonesketch') && noSketch.indexOf(move.name) < 0 && !set.sketchmonsMove && !move.noSketch && !move.isZ) {
+						if (allowOneSketch && noSketch.indexOf(move.name) < 0 && !set.sketchmonsMove && && !move.noSketch && !move.isZ) {
 							set.sketchmonsMove = move.id;
 							continue;
 						}
@@ -309,6 +310,14 @@ class Validator {
 							problemString = problemString.concat(` because it needs to be from generation ${problem.gen} or later.`);
 						} else {
 							problemString = problemString.concat(`.`);
+						}
+						// Sketchmons hack part 2
+						if (allowOneSketch) {
+							if (noSketch.indexOf(move.name) >= 0) {
+								problemString = problemString.concat(` (${move.name} is banned from being sketched in ${format.name}.)`);
+							} else if (set.sketchmonsMove !== move.id) {
+								problemString = problemString.concat(` (You cannot sketch more than one move per Pok\u00E9mon.)`);
+							}
 						}
 						problems.push(problemString);
 					}

--- a/team-validator.js
+++ b/team-validator.js
@@ -294,7 +294,7 @@ class Validator {
 						// Sketchmons hack
 						const allowOneSketch = ruleTable.has('allowonesketch');
 						const noSketch = format.noSketch || dex.getFormat('gen7sketchmons').noSketch;
-						if (allowOneSketch && noSketch.indexOf(move.name) < 0 && !set.sketchmonsMove && && !move.noSketch && !move.isZ) {
+						if (allowOneSketch && noSketch.indexOf(move.name) < 0 && !set.sketchmonsMove && !move.noSketch && !move.isZ) {
 							set.sketchmonsMove = move.id;
 							continue;
 						}


### PR DESCRIPTION
I left this to sit overnight so I could review it with fresh eyes in the morning and forgot about it for 12 days... Anyway, this should give users a much more informative message than "(Pokemon) cannot learn (move)" when validating a Sketchmons set that either has a banned sketch move or more than one.