### PR TITLE
Sockets: implement permessage-deflate support

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -22,6 +22,22 @@ exports.bindaddress = '0.0.0.0';
 //   to 1.
 exports.workers = 1;
 
+// websocketcompression - compresses WebSocket messages
+//	 Toggles use of the Sec-WebSocket-Extension permessage-deflate extension.
+//	 This compresses messages sent and received over a WebSocket connection
+//	 using the zlib compression algorithm. As a caveat, message compression
+//	 may make messages take longer to procress.
+//exports.wsdeflate = null;
+exports.wsdeflate = {
+	level: 5,
+	memLevel: 8,
+	strategy: 0,
+	noContextTakeover: true,
+	requestNoContextTakeover: true,
+	maxWindowBits: 15,
+	requestMaxWindowBits: 15,
+};
+
 // TODO: allow SSL to actually be possible to use for third-party servers at
 // some point.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1782,6 +1782,11 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
+    "permessage-deflate": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.6.tgz",
+      "integrity": "sha1-WB8c7fvUQPrEfQd3vohjM4a5kt4="
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   },
   "optionalDependencies": {
     "cloud-env": "0.2.2",
+    "node-oom-heapdump": "^1.0.10",
     "node-static": "0.7.10",
     "nodemailer": "4.4.0",
-    "node-oom-heapdump": "^1.0.10"
+    "permessage-deflate": "^0.1.6"
   },
   "engines": {
     "node": ">=7.7.0"

--- a/sockets.js
+++ b/sockets.js
@@ -301,14 +301,22 @@ if (cluster.isMaster) {
 	// and doing things on our server.
 
 	const sockjs = require('sockjs');
-	const server = sockjs.createServer({
+	const options = {
 		sockjs_url: "//play.pokemonshowdown.com/js/lib/sockjs-1.1.1-nwjsfix.min.js",
-		log: (severity, message) => {
-			if (severity === 'error') console.log('ERROR: ' + message);
-		},
 		prefix: '/showdown',
-	});
+		log(severity, message) {
+			if (severity === 'error') Monitor.warn(`ERROR: ${message}`);
+		},
+	};
 
+	try {
+		const deflate = require('permessage-deflate').configure(Config.wsdeflate);
+		options.faye_server_options = [deflate];
+	} catch (e) {
+		require('./crashlogger')(new Error("Dependency permessage-deflate is not installed or is otherwise unaccessable. No message compression will take place until server restart."), "Sockets");
+	}
+
+	const server = sockjs.createServer(options);
 	const sockets = new Map();
 	const channels = new Map();
 	const subchannels = new Map();


### PR DESCRIPTION
Permessage-deflate is an extensIon that compresses websocket messages with zlib.
SockJS already supports it (indirectly) and the client's load balancer already
inserts the header in the opening handshake when making a WebSocket connection.

`Config.wsdeflate` makes this optional and allows tweaking the extension's resource
usage.