### PR TITLE
Throat Chop shouldn't block Z-moves

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -17432,7 +17432,7 @@ exports.BattleMovedex = {
 			},
 			onBeforeMovePriority: 6,
 			onBeforeMove: function (pokemon, target, move) {
-				if (move.flags['sound']) {
+				if (!move.isZ && move.flags['sound']) {
 					this.add('cant', pokemon, 'move: Throat Chop');
 					return false;
 				}


### PR DESCRIPTION
Originally seen with Clangorous Soulblaze in a YouTube video but confirmed for Z-Parting Shot in the US/UM mechanics research thread.

I don't know about other effects such as Gravity yet.