### PR TITLE
Update Test API: Abilities A-M

### DIFF
--- a/test/simulator/abilities/angerpoint.js
+++ b/test/simulator/abilities/angerpoint.js
@@ -15,17 +15,17 @@ describe('Anger Point', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Cryogonal", ability: 'noguard', moves: ['frostbreath']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['endure']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move frostbreath', 'move endure');
 		assert.statStage(p2.active[0], 'atk', 6);
 	});
 
 	it('should maximize Attack when hit by a critical hit even if the foe has Mold Breaker', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Haxorus", ability: 'moldbreaker', item: 'scopelens', moves: ['focusenergy', 'falseswipe']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Haxorus", ability: 'moldbreaker', item: 'scopelens', moves: ['focusenergy', 'falseswipe']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['defensecurl']}]);
 
-		battle.commitDecisions();
-		p1.chooseMove(2).foe.chooseMove(1);
+		battle.makeChoices('move focusenergy', 'move defensecurl');
+		battle.makeChoices('move falseswipe', 'move defensecurl');
 		assert.statStage(p2.active[0], 'atk', 6);
 	});
 
@@ -34,7 +34,7 @@ describe('Anger Point', function () {
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Cryogonal", ability: 'noguard', moves: ['endure']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['stormthrow']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move endure', 'move stormthrow');
 		assert.statStage(p1.active[0], 'atk', 0);
 		assert.statStage(p2.active[0], 'atk', 0);
 	});
@@ -44,7 +44,7 @@ describe('Anger Point', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Cryogonal", ability: 'noguard', item: 'laggingtail', moves: ['frostbreath']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['substitute']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move frostbreath', 'move substitute');
 		assert.statStage(p2.active[0], 'atk', 0);
 	});
 });

--- a/test/simulator/abilities/arenatrap.js
+++ b/test/simulator/abilities/arenatrap.js
@@ -13,50 +13,43 @@ describe('Arena Trap', function () {
 	it('should prevent grounded Pokemon that are not immune to trapping from switching out normally', function () {
 		this.timeout(0);
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Dugtrio", ability: 'arenatrap', moves: ['snore', 'telekinesis', 'gravity']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Dugtrio", ability: 'arenatrap', moves: ['snore', 'telekinesis', 'gravity']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [
 			{species: "Tornadus", ability: 'defiant', moves: ['tailwind']},
 			{species: "Heatran", ability: 'flashfire', item: 'airballoon', moves: ['roar']},
 			{species: "Claydol", ability: 'levitate', moves: ['rest']},
 			{species: "Dusknoir", ability: 'frisk', moves: ['rest']},
 			{species: "Magnezone", ability: 'magnetpull', moves: ['magnetrise']},
-			{species: "Vaporeon", ability: 'waterabsorb', moves: ['roar']},
+			{species: "Vaporeon", ability: 'waterabsorb', moves: ['healbell']},
 		]);
-		p2.chooseSwitch(2).foe.chooseMove(1);
+		battle.makeChoices('move snore', 'switch 2');
 		assert.species(p2.active[0], 'Heatran');
-		p2.chooseSwitch(3).foe.chooseMove(1);
+		battle.makeChoices('move snore', 'switch 3');
 		assert.species(p2.active[0], 'Claydol');
-		p2.chooseSwitch(4).foe.chooseMove(1);
+		battle.makeChoices('move snore', 'switch 4');
 		assert.species(p2.active[0], 'Dusknoir');
-		p2.chooseSwitch(5).foe.chooseMove(1);
+		battle.makeChoices('move snore', 'switch 5');
+		assert.species(p2.active[0], 'Magnezone'); // Magnezone is trapped
+
+		battle.makeChoices('move snore', 'switch 6');
 		assert.species(p2.active[0], 'Magnezone');
 
-		assert.false(p2.chooseSwitch(6)); // Magnezone is trapped
-		battle.commitDecisions();
-		assert.species(p2.active[0], 'Magnezone');
+		battle.makeChoices('move snore', 'move magnetrise');
 
-		assert.strictEqual(p2.active[0].name, "Magnezone");
-		p2.chooseMove(1); // Magnet Rise
-		battle.commitDecisions();
-
-		p2.chooseSwitch(6).foe.chooseMove(1);
+		battle.makeChoices('move snore', 'switch 6');
 		assert.species(p2.active[0], 'Vaporeon');
 
-		assert.false(p2.chooseSwitch(2)); // Vaporeon is trapped
-		battle.commitDecisions();
-		assert.species(p2.active[0], 'Vaporeon');
+		battle.makeChoices('move snore', 'switch 2');
+		assert.species(p2.active[0], 'Vaporeon'); // Vaporeon is trapped
 
-		p1.chooseMove(2); // Telekinesis
-		battle.commitDecisions();
+		battle.makeChoices('move telekinesis', 'move healbell');
 
-		p2.chooseSwitch(2).foe.chooseMove(1);
+		battle.makeChoices('move snore', 'switch 2');
 		assert.species(p2.active[0], 'Tornadus');
 
-		p1.chooseMove(3); // Gravity
-		battle.commitDecisions();
+		battle.makeChoices('move gravity', 'move tailwind');
 
-		assert.false(p2.chooseSwitch(4)); // Tornadus is trapped
-		battle.commitDecisions();
-		assert.species(p2.active[0], 'Tornadus');
+		battle.makeChoices('move snore', 'switch 2');
+		assert.species(p2.active[0], 'Tornadus'); // Tornadus is trapped
 	});
 });

