### PR TITLE
Lock: Don't allow regular locks to stack

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1559,7 +1559,7 @@ exports.commands = {
 			name = targetUser.getLastName();
 			userid = targetUser.getLastId();
 
-			if (targetUser.locked && !target) {
+			if (targetUser.locked && !week) {
 				return this.privateModCommand(`(${name} would be locked by ${user.name} but was already locked.)`);
 			}
 


### PR DESCRIPTION
If someone is already locked, the only reason why they should get another lock is for a weeklock for extending a lock.

This happens a lot when someone goes in several rooms, they will often be locked more than once in a short span of time.