### PR TITLE
Fix Dual Wielding's duplicate Z- prefix

### DIFF
--- a/mods/dualwielding/scripts.js
+++ b/mods/dualwielding/scripts.js
@@ -46,7 +46,6 @@ exports.BattleScripts = {
 
 		if (move.category === 'Status') {
 			zMove = this.getMoveCopy(move);
-			if (!zMove.isZ) zMove.name = 'Z-' + zMove.name;
 			zMove.isZ = true;
 			return zMove;
 		}


### PR DESCRIPTION
Because I had been playing around with where the `Z-` prefix got added to the move name on ROM...