--- a/test/simulator/abilities/battlearmor.js
+++ b/test/simulator/abilities/battlearmor.js
@@ -11,10 +11,9 @@ describe('Battle Armor', function () {
 	});
 
 	it('should prevent moves from dealing critical hits', function () {
-		battle = common.createBattle([
-			[{species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack']}],
-			[{species: 'Cryogonal', ability: 'noguard', moves: ['frostbreath']}],
-		]);
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Cryogonal', ability: 'noguard', moves: ['frostbreath']}]);
 		let successfulEvent = false;
 		battle.onEvent('ModifyDamage', battle.getFormat(), function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
@@ -22,16 +21,14 @@ describe('Battle Armor', function () {
 				assert.ok(!move.crit);
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move quickattack', 'move frostbreath');
 		assert.ok(successfulEvent);
 	});
 
 	it('should be suppressed by Mold Breaker', function () {
-		battle = common.createBattle([
-			[{species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack']}],
-			[{species: 'Cryogonal', ability: 'moldbreaker', item: 'zoomlens', moves: ['frostbreath']}],
-		]);
-		battle.commitDecisions(); // Team Preview
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Cryogonal', ability: 'moldbreaker', item: 'zoomlens', moves: ['frostbreath']}]);
 		let successfulEvent = false;
 		battle.onEvent('ModifyDamage', battle.getFormat(), function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
@@ -39,7 +36,7 @@ describe('Battle Armor', function () {
 				assert.ok(move.crit);
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move quickattack', 'move frostbreath');
 		assert.ok(successfulEvent);
 	});
 });

--- a/test/simulator/abilities/clearbody.js
+++ b/test/simulator/abilities/clearbody.js
@@ -17,8 +17,7 @@ describe('Clear Body', function () {
 
 		const stats = ['spd', 'def', 'spe', 'atk', 'spa'];
 		stats.forEach((stat, index) => {
-			battle.p2.chooseMove(index + 1).foe.chooseMove(1);
-			assert.statStage(battle.p1.active[0], stat, 0);
+			battle.makeChoices(`move recover`, `move ${index + 1}`);
 		});
 		stats.forEach(stat => assert.statStage(battle.p1.active[0], stat, 0));
 	});
@@ -27,7 +26,7 @@ describe('Clear Body', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tentacruel', ability: 'clearbody', moves: ['superpower']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Arbok', ability: 'unnerve', moves: ['coil']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move superpower', 'coil');
 		assert.statStage(battle.p1.active[0], 'atk', -1);
 		assert.statStage(battle.p1.active[0], 'def', -1);
 	});
@@ -36,7 +35,7 @@ describe('Clear Body', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tentacruel', ability: 'clearbody', moves: ['shadowsneak']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Arbok', ability: 'unnerve', moves: ['swagger']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move shadowsneak', 'move swagger');
 		assert.statStage(battle.p1.active[0], 'atk', 2);
 	});
 
@@ -44,7 +43,7 @@ describe('Clear Body', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tentacruel', ability: 'clearbody', moves: ['coil']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Arbok', ability: 'unnerve', moves: ['topsyturvy']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move coil', 'move topsyturvy');
 		assert.statStage(battle.p1.active[0], 'atk', -1);
 		assert.statStage(battle.p1.active[0], 'def', -1);
 		assert.statStage(battle.p1.active[0], 'accuracy', -1);

--- a/test/simulator/abilities/cloudnine.js
+++ b/test/simulator/abilities/cloudnine.js
@@ -14,7 +14,7 @@ describe('Cloud Nine', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['sunnyday']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Cherrim', ability: 'flowergift', item: 'laggingtail', moves: ['solarbeam']}]);
-		assert.false.hurts(p1.active[0], () => battle.commitDecisions()); // Solar Beam must charge
+		assert.false.hurts(p1.active[0], () => battle.makeChoices('move sunnyday', 'move solarbeam')); // Solar Beam must charge
 		assert.ok(battle.isWeather('', p2.active[0]));
 		assert.species(p2.active[0], 'Cherrim');
 	});
@@ -24,7 +24,7 @@ describe('Cloud Nine', function () {
 		let move, basePower;
 		battle.join('p1', 'Guest 1', 1, [{species: 'Groudon', ability: 'drought', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move rest', 'move calmmind');
 		move = Dex.getMove('firepledge');
 		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -38,7 +38,7 @@ describe('Cloud Nine', function () {
 		let move, basePower;
 		battle.join('p1', 'Guest 1', 1, [{species: 'Kyogre', ability: 'drizzle', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move rest', 'move calmmind');
 		move = Dex.getMove('firepledge');
 		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -51,46 +51,46 @@ describe('Cloud Nine', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tyranitar', ability: 'sandstream', moves: ['dragondance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
-		assert.false.hurts(battle.p2.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p2.active[0], () => battle.makeChoices('move dragondance', 'move calmmind'));
 	});
 
 	it('should negate the damage-dealing effects of Hail', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Abomasnow', ability: 'snowwarning', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
-		assert.false.hurts(battle.p2.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p2.active[0], () => battle.makeChoices('move rest', 'move calmmind'));
 	});
 
 	it('should not negate Desolate Land\'s ability to prevent other weathers from activating', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Groudon', ability: 'desolateland', moves: ['sunnyday']}]);
-		assert.constant(() => battle.weather, () => battle.commitDecisions());
+		assert.constant(() => battle.weather, () => battle.makeChoices('move raindance', 'move sunnyday'));
 	});
 
 	it('should not negate Primordial Sea\'s ability to prevent other weathers from activating', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Kyogre', ability: 'primordialsea', moves: ['sunnyday']}]);
-		assert.constant(() => battle.weather, () => battle.commitDecisions());
+		assert.constant(() => battle.weather, () => battle.makeChoices('move raindance', 'move sunnyday'));
 	});
 
 	it('should not negate Delta Stream\'s ability to prevent other weathers from activating', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Rayquaza', ability: 'deltastream', moves: ['sunnyday']}]);
-		assert.constant(() => battle.weather, () => battle.commitDecisions());
+		assert.constant(() => battle.weather, () => battle.makeChoices('move raindance', 'move sunnyday'));
 	});
 
 	it('should still display status of the weather', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Sunkern', ability: 'solarpower', moves: ['sunnyday']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move sunnyday');
 		assert.strictEqual(battle.log[battle.lastMoveLine + 1], '|-weather|SunnyDay');
 		for (let i = 0; i < 4; i++) {
 			assert.strictEqual(battle.log[battle.lastMoveLine + 3], '|-weather|SunnyDay|[upkeep]');
-			battle.commitDecisions();
+			battle.makeChoices('move calmmind', 'move sunnyday');
 		}
 		assert.strictEqual(battle.log[battle.lastMoveLine + 3], '|-weather|none');
 	});

--- a/test/simulator/abilities/colorchange.js
+++ b/test/simulator/abilities/colorchange.js
@@ -14,7 +14,7 @@ describe('Color Change', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Kecleon", ability: 'colorchange', moves: ['recover']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Paras", ability: 'damp', moves: ['absorb']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move recover', 'move absorb');
 		assert.ok(p1.active[0].hasType('Grass'));
 	});
 
@@ -22,7 +22,7 @@ describe('Color Change', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Kecleon", ability: 'colorchange', moves: ['substitute']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Machamp", ability: 'purepower', item: 'laggingtail', moves: ['closecombat']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move closecombat');
 		assert.false(p1.active[0].hasType('Fighting'));
 	});
 });

--- a/test/simulator/abilities/comatose.js
+++ b/test/simulator/abilities/comatose.js
@@ -14,8 +14,8 @@ describe('Comatose', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['shadowclaw']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'noguard', moves: ['spore', 'glare', 'willowisp', 'toxic']}]);
-		for (let i = 1; i <= 4; i++) {
-			assert.constant(() => p1.active[0].status, () => p2.chooseMove(i).foe.chooseDefault());
+		for (const move of p2.active[0].moveSlots) {
+			assert.constant(() => p1.active[0].status, () => battle.makeChoices(`move shadowclaw`, `move ${move.id}`));
 		}
 	});
 
@@ -23,8 +23,8 @@ describe('Comatose', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['shadowclaw']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'moldbreaker', moves: ['spore', 'glare', 'willowisp', 'toxic']}]);
-		for (let i = 1; i <= 4; i++) {
-			assert.constant(() => p1.active[0].status, () => p2.chooseMove(i).foe.chooseDefault());
+		for (const move of p2.active[0].moveSlots) {
+			assert.constant(() => p1.active[0].status, () => battle.makeChoices(`move shadowclaw`, `move ${move.id}`));
 		}
 	});
 
@@ -32,16 +32,16 @@ describe('Comatose', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['aquajet']}]);
-		assert.hurts(p1.active[0], () => battle.commitDecisions());
-		assert.constant(() => p1.active[0].status, () => battle.commitDecisions());
+		assert.hurts(p1.active[0], () => battle.makeChoices('move rest', 'move aquajet'));
+		assert.constant(() => p1.active[0].status, () => battle.makeChoices('move rest', 'move aquajet'));
 	});
 
 	it('should allow the use of Snore and Sleep Talk as if the user were asleep', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['snore', 'sleeptalk', 'brickbreak']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['snore', 'sleeptalk', 'brickbreak']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['endure']}]);
-		for (let i = 1; i <= 2; i++) {
-			assert.hurts(p2.active[0], () => p1.chooseMove(i).foe.chooseDefault());
+		for (const move of p2.active[0].moveSlots) {
+			assert.hurts(p2.active[0], () => battle.makeChoices(`move ${move.id}`, `move endure`));
 		}
 	});
 
@@ -49,23 +49,19 @@ describe('Comatose', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['shadowclaw']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['dreameater']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move shadowclaw', 'move dreameater'));
 	});
 
 	it('should cause Wake-Up Slap and Hex to have doubled base power when used against the user', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', item: 'ringtarget', moves: ['endure']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['hex', 'wakeupslap']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['hex', 'wakeupslap']}]);
 
-		let bp = 0;
 		battle.onEvent('BasePower', battle.getFormat(), function (basePower, pokemon, target, move) {
-			bp = basePower;
+			assert.strictEqual(basePower, battle.getMove(move.id).basePower * 2);
 		});
 
-		p2.chooseMove(1).foe.chooseDefault();
-		assert.strictEqual(bp, battle.getMove('hex').basePower * 2);
-
-		p2.chooseMove(2).foe.chooseDefault();
-		assert.strictEqual(bp, battle.getMove('wakeupslap').basePower * 2);
+		battle.makeChoices('move endure', 'move hex');
+		battle.makeChoices('move endure', 'move wakeupslap');
 	});
 });

--- a/test/simulator/abilities/contrary.js
+++ b/test/simulator/abilities/contrary.js
@@ -15,7 +15,7 @@ describe('Contrary', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Spinda", ability: 'contrary', moves: ['superpower']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['dragondance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move superpower', 'move dragondance');
 		assert.statStage(p1.active[0], 'atk', 1);
 		assert.statStage(p1.active[0], 'def', 1);
 	});
