### PR TITLE
Users: Fix marking guest numbers as autoconfirmed

### DIFF
--- a/users.js
+++ b/users.js
@@ -733,8 +733,8 @@ class User {
 			}
 		}
 		if (Users.isTrusted(userid)) {
-			this.trusted = this.userid;
-			this.autoconfirmed = this.userid;
+			this.trusted = userid;
+			this.autoconfirmed = userid;
 		}
 		if (this.trusted) {
 			this.locked = null;


### PR DESCRIPTION
This is a bug that was introduced in https://github.com/Zarel/Pokemon-Showdown/commit/0b64df7f3cc507f44f51cbd753e8a6a4a641592b