### PR TITLE
Called status moves don't inherit Z power

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -25,7 +25,7 @@ exports.BattleScripts = {
 			}
 		}
 		let baseMove = this.getMove(move);
-		move = zMove ? this.getZMoveCopy(move, pokemon) : baseMove;
+		move = zMove ? this.getZMoveCopy(baseMove, pokemon) : baseMove;
 		if (!target && target !== false) target = this.resolveTarget(pokemon, move);
 
 		// copy the priority for Quick Guard
@@ -134,15 +134,14 @@ exports.BattleScripts = {
 	},
 	useMoveInner: function (move, pokemon, target, sourceEffect, zMove) {
 		if (!sourceEffect && this.effect.id) sourceEffect = this.effect;
+		move = this.getMoveCopy(move);
 		if (zMove && move.id === 'weatherball') {
 			let baseMove = move;
 			this.singleEvent('ModifyMove', move, null, pokemon, target, move, move);
 			move = this.getZMoveCopy(move, pokemon);
 			if (move.type !== 'Normal') sourceEffect = baseMove;
-		} else if (zMove || (sourceEffect && sourceEffect.isZ && sourceEffect.id !== 'instruct')) {
+		} else if (zMove || (move.category !== 'Status' && sourceEffect && sourceEffect.isZ && sourceEffect.id !== 'instruct')) {
 			move = this.getZMoveCopy(move, pokemon);
-		} else {
-			move = this.getMoveCopy(move);
 		}
 		if (this.activeMove) {
 			move.priority = this.activeMove.priority;
@@ -835,7 +834,6 @@ exports.BattleScripts = {
 	},
 
 	getZMoveCopy: function (move, pokemon) {
-		move = this.getMove(move);
 		let zMove;
 		if (pokemon) {
 			let item = pokemon.getItem();


### PR DESCRIPTION
Latest [research](http://www.smogon.com/forums/posts/7625046) shows that although Z-Synthesis passes Heal Block, using Z-Copycat to copy Synthesis does not. (Z-Copycat on a damaging move does of course turn into a damaging Z-move.)

Note that this doesn't fix the message (because the Synthesis gets blocked at the healing level rather than at the use) but that's a different issue that affects several move blocking effects against copied moves.