### PR TITLE
Fix clearing volatiles

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -2394,6 +2394,7 @@ class Battle extends Dex.ModdedDex {
 				faintData.target.side.pokemonLeft--;
 				this.runEvent('Faint', faintData.target, faintData.source, faintData.effect);
 				this.singleEvent('End', this.getAbility(faintData.target.ability), faintData.target.abilityData, faintData.target);
+				faintData.target.clearVolatile();
 				faintData.target.fainted = true;
 				faintData.target.isActive = false;
 				faintData.target.isStarted = false;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -1401,7 +1401,7 @@ class Pokemon {
 		for (let linkedPoke of linkedPokemon) {
 			if (linkedPoke.volatiles[linkedStatus]) {
 				linkedPoke.volatiles[linkedStatus].linkedPokemon.splice(linkedPoke.volatiles[linkedStatus].linkedPokemon.indexOf(this), 1);
-				if (linkedPoke.volatiles[linkedStatus].linkedPokemon. length === 0) {
+				if (linkedPoke.volatiles[linkedStatus].linkedPokemon.length === 0) {
 					linkedPoke.removeVolatile(linkedStatus);
 				}
 			}

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -687,7 +687,10 @@ class Pokemon {
 			if (this.volatiles[i].linkedPokemon) {
 				delete pokemon.volatiles[i].linkedPokemon;
 				delete pokemon.volatiles[i].linkedStatus;
-				this.volatiles[i].linkedPokemon.volatiles[this.volatiles[i].linkedStatus].linkedPokemon = this;
+				for (let linkedPoke of this.volatiles[i].linkedPokemon) {
+					let linkedPokeLinks = linkedPoke.volatiles[this.volatiles[i].linkedStatus].linkedPokemon;
+					linkedPokeLinks[linkedPokeLinks.indexOf(pokemon)] = this;
+				}
 			}
 		}
 		pokemon.clearVolatile();
@@ -851,7 +854,10 @@ class Pokemon {
 		this.hpPower = this.baseHpPower;
 		for (let i in this.volatiles) {
 			if (this.volatiles[i].linkedStatus) {
-				this.volatiles[i].linkedPokemon.removeVolatile(this.volatiles[i].linkedStatus);
+				// for (let linkedPoke of this.volatiles[i].linkedPokemon) {
+				// 	linkedPoke.removeVolatile(this.volatiles[i].linkedStatus);
+				// }
+				this.removeLinkedVolatiles(this.volatiles[i].linkedStatus, this.volatiles[i].linkedPokemon);
 			}
 		}
 		this.volatiles = {};
@@ -1319,6 +1325,11 @@ class Pokemon {
 		}
 
 		if (this.volatiles[status.id]) {
+			// if (linkedStatus && this.volatiles[status.id].linkedPokemon) {
+			// 	if (this.volatiles[status.id].linkedPokemon.indexOf(source) < 0) {
+			// 		this.volatiles[status.id].linkedPokemon.push(source);
+			// 	}
+			// }
 			if (!status.onRestart) return false;
 			return this.battle.singleEvent('Restart', status, this.volatiles[status.id], this, source, sourceEffect);
 		}
@@ -1349,11 +1360,15 @@ class Pokemon {
 			delete this.volatiles[status.id];
 			return result;
 		}
-		if (linkedStatus && source && !source.volatiles[linkedStatus.toString()]) {
-			source.addVolatile(linkedStatus, this, sourceEffect, status);
-			source.volatiles[linkedStatus.toString()].linkedPokemon = this;
-			source.volatiles[linkedStatus.toString()].linkedStatus = status;
-			this.volatiles[status.toString()].linkedPokemon = source;
+		if (linkedStatus && source) {
+			if (!source.volatiles[linkedStatus.toString()]) {
+				source.addVolatile(linkedStatus, this, sourceEffect);
+				source.volatiles[linkedStatus.toString()].linkedPokemon = [this];
+				source.volatiles[linkedStatus.toString()].linkedStatus = status;
+			} else {
+				source.volatiles[linkedStatus.toString()].linkedPokemon.push(this);
+			}
+			this.volatiles[status.toString()].linkedPokemon = [source];
 			this.volatiles[status.toString()].linkedStatus = linkedStatus;
 		}
 		return true;
@@ -1379,10 +1394,26 @@ class Pokemon {
 		let linkedPokemon = this.volatiles[status.id].linkedPokemon;
 		let linkedStatus = this.volatiles[status.id].linkedStatus;
 		delete this.volatiles[status.id];
-		if (linkedPokemon && linkedPokemon.volatiles[linkedStatus]) {
-			linkedPokemon.removeVolatile(linkedStatus);
+		if (linkedPokemon) {
+			this.removeLinkedVolatiles(linkedStatus, linkedPokemon);
 		}
 		return true;
+	}
+
+	/**
+	 * @param {string | Effect} linkedStatus
+	 * @param {Pokemon[]} linkedPokemon
+	 */
+	removeLinkedVolatiles(linkedStatus, linkedPokemon) {
+		linkedStatus = linkedStatus.toString();
+		for (let linkedPoke of linkedPokemon) {
+			if (linkedPoke.volatiles[linkedStatus]) {
+				linkedPoke.volatiles[linkedStatus].linkedPokemon.splice(linkedPoke.volatiles[linkedStatus].linkedPokemon.indexOf(this), 1);
+				if (linkedPoke.volatiles[linkedStatus].linkedPokemon. length === 0) {
+					linkedPoke.removeVolatile(linkedStatus);
+				}
+			}
+		}
 	}
 
 	/**

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -854,9 +854,6 @@ class Pokemon {
 		this.hpPower = this.baseHpPower;
 		for (let i in this.volatiles) {
 			if (this.volatiles[i].linkedStatus) {
-				// for (let linkedPoke of this.volatiles[i].linkedPokemon) {
-				// 	linkedPoke.removeVolatile(this.volatiles[i].linkedStatus);
-				// }
 				this.removeLinkedVolatiles(this.volatiles[i].linkedStatus, this.volatiles[i].linkedPokemon);
 			}
 		}
@@ -1325,11 +1322,6 @@ class Pokemon {
 		}
 
 		if (this.volatiles[status.id]) {
-			// if (linkedStatus && this.volatiles[status.id].linkedPokemon) {
-			// 	if (this.volatiles[status.id].linkedPokemon.indexOf(source) < 0) {
-			// 		this.volatiles[status.id].linkedPokemon.push(source);
-			// 	}
-			// }
 			if (!status.onRestart) return false;
 			return this.battle.singleEvent('Restart', status, this.volatiles[status.id], this, source, sourceEffect);
 		}

--- a/test/simulator/misc/trapmoves.js
+++ b/test/simulator/misc/trapmoves.js
@@ -4,7 +4,7 @@ const assert = require('./../../assert');
 const common = require('./../../common');
 
 let battle;
-let trappers = ['Block', 'Mean Look', 'Spider Web', 'Thousand Waves'];
+let trappers = ['Block', 'Mean Look', 'Spider Web', 'Thousand Waves', 'Anchor Shot', 'Spirit Shackle'];
 let partialtrappers = ['Bind', 'Clamp', 'Fire Spin', 'Infestation', 'Magma Storm', 'Sand Tomb', 'Whirlpool', 'Wrap'];
 
 describe('Trapping Moves', function () {
@@ -65,6 +65,30 @@ describe('Trapping Moves', function () {
 			battle.choose('p2', 'switch 2');
 			battle.commitDecisions();
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
+		});
+
+		it('should free all trapped Pokemon if the user is no longer active', function () {
+			battle = common.createBattle({gameType: 'doubles'});
+			const p1 = battle.join('p1', 'Guest 1', 1, [
+				{species: "Smeargle", ability: 'prankster', moves: [toId(trappers[i])]},
+				{species: "Cobalion", ability: 'justified', item: 'laggingtail', moves: ['swordsdance', 'closecombat']},
+			]);
+			battle.join('p2', 'Guest 2', 1, [
+				{species: "Tangrowth", ability: 'leafguard', moves: ['synthesis']},
+				{species: "Starmie", ability: 'illuminate', moves: ['recover']},
+				{species: "Cradily", ability: 'suctioncups', moves: ['recover']},
+				{species: "Hippowdon", ability: 'sandstream', moves: ['slackoff']},
+			]);
+			if (trappers[i] !== 'Thousand Waves') {
+				p1.chooseMove(1, 1).chooseMove(1).foe.chooseMove(1).chooseMove(1);
+				p1.chooseMove(1, 2).chooseMove(2, -1).foe.chooseMove(1).chooseMove(1);
+			} else {
+				p1.chooseMove(1).chooseMove(2, -1).foe.chooseMove(1).chooseMove(1);
+			}
+			battle.choose('p2', 'switch 3, switch 4');
+			battle.commitDecisions();
+			assert.strictEqual(battle.p2.active[0].template.speciesid, 'cradily');
+			assert.strictEqual(battle.p2.active[1].template.speciesid, 'hippowdon');
 		});
 	}
 });

--- a/test/simulator/misc/trapmoves.js
+++ b/test/simulator/misc/trapmoves.js
@@ -90,6 +90,33 @@ describe('Trapping Moves', function () {
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'cradily');
 			assert.strictEqual(battle.p2.active[1].template.speciesid, 'hippowdon');
 		});
+
+		if (i < 3) {
+			// Only test on moves that existed in gen 4
+			it('should be passed when the user uses Baton Pass in Gen 4', function () {
+				battle = common.gen(4).createBattle();
+				battle.join('p1', 'Guest 1', 1, [
+					{species: "Smeargle", ability: 'prankster', moves: [toId(trappers[i]), 'batonpass']},
+					{species: "Shedinja", ability: 'wonderguard', moves: ['rest']},
+				]);
+				battle.join('p2', 'Guest 2', 1, [
+					{species: "Tangrowth", ability: 'leafguard', moves: ['synthesis', 'roar']},
+					{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
+				]);
+				battle.commitDecisions();
+				battle.choose('p1', 'move 2');
+				battle.commitDecisions();
+				battle.choose('p1', 'switch 2');
+				battle.choose('p2', 'switch 2');
+				battle.commitDecisions();
+				assert.strictEqual(battle.p2.active[0].template.speciesid, 'tangrowth');
+				battle.choose('p2', 'move 2');
+				battle.commitDecisions();
+				battle.choose('p2', 'switch 2');
+				battle.commitDecisions();
+				assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
+			});
+		}
 	}
 });
 

--- a/test/simulator/moves/skydrop.js
+++ b/test/simulator/moves/skydrop.js
@@ -83,7 +83,6 @@ describe('Sky Drop', function () {
 		]);
 		battle.choose('p1', 'move 1 1, move 1 -1');
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'skydrop');
 		assert.strictEqual(battle.p2.active[0].boosts['atk'], 1);
 		assert.strictEqual(battle.p2.active[0].boosts['def'], 1);
 	});


### PR DESCRIPTION
- Fixes a case where if a single Pokemon trapped more than one other Pokemon, they wouldn't all be freed when the trapper switched out, was forced out, or was KO'd.
- Fixes a case where a trapper that was KO'd and not replaced wouldn't free any Pokemon it had trapped, even if it had only trapped one.
- Fixes a case where a Pokemon that transformed into an opposing Pokemon and fainted or was forced out on the same turn would leak the ability and moveset of the Pokemon it transformed into if its owner moused over it in the party menu before sending in a replacement.

In order to get the build to pass, I had to alter an apparently unnecessary assertion from an unrelated test. As far as I know, there's way that Aerodactyl could possibly not have used Sky Drop in that test unless somehow Kyogre outsped it (which would most likely not be an isolated error), and if there's a reason why a fainted Pokemon needs to retain the `lastMove` property, that should be in its own test anyway.