### PR TITLE
/mnm: Remove redundant parts of warning messages

### DIFF
--- a/chat-plugins/othermetas.js
+++ b/chat-plugins/othermetas.js
@@ -64,7 +64,7 @@ exports.commands = {
 		}
 		let bannedStones = Dex.getFormat('gen7mixandmega').bannedStones;
 		if (bannedStones.includes(stone.name) && template.name !== stone.megaEvolves) {
-			this.errorReply(`Warning: ${stone.name} is restricted to ${stone.megaEvolves} in Mix and Mega; therefore, ${template.name} cannot use ${stone.name} in actual play.`);
+			this.errorReply(`Warning: ${stone.name} is restricted to ${stone.megaEvolves} in Mix and Mega.`);
 		}
 		let cannotMega = Dex.getFormat('gen7mixandmega').cannotMega;
 		if (cannotMega.includes(template.name) && template.name !== stone.megaEvolves && !template.isMega) { // Separate messages because there's a difference between being already mega evolved / NFE and being banned from mega evolving
@@ -74,7 +74,7 @@ exports.commands = {
 			this.errorReply(`Warning: ${stone.name} is unreleased and is not usable in current Mix and Mega.`);
 		}
 		if (toId(sep[1]) === 'dragonascent' && !['smeargle', 'rayquaza', 'rayquazamega'].includes(toId(sep[0]))) {
-			this.errorReply(`Warning: Only Pokemon with access to Dragon Ascent can mega evolve with Mega Rayquaza's traits; therefore, ${template.name} cannot mega evolve with Dragon Ascent.`);
+			this.errorReply(`Warning: Only Pokemon with access to Dragon Ascent can mega evolve with Mega Rayquaza's traits.`);
 		}
 		// Fake Pokemon and Mega Stones
 		if (template.isNonstandard) {


### PR DESCRIPTION
I'm purposely not accounting for regular Greninja, as it has more than one ability in its base forme.

I also removed unnecessary information from warning messages, as it just elongated them for no reason.