### PR TITLE
Safe FS writing

### DIFF
--- a/chat-plugins/health-fitness.js
+++ b/chat-plugins/health-fitness.js
@@ -26,27 +26,9 @@ class HealthFitness {
 		} catch (error) {
 			if (error.code !== 'MODULE_NOT_FOUND') throw error;
 		}
-
-		this.saveData = (() => {
-			let writing = false;
-			let writePending = false;
-			return async () => {
-				if (writing) {
-					writePending = true;
-					return;
-				}
-				writing = true;
-
-				await FS(`${HF_DATA_PATH}.0`).write(JSON.stringify(this.hfData));
-				await FS(`${HF_DATA_PATH}.0`).rename(HF_DATA_PATH);
-
-				writing = false;
-				if (writePending) {
-					writePending = false;
-					setImmediate(() => this.saveData());
-				}
-			};
-		})();
+	}
+	saveData() {
+		FS(HF_DATA_PATH).writeUpdate(() => JSON.stringify(this.hfData));
 	}
 	setCardio(cardio) {
 		this.hfData.cardio = cardio;

--- a/chat-plugins/trivia.js
+++ b/chat-plugins/trivia.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const fs = require('fs');
+const FS = require('../fs');
 
 const CATEGORIES = {
 	ae: 'Arts and Entertainment',
@@ -69,35 +69,11 @@ if (triviaData.ugm) {
 if (triviaData.questions.some(q => !q.type)) { triviaData.questions = triviaData.questions.map(q => Object.assign(q, {type: 'trivia'})); }
 
 
-const writeTriviaData = (() => {
-	let writing = false;
-	let writePending = false;
-	return () => {
-		if (writing) {
-			writePending = true;
-			return;
-		}
-		writing = true;
-
-		let data = JSON.stringify(triviaData, null, 2);
-		let path = 'config/chat-plugins/triviadata.json';
-		let tempPath = `${path}.0`;
-
-		fs.writeFile(tempPath, data, () => {
-			fs.rename(tempPath, path, () => {
-				writing = false;
-				if (writePending) {
-					writePending = false;
-					setImmediate(() => writeTriviaData());
-				}
-
-				data = null;
-				path = null;
-				tempPath = null;
-			});
-		});
-	};
-})();
+function writeTriviaData() {
+	FS('config/chat-plugins/triviadata.json').writeUpdate(() => (
+		JSON.stringify(triviaData, null, 2)
+	));
+}
 
 // Binary search for the index at which to splice in new questions in a category,
 // or the index at which to slice up to for a category's questions

--- a/fs.js
+++ b/fs.js
@@ -105,9 +105,18 @@ class FSPath {
 		FS(this.path + '.NEW').renameSync(this.path);
 	}
 	/**
-	 * Safest way to update a file with in-memory state.
+	 * Safest way to update a file with in-memory state. Pass a callback
+	 * that fetches the data to be written. It will write an update,
+	 * avoiding race conditions. The callback may not necessarily be
+	 * called, if `writeUpdate` is called many times in a short period.
 	 *
-	 * Ignore the returned Promise; it's not meaningful.
+	 * `options.throttle`, if it exists, will make sure updates are not
+	 * written more than once every `options.throttle` milliseconds.
+	 *
+	 * No synchronous version because there's no risk of race conditions
+	 * with synchronous code; just use `safeWriteSync`.
+	 *
+	 * DO NOT do anything with the returned Promise; it's not meaningful.
 	 *
 	 * @param {() => string | Buffer} dataFetcher
 	 * @param {Object} options


### PR DESCRIPTION
Writing program state to a file is fairly hard to do safely, especially with Node's async FS writing. PS previously reimplemented the code necessary to do it safely basically everywhere it was needed. FS().writeUpdate now consolidates that code so anyone can easily safely update a file.

Would like code review on this.

#4110 should be rebased on this.