### PR TITLE
Hidetext: Allow hiding of muted user's messages

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2328,10 +2328,10 @@ exports.commands = {
 		let hidetype = '';
 		if (!user.can('lock', targetUser) && !this.can('ban', targetUser, room)) return false;
 
-		if (targetUser.locked || Punishments.isRoomBanned(targetUser, room.id) || user.can('rangeban')) {
+		if (targetUser.locked || Punishments.isRoomBanned(targetUser, room.id) || room.isMuted(targetUser) || user.can('rangeban')) {
 			hidetype = 'hide|';
 		} else {
-			return this.errorReply("User '" + name + "' is not banned from this room or locked.");
+			return this.errorReply("User '" + name + "' is not muted/banned from this room or locked.");
 		}
 
 		if (cmd === 'hidealtstext' || cmd === 'hidetextalts' || cmd === 'hidealttext') {
@@ -2352,8 +2352,8 @@ exports.commands = {
 		}
 	},
 	hidetexthelp: [
-		"/hidetext [username] - Removes a locked or banned user's messages from chat (includes users banned from the room). Requires: % (global only), @ * # & ~",
-		"/hidealtstext [username] - Removes a locked or banned user's messages, and their alternate account's messages from the chat (includes users banned from the room).  Requires: % (global only), @ * # & ~",
+		"/hidetext [username] - Removes a locked or muted/banned user's messages from chat (includes users banned from the room). Requires: % (global only), @ * # & ~",
+		"/hidealtstext [username] - Removes a locked or muted/banned user's messages, and their alternate account's messages from the chat (includes users banned from the room).  Requires: % (global only), @ * # & ~",
 	],
 
 	ab: 'blacklist',


### PR DESCRIPTION
I've seen several cases where a roomdriver wants to hide a muted users messages but its not worthy of a roomban/lock, and so their natural reaction is to spam the chat with broadcasted commands such as !roomintro.

The correct and more elegant solution for cases like this is for them to be able to use /hidetext. Having to call in a global upper staff for these cases can get frustrating and is not always an easy task.