### PR TITLE
Tickets: Fix crash on escalation

### DIFF
--- a/chat-plugins/tickets.js
+++ b/chat-plugins/tickets.js
@@ -76,7 +76,7 @@ class HelpTicket extends Rooms.RoomGame {
 		} else {
 			this.modnote(staff, `${staff.name} escalated this ticket.`);
 		}
-		this.ticket.escalator = staff;
+		this.ticket.escalator = staff.name;
 		this.ticket.created = Date.now(); // Bump the ticket so it shows as the newest
 		writeTickets();
 		notifyStaff();


### PR DESCRIPTION
Tickets would store the user object of the staff that escalated it, which crashes when it tries to stringify it.