### PR TITLE
AAA: Actually unban Mega Metagross

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -478,7 +478,7 @@ exports.Formats = [
 		mod: 'gen7',
 		ruleset: ['[Gen 7] OU', 'Ability Clause', 'Ignore Illegal Abilities'],
 		banlist: ['Archeops', 'Dragonite', 'Hoopa-Unbound', 'Kartana', 'Keldeo', 'Kyurem-Black', 'Regigigas', 'Shedinja', 'Slaking', 'Terrakion'],
-		unbanlist: ['Genesect', 'Landorus', 'Metagrossite'],
+		unbanlist: ['Genesect', 'Landorus', 'Metagross-Mega'],
 		bannedAbilities: [
 			'Comatose', 'Contrary', 'Fluffy', 'Fur Coat', 'Huge Power', 'Illusion', 'Imposter', 'Innards Out', 'Parental Bond', 'Protean',
 			'Pure Power', 'Simple', 'Speed Boost', 'Stakeout', 'Water Bubble', 'Wonder Guard',


### PR DESCRIPTION
unbanning just the item in `unbanlist` still labels the Pokemon that it
Mega Evolves as Uber, thus leaving it banned