### PR TITLE
Fix interaction between Encore and status Z-Moves

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4408,7 +4408,7 @@ exports.BattleMovedex = {
 			onStart: function (target) {
 				let noEncore = ['assist', 'copycat', 'encore', 'mefirst', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'sketch', 'sleeptalk', 'struggle', 'transform'];
 				let moveIndex = target.moves.indexOf(target.lastMove);
-				if (!target.lastMove || this.getMove(target.lastMove).isZ || noEncore.includes(target.lastMove) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
+				if (!target.lastMove || target.lastMoveIsZ || noEncore.includes(target.lastMove) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
 					// it failed
 					delete target.volatiles['encore'];
 					return false;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -60,6 +60,7 @@ exports.BattleScripts = {
 			}
 		}
 		pokemon.lastDamage = 0;
+
 		let lockedMove;
 		if (!externalMove) {
 			lockedMove = this.runEvent('LockMove', pokemon);
@@ -79,6 +80,7 @@ exports.BattleScripts = {
 			pokemon.moveUsed(move, targetLoc);
 		}
 
+		pokemon.lastMoveIsZ = undefined;
 		// Dancer Petal Dance hack
 		// TODO: implement properly
 		let noLock = externalMove && !pokemon.volatiles.lockedmove;
@@ -89,6 +91,7 @@ exports.BattleScripts = {
 			}
 			this.add('-zpower', pokemon);
 			pokemon.side.zMoveUsed = true;
+			pokemon.lastMoveIsZ = true;
 		}
 		let moveDidSomething = this.useMove(baseMove, pokemon, target, sourceEffect, zMove);
 		this.singleEvent('AfterMove', move, null, pokemon, target, move);

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -90,6 +90,7 @@ class Pokemon {
 		this.draggedIn = null;
 
 		this.lastMove = '';
+		this.lastMoveIsZ = undefined;
 		/**@type {string | boolean} */
 		this.moveThisTurn = '';
 


### PR DESCRIPTION
This fixes the issue where Encore does not fail when used against status Z-Moves (described in #2367).  This works by adding a new flag to the Pokemon class (lastMoveIsZ) that is set to true if the last successful move was a Z-Move (regardless of whether it is a damaging move or status move) and undefined otherwise.  Encore will then fail if this flag is set to true.