@@ -24,7 +24,7 @@ describe('Contrary', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Serperior", ability: 'contrary', moves: ['leechseed']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Growlithe", ability: 'intimidate', moves: ['topsyturvy']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move leechseed', 'move topsyturvy');
 		assert.statStage(p1.active[0], 'atk', -1);
 	});
 
@@ -32,7 +32,7 @@ describe('Contrary', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Spinda", ability: 'contrary', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['dragondance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bellydrum', 'move dragondance');
 		assert.statStage(p1.active[0], 'atk', -6);
 	});
 
@@ -40,7 +40,7 @@ describe('Contrary', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Spinda", ability: 'contrary', moves: ['tackle']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", ability: 'moldbreaker', moves: ['growl']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move tackle', 'move growl');
 		assert.statStage(p1.active[0], 'atk', -1);
 	});
 });

--- a/test/simulator/abilities/damp.js
+++ b/test/simulator/abilities/damp.js
@@ -14,7 +14,7 @@ describe('Damp', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Politoed', ability: 'damp', moves: ['calmmind']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Electrode', ability: 'static', moves: ['explosion']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move explosion');
 		assert.fullHP(p1.active[0]);
 		assert.fullHP(p2.active[0]);
 	});
@@ -23,7 +23,7 @@ describe('Damp', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Poliwrath', ability: 'damp', moves: ['closecombat']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Aron', ability: 'aftermath', moves: ['leer']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move closecombat', 'move leer');
 		assert.fullHP(p1.active[0]);
 		assert.fainted(p2.active[0]);
 	});
@@ -32,7 +32,7 @@ describe('Damp', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Politoed', ability: 'damp', moves: ['calmmind']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Electrode', ability: 'moldbreaker', moves: ['explosion']}]);
-		assert.hurts(p1.active[0], () => battle.commitDecisions());
+		assert.hurts(p1.active[0], () => battle.makeChoices('move calmmind', 'move explosion'));
 		assert.fainted(p2.active[0]);
 	});
 });

--- a/test/simulator/abilities/dancer.js
+++ b/test/simulator/abilities/dancer.js
@@ -15,7 +15,7 @@ describe('Dancer', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Oricorio', ability: 'dancer', moves: ['swordsdance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Oricorio', ability: 'dancer', moves: ['howl']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move swordsdance', 'move howl');
 		assert.statStage(battle.p1.active[0], 'atk', 2);
 		assert.statStage(battle.p2.active[0], 'atk', 3);
 	});
@@ -31,7 +31,7 @@ describe('Dancer', function () {
 			{species: 'Shedinja', ability: 'dancer', moves: ['sleeptalk']},
 		]);
 		p1.active[1].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1);
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance 1, move sleeptalk');
 		assert.fainted(battle.p2.active[0]);
 		assert.fainted(battle.p2.active[1]);
 	});
@@ -48,8 +48,8 @@ describe('Dancer', function () {
 		]);
 		p1.active[1].boostBy({spe: 6});
 		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1);
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move trickroom, move sleeptalk');
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance 1, move sleeptalk');
 		assert.fainted(battle.p2.active[0]);
 		assert.fainted(battle.p2.active[1]);
 	});
@@ -57,36 +57,30 @@ describe('Dancer', function () {
 	it('should not copy a move that failed or was blocked by Protect', function () {
 		battle = common.createBattle({gameType: 'doubles'}, null, new PRNG([1, 2, 3, 4]));
 		const p1 = battle.join('p1', 'Guest 1', 1, [
-			{species: 'Oricorio', level: 98, ability: 'dancer', item: 'laggingtail', moves: ['dragondance', 'protect', 'teeterdance']},
-			{species: 'Oricorio', level: 99, ability: 'dancer', moves: ['featherdance']},
+			{species: "Oricorio-Pa'u", level: 98, ability: 'dancer', item: 'laggingtail', moves: ['dragondance', 'protect', 'teeterdance']},
+			{species: 'Oricorio-Pom-Pom', level: 99, ability: 'dancer', moves: ['featherdance']},
 		]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [
-			{species: 'Oricorio', ability: 'dancer', moves: ['fierydance', 'protect', 'teeterdance']},
+			{species: 'Oricorio-Sensu', ability: 'dancer', moves: ['fierydance', 'protect', 'teeterdance']},
 			{species: 'Shedinja', ability: 'wonderguard', moves: ['finalgambit']},
 		]);
-		p1.active[0].boostBy({atk: 6, spe: 6});
-		p2.active[0].boostBy({atk: -6});
-		p2.active[1].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1, 1);
-		p2.chooseMove(1, -2).chooseMove(1, 1);
-		assert.fullHP(p2.active[0]);
-		assert.statStage(p1.active[0], 'atk', 6);
-		assert.statStage(p1.active[1], 'atk', 0);
-		assert.statStage(p2.active[0], 'atk', -6);
-		assert.statStage(p2.active[0], 'spe', 0);
-		// Next turn
-		battle.choose('p1', 'move 1');
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
-		assert.statStage(p1.active[0], 'atk', 6);
-		assert.statStage(p1.active[1], 'atk', 0);
-		// Next turn: Teeter Dance should be copied as long as it hits one thing
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 3');
-		battle.commitDecisions();
-		// Next turn: Teeter Dance should NOT be copied if everything it hits is already confused
-		battle.choose('p1', 'move 3');
-		assert.constant(() => p1.active[0].volatiles['confusion'], () => battle.commitDecisions());
+		p1.active[0].boostBy({atk: 6, spe: 6}); // Dragon Dance will fail
+		p2.active[0].boostBy({atk: -6}); // Feather dance will fail
+		p2.active[1].boostBy({spe: 6}); // Shedinja will move first
+		battle.makeChoices('move dragondance, move featherdance 1', 'move fierydance -2, move finalgambit');
+		assert.fullHP(p2.active[0], "Player 1's Oricorio should not copy a failed Fiery Dance");
+		assert.statStage(p1.active[0], 'atk', 6, "Oricorio-Sensu should not copy a failed Feather Dance");
+		assert.statStage(p1.active[1], 'atk', 0, "Oricorio-Sensu should not copy a failed Feather Dance, and Oricorio-Pom-Pom should not copy a failed Dragon Dance");
+		assert.statStage(p2.active[0], 'atk', -6, "Oricorio-Sensu should not copy a failed Dragon Dance");
+
+		battle.makeChoices('move dragondance, move featherdance', 'move protect');
+		assert.statStage(p1.active[0], 'atk', 6, "Oricorio-Sensu should not copy a Feather Dance that was blocked by Protect");
+		assert.statStage(p1.active[1], 'atk', 0, "Oricorio-Sensu should not copy a Feather Dance that was blocked by Protect");
+
+		battle.makeChoices('move protect, move featherdance', 'move teeterdance');
+		assert.ok(p2.active[0].volatiles['confusion'], "Oricorio-Pa'u should copy Teeter Dance as long as it was successful against at least one target");
+
+		assert.constant(() => p1.active[0].volatiles['confusion'], () => battle.makeChoices('move teeterdance, move featherdance', 'move fierydance'), "Teeter Dance should not be copied if it fails against every target");
 	});
 
 	it('should not copy a move that missed', function () {
@@ -95,9 +89,9 @@ describe('Dancer', function () {
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Oricorio', ability: 'dancer', item: 'brightpowder', moves: ['dig']}]);
 		p1.active[0].boostBy({accuracy: -6});
 		p2.active[0].boostBy({evasion: 6});
-		battle.commitDecisions();
+		battle.makeChoices('move revelationdance', 'move dig');
 		assert.fullHP(p1.active[0]);
-		battle.commitDecisions();
+		battle.makeChoices('move revelationdance', 'move dig');
 		assert.fullHP(p1.active[0]);
 	});
 
@@ -105,6 +99,6 @@ describe('Dancer', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Oricorio', ability: 'dancer', moves: ['fierydance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Shedinja', ability: 'dancer', item: 'focussash', moves: ['meanlook']}]);
-		assert.hurts(p1.active[0], () => battle.commitDecisions());
+		assert.hurts(p1.active[0], () => battle.makeChoices('move fierydance', 'move meanlook'));
 	});
 });

