### PR TITLE
Make Contrary Competitive/Defiant self-inflicted

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -463,7 +463,7 @@ exports.BattleAbilities = {
 				}
 			}
 			if (statsLowered) {
-				this.boost({spa: 2}, null, null, null, true);
+				this.boost({spa: 2}, target, target, null, true);
 			}
 		},
 		id: "competitive",
@@ -630,7 +630,7 @@ exports.BattleAbilities = {
 				}
 			}
 			if (statsLowered) {
-				this.boost({atk: 2}, null, null, null, true);
+				this.boost({atk: 2}, target, target, null, true);
 			}
 		},
 		id: "defiant",


### PR DESCRIPTION
So that when Partners in Crime has both Contrary and Competitive active at once, the stat drops caused by Contrary Competitive don't retrigger Competitive.