### PR TITLE
Fix phrasing when trying to change names while in a tournament

### DIFF
--- a/users.js
+++ b/users.js
@@ -599,7 +599,7 @@ class User {
 			let game = Rooms(roomid).game;
 			if (!game || game.ended) continue; // should never happen
 			if (game.allowRenames || !this.named) continue;
-			this.popup(`You can't change your name right now because you're in the middle of a rated game or have joined a room tournament.`);
+			this.popup(`You can't change your name right now because you're in the middle of a game that doesn't allow renaming`);
 			return false;
 		}
 

--- a/users.js
+++ b/users.js
@@ -599,7 +599,7 @@ class User {
 			let game = Rooms(roomid).game;
 			if (!game || game.ended) continue; // should never happen
 			if (game.allowRenames || !this.named) continue;
-			this.popup(`You can't change your name right now because you're in the middle of a rated game.`);
+			this.popup(`You can't change your name right now because you're in the middle of a rated game or have joined a room tournament.`);
 			return false;
 		}
 


### PR DESCRIPTION
Currently it would only say "rated games" even when it's not the case (https://i.imgur.com/XAJsjpa.png). There's probably a way to have the message differ for each case but my level's not advanced enough ¯\_(ツ)_/¯