### PR TITLE
Fix this unnecessary reference to battle

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -14823,16 +14823,16 @@ exports.BattleMovedex = {
 			} else {
 				this.add('-activate', source, 'move: Skill Swap', targetAbility, sourceAbility, '[of] ' + target);
 			}
-			source.battle.singleEvent('End', sourceAbility, source.abilityData, source);
-			target.battle.singleEvent('End', targetAbility, target.abilityData, target);
+			this.singleEvent('End', sourceAbility, source.abilityData, source);
+			this.singleEvent('End', targetAbility, target.abilityData, target);
 			if (targetAbility.id !== sourceAbility.id) {
 				source.ability = targetAbility.id;
 				target.ability = sourceAbility.id;
 				source.abilityData = {id: source.ability.id, target: source};
 				target.abilityData = {id: target.ability.id, target: target};
 			}
-			source.battle.singleEvent('Start', targetAbility, source.abilityData, source);
-			target.battle.singleEvent('Start', sourceAbility, target.abilityData, target);
+			this.singleEvent('Start', targetAbility, source.abilityData, source);
+			this.singleEvent('Start', sourceAbility, target.abilityData, target);
 		},
 		secondary: false,
 		target: "normal",

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -233,8 +233,8 @@ exports.BattleMovedex = {
 			// If both are true, counter will deal twice the last damage dealt in battle, no matter what was the move.
 			// That means that, if opponent switches, counter will use last counter damage * 2.
 			let lastUsedMove = this.getMove(target.side.lastMove);
-			if (lastUsedMove && lastUsedMove.basePower > 0 && ['Normal', 'Fighting'].includes(lastUsedMove.type) && target.battle.lastDamage > 0 && !this.willMove(target)) {
-				return 2 * target.battle.lastDamage;
+			if (lastUsedMove && lastUsedMove.basePower > 0 && ['Normal', 'Fighting'].includes(lastUsedMove.type) && this.lastDamage > 0 && !this.willMove(target)) {
+				return 2 * this.lastDamage;
 			}
 			this.add('-fail', pokemon);
 			return false;

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -215,7 +215,7 @@ exports.BattleScripts = {
 		// This only happens on moves that don't deal damage but call GetDamageVarsForPlayerAttack (disassembly).
 		if (!damage && (move.category !== 'Status' || (move.category === 'Status' && !['psn', 'tox', 'par'].includes(move.status))) &&
 		!['conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest'].includes(move.id)) {
-			pokemon.battle.lastDamage = 0;
+			this.lastDamage = 0;
 		}
 
 		// Go ahead with results of the used move.
@@ -653,7 +653,7 @@ exports.BattleScripts = {
 		if (!['recoil', 'drain'].includes(effect.id) && effect.effectType !== 'Status') {
 			// FIXME: The stored damage should be calculated ignoring Substitute.
 			// https://github.com/Zarel/Pokemon-Showdown/issues/2598
-			target.battle.lastDamage = damage;
+			this.lastDamage = damage;
 		}
 		damage = target.damage(damage, source, effect);
 		if (source) source.lastDamage = damage;

--- a/mods/gennext/statuses.js
+++ b/mods/gennext/statuses.js
@@ -22,7 +22,7 @@ exports.BattleStatuses = {
 			}
 		},
 		onEnd: function (target) {
-			this.battle.add('-curestatus', target, 'frz');
+			this.add('-curestatus', target, 'frz');
 		},
 	},
 	lockedmove: {

--- a/mods/pic/moves.js
+++ b/mods/pic/moves.js
@@ -11,13 +11,13 @@ exports.BattleMovedex = {
 			} else {
 				this.add('-activate', source, 'move: Skill Swap', targetAbility, sourceAbility, '[of] ' + target);
 			}
-			source.battle.singleEvent('End', sourceAbility, source.abilityData, source);
+			this.singleEvent('End', sourceAbility, source.abilityData, source);
 			let sourceAlly = source.side.active.find(ally => ally && ally !== source && !ally.fainted);
 			if (sourceAlly && sourceAlly.innate) {
 				sourceAlly.removeVolatile(sourceAlly.innate);
 				delete sourceAlly.innate;
 			}
-			target.battle.singleEvent('End', targetAbility, target.abilityData, target);
+			this.singleEvent('End', targetAbility, target.abilityData, target);
 			let targetAlly = target.side.active.find(ally => ally && ally !== target && !ally.fainted);
 			if (targetAlly && targetAlly.innate) {
 				targetAlly.removeVolatile(targetAlly.innate);
@@ -57,10 +57,10 @@ exports.BattleMovedex = {
 					target.volatiles[volatile].sourcePosition = targetAlly.position;
 				}
 			}
-			source.battle.singleEvent('Start', targetAbility, source.abilityData, source);
-			sourceAlly.battle.singleEvent('Start', sourceAlly.innate, sourceAlly.volatiles[sourceAlly.innate], sourceAlly);
-			target.battle.singleEvent('Start', sourceAbility, target.abilityData, target);
-			targetAlly.battle.singleEvent('Start', targetAlly.innate, targetAlly.volatiles[sourceAlly.innate], targetAlly);
+			this.singleEvent('Start', targetAbility, source.abilityData, source);
+			this.singleEvent('Start', sourceAlly.innate, sourceAlly.volatiles[sourceAlly.innate], sourceAlly);
+			this.singleEvent('Start', sourceAbility, target.abilityData, target);
+			this.singleEvent('Start', targetAlly.innate, targetAlly.volatiles[sourceAlly.innate], targetAlly);
 		},
 	},
 };

--- a/mods/stadium/scripts.js
+++ b/mods/stadium/scripts.js
@@ -646,7 +646,7 @@ exports.BattleScripts = {
 			}
 		}
 		if (damage !== 0) damage = this.clampIntRange(damage, 1);
-		target.battle.lastDamage = damage;
+		this.lastDamage = damage;
 		damage = target.damage(damage, source, effect);
 		if (source) source.lastDamage = damage;
 		let name = effect.fullname;


### PR DESCRIPTION
Most functions run in the battle context so they should be using `this` rather than (e.g.) `target.battle`.