### PR TITLE
Allow other legal forms in Challenge Cup

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -231,7 +231,7 @@ class RandomTeams extends Dex.ModdedDex {
 		for (let id in this.data.Pokedex) {
 			if (!(this.data.Pokedex[id].num in hasDexNumber)) continue;
 			let template = this.getTemplate(id);
-			if (template.gen <= this.gen && template.learnset && template.species !== 'Pichu-Spiky-eared' && template.species.substr(0, 8) !== 'Pikachu-') {
+			if (template.gen <= this.gen && template.species !== 'Pichu-Spiky-eared' && template.species.substr(0, 8) !== 'Pikachu-') {
 				formes[hasDexNumber[template.num]].push(template.species);
 			}
 		}


### PR DESCRIPTION
Before ad8ef6c unified them, Challenge Cup and Hackmons Cup had slightly different team generators: Hackmons Cup excluded all forms without their own learnset while instead Challenge Cup reverted battle-only formes to their base species while still allowing normally usable forms such as Gourgeist or Oricorio forms. This switches the shared generator to allowing all formes, which thus allows Gourgiest and Oricoria forms in Challenge Cup, but also currently allows battle-only forms in Hackmons Cup (but then again, they're allowed in Balanced Hackmons...); if this is undesirable then I can switch the check to `!template.battleOnly` although I would then also want to remove the Challenge Cup code that excludes battle-only formes.