### PR TITLE
Fix Clangorous Soulblaze in Doubles when one foe Protects

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -2242,6 +2242,7 @@ class Battle extends Dex.ModdedDex {
 		if (move.isZ && move.zBrokeProtect) {
 			baseDamage = this.modify(baseDamage, 0.25);
 			this.add('-message', target.name + " couldn't fully protect itself and got hurt! (placeholder)");
+			move.zBrokeProtect = false;
 		}
 
 		if (this.gen !== 5 && !Math.floor(baseDamage)) {


### PR DESCRIPTION
So that when the next foe is processed, it's not considered has having broken protect unless it really did.

Relevant [replay](http://replay.pokemonshowdown.com/gen7doublesou-661362162).