### PR TITLE
Account for Ultra Necrozma in Same Type Clause

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -719,8 +719,9 @@ exports.BattleFormats = {
 						template = this.getTemplate(item.megaStone);
 						typeTable = typeTable.filter(type => template.types.indexOf(type) >= 0);
 					}
-					if (item.id === "ultranecroziumz" && template.species.baseSpecies && template.species.baseSpecies === "Necrozma")
+					if (item.id === "ultranecroziumz" && template.species.baseSpecies && template.species.baseSpecies === "Necrozma") {
 						typeTable = typeTable.filter(type => type === "Psychic");
+					}
 				}
 				if (!typeTable.length) return ["Your team must share a type."];
 			}

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -719,6 +719,8 @@ exports.BattleFormats = {
 						template = this.getTemplate(item.megaStone);
 						typeTable = typeTable.filter(type => template.types.indexOf(type) >= 0);
 					}
+					if (item.id === "ultranecroziumz" && template.species.baseSpecies && template.species.baseSpecies === "Necrozma")
+						typeTable = typeTable.filter(type => type === "Psychic");
 				}
 				if (!typeTable.length) return ["Your team must share a type."];
 			}


### PR DESCRIPTION
Ultra Necrozma is only valid on Psychic teams, not Ghost or Steel, for the same reason Mega Gyarados can't be used on a Flying team.

It should be noted that neither Necrozma Dawn Wings nor Necrozma Dusk Mane are legal in standard Monotype, and that this change will therefore only affect other things that use this rule, such as Monotype Ubers tournaments run in the Monotype room. If that's not a good enough reason for this commit (and an extra unneccesary check for each mon in each mono team) then feel free to reject this commit, however my understanding is that the rule should be valid for all possible situations, rather than just those it's currently often used for.