### PR TITLE
Variable healing moves should have fail messages

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -1459,7 +1459,6 @@ exports.BattleMovedex = {
 		onHit: function (target, source, move) {
 			if (!target.addVolatile('trapped', source, move, 'trapper')) {
 				this.add('-fail', target);
-				return false;
 			}
 		},
 		secondary: false,
@@ -15625,7 +15624,6 @@ exports.BattleMovedex = {
 		onHit: function (target, source, move) {
 			if (!target.addVolatile('trapped', source, move, 'trapper')) {
 				this.add('-fail', target);
-				return false;
 			}
 		},
 		secondary: false,

--- a/data/moves.js
+++ b/data/moves.js
@@ -1459,6 +1459,7 @@ exports.BattleMovedex = {
 		onHit: function (target, source, move) {
 			if (!target.addVolatile('trapped', source, move, 'trapper')) {
 				this.add('-fail', target);
+				return false;
 			}
 		},
 		secondary: false,
@@ -5462,11 +5463,13 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, heal: 1, mystery: 1},
 		onHit: function (target) {
+			let healResult = false;
 			if (this.isTerrain('grassyterrain')) {
-				this.heal(this.modify(target.maxhp, 0.667)); // TODO: find out the real value
+				healResult = this.heal(this.modify(target.maxhp, 0.667)); // TODO: find out the real value
 			} else {
-				this.heal(Math.ceil(target.maxhp * 0.5));
+				healResult = this.heal(Math.ceil(target.maxhp * 0.5));
 			}
+			return healResult;
 		},
 		secondary: false,
 		target: "normal",
@@ -7166,11 +7169,13 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, pulse: 1, reflectable: 1, distance: 1, heal: 1, mystery: 1},
 		onHit: function (target, source) {
+			let healResult = false;
 			if (source.hasAbility('megalauncher')) {
-				this.heal(this.modify(target.maxhp, 0.75));
+				healResult = this.heal(this.modify(target.maxhp, 0.75));
 			} else {
-				this.heal(Math.ceil(target.maxhp * 0.5));
+				healResult = this.heal(Math.ceil(target.maxhp * 0.5));
 			}
+			return healResult;
 		},
 		secondary: false,
 		target: "any",
@@ -10608,13 +10613,15 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onHit: function (pokemon) {
+			let healResult = false;
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
-				this.heal(this.modify(pokemon.maxhp, 0.667));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else if (this.isWeather(['raindance', 'primordialsea', 'sandstorm', 'hail'])) {
-				this.heal(this.modify(pokemon.maxhp, 0.25));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.25));
 			} else {
-				this.heal(this.modify(pokemon.maxhp, 0.5));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
+			return healResult;
 		},
 		secondary: false,
 		target: "self",
@@ -10636,13 +10643,15 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onHit: function (pokemon) {
+			let healResult = false;
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
-				this.heal(this.modify(pokemon.maxhp, 0.667));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else if (this.isWeather(['raindance', 'primordialsea', 'sandstorm', 'hail'])) {
-				this.heal(this.modify(pokemon.maxhp, 0.25));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.25));
 			} else {
-				this.heal(this.modify(pokemon.maxhp, 0.5));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
+			return healResult;
 		},
 		secondary: false,
 		target: "self",
