### PR TITLE
STABmons: Fix move validation error

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -548,7 +548,7 @@ exports.Formats = [
 		searchShow: false,
 		ruleset: ['Gen 7] OU', 'Ignore STAB Moves'],
 		banlist: ['Kartana', 'Komala', 'Kyurem-Black', 'Silvally-Ghost', 'Tapu Koko', 'Tapu Lele', 'Aerodactylite', 'King\'s Rock', 'Metagrossite', 'Razor Fang'],
-		noLearn: ['acupressure', 'bellydrum', 'chatter', 'geomancy', 'shellsmash', 'shiftgear', 'thousandarrows'],
+		noLearn: ['Acupressure', 'Belly Drum', 'Chatter', 'Geomancy', 'Shell Smash', 'Shift Gear', 'Thousand Arrows'],
 	},
 	{
 		name: "[Gen 7] 2v2 Doubles",

--- a/config/formats.js
+++ b/config/formats.js
@@ -548,7 +548,7 @@ exports.Formats = [
 		searchShow: false,
 		ruleset: ['Gen 7] OU', 'Ignore STAB Moves'],
 		banlist: ['Kartana', 'Komala', 'Kyurem-Black', 'Silvally-Ghost', 'Tapu Koko', 'Tapu Lele', 'Aerodactylite', 'King\'s Rock', 'Metagrossite', 'Razor Fang'],
-		noLearn: ['Acupressure', 'Belly Drum', 'Chatter', 'Geomancy', 'Shell Smash', 'Shift Gear', 'Thousand Arrows'],
+		noLearn: ['acupressure', 'bellydrum', 'chatter', 'geomancy', 'shellsmash', 'shiftgear', 'thousandarrows'],
 	},
 	{
 		name: "[Gen 7] 2v2 Doubles",

--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -902,7 +902,7 @@ class Validator {
 			if (dex.gen === 2 && template.gen === 1) tradebackEligible = true;
 			// STABmons hack to avoid copying all of validateSet to formats
 			let noLearn = format. noLearn || dex.getFormat('gen7stabmons').noLearn;
-			if (ruleTable.has('ignorestabmoves') && noLearn.indexOf(moveid) < 0 && !move.isZ) {
+			if (ruleTable.has('ignorestabmoves') && noLearn.indexOf(move.name) < 0 && !move.isZ) {
 				let types = template.types;
 				if (template.baseSpecies === 'Rotom') types = ['Electric', 'Ghost', 'Fire', 'Water', 'Ice', 'Flying', 'Grass'];
 				if (template.baseSpecies === 'Shaymin') types = ['Grass', 'Flying'];

--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -901,7 +901,8 @@ class Validator {
 			alreadyChecked[template.speciesid] = true;
 			if (dex.gen === 2 && template.gen === 1) tradebackEligible = true;
 			// STABmons hack to avoid copying all of validateSet to formats
-			if (ruleTable.has('ignorestabmoves') && format.noLearn.indexOf(moveid) < 0 && !move.isZ) {
+			let noLearn = format. noLearn || dex.getFormat('gen7stabmons').noLearn;
+			if (ruleTable.has('ignorestabmoves') && noLearn.indexOf(moveid) < 0 && !move.isZ) {
 				let types = template.types;
 				if (template.baseSpecies === 'Rotom') types = ['Electric', 'Ghost', 'Fire', 'Water', 'Ice', 'Flying', 'Grass'];
 				if (template.baseSpecies === 'Shaymin') types = ['Grass', 'Flying'];

--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -901,7 +901,7 @@ class Validator {
 			alreadyChecked[template.speciesid] = true;
 			if (dex.gen === 2 && template.gen === 1) tradebackEligible = true;
 			// STABmons hack to avoid copying all of validateSet to formats
-			let noLearn = format. noLearn || dex.getFormat('gen7stabmons').noLearn;
+			let noLearn = format.noLearn || dex.getFormat('gen7stabmons').noLearn;
 			if (ruleTable.has('ignorestabmoves') && noLearn.indexOf(move.name) < 0 && !move.isZ) {
 				let types = template.types;
 				if (template.baseSpecies === 'Rotom') types = ['Electric', 'Ghost', 'Fire', 'Water', 'Ice', 'Flying', 'Grass'];


### PR DESCRIPTION
http://replay.pokemonshowdown.com/gen7stabmons-654178506

Pokemon were allowed to use banned moves still.