--- a/test/simulator/abilities/deltastream.js
+++ b/test/simulator/abilities/deltastream.js
@@ -22,8 +22,8 @@ describe('Delta Stream', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Tornadus", ability: 'deltastream', item: 'weaknesspolicy', moves: ['recover']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['thundershock', 'powdersnow', 'powergem']}]);
 		const pokemon = battle.p1.active[0];
-		for (let i = 1; i <= 3; i++) {
-			battle.p2.chooseMove(i).foe.chooseDefault();
+		for (const move of pokemon.moveSlots) {
+			battle.makeChoices(`move recover`, `move ${move.id}`);
 			assert.statStage(pokemon, 'atk', 0);
 			assert.statStage(pokemon, 'spa', 0);
 			assert.holdsItem(pokemon);
@@ -34,7 +34,7 @@ describe('Delta Stream', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Rayquaza", ability: 'deltastream', item: 'weaknesspolicy', moves: ['recover']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['dragonpulse']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move recover', 'move dragonpulse');
 		const pokemon = battle.p1.active[0];
 		assert.statStage(pokemon, 'atk', 2);
 		assert.statStage(pokemon, 'spa', 2);
@@ -53,52 +53,51 @@ describe('Delta Stream', function () {
 		]);
 		for (let i = 2; i <= 5; i++) {
 			battle.p2.chooseSwitch(i).foe.chooseDefault();
+			battle.makeChoices(`move helpinghand`, `switch ${i}`);
 			assert.ok(battle.isWeather('deltastream'));
-			battle.commitDecisions();
+			battle.makeChoices('move helpinghand', 'move 1');
 			assert.ok(battle.isWeather('deltastream'));
 		}
 	});
 
 	it('should cause the Delta Stream weather to fade if it switches out and no other Delta Stream Pokemon are active', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [
+		battle.join('p1', 'Guest 1', 1, [
 			{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']},
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['roost']}]);
-		p1.chooseSwitch(2);
-		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.makeChoices('switch 2', 'move roost'));
 	});
 
 	it('should not cause the Delta Stream weather to fade if it switches out and another Delta Stream Pokemon is active', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [
+		battle.join('p1', 'Guest 1', 1, [
 			{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']},
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['bulkup']}]);
-		p1.chooseSwitch(2);
-		assert.constant(() => battle.isWeather('deltastream'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('deltastream'), () => battle.makeChoices('switch 2', 'move bulkup'));
 	});
 
 	it('should cause the Delta Stream weather to fade if its ability is suppressed and no other Delta Stream Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['gastroacid']}]);
-		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should not cause the Delta Stream weather to fade if its ability is suppressed and another Delta Stream Pokemon is active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['gastroacid']}]);
-		assert.constant(() => battle.isWeather('deltastream'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('deltastream'), () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should cause the Delta Stream weather to fade if its ability is changed and no other Delta Stream Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['entrainment']}]);
-		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.makeChoices('move helpinghand', 'move entrainment'));
 	});
 });

--- a/test/simulator/abilities/desolateland.js
+++ b/test/simulator/abilities/desolateland.js
@@ -24,7 +24,7 @@ describe('Desolate Land', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Cryogonal', ability: 'levitate', moves: ['splash']}]);
 		const attacker = battle.p1.active[0];
 		const defender = battle.p2.active[0];
-		assert.hurtsBy(defender, 152, () => battle.commitDecisions());
+		assert.hurtsBy(defender, 152, () => battle.makeChoices('move incinerate', 'move splash'));
 		const move = Dex.getMove('incinerate');
 		const basePower = battle.runEvent('BasePower', attacker, defender, move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -34,7 +34,7 @@ describe('Desolate Land', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blastoise", ability: 'torrent', moves: ['surf']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move helpinghand', 'move surf');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
@@ -43,7 +43,7 @@ describe('Desolate Land', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blastoise", ability: 'torrent', moves: ['soak']}]);
 		const soakTarget = battle.p1.active[0];
-		assert.sets(() => soakTarget.getTypes().join('/'), 'Water', () => battle.commitDecisions());
+		assert.sets(() => soakTarget.getTypes().join('/'), 'Water', () => battle.makeChoices('move helpinghand', 'move soak'));
 	});
 
 	it('should prevent moves and abilities from setting the weather to Sunny Day, Rain Dance, Sandstorm, or Hail', function () {
@@ -57,16 +57,16 @@ describe('Desolate Land', function () {
 			{species: "Abomasnow", ability: 'snowwarning', moves: ['hail']},
 		]);
 		for (let i = 2; i <= 5; i++) {
-			battle.p2.chooseSwitch(i).foe.chooseDefault();
+			battle.makeChoices(`move helpinghand`, `switch ${i}`);
 			assert.ok(battle.isWeather('desolateland'));
-			battle.commitDecisions();
+			battle.makeChoices('move helpinghand', 'move 1');
 			assert.ok(battle.isWeather('desolateland'));
 		}
 	});
 
 	it('should be treated as Sunny Day for any forme, move or ability that requires it', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand', 'solarbeam']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand', 'solarbeam']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [
 			{species: "Castform", ability: 'forecast', moves: ['weatherball']},
 			{species: "Cherrim", ability: 'flowergift', moves: ['growth']},
@@ -79,16 +79,16 @@ describe('Desolate Land', function () {
 				assert.strictEqual(move.type, 'Fire');
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move helpinghand', 'move weatherball');
 		assert.species(p2.active[0], 'Castform-Sunny');
-		p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move helpinghand', 'switch 2');
 		assert.species(p2.active[0], 'Cherrim-Sunshine');
-		p2.chooseSwitch(3).foe.chooseDefault();
+		battle.makeChoices('move helpinghand', 'switch 3');
 		assert.false.fullHP(p2.active[0], "Charizard should be hurt by Solar Power");
-		p1.chooseMove(2).foe.chooseSwitch(4);
+		battle.makeChoices('move solarbeam', 'switch 4');
 		assert.strictEqual(p2.active[0].getStat('spe'), 2 * p2.active[0].stats['spe'], "Venusaur's speed should be doubled by Chlorophyll");
 		assert.false.fullHP(p2.active[0], "Solar Beam should skip its charge turn");
-		p2.chooseSwitch(5).foe.chooseDefault();
+		battle.makeChoices('move helpinghand', 'switch 5');
 		assert.false.fullHP(p2.active[0], "Toxicroak should be hurt by Dry Skin");
 	});
 
@@ -99,8 +99,7 @@ describe('Desolate Land', function () {
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['roost']}]);
-		battle.p1.chooseSwitch(2);
-		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.makeChoices('switch 2', 'move roost'));
 	});
 
 	it('should not cause the Desolate Land weather to fade if it switches out and another Desolate Land Pokemon is active', function () {
@@ -111,27 +110,27 @@ describe('Desolate Land', function () {
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Groudon", ability: 'desolateland', moves: ['bulkup']}]);
 		battle.p2.chooseSwitch(2);
-		assert.constant(() => battle.isWeather('desolateland'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('desolateland'), () => battle.makeChoices('switch 2', 'move bulkup'));
 	});
 
 	it('should cause the Desolate Land weather to fade if its ability is suppressed and no other Desolate Land Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['gastroacid']}]);
-		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should not cause the Desolate Land weather to fade if its ability is suppressed and another Desolate Land Pokemon is active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Groudon", ability: 'desolateland', moves: ['gastroacid']}]);
-		assert.constant(() => battle.isWeather('desolateland'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('desolateland'), () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should cause the Desolate Land weather to fade if its ability is changed and no other Desolate Land Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['entrainment']}]);
-		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.makeChoices('move helpinghand', 'move entrainment'));
 	});
 });

