### PR TITLE
Punishments: Fix a few display issues

### DIFF
--- a/punishments.js
+++ b/punishments.js
@@ -1369,6 +1369,7 @@ Punishments.getRoomPunishments = function (user, options) {
  */
 Punishments.monitorRoomPunishments = function (user) {
 	if (user.locked) return;
+	const userid = toId(user);
 
 	const minPunishments = (typeof Config.monitorminpunishments === 'number' ? Config.monitorminpunishments : 3); // Default to 3 if the Config option is not defined or valid
 	if (!minPunishments) return;
@@ -1383,7 +1384,7 @@ Punishments.monitorRoomPunishments = function (user) {
 			if (punishType in PUNISHMENT_POINT_VALUES) points += PUNISHMENT_POINT_VALUES[punishType];
 			let punishDesc = Punishments.roomPunishmentTypes.get(punishType);
 			if (!punishDesc) punishDesc = `punished`;
-			if (punishUserid !== user.userid) punishDesc += ` as ${punishUserid}`;
+			if (punishUserid !== userid) punishDesc += ` as ${punishUserid}`;
 
 			if (reason) punishDesc += `: ${reason}`;
 			return `<<${room}>> (${punishDesc})`;
@@ -1392,12 +1393,12 @@ Punishments.monitorRoomPunishments = function (user) {
 		if (Config.punishmentautolock && points >= AUTOLOCK_POINT_THRESHOLD) {
 			let rooms = punishments.map(([room]) => room).join(', ');
 			let reason = `Autolocked for having punishments in ${punishments.length} rooms: ${rooms}`;
-			let message = `${user.name || `[${toId(user)}]`} was locked for having punishments in ${punishments.length} rooms: ${punishmentText}`;
+			let message = `${user.name || userid} was locked for having punishments in ${punishments.length} rooms: ${punishmentText}`;
 
 			Punishments.autolock(user, 'staff', 'PunishmentMonitor', reason, message);
 			if (typeof user !== 'string') user.popup("|modal|You've been locked for breaking the rules in multiple chatrooms.\n\nIf you feel that your lock was unjustified, you can still PM staff members (%, @, &, and ~) to discuss it" + (Config.appealurl ? " or you can appeal:\n" + Config.appealurl : ".") + "\n\nYour lock will expire in a few days.");
 		} else {
-			Monitor.log(`[PunishmentMonitor] ${user.name} currently has punishments in ${punishments.length} rooms: ${punishmentText}`);
+			Monitor.log(`[PunishmentMonitor] ${user.name || userid} currently has punishments in ${punishments.length} rooms: ${punishmentText}`);
 		}
 	}
 };


### PR DESCRIPTION
This happens when you use `/nameblacklist` on a user that already has some punishments, can get something like
![image](https://user-images.githubusercontent.com/22896712/34368944-5c7051b6-ea75-11e7-870e-a0bcf50f990f.png)
