### PR TITLE
Protect should not affect Clangorous Soulblaze's other target

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -564,6 +564,7 @@ exports.BattleScripts = {
 	moveHit: function (target, pokemon, move, moveData, isSecondary, isSelf) {
 		let damage;
 		move = this.getMoveCopy(move);
+		move.zBrokeProtect = false;
 
 		if (!moveData) moveData = move;
 		if (!moveData.flags) moveData.flags = {};


### PR DESCRIPTION
Reported [here](http://www.smogon.com/forums/posts/7610701).

Clangorous Soulblaze broke through Tapu Lele's Protect (despite it being immune anyway), and that status was then carried over to its hit on Zapdos.