--- a/test/simulator/abilities/dryskin.js
+++ b/test/simulator/abilities/dryskin.js
@@ -14,23 +14,22 @@ describe('Dry Skin', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Ninetales', ability: 'flashfire', moves: ['sunnyday']}]);
-		assert.hurtsBy(p1.active[0], Math.floor(p1.active[0].maxhp / 8), () => battle.commitDecisions());
+		assert.hurtsBy(p1.active[0], Math.floor(p1.active[0].maxhp / 8), () => battle.makeChoices('move bulkup', 'move sunnyday'));
 	});
 
 	it('should heal 1/8 max HP every turn that Rain Dance is active', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['substitute']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Politoed', ability: 'damp', moves: ['encore', 'raindance']}]);
-		battle.commitDecisions();
-		p2.chooseMove('raindance');
-		assert.hurtsBy(p1.active[0], -Math.floor(p1.active[0].maxhp / 8), () => battle.commitDecisions());
+		battle.join('p2', 'Guest 2', 1, [{species: 'Politoed', ability: 'damp', moves: ['encore', 'raindance']}]);
+		battle.makeChoices('move substitute', 'move encore');
+		assert.hurtsBy(p1.active[0], -Math.floor(p1.active[0].maxhp / 8), () => battle.makeChoices('move substitute', 'move raindance'));
 	});
 
 	it('should grant immunity to Water-type moves and heal 1/4 max HP', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['substitute']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Politoed', ability: 'damp', moves: ['watergun']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move watergun');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
@@ -38,7 +37,7 @@ describe('Dry Skin', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'unnerve', moves: ['incinerate']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bulkup', 'move incinerate');
 		let damage = battle.p1.active[0].maxhp - battle.p1.active[0].hp;
 		assert.bounded(damage, [51, 61]);
 	});
@@ -47,11 +46,10 @@ describe('Dry Skin', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['incinerate', 'surf']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bulkup', 'move incinerate');
 		const target = battle.p1.active[0];
 		const damage = target.maxhp - target.hp;
 		assert.bounded(damage, [41, 49]);
-		battle.p2.chooseMove('surf');
-		assert.hurts(target, () => battle.commitDecisions());
+		assert.hurts(target, () => battle.makeChoices('move bulkup', 'move surf'));
 	});
 });