@@ -14442,11 +14451,13 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onHit: function (pokemon) {
+			let healResult = false;
 			if (this.isWeather('sandstorm')) {
-				this.heal(this.modify(pokemon.maxhp, 0.667));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else {
-				this.heal(this.modify(pokemon.maxhp, 0.5));
+				healResult =this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
+			return healResult;
 		},
 		secondary: false,
 		target: "self",
@@ -15614,6 +15625,7 @@ exports.BattleMovedex = {
 		onHit: function (target, source, move) {
 			if (!target.addVolatile('trapped', source, move, 'trapper')) {
 				this.add('-fail', target);
+				return false;
 			}
 		},
 		secondary: false,
@@ -16732,13 +16744,15 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onHit: function (pokemon) {
+			let healResult = false;
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
-				this.heal(this.modify(pokemon.maxhp, 0.667));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else if (this.isWeather(['raindance', 'primordialsea', 'sandstorm', 'hail'])) {
-				this.heal(this.modify(pokemon.maxhp, 0.25));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.25));
 			} else {
-				this.heal(this.modify(pokemon.maxhp, 0.5));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
+			return healResult;
 		},
 		secondary: false,
 		target: "self",

--- a/data/moves.js
+++ b/data/moves.js
@@ -5462,13 +5462,11 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, heal: 1, mystery: 1},
 		onHit: function (target) {
-			let healResult = false;
 			if (this.isTerrain('grassyterrain')) {
-				healResult = this.heal(this.modify(target.maxhp, 0.667)); // TODO: find out the real value
+				return this.heal(this.modify(target.maxhp, 0.667)); // TODO: find out the real value
 			} else {
-				healResult = this.heal(Math.ceil(target.maxhp * 0.5));
+				return this.heal(Math.ceil(target.maxhp * 0.5));
 			}
-			return healResult;
 		},
 		secondary: false,
 		target: "normal",
@@ -7168,13 +7166,11 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, pulse: 1, reflectable: 1, distance: 1, heal: 1, mystery: 1},
 		onHit: function (target, source) {
-			let healResult = false;
 			if (source.hasAbility('megalauncher')) {
-				healResult = this.heal(this.modify(target.maxhp, 0.75));
+				return this.heal(this.modify(target.maxhp, 0.75));
 			} else {
-				healResult = this.heal(Math.ceil(target.maxhp * 0.5));
+				return this.heal(Math.ceil(target.maxhp * 0.5));
 			}
-			return healResult;
 		},
 		secondary: false,
 		target: "any",
@@ -10612,15 +10608,13 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onHit: function (pokemon) {
-			let healResult = false;
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
+				return this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else if (this.isWeather(['raindance', 'primordialsea', 'sandstorm', 'hail'])) {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.25));
+				return this.heal(this.modify(pokemon.maxhp, 0.25));
 			} else {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.5));
+				return this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
-			return healResult;
 		},
 		secondary: false,
 		target: "self",
@@ -10642,15 +10636,13 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onHit: function (pokemon) {
-			let healResult = false;
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
+				return this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else if (this.isWeather(['raindance', 'primordialsea', 'sandstorm', 'hail'])) {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.25));
+				return this.heal(this.modify(pokemon.maxhp, 0.25));
 			} else {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.5));
+				return this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
-			return healResult;
 		},
 		secondary: false,
 		target: "self",
@@ -14450,13 +14442,11 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onHit: function (pokemon) {
-			let healResult = false;
 			if (this.isWeather('sandstorm')) {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
+				return this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.5));
+				return this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
-			return healResult;
 		},
 		secondary: false,
 		target: "self",
@@ -16742,15 +16732,13 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onHit: function (pokemon) {
-			let healResult = false;
 			if (this.isWeather(['sunnyday', 'desolateland'])) {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
+				return this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else if (this.isWeather(['raindance', 'primordialsea', 'sandstorm', 'hail'])) {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.25));
+				return this.heal(this.modify(pokemon.maxhp, 0.25));
 			} else {
-				healResult = this.heal(this.modify(pokemon.maxhp, 0.5));
+				return this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
-			return healResult;
 		},
 		secondary: false,
 		target: "self",

--- a/data/moves.js
+++ b/data/moves.js
@@ -14454,7 +14454,7 @@ exports.BattleMovedex = {
 			if (this.isWeather('sandstorm')) {
 				healResult = this.heal(this.modify(pokemon.maxhp, 0.667));
 			} else {
-				healResult =this.heal(this.modify(pokemon.maxhp, 0.5));
+				healResult = this.heal(this.modify(pokemon.maxhp, 0.5));
 			}
 			return healResult;
 		},


### PR DESCRIPTION
Now they'll return false when they don't heal, which will cause the "But it Failed!" message to appear. At some point, someone should implement a unique failure message ("{Pokemon}'s HP is full!") for when these moves and Recover clones fail to restore HP, but for now this should be sufficient for any future implementation of Stomping Tantrum, as far as actually recording the failure.