### PR TITLE
Checkpunishment: show punishments for offline users

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -222,7 +222,7 @@ exports.commands = {
 			}
 		}
 
-		let punishments = Punishments.getRoomPunishments(targetUser);
+		let punishments = Punishments.getRoomPunishments(targetUser || {userid});
 
 		if (punishments && punishments.length) {
 			buf += `<br />Room punishments: `;
@@ -231,7 +231,7 @@ exports.commands = {
 				const [punishType, punishUserid, expireTime, reason] = punishment;
 				let punishDesc = Punishments.roomPunishmentTypes.get(punishType);
 				if (!punishDesc) punishDesc = `punished`;
-				if (punishUserid !== targetUser.userid) punishDesc += ` as ${punishUserid}`;
+				if (punishUserid !== userid) punishDesc += ` as ${punishUserid}`;
 				let expiresIn = new Date(expireTime).getTime() - Date.now();
 				let expireString = Chat.toDurationString(expiresIn, {precision: 1});
 				punishDesc += ` for ${expireString}`;


### PR DESCRIPTION
```
[10:03:58] @panpawn: nagandel overrated, rainbowzigzagoon has no punishments associated with it
[10:04:06] @panpawn: its possible those punishments have already expired
[10:04:16] nagandel overrated: ?? expireee
[10:04:18] nagandel overrated: i was blacklisted
[10:04:22] nagandel overrated: aint it permaban
[10:04:28] @panpawn: blacklists are for a year
[10:04:38] nagandel overrated: :OO thankss
[10:04:39] @panpawn: but i dont see any blacklists on the name "rainbowzigzagoon"
[10:04:46] @panpawn: are you sure you were blacklisted recently?
[10:04:50] %sparkychild: your lobby blacklist still lasts for another 100 days on - rainbowzigzagoon
```

I think even if they're offline, you should be able to see their punishments