--- a/test/simulator/abilities/emergencyexit.js
+++ b/test/simulator/abilities/emergencyexit.js
@@ -11,97 +11,120 @@ describe(`Emergency Exit`, function () {
 	afterEach(() => battle.destroy());
 
 	it(`should request switch-out if damaged below 50% HP`, function () {
-		battle = common.createBattle([
-			[{species: "Golisopod", ability: 'emergencyexit', moves: ['superfang'], ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
-			[{species: "Raticate", ability: 'guts', moves: ['superfang']}],
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Golisopod", ability: 'emergencyexit', moves: ['superfang'], ivs: EMPTY_IVS},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
 		]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Raticate", ability: 'guts', moves: ['superfang']}]);
 		const eePokemon = battle.p1.active[0];
 		const foePokemon = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move superfang', 'move superfang');
 		assert.strictEqual(foePokemon.hp, foePokemon.maxhp);
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 		assert.strictEqual(battle.currentRequest, 'switch');
 	});
 
 	it(`should not request switch-out if first healed by berry`, function () {
-		battle = common.createBattle([
-			[{species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'], item: 'sitrusberry', ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
-			[{species: "Raticate", ability: 'guts', moves: ['superfang']}],
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'], item: 'sitrusberry', ivs: EMPTY_IVS},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
 		]);
-		battle.commitDecisions();
+		battle.join('p2', 'Guest 2', 1, [{species: "Raticate", ability: 'guts', moves: ['superfang']}]);
+		battle.makeChoices('move sleeptalk', 'move superfang');
 		assert.strictEqual(battle.currentRequest, 'move');
 	});
 
 	it(`should not request switch-out on usage of Substitute`, function () {
-		battle = common.createBattle([
-			[{species: "Golisopod", ability: 'emergencyexit', moves: ['substitute'], ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
-			[{species: "Deoxys-Attack", ability: 'pressure', item: 'laggingtail', moves: ['thunderbolt']}],
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Golisopod", ability: 'emergencyexit', moves: ['substitute'], ivs: EMPTY_IVS},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
 		]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys-Attack", ability: 'pressure', item: 'laggingtail', moves: ['thunderbolt']}]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move thunderbolt');
 		assert.false.atMost(eePokemon.hp, eePokemon.maxhp / 2);
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move thunderbolt');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 		assert.strictEqual(battle.currentRequest, 'move');
 	});
 
 	it(`should prevent Volt Switch after-switches`, function () {
-		battle = common.createBattle([
-			[{species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'], ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
-			[{species: "Zekrom", ability: 'pressure', moves: ['voltswitch']}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'], ivs: EMPTY_IVS},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Zekrom", ability: 'pressure', moves: ['voltswitch']},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move voltswitch');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 
 		assert.false.holdsItem(eePokemon);
 		assert.strictEqual(battle.currentRequest, 'switch');
 
-		battle.commitDecisions();
+		battle.makeChoices('switch 2');
 		assert.species(battle.p1.active[0], 'Clefable');
 		assert.species(battle.p2.active[0], 'Zekrom');
 	});
 
 	it(`should not prevent Red Card's activation`, function () {
-		battle = common.createBattle([
-			[{species: "Golisopod", ability: 'emergencyexit', item: 'redcard', moves: ['sleeptalk'], ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
-			[{species: "Raticate", ability: 'guts', moves: ['superfang']}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Golisopod", ability: 'emergencyexit', item: 'redcard', moves: ['sleeptalk'], ivs: EMPTY_IVS},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Raticate", ability: 'guts', moves: ['superfang']},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move superfang');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 
 		assert.false.holdsItem(eePokemon);
 		assert.strictEqual(battle.currentRequest, 'switch');
 
-		battle.commitDecisions();
+		battle.makeChoices('switch 2', 'switch 2');
 		assert.species(battle.p1.active[0], 'Clefable');
 		assert.species(battle.p2.active[0], 'Clefable');
 	});
 
 	it(`should not prevent Eject Button's activation`, function () {
-		battle = common.createBattle([
-			[{species: "Golisopod", ability: 'emergencyexit', item: 'ejectbutton', moves: ['sleeptalk'], ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
-			[{species: "Raticate", ability: 'guts', moves: ['superfang']}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Golisopod", ability: 'emergencyexit', item: 'ejectbutton', moves: ['sleeptalk'], ivs: EMPTY_IVS},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Raticate", ability: 'guts', moves: ['superfang']},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move superfang');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 
 		assert.false.holdsItem(eePokemon);
 		assert.strictEqual(battle.currentRequest, 'switch');
 
-		battle.commitDecisions();
+		battle.makeChoices('switch 2');
 		assert.species(battle.p1.active[0], 'Clefable');
 	});
 
 	it(`should be suppressed by Sheer Force`, function () {
-		battle = common.createBattle([
-			[{species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'], ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
-			[{species: "Nidoking", ability: 'sheerforce', moves: ['thunder']}],
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'], ivs: EMPTY_IVS},
+			{species: "Clefable", ability: 'Unaware', moves: ['metronome']},
 		]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Nidoking", ability: 'sheerforce', moves: ['thunder']}]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move thunder');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 		assert.strictEqual(battle.currentRequest, 'move');
 	});

--- a/test/simulator/abilities/flashfire.js
+++ b/test/simulator/abilities/flashfire.js
@@ -14,7 +14,7 @@ describe('Flash Fire', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['incinerate']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['flareblitz']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move incinerate', 'move flareblitz');
 		assert.fullHP(p1.active[0]);
 		let damage = p2.active[0].maxhp - p2.active[0].hp;
 		assert.bounded(damage, [82, 97]);
@@ -25,23 +25,23 @@ describe('Flash Fire', function () {
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['flareblitz']}]);
 		p1.active[0].setStatus('frz');
-		assert.false.hurts(p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(p1.active[0], () => battle.makeChoices('move sleeptalk', 'move flareblitz'));
 	});
 
 	it('should have its Fire-type immunity suppressed by Mold Breaker', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['incinerate']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['firepunch']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move incinerate', 'move firepunch'));
 	});
 
 	it('should lose the Flash Fire boost if its ability is changed', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['sleeptalk', 'incinerate']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['incinerate', 'worryseed']}]);
-		battle.commitDecisions();
+		battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['incinerate', 'worryseed']}]);
+		battle.makeChoices('move sleeptalk', 'move incinerate');
 		battle.resetRNG();
-		p2.chooseMove('worryseed').foe.chooseMove('incinerate');
+		battle.makeChoices('move incinerate', 'move worryseed');
 		let damage = battle.p2.active[0].maxhp - battle.p2.active[0].hp;
 		assert.bounded(damage, [54, 65]);
 	});
@@ -58,6 +58,6 @@ describe('Flash Fire [Gen 4]', function () {
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Charizard', ability: 'blaze', moves: ['flamethrower']}]);
 		p1.active[0].setStatus('frz');
-		assert.false.hurts(p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(p1.active[0], () => battle.makeChoices('move sleeptalk', 'move flamethrower'));
 	});
 });

--- a/test/simulator/abilities/flowergift.js
+++ b/test/simulator/abilities/flowergift.js
@@ -10,10 +10,15 @@ describe('Flower Gift', function () {
 		battle.destroy();
 	});
 
-	it('should boost allies\' Attack and Special Defense stats', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[{species: "Cherrim", ability: 'flowergift', moves: ['healbell']}, {species: "Snorlax", ability: 'immunity', moves: ['healbell']}],
-			[{species: "Blissey", ability: 'serenegrace', moves: ['healbell']}, {species: "Blissey", ability: 'serenegrace', moves: ['healbell']}],
+	it("should boost allies' Attack and Special Defense stats", function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Cherrim", ability: 'flowergift', moves: ['healbell']},
+			{species: "Snorlax", ability: 'immunity', moves: ['healbell']},
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Blissey", ability: 'serenegrace', moves: ['healbell']},
+			{species: "Blissey", ability: 'serenegrace', moves: ['healbell']},
 		]);
 
 		let cherAtk = battle.p1.active[0].getStat('atk');
@@ -29,14 +34,20 @@ describe('Flower Gift', function () {
 		assert.strictEqual(battle.p1.active[1].getStat('spd'), battle.modify(baseSpd, 1.5));
 	});
 
-	it('should still work if Cherrim transforms into something with Flower Gift without originally having it', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[{species: "Cherrim", ability: 'serenegrace', moves: ['transform']}, {species: "Snorlax", ability: 'immunity', moves: ['healbell']}],
-			[{species: "Blissey", ability: 'flowergift', moves: ['healbell']}, {species: "Blissey", ability: 'flowergift', moves: ['healbell']}],
+	it("should still work if Cherrim transforms into something with Flower Gift without originally having it", function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Cherrim", ability: 'serenegrace', moves: ['transform']},
+			{species: "Snorlax", ability: 'immunity', moves: ['healbell']},
+		]);
+		battle.join('p2', 'Guest 2', 1, 	[
+			{species: "Blissey", ability: 'flowergift', moves: ['healbell']},
+			{species: "Blissey", ability: 'flowergift', moves: ['healbell']},
 		]);
 
 		battle.choose('p1', 'move 1 1, move 1');
 		battle.choose('p2', 'move 1, move 1');
+		battle.makeChoices('move transform 1, move healbell', 'move healbell, move healbell');
 		let cherAtk = battle.p1.active[0].getStat('atk');
 		let cherSpd = battle.p1.active[0].getStat('spd');
 		let baseAtk = battle.p1.active[1].getStat('atk');

--- a/test/simulator/abilities/immunity.js
+++ b/test/simulator/abilities/immunity.js
@@ -14,7 +14,7 @@ describe('Immunity', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Snorlax', ability: 'immunity', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'infiltrator', moves: ['toxic']}]);
-		assert.constant(() => battle.p1.active[0].status, () => battle.commitDecisions());
+		assert.constant(() => battle.p1.active[0].status, () => battle.makeChoices('move curse', 'move toxic'));
 	});
 
 	it('should cure poison if a Pokemon receives the ability', function () {
@@ -22,16 +22,15 @@ describe('Immunity', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Snorlax', ability: 'thickfat', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'immunity', moves: ['toxic', 'skillswap']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.status, 'tox', () => battle.commitDecisions());
-		battle.p2.chooseMove('skillswap');
-		assert.sets(() => target.status, '', () => battle.commitDecisions());
+		assert.sets(() => target.status, 'tox', () => battle.makeChoices('move curse', 'move toxic'));
+		assert.sets(() => target.status, '', () => battle.makeChoices('move curse', 'move skillswap'));
 	});
 
 	it('should have its immunity to poison temporarily suppressed by Mold Breaker, but should cure the status immediately afterwards', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Snorlax', ability: 'immunity', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'moldbreaker', moves: ['toxic']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move toxic');
 		assert.strictEqual(battle.log.filter(line => line.match(/-status\|.*\|tox/)).length, 1);
 		assert.strictEqual(battle.p1.active[0].status, '');
 	});

--- a/test/simulator/abilities/intimidate.js
+++ b/test/simulator/abilities/intimidate.js
@@ -26,8 +26,8 @@ describe('Intimidate', function () {
 			{species: "Greninja", item: 'laggingtail', ability: 'protean', moves: ['uturn']},
 			{species: "Gyarados", item: 'leftovers', ability: 'intimidate', moves: ['splash']},
 		]);
-		battle.commitDecisions(); // Team Preview
-		battle.p2.chooseSwitch(2);
+		battle.makeChoices('move substitute', 'move uturn');
+		battle.makeChoices('switch 2');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 	});
 
@@ -58,7 +58,7 @@ describe('Intimidate', function () {
 			assert.species(source, intimidateCount === 0 ? 'Arcanine' : 'Gyarados');
 			intimidateCount++;
 		});
-		battle.commitDecisions(); // Finish Team Preview, switch both Pokemon in
+		battle.makeChoices('switch 1', 'switch 1'); // Finish Team Preview, switch both Pokemon in
 		assert.strictEqual(intimidateCount, 2);
 		assert.statStage(p1.active[0], 'atk', -1);
 		assert.statStage(p2.active[0], 'atk', -1);
@@ -73,7 +73,7 @@ describe('Intimidate', function () {
 			assert.species(source, intimidateCount === 0 ? 'Arcanine' : 'Gyarados');
 			intimidateCount++;
 		});
-		battle.commitDecisions(); // Finish Team Preview, switch both Pokemon in
+		battle.makeChoices('switch 1', 'switch 1'); // Finish Team Preview, switch both Pokemon in
 		assert.strictEqual(intimidateCount, 2);
 		assert.statStage(p1.active[0], 'atk', -1);
 		assert.statStage(p2.active[0], 'atk', -1);
@@ -96,17 +96,17 @@ describe('Intimidate', function () {
 			assert.species(source, intimidateCount % 2 === 0 ? 'Arcanine' : 'Gyarados');
 			intimidateCount++;
 		});
-		battle.commitDecisions(); // Team Preview
+		battle.makeChoices('switch 1', 'switch 1'); // Team Preview
 
-		battle.commitDecisions();
-		p1.chooseSwitch(2).foe.chooseSwitch(2);
+		battle.makeChoices('move healingwish', 'move healingwish');
+		battle.makeChoices('switch 2', 'switch 2');
 		// Both Pokemon switched in at the same time
 		assert.strictEqual(intimidateCount, 2);
 		assert.statStage(p1.active[0], 'atk', -1);
 		assert.statStage(p2.active[0], 'atk', -1);
 		// Do it again with the Pokemon in reverse order
-		battle.commitDecisions();
-		p1.chooseSwitch(3).foe.chooseSwitch(3);
+		battle.makeChoices('move healingwish', 'move healingwish');
+		battle.makeChoices('switch 3', 'switch 3');
 		assert.strictEqual(intimidateCount, 4);
 		assert.statStage(p1.active[0], 'atk', -1);
 		assert.statStage(p2.active[0], 'atk', -1);

--- a/test/simulator/abilities/klutz.js
+++ b/test/simulator/abilities/klutz.js
@@ -15,7 +15,7 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'leftovers', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Giratina", ability: 'pressure', moves: ['shadowsneak']}]);
 		const klutzMon = battle.p1.active[0];
-		assert.hurtsBy(klutzMon, Math.floor(klutzMon.maxhp / 2), () => battle.commitDecisions(), "Leftovers healing should not apply");
+		assert.hurtsBy(klutzMon, Math.floor(klutzMon.maxhp / 2), () => battle.makeChoices('move bellydrum', 'move shadowsneak'), "Leftovers healing should not apply");
 	});
 
 	it('should prevent items from being consumed', function () {
@@ -23,7 +23,7 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", level: 1, ability: 'klutz', item: 'sitrusberry', moves: ['endure']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['psychic']}]);
 		const klutzMon = battle.p1.active[0];
-		assert.constant(() => klutzMon.item, () => battle.commitDecisions());
+		assert.constant(() => klutzMon.item, () => battle.makeChoices('move endure', 'move psychic'));
 		assert.strictEqual(klutzMon.hp, 1);
 	});
 
@@ -31,7 +31,7 @@ describe('Klutz', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'assaultvest', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['psychic']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move protect', 'move psychic');
 		assert.strictEqual(battle.p1.active[0].lastMove, 'protect');
 	});
 
@@ -40,7 +40,7 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Genesect", ability: 'klutz', item: 'dousedrive', moves: ['calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['trick']}]);
 		const klutzMon = battle.p1.active[0];
-		assert.constant(() => klutzMon.item, () => battle.commitDecisions());
+		assert.constant(() => klutzMon.item, () => battle.makeChoices('move calmmind', 'move trick'));
 	});
 
 	it('should cause Fling to fail', function () {
@@ -48,14 +48,14 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'seaincense', moves: ['fling']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['calmmind']}]);
 		const klutzMon = battle.p1.active[0];
-		assert.constant(() => klutzMon.item, () => battle.commitDecisions());
+		assert.constant(() => klutzMon.item, () => battle.makeChoices('move fling', 'move calmmind'));
 	});
 
 	it('should not prevent Pokemon from Mega Evolving', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'lopunnite', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['calmmind']}]);
-		battle.p1.chooseMove('protect', 0, true).foe.chooseDefault();
+		battle.makeChoices('move protect mega', 'move calmmind');
 		assert.species(battle.p1.active[0], 'Lopunny-Mega');
 	});
 });

