### PR TITLE
Ban Wishiwashi from Mediocremons

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -479,7 +479,7 @@ exports.Formats = [
 
 		mod: 'gen7',
 		ruleset: ['[Gen 7] OU'],
-		banlist: ['Silvally', 'Type: Null', 'Huge Power', 'Pure Power'],
+		banlist: ['Silvally', 'Type: Null', 'Wishiwashi', 'Huge Power', 'Pure Power'],
 		onValidateSet: function (set) {
 			let problems = [];
 			let template = this.getTemplate(set.species);


### PR DESCRIPTION
I don't think there are any other cases like this, but lemme know if you think of one. Technically, a Wisihiwashi below level 20 can't transform and would technically satisfy the rules of the meta, but I figured nobody would actually want that.