--- a/test/simulator/abilities/levitate.js
+++ b/test/simulator/abilities/levitate.js
@@ -14,14 +14,14 @@ describe('Levitate', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rotom', ability: 'levitate', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Aggron', ability: 'sturdy', moves: ['earthquake']}]);
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move earthquake'));
 	});
 
 	it('should make the user airborne', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Unown', ability: 'levitate', moves: ['spore']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Espeon', ability: 'magicbounce', moves: ['electricterrain']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move spore', 'move electricterrain');
 		assert.strictEqual(battle.p1.active[0].status, 'slp', "Levitate Pokémon should not be awaken by Electric Terrain");
 	});
 
@@ -29,7 +29,7 @@ describe('Levitate', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['earthquake']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move earthquake'));
 	});
 
 	it('should have its airborne property suppressed by Mold Breaker if it is forced out by a move', function () {
@@ -39,8 +39,8 @@ describe('Levitate', function () {
 			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['roar', 'spikes']}]);
-		battle.p2.chooseMove('spikes').foe.chooseDefault();
-		assert.hurts(battle.p1.pokemon[1], () => battle.commitDecisions());
+		battle.makeChoices('move sleeptalk', 'move spikes');
+		assert.hurts(battle.p1.pokemon[1], () => battle.makeChoices('move sleeptalk', 'move roar'));
 	});
 
 	it('should not have its airborne property suppressed by Mold Breaker if it switches out via Eject Button', function () {
@@ -50,9 +50,9 @@ describe('Levitate', function () {
 			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['tackle', 'spikes']}]);
-		battle.p2.chooseMove('spikes').foe.chooseDefault();
-		battle.commitDecisions();
-		assert.false.hurts(battle.p1.pokemon[1], () => battle.p1.chooseSwitch(2));
+		battle.makeChoices('move sleeptalk', 'move spikes');
+		battle.makeChoices('move sleeptalk', 'move tackle');
+		assert.false.hurts(battle.p1.pokemon[1], () => battle.makeChoices('switch 2'));
 	});
 
 	it('should not have its airborne property suppressed by Mold Breaker if that Pokemon is no longer active', function () {
@@ -62,7 +62,7 @@ describe('Levitate', function () {
 			{species: 'Haxorus', ability: 'moldbreaker', item: 'laggingtail', moves: ['tackle']},
 			{species: 'Rotom', ability: 'levitate', moves: ['rest']},
 		]);
-		assert.false.hurts(battle.p2.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p2.active[0], () => battle.makeChoices('move spikes', 'move tackle'));
 	});
 });
 
@@ -72,11 +72,13 @@ describe('Levitate [Gen 4]', function () {
 	});
 
 	it('should not have its airborne property suppressed by Mold Breaker if it is forced out by a move', function () {
-		battle = common.gen(4).createBattle([
-			[{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}, {species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}],
-			[{species: 'Rampardos', ability: 'moldbreaker', moves: ['roar', 'spikes']}],
+		battle = common.gen(4).createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']},
+			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']},
 		]);
-		battle.p2.chooseMove('spikes').foe.chooseDefault();
-		assert.false.hurts(battle.p1.pokemon[1], () => battle.commitDecisions());
+		battle.join('p2', 'Guest 2', 1, [{species: 'Rampardos', ability: 'moldbreaker', moves: ['roar', 'spikes']}]);
+		battle.makeChoices('move sleeptalk', 'move spikes');
+		assert.false.hurts(battle.p1.pokemon[1], () => battle.makeChoices('move sleeptalk', 'move roar'));
 	});
 });

--- a/test/simulator/abilities/lightningrod.js
+++ b/test/simulator/abilities/lightningrod.js
@@ -14,7 +14,7 @@ describe('Lightning Rod', function () {
 		battle = common.gen(6).createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Manectric', ability: 'lightningrod', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'static', moves: ['thunderbolt']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move thunderbolt');
 		assert.fullHP(battle.p1.active[0]);
 		assert.statStage(battle.p1.active[0], 'spa', 1);
 	});
@@ -23,7 +23,7 @@ describe('Lightning Rod', function () {
 		battle = common.gen(6).createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rhydon', ability: 'lightningrod', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'static', moves: ['thunderbolt']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move thunderbolt');
 		assert.statStage(battle.p1.active[0], 'spa', 0);
 	});
 
@@ -31,7 +31,7 @@ describe('Lightning Rod', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rhydon', ability: 'lightningrod', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'static', moves: ['thunderbolt']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move thunderbolt');
 		assert.fullHP(battle.p1.active[0]);
 		assert.statStage(battle.p1.active[0], 'spa', 1);
 	});
@@ -49,11 +49,10 @@ describe('Lightning Rod', function () {
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 		]);
-		p1.chooseMove(1).chooseMove(1, 1).chooseMove(1, 1);
-		p2.chooseMove(1, 3).chooseMove(1, 3).chooseMove(1, 2);
-		assert.statStage(battle.p1.active[0], 'spa', 3);
-		assert.false.fullHP(battle.p1.active[2]);
-		assert.false.fullHP(battle.p2.active[0]);
+		battle.makeChoices('move sleeptalk, move thunderbolt 1, move thunderbolt 1', 'move thunderbolt 3, move thunderbolt 3, move thunderbolt 2');
+		assert.statStage(p1.active[0], 'spa', 3);
+		assert.false.fullHP(p1.active[2]);
+		assert.false.fullHP(p2.active[0]);
 	});
 
 	it('should redirect to the fastest Pokemon with the ability', function () {
@@ -67,7 +66,7 @@ describe('Lightning Rod', function () {
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 		]);
 		p1.active[0].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1, 2);
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move thunderbolt 1, move thunderbolt 2');
 		assert.statStage(p1.active[0], 'spa', 2);
 		assert.statStage(p1.active[1], 'spa', 0);
 	});
@@ -82,7 +81,7 @@ describe('Lightning Rod', function () {
 			{species: 'Pichu', ability: 'static', moves: ['thunderbolt']},
 			{species: 'Pichu', ability: 'static', moves: ['thunderbolt']},
 		]);
-		p1.chooseMove(1, -2).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1, 2);
+		battle.makeChoices('move roleplay -2, move sleeptalk', 'move thunderbolt 1, move thunderbolt 2');
 		assert.statStage(p1.active[0], 'spa', 0);
 		assert.statStage(p1.active[1], 'spa', 2);
 	});
@@ -98,7 +97,7 @@ describe('Lightning Rod', function () {
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 		]);
 		p1.active[0].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 2).chooseMove(1, 1);
+		battle.makeChoices('move sleeptalk, move followme', 'move thunderbolt 2, move thunderbolt 1');
 		assert.statStage(p1.active[0], 'spa', 0);
 		assert.false.fullHP(p1.active[1]);
 	});
@@ -109,11 +108,11 @@ describe('Lightning Rod', function () {
 			{species: 'Manectric', ability: 'lightningrod', moves: ['endure']},
 			{species: 'Manaphy', ability: 'hydration', moves: ['tailglow']},
 		]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [
+		battle.join('p2', 'Guest 2', 1, [
 			{species: 'Haxorus', ability: 'moldbreaker', moves: ['thunderpunch']},
 			{species: 'Zekrom', ability: 'teravolt', moves: ['shockwave']},
 		]);
-		p2.chooseMove(1, 1).chooseMove(1, 2).foe.chooseDefault();
+		battle.makeChoices('move endure, move tailglow', 'move thunderpunch 1, move shockwave 2');
 		assert.false.fullHP(p1.active[0]);
 		assert.false.fullHP(p1.active[1]);
 	});

--- a/test/simulator/abilities/magicbounce.js
+++ b/test/simulator/abilities/magicbounce.js
@@ -16,7 +16,7 @@ describe('Magic Bounce', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Bulbasaur", ability: 'overgrow', moves: ['growl']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['futuresight']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move growl', 'move futuresight');
 		assert.statStage(battle.p1.active[0], 'atk', -1);
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 	});
@@ -25,7 +25,7 @@ describe('Magic Bounce', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Xatu", ability: 'magicbounce', moves: ['roost']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['growl']}]);
-		assert.doesNotThrow(() => battle.commitDecisions());
+		assert.doesNotThrow(() => battle.makeChoices('move roost', 'move growl'));
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'atk', -1);
 	});
@@ -37,7 +37,8 @@ describe('Magic Bounce', function () {
 			{species: "Xatu", item: 'choicescarf', ability: 'magicbounce', moves: ['roost', 'growl']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['growl', 'recover']}]);
-		battle.p1.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('switch 2', 'move growl');
+		battle.makeChoices('move roost', 'move recover');
 		battle.p2.chooseMove(2).foe.chooseDefault();
 		assert.notStrictEqual(battle.p1.active[0].lastMove, 'growl');
 	});
@@ -46,7 +47,7 @@ describe('Magic Bounce', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Bulbasaur", ability: 'moldbreaker', moves: ['growl']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['futuresight']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move growl', 'move futuresight');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'atk', -1);
 	});

--- a/test/simulator/abilities/magicguard.js
+++ b/test/simulator/abilities/magicguard.js
@@ -17,12 +17,11 @@ describe('Magic Guard', function () {
 			{species: 'Clefable', ability: 'magicguard', item: 'lifeorb', moves: ['doubleedge', 'mindblown']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'roughskin', moves: ['spikes', 'toxic']}]);
-		battle.commitDecisions();
-		battle.p1.chooseSwitch(2).foe.chooseMove('toxic');
+		battle.makeChoices('move splash', 'move spikes');
+		battle.makeChoices('switch 2', 'move toxic');
 		assert.strictEqual(battle.p1.active[0].status, 'tox');
 		assert.fullHP(battle.p1.active[0]);
-		battle.p1.chooseMove('mindblown').foe.chooseMove('toxic');
-		battle.commitDecisions();
+		battle.makeChoices('move mindblown', 'move spikes');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
@@ -33,8 +32,8 @@ describe('Magic Guard', function () {
 			{species: 'Clefable', ability: 'magicguard', moves: ['doubleedge']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['stealthrock', 'roar']}]);
-		battle.commitDecisions();
-		battle.p2.chooseMove('roar').foe.chooseDefault();
+		battle.makeChoices('move splash', 'move stealthrock');
+		battle.makeChoices('move splash', 'move roar');
 		assert.fullHP(battle.p1.active[0]);
 	});
 });

--- a/test/simulator/abilities/magnetpull.js
+++ b/test/simulator/abilities/magnetpull.js
@@ -12,20 +12,18 @@ describe('Magnet Pull', function () {
 
 	it('should prevent Steel-type Pokemon from switching out normally', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Magnezone", ability: 'magnetpull', moves: ['soak', 'charge']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Magnezone", ability: 'magnetpull', moves: ['soak', 'charge']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [
 			{species: "Heatran", ability: 'flashfire', moves: ['curse']},
 			{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 		]);
-		assert.false(p2.chooseSwitch(2));
-		battle.commitDecisions();
-		assert.species(battle.p2.active[0], 'Heatran');
-		p2.chooseSwitch(2).foe.chooseDefault();
-		assert.species(battle.p2.active[0], 'Starmie');
-		p1.chooseMove(2).foe.chooseMove('reflecttype'); // Reflect Type makes Starmie part Steel
-		assert.false(p2.chooseSwitch(2));
-		battle.commitDecisions();
-		assert.species(battle.p2.active[0], 'Starmie');
+		battle.makeChoices('move soak', 'switch 2');
+		assert.species(p2.active[0], 'Heatran');
+		battle.makeChoices('move charge', 'switch 2');
+		assert.species(p2.active[0], 'Starmie');
+		battle.makeChoices('move charge', 'move reflecttype'); // Reflect Type makes Starmie part Steel
+		battle.makeChoices('move charge', 'switch 2');
+		assert.species(p2.active[0], 'Starmie');
 	});
 
 	it('should not prevent Steel-type Pokemon from switching out using moves', function () {
@@ -35,8 +33,8 @@ describe('Magnet Pull', function () {
 			{species: "Heatran", ability: 'flashfire', moves: ['batonpass']},
 			{species: "Tentacruel", ability: 'clearbody', moves: ['rapidspin']},
 		]);
-		battle.p2.chooseMove('batonpass').foe.chooseDefault();
-		battle.p2.chooseSwitch(2);
+		battle.makeChoices('move toxic', 'move batonpass');
+		battle.makeChoices('switch 2');
 		assert.species(battle.p2.active[0], 'Tentacruel');
 	});
 
@@ -47,7 +45,7 @@ describe('Magnet Pull', function () {
 			{species: "Aegislash", ability: 'stancechange', moves: ['swordsdance']},
 			{species: "Arcanine", ability: 'flashfire', moves: ['roar']},
 		]);
-		battle.p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move substitute', 'switch 2');
 		assert.species(battle.p2.active[0], 'Arcanine');
 	});
 });

--- a/test/simulator/abilities/multiscale.js
+++ b/test/simulator/abilities/multiscale.js
@@ -16,11 +16,11 @@ describe('Multiscale', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moxie', moves: ['incinerate']}]);
 		let damage, curhp;
 		let pokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move incinerate');
 		damage = pokemon.maxhp - pokemon.hp;
 		curhp = pokemon.hp;
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move incinerate');
 		assert.strictEqual(damage, battle.modify(curhp - pokemon.hp, 0.5));
 	});
 
@@ -30,11 +30,11 @@ describe('Multiscale', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moldbreaker', moves: ['incinerate']}]);
 		let damage, curhp;
 		let pokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move incinerate');
 		damage = pokemon.maxhp - pokemon.hp;
 		curhp = pokemon.hp;
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move incinerate');
 		assert.strictEqual(curhp - pokemon.hp, damage);
 	});
 });

--- a/test/simulator/moves/endure.js
+++ b/test/simulator/moves/endure.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('False Swipe', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should leave the user with 1 HP if hit by an attack that would knock it out', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: "Necrozma", ability: 'pressure', moves: ['photongeyser']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, moves: ['endure']}]);
+		battle.makeChoices('move photongeyser', 'move endure');
+		assert.strictEqual(battle.p2.active[0].hp, 1);
+	});
+});

--- a/test/simulator/moves/falseswipe.js
+++ b/test/simulator/moves/falseswipe.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('False Swipe', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should leave the target with 1 HP if the attack would KO it', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: "Regigigas", ability: 'pressure', moves: ['falseswipe']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', moves: ['snore']}]);
+		battle.makeChoices('move falseswipe', 'move rest');
+		assert.strictEqual(battle.p2.active[0].hp, 1);
+	});
+});


### PR DESCRIPTION
Replaces all other choice syntax with battle.makeChoices() and makes all tests use the battle.join() function to create teams.

I was going to do all the abilities in one PR, but I figure that would be way to much to expect anyone to review at once.