### PR TITLE
Change lastMove from a string to a Move

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -2814,7 +2814,7 @@ exports.BattleItems = {
 		},
 		onUpdate: function (pokemon) {
 			if (!pokemon.hp) return;
-			let moveSlot = pokemon.getMoveData(pokemon.lastMove);
+			let moveSlot = pokemon.lastMove && pokemon.getMoveData(pokemon.lastMove.id);
 			if (moveSlot && moveSlot.pp === 0) {
 				pokemon.addVolatile('leppaberry');
 				pokemon.volatiles['leppaberry'].moveSlot = moveSlot;
@@ -6061,7 +6061,7 @@ exports.BattleItems = {
 			type: "Fighting",
 		},
 		onUpdate: function (pokemon) {
-			let moveSlot = pokemon.getMoveData(pokemon.lastMove);
+			let moveSlot = pokemon.lastMove && pokemon.getMoveData(pokemon.lastMove.id);
 			if (moveSlot && moveSlot.pp === 0) {
 				pokemon.addVolatile('leppaberry');
 				pokemon.volatiles['leppaberry'].moveSlot = moveSlot;

--- a/data/moves.js
+++ b/data/moves.js
@@ -2573,7 +2573,7 @@ exports.BattleMovedex = {
 				return false;
 			}
 			let possibleTypes = [];
-			let attackType = this.getMove(target.lastMove).type;
+			let attackType = target.lastMove.type;
 			for (let type in this.data.TypeChart) {
 				if (source.hasType(type) || target.hasType(type)) continue;
 				let typeCheck = this.data.TypeChart[type].damageTaken[attackType];
@@ -2609,10 +2609,10 @@ exports.BattleMovedex = {
 		flags: {},
 		onHit: function (pokemon) {
 			let noCopycat = ['assist', 'banefulbunker', 'bestow', 'chatter', 'circlethrow', 'copycat', 'counter', 'covet', 'destinybond', 'detect', 'dragontail', 'endure', 'feint', 'focuspunch', 'followme', 'helpinghand', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'naturepower', 'protect', 'ragepowder', 'roar', 'sketch', 'sleeptalk', 'snatch', 'struggle', 'switcheroo', 'thief', 'transform', 'trick', 'whirlwind'];
-			if (!this.lastMove || noCopycat.includes(this.lastMove) || this.getMove(this.lastMove).isZ) {
+			if (!this.lastMove || noCopycat.includes(this.lastMove.id) || this.lastMove.isZ) {
 				return false;
 			}
-			this.useMove(this.lastMove, pokemon);
+			this.useMove(this.lastMove.id, pokemon);
 		},
 		secondary: false,
 		target: "self",
@@ -3414,7 +3414,7 @@ exports.BattleMovedex = {
 					return false;
 				}
 				for (const moveSlot of pokemon.moveSlots) {
-					if (moveSlot.id === pokemon.lastMove) {
+					if (moveSlot.id === pokemon.lastMove.id) {
 						if (!moveSlot.pp) {
 							this.debug('Move out of PP');
 							return false;
@@ -3424,7 +3424,7 @@ exports.BattleMovedex = {
 							} else {
 								this.add('-start', pokemon, 'Disable', moveSlot.move);
 							}
-							this.effectData.move = pokemon.lastMove;
+							this.effectData.move = pokemon.lastMove.id;
 							return;
 						}
 					}
@@ -4407,13 +4407,13 @@ exports.BattleMovedex = {
 			noCopy: true, // doesn't get copied by Z-Baton Pass
 			onStart: function (target) {
 				let noEncore = ['assist', 'copycat', 'encore', 'mefirst', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'sketch', 'sleeptalk', 'struggle', 'transform'];
-				let moveIndex = target.moves.indexOf(target.lastMove);
-				if (!target.lastMove || this.getMove(target.lastMove).isZ || noEncore.includes(target.lastMove) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
+				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove) : -1;
+				if (!target.lastMove || target.lastMove.isZ || noEncore.includes(target.lastMove.id) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
 					// it failed
 					delete target.volatiles['encore'];
 					return false;
 				}
-				this.effectData.move = target.lastMove;
+				this.effectData.move = target.lastMove.id;
 				this.add('-start', target, 'Encore');
 				if (!this.willMove(target)) {
 					this.effectData.duration++;
@@ -4424,7 +4424,7 @@ exports.BattleMovedex = {
 			},
 			onResidualOrder: 13,
 			onResidual: function (target) {
-				if (target.moves.indexOf(target.lastMove) >= 0 && target.moveSlots[target.moves.indexOf(target.lastMove)].pp <= 0) { // early termination if you run out of PP
+				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) { // early termination if you run out of PP
 					delete target.volatiles.encore;
 					this.add('-end', target, 'Encore');
 				}
@@ -6740,9 +6740,9 @@ exports.BattleMovedex = {
 				if (!source || !effect) return;
 				if (effect.effectType === 'Move' && !effect.isFutureMove) {
 					for (const moveSlot of source.moveSlots) {
-						if (moveSlot.id === source.lastMove) {
+						if (moveSlot.id === source.lastMove.id) {
 							moveSlot.pp = 0;
-							this.add('-activate', source, 'move: Grudge', this.getMove(source.lastMove).name);
+							this.add('-activate', source, 'move: Grudge', this.getMove(source.lastMove.id).name);
 						}
 					}
 				}
@@ -8219,7 +8219,7 @@ exports.BattleMovedex = {
 				}
 			},
 			onResidual: function (target) {
-				if (target.lastMove === 'struggle') {
+				if (target.lastMove && target.lastMove.id === 'struggle') {
 					// don't lock
 					delete target.volatiles['iceball'];
 				}
@@ -8615,8 +8615,8 @@ exports.BattleMovedex = {
 		flags: {protect: 1, authentic: 1, mystery: 1},
 		onHit: function (target, source) {
 			if (!target.lastMove) return false;
-			let lastMove = this.getMove(target.lastMove);
-			let moveIndex = target.moves.indexOf(target.lastMove);
+			let lastMove = target.lastMove;
+			let moveIndex = target.moves.indexOf(lastMove.id);
 			let noInstruct = [
 				'assist', 'beakblast', 'bide', 'copycat', 'focuspunch', 'iceball', 'instruct', 'mefirst', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'outrage', 'petaldance', 'rollout', 'shelltrap', 'sketch', 'sleeptalk', 'thrash', 'transform',
 			];
@@ -8624,7 +8624,7 @@ exports.BattleMovedex = {
 				return false;
 			}
 			this.add('-singleturn', target, 'move: Instruct', '[of] ' + source);
-			this.runMove(target.lastMove, target, target.lastMoveTargetLoc);
+			this.runMove(target.lastMove.id, target, target.lastMoveTargetLoc);
 		},
 		secondary: false,
 		target: "normal",
@@ -10308,10 +10308,10 @@ exports.BattleMovedex = {
 		flags: {protect: 1, authentic: 1, mystery: 1},
 		onHit: function (target, source) {
 			let disallowedMoves = ['chatter', 'mimic', 'sketch', 'struggle', 'transform'];
-			if (source.transformed || !target.lastMove || disallowedMoves.includes(target.lastMove) || source.moves.indexOf(target.lastMove) >= 0) return false;
+			if (source.transformed || !target.lastMove || disallowedMoves.includes(target.lastMove.id) || source.moves.indexOf(target.lastMove.id) >= 0 || target.lastMove.isZ) return false;
 			let mimicIndex = source.moves.indexOf('mimic');
 			if (mimicIndex < 0) return false;
-			let move = this.getMove(target.lastMove);
+			let move = this.getMove(target.lastMove.id);
 			source.moveSlots[mimicIndex] = {
 				move: move.name,
 				id: move.id,
@@ -10514,10 +10514,10 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {},
 		onTryHit: function (target, pokemon) {
-			if (!target.lastMove || !this.getMove(target.lastMove).flags['mirror']) {
+			if (!target.lastMove || !target.lastMove.flags['mirror']) {
 				return false;
 			}
-			this.useMove(target.lastMove, pokemon, target);
+			this.useMove(target.lastMove.id, pokemon, target);
 			return null;
 		},
 		secondary: false,
@@ -13744,7 +13744,7 @@ exports.BattleMovedex = {
 				}
 			},
 			onResidual: function (target) {
-				if (target.lastMove === 'struggle') {
+				if (target.lastMove && target.lastMove.id === 'struggle') {
 					// don't lock
 					delete target.volatiles['rollout'];
 				}
@@ -14777,7 +14777,7 @@ exports.BattleMovedex = {
 		flags: {authentic: 1, mystery: 1},
 		onHit: function (target, source) {
 			let disallowedMoves = ['chatter', 'sketch', 'struggle'];
-			if (source.transformed || !target.lastMove || disallowedMoves.includes(target.lastMove) || source.moves.indexOf(target.lastMove) >= 0) return false;
+			if (source.transformed || !target.lastMove || disallowedMoves.includes(target.lastMove.id) || source.moves.indexOf(target.lastMove.id) >= 0 || target.lastMove.isZ) return false;
 			let sketchIndex = source.moves.indexOf('sketch');
 			if (sketchIndex < 0) return false;
 			let move = this.getMove(target.lastMove);
@@ -15911,8 +15911,8 @@ exports.BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1, authentic: 1},
 		onHit: function (target) {
-			if (target.deductPP(target.lastMove, 4)) {
-				this.add("-activate", target, 'move: Spite', this.getMove(target.lastMove).name, 4);
+			if (target.lastMove && target.deductPP(target.lastMove.id, 4)) {
+				this.add("-activate", target, 'move: Spite', this.getMove(target.lastMove.id).name, 4);
 				return;
 			}
 			return false;
@@ -17666,7 +17666,7 @@ exports.BattleMovedex = {
 				this.add('-end', pokemon, 'Torment');
 			},
 			onDisableMove: function (pokemon) {
-				if (pokemon.lastMove !== 'struggle') pokemon.disableMove(pokemon.lastMove);
+				if (pokemon.lastMove && pokemon.lastMove.id !== 'struggle') pokemon.disableMove(pokemon.lastMove.id);
 			},
 		},
 		secondary: false,
@@ -17998,7 +17998,7 @@ exports.BattleMovedex = {
 		accuracy: true,
 		basePower: 0,
 		basePowerCallback: function (pokemon) {
-			let move = pokemon.getMoveData(pokemon.lastMove); // Account for calling Trump Card via other moves
+			let move = pokemon.getMoveData(pokemon.lastMove.id); // Account for calling Trump Card via other moves
 			switch (move.pp) {
 			case 0:
 				return 200;
@@ -18137,7 +18137,7 @@ exports.BattleMovedex = {
 				this.add('-start', target, 'Uproar');
 			},
 			onResidual: function (target) {
-				if (target.lastMove === 'struggle') {
+				if (target.lastMove && target.lastMove.id === 'struggle') {
 					// don't lock
 					delete target.volatiles['uproar'];
 				}

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -232,7 +232,7 @@ exports.BattleMovedex = {
 			// It will fail if the last move selected by the opponent has base power 0 or is not Normal or Fighting Type.
 			// If both are true, counter will deal twice the last damage dealt in battle, no matter what was the move.
 			// That means that, if opponent switches, counter will use last counter damage * 2.
-			let lastUsedMove = this.getMove(target.side.lastMove);
+			let lastUsedMove = target.side.lastMove && this.getMove(target.side.lastMove.id);
 			if (lastUsedMove && lastUsedMove.basePower > 0 && ['Normal', 'Fighting'].includes(lastUsedMove.type) && this.lastDamage > 0 && !this.willMove(target)) {
 				return 2 * this.lastDamage;
 			}
@@ -554,10 +554,10 @@ exports.BattleMovedex = {
 		inherit: true,
 		onHit: function (pokemon) {
 			let foe = pokemon.side.foe.active[0];
-			if (!foe || !foe.lastMove || foe.lastMove === 'mirrormove') {
+			if (!foe || !foe.lastMove || foe.lastMove.id === 'mirrormove') {
 				return false;
 			}
-			this.useMove(foe.lastMove, pokemon);
+			this.useMove(foe.lastMove.id, pokemon);
 		},
 	},
 	nightshade: {

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -21,7 +21,7 @@ exports.BattleScripts = {
 	// This is because there was actually no side, just Battle and active Pokémon effects.
 	// Side's lastMove is used for Counter and Mirror Move.
 	side: {
-		lastMove: '',
+		lastMove: null,
 	},
 	// BattlePokemon scripts.
 	pokemon: {
@@ -100,8 +100,8 @@ exports.BattleScripts = {
 		if (!lockedMove && (!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].locked !== target)) {
 			pokemon.deductPP(move, null, target);
 			// On gen 1 moves are stored when they are chosen and a PP is deducted.
-			pokemon.side.lastMove = move.id;
-			pokemon.lastMove = move.id;
+			pokemon.side.lastMove = move;
+			pokemon.lastMove = move;
 		} else {
 			sourceEffect = move;
 		}

--- a/mods/gen1/statuses.js
+++ b/mods/gen1/statuses.js
@@ -71,7 +71,7 @@ exports.BattleStatuses = {
 			if (pokemon.statusData.time > 0) {
 				this.add('cant', pokemon, 'slp');
 			}
-			pokemon.lastMove = '';
+			pokemon.lastMove = null;
 			return false;
 		},
 		onAfterMoveSelf: function (pokemon) {
@@ -86,7 +86,7 @@ exports.BattleStatuses = {
 		onBeforeMovePriority: 10,
 		onBeforeMove: function (pokemon, target, move) {
 			this.add('cant', pokemon, 'frz');
-			pokemon.lastMove = '';
+			pokemon.lastMove = null;
 			return false;
 		},
 		onHit: function (target, source, move) {
@@ -214,7 +214,7 @@ exports.BattleStatuses = {
 			return duration;
 		},
 		onResidual: function (target) {
-			if (target.lastMove === 'struggle' || target.status === 'slp') {
+			if (target.lastMove && target.lastMove.id === 'struggle' || target.status === 'slp') {
 				delete target.volatiles['partialtrappinglock'];
 			}
 		},

--- a/mods/gen2/statuses.js
+++ b/mods/gen2/statuses.js
@@ -145,7 +145,7 @@ exports.BattleStatuses = {
 			return this.random(2, 4);
 		},
 		onResidual: function (target) {
-			if (target.lastMove === 'struggle' || target.status === 'slp') {
+			if ((target.lastMove.id === 'struggle') || target.status === 'slp') {
 				// don't lock, and bypass confusion for calming
 				delete target.volatiles['lockedmove'];
 			}

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -173,12 +173,12 @@ exports.BattleMovedex = {
 					return false;
 				}
 				for (const moveSlot of pokemon.moveSlots) {
-					if (moveSlot.id === pokemon.lastMove) {
+					if (moveSlot.id === pokemon.lastMove.id) {
 						if (!moveSlot.pp) {
 							return false;
 						} else {
 							this.add('-start', pokemon, 'Disable', moveSlot.move);
-							this.effectData.move = pokemon.lastMove;
+							this.effectData.move = pokemon.lastMove.id;
 							return;
 						}
 					}
@@ -223,14 +223,14 @@ exports.BattleMovedex = {
 			},
 			onStart: function (target) {
 				let noEncore = ['encore', 'mimic', 'mirrormove', 'sketch', 'struggle', 'transform'];
-				let moveIndex = target.moves.indexOf(target.lastMove);
-				if (!target.lastMove || noEncore.includes(target.lastMove) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
+				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
+				if (!target.lastMove || noEncore.includes(target.lastMove.id) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
 					// it failed
 					this.add('-fail', target);
 					delete target.volatiles['encore'];
 					return;
 				}
-				this.effectData.move = target.lastMove;
+				this.effectData.move = target.lastMove.id;
 				this.add('-start', target, 'Encore');
 				if (!this.willMove(target)) {
 					this.effectData.duration++;
@@ -241,7 +241,7 @@ exports.BattleMovedex = {
 			},
 			onResidualOrder: 13,
 			onResidual: function (target) {
-				if (target.moves.indexOf(target.lastMove) >= 0 && target.moveSlots[target.moves.indexOf(target.lastMove)].pp <= 0) {
+				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) {
 					// early termination if you run out of PP
 					delete target.volatiles.encore;
 					this.add('-end', target, 'Encore');
@@ -458,8 +458,8 @@ exports.BattleMovedex = {
 		shortDesc: "Lowers the PP of the target's last move by 2-5.",
 		onHit: function (target) {
 			let roll = this.random(2, 6);
-			if (target.deductPP(target.lastMove, roll)) {
-				this.add("-activate", target, 'move: Spite', target.lastMove, roll);
+			if (target.lastMove && target.deductPP(target.lastMove.id, roll)) {
+				this.add("-activate", target, 'move: Spite', target.lastMove.id, roll);
 				return;
 			}
 			return false;

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -199,10 +199,10 @@ exports.BattleMovedex = {
 		inherit: true,
 		onHit: function (pokemon) {
 			let noCopycat = ['assist', 'chatter', 'copycat', 'counter', 'covet', 'destinybond', 'detect', 'endure', 'feint', 'focuspunch', 'followme', 'helpinghand', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'protect', 'sketch', 'sleeptalk', 'snatch', 'struggle', 'switcheroo', 'thief', 'trick'];
-			if (!this.lastMove || noCopycat.includes(this.lastMove)) {
+			if (!this.lastMove || noCopycat.includes(this.lastMove.id)) {
 				return false;
 			}
-			this.useMove(this.lastMove, pokemon);
+			this.useMove(this.lastMove.id, pokemon);
 		},
 	},
 	cottonspore: {
@@ -286,12 +286,12 @@ exports.BattleMovedex = {
 					return false;
 				}
 				for (const moveSlot of pokemon.moveSlots) {
-					if (moveSlot.id === pokemon.lastMove) {
+					if (moveSlot.id === pokemon.lastMove.id) {
 						if (!moveSlot.pp) {
 							return false;
 						} else {
 							this.add('-start', pokemon, 'Disable', moveSlot.move);
-							this.effectData.move = pokemon.lastMove;
+							this.effectData.move = pokemon.lastMove.id;
 							return;
 						}
 					}
@@ -396,14 +396,14 @@ exports.BattleMovedex = {
 			},
 			onStart: function (target) {
 				let noEncore = ['encore', 'mimic', 'mirrormove', 'sketch', 'struggle', 'transform'];
-				let moveIndex = target.moves.indexOf(target.lastMove);
-				if (!target.lastMove || noEncore.includes(target.lastMove) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
+				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
+				if (!target.lastMove || noEncore.includes(target.lastMove.id) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
 					// it failed
 					this.add('-fail', target);
 					delete target.volatiles['encore'];
 					return;
 				}
-				this.effectData.move = target.lastMove;
+				this.effectData.move = target.lastMove.id;
 				this.add('-start', target, 'Encore');
 				if (!this.willMove(target)) {
 					this.effectData.duration++;
@@ -414,7 +414,7 @@ exports.BattleMovedex = {
 			},
 			onResidualOrder: 13,
 			onResidual: function (target) {
-				if (target.moves.indexOf(target.lastMove) >= 0 && target.moveSlots[target.moves.indexOf(target.lastMove)].pp <= 0) {
+				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) {
 					// early termination if you run out of PP
 					delete target.volatiles.encore;
 					this.add('-end', target, 'Encore');
@@ -821,10 +821,10 @@ exports.BattleMovedex = {
 		inherit: true,
 		onHit: function (target, source) {
 			let disallowedMoves = ['chatter', 'metronome', 'mimic', 'sketch', 'struggle', 'transform'];
-			if (source.transformed || !target.lastMove || disallowedMoves.includes(target.lastMove) || source.moves.indexOf(target.lastMove) !== -1 || target.volatiles['substitute']) return false;
+			if (source.transformed || !target.lastMove || disallowedMoves.includes(target.lastMove.id) || source.moves.indexOf(target.lastMove.id) !== -1 || target.volatiles['substitute']) return false;
 			let mimicIndex = source.moves.indexOf('mimic');
 			if (mimicIndex < 0) return false;
-			let move = this.getMove(target.lastMove);
+			let move = this.getMove(target.lastMove.id);
 			source.moveSlots[mimicIndex] = {
 				move: move.name,
 				id: move.id,
@@ -1025,10 +1025,10 @@ exports.BattleMovedex = {
 		inherit: true,
 		onHit: function (target, source) {
 			let disallowedMoves = ['chatter', 'sketch', 'struggle'];
-			if (source.transformed || !target.lastMove || disallowedMoves.includes(target.lastMove) || source.moves.includes(target.lastMove) || target.volatiles['substitute']) return false;
+			if (source.transformed || !target.lastMove || disallowedMoves.includes(target.lastMove.id) || source.moves.includes(target.lastMove.id) || target.volatiles['substitute']) return false;
 			let sketchIndex = source.moves.indexOf('sketch');
 			if (sketchIndex < 0) return false;
-			let move = this.getMove(target.lastMove);
+			let move = this.getMove(target.lastMove.id);
 			let sketchedMove = {
 				move: move.name,
 				id: move.id,

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -144,10 +144,10 @@ exports.BattleMovedex = {
 		desc: "The user uses the last move used by any Pokemon, including itself. Fails if no move has been used, or if the last move used was Assist, Bestow, Chatter, Circle Throw, Copycat, Counter, Covet, Destiny Bond, Detect, Dragon Tail, Endure, Feint, Focus Punch, Follow Me, Helping Hand, Me First, Metronome, Mimic, Mirror Coat, Mirror Move, Nature Power, Protect, Rage Powder, Sketch, Sleep Talk, Snatch, Struggle, Switcheroo, Thief, Transform, or Trick.",
 		onHit: function (pokemon) {
 			let noCopycat = ['assist', 'bestow', 'chatter', 'circlethrow', 'copycat', 'counter', 'covet', 'destinybond', 'detect', 'dragontail', 'endure', 'feint', 'focuspunch', 'followme', 'helpinghand', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'naturepower', 'protect', 'ragepowder', 'sketch', 'sleeptalk', 'snatch', 'struggle', 'switcheroo', 'thief', 'transform', 'trick'];
-			if (!this.lastMove || noCopycat.includes(this.lastMove)) {
+			if (!this.lastMove || noCopycat.includes(this.lastMove.id)) {
 				return false;
 			}
-			this.useMove(this.lastMove, pokemon);
+			this.useMove(this.lastMove.id, pokemon);
 		},
 	},
 	cottonspore: {

--- a/mods/gen6/moves.js
+++ b/mods/gen6/moves.js
@@ -61,13 +61,13 @@ exports.BattleMovedex = {
 			duration: 3,
 			onStart: function (target) {
 				let noEncore = ['encore', 'mimic', 'mirrormove', 'sketch', 'struggle', 'transform'];
-				let moveIndex = target.moves.indexOf(target.lastMove);
-				if (!target.lastMove || this.getMove(target.lastMove).isZ || noEncore.includes(target.lastMove) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
+				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
+				if (!target.lastMove || noEncore.includes(target.lastMove.id) || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
 					// it failed
 					delete target.volatiles['encore'];
 					return false;
 				}
-				this.effectData.move = target.lastMove;
+				this.effectData.move = target.lastMove.id;
 				this.add('-start', target, 'Encore');
 				if (!this.willMove(target)) {
 					this.effectData.duration++;
@@ -78,7 +78,7 @@ exports.BattleMovedex = {
 			},
 			onResidualOrder: 13,
 			onResidual: function (target) {
-				if (target.moves.indexOf(target.lastMove) >= 0 && target.moveSlots[target.moves.indexOf(target.lastMove)].pp <= 0) { // early termination if you run out of PP
+				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) { // early termination if you run out of PP
 					delete target.volatiles.encore;
 					this.add('-end', target, 'Encore');
 				}

--- a/mods/gennext/statuses.js
+++ b/mods/gennext/statuses.js
@@ -31,7 +31,7 @@ exports.BattleStatuses = {
 			return this.random(2, 4);
 		},
 		onResidual: function (target) {
-			let move = this.getMove(target.lastMove);
+			let move = target.lastMove;
 			if (!move.self || move.self.volatileStatus !== 'lockedmove') {
 				// don't lock, and bypass confusion for calming
 				delete target.volatiles['lockedmove'];
@@ -44,7 +44,7 @@ exports.BattleStatuses = {
 			target.addVolatile('confusion');
 		},
 		onLockMove: function (pokemon) {
-			return pokemon.lastMove;
+			return pokemon.lastMove.id;
 		},
 	},
 	confusion: {

--- a/mods/stadium/statuses.js
+++ b/mods/stadium/statuses.js
@@ -47,7 +47,7 @@ exports.BattleStatuses = {
 		onBeforeMove: function (pokemon, target, move) {
 			pokemon.statusData.time--;
 			this.add('cant', pokemon, 'slp');
-			pokemon.lastMove = '';
+			pokemon.lastMove = null;
 			return false;
 		},
 		onAfterMoveSelf: function (pokemon) {
@@ -62,7 +62,7 @@ exports.BattleStatuses = {
 		onBeforeMovePriority: 2,
 		onBeforeMove: function (pokemon, target, move) {
 			this.add('cant', pokemon, 'frz');
-			pokemon.lastMove = '';
+			pokemon.lastMove = null;
 			return false;
 		},
 		onHit: function (target, source, move) {

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -143,7 +143,8 @@ class Battle extends Dex.ModdedDex {
 		this.started = false;
 		this.active = false;
 		this.eventDepth = 0;
-		this.lastMove = '';
+		/**@type {?Move} */
+		this.lastMove = null;
 		this.activeMove = null;
 		this.activePokemon = null;
 		this.activeTarget = null;
@@ -433,7 +434,7 @@ class Battle extends Dex.ModdedDex {
 	clearActiveMove(failed) {
 		if (this.activeMove) {
 			if (!failed) {
-				this.lastMove = this.activeMove.id;
+				this.lastMove = this.activeMove;
 			}
 			this.activeMove = null;
 			this.activePokemon = null;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -89,7 +89,8 @@ class Pokemon {
 		/**@type {?number} */
 		this.draggedIn = null;
 
-		this.lastMove = '';
+		/**@type {?Move} */
+		this.lastMove = null;
 		/**@type {string | boolean} */
 		this.moveThisTurn = '';
 
@@ -501,13 +502,13 @@ class Pokemon {
 	}
 
 	/**
-	 * @param {string | Move} move
+	 * @param {Move} move
 	 * @param {number} targetLoc
 	 */
 	moveUsed(move, targetLoc) {
-		this.lastMove = this.battle.getMove(move).id;
+		this.lastMove = move;
 		this.lastMoveTargetLoc = targetLoc;
-		this.moveThisTurn = this.lastMove;
+		this.moveThisTurn = move.id;
 	}
 
 	/**
@@ -881,7 +882,7 @@ class Pokemon {
 			this.forceSwitchFlag = false;
 		}
 
-		this.lastMove = '';
+		this.lastMove = null;
 		this.moveThisTurn = '';
 
 		this.lastDamage = 0;

--- a/test/simulator/abilities/klutz.js
+++ b/test/simulator/abilities/klutz.js
@@ -32,7 +32,7 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'assaultvest', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['psychic']}]);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'protect');
+		assert.strictEqual(battle.p1.active[0].lastMove.id, 'protect');
 	});
 
 	it('should not ignore item effects that prevent item removal', function () {

--- a/test/simulator/abilities/magicbounce.js
+++ b/test/simulator/abilities/magicbounce.js
@@ -39,7 +39,7 @@ describe('Magic Bounce', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['growl', 'recover']}]);
 		battle.p1.chooseSwitch(2).foe.chooseDefault();
 		battle.p2.chooseMove(2).foe.chooseDefault();
-		assert.notStrictEqual(battle.p1.active[0].lastMove, 'growl');
+		assert.notStrictEqual(battle.p1.active[0].lastMove.id, 'growl');
 	});
 
 	it('should be suppressed by Mold Breaker', function () {

--- a/test/simulator/items/assaultvest.js
+++ b/test/simulator/items/assaultvest.js
@@ -15,7 +15,7 @@ describe('Assault Vest', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Abra', ability: 'synchronize', moves: ['teleport']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', item: 'assaultvest', moves: ['teleport']}]);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
 	it('should not prevent the use of Status moves', function () {

--- a/test/simulator/misc/decisions.js
+++ b/test/simulator/misc/decisions.js
@@ -135,8 +135,8 @@ describe('Choices', function () {
 					const beforeAtk = activeMons.map(pokemon => pokemon.boosts.atk);
 					battle.p1.chooseMove(i + 1);
 					battle.p2.chooseMove(j + 1);
-					assert.strictEqual(activeMons[0].lastMove, MOVES[0][i]);
-					assert.strictEqual(activeMons[1].lastMove, MOVES[1][j]);
+					assert.strictEqual(activeMons[0].lastMove.id, MOVES[0][i]);
+					assert.strictEqual(activeMons[1].lastMove.id, MOVES[1][j]);
 
 					if (i >= 1) { // p1 used a damaging move
 						assert.atMost(activeMons[1].hp, beforeHP[1] - 1);
@@ -299,11 +299,11 @@ describe('Choices', function () {
 
 			// Implementation-dependent paths
 			if (battle.turn === 3) {
-				assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+				assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 			} else {
 				battle.choose('p2', 'move 1');
 				assert.strictEqual(battle.turn, 3);
-				assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+				assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 			}
 		});
 
@@ -316,7 +316,7 @@ describe('Choices', function () {
 			battle.p2.chooseMove(2);
 
 			assert.strictEqual(battle.turn, 2);
-			assert.notStrictEqual(battle.p2.active[0].lastMove, 'struggle');
+			assert.notStrictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 		});
 
 		it('should not force Struggle usage on move attempt when choosing a disabled move', function () {
@@ -328,11 +328,11 @@ describe('Choices', function () {
 
 			battle.p1.chooseMove(1);
 			assert.strictEqual(battle.turn, 1);
-			assert.notStrictEqual(failingAttacker.lastMove, 'struggle');
+			assert.notStrictEqual(failingAttacker.lastMove && failingAttacker.lastMove.id, 'struggle');
 
 			battle.p1.chooseMove('recover');
 			assert.strictEqual(battle.turn, 1);
-			assert.notStrictEqual(failingAttacker.lastMove, 'struggle');
+			assert.notStrictEqual(failingAttacker.lastMove && failingAttacker.lastMove.id, 'struggle');
 		});
 
 		it('should send meaningful feedback to players if they try to use a disabled move', function () {
@@ -751,8 +751,8 @@ describe('Choice extensions', function () {
 				battle.choose('p1', 'move growl');
 
 				assert.strictEqual(battle.turn, 2);
-				assert.strictEqual(battle.p1.active[0].lastMove, 'tackle');
-				assert.strictEqual(battle.p2.active[0].lastMove, 'growl');
+				assert.strictEqual(battle.p1.active[0].lastMove.id, 'tackle');
+				assert.strictEqual(battle.p2.active[0].lastMove.id, 'growl');
 			});
 
 			it(`should support to ${mode} move decisions`, function () {
@@ -766,7 +766,7 @@ describe('Choice extensions', function () {
 				battle.choose('p2', 'move growl');
 
 				assert.strictEqual(battle.turn, 2);
-				assert.strictEqual(battle.p1.active[0].lastMove, 'growl');
+				assert.strictEqual(battle.p1.active[0].lastMove.id, 'growl');
 			});
 
 			it(`should disallow to ${mode} move decisions for maybe-disabled Pokémon`, function () {
@@ -783,7 +783,7 @@ describe('Choice extensions', function () {
 				battle.choose('p1', 'move growl');
 				battle.choose('p2', 'move scratch');
 
-				assert.strictEqual(target.lastMove, 'tackle');
+				assert.strictEqual(target.lastMove.id, 'tackle');
 			});
 
 			it(`should disallow to ${mode} move decisions by default`, function () {
@@ -797,8 +797,8 @@ describe('Choice extensions', function () {
 				battle.choose('p2', 'move growl');
 
 				assert.strictEqual(battle.turn, 2);
-				assert.strictEqual(battle.p1.active[0].lastMove, 'tackle');
-				assert.strictEqual(battle.p2.active[0].lastMove, 'growl');
+				assert.strictEqual(battle.p1.active[0].lastMove.id, 'tackle');
+				assert.strictEqual(battle.p2.active[0].lastMove.id, 'growl');
 			});
 
 			it(`should support to ${mode} switch decisions on move requests`, function () {
@@ -817,7 +817,7 @@ describe('Choice extensions', function () {
 				battle.choose('p2', 'move 1');
 
 				['Bulbasaur', 'Ivysaur', 'Venusaur'].forEach((species, index) => assert.species(battle.p1.pokemon[index], species));
-				assert.strictEqual(battle.p1.active[0].lastMove, 'synthesis');
+				assert.strictEqual(battle.p1.active[0].lastMove.id, 'synthesis');
 
 				battle.destroy();
 				battle = common.createBattle({cancel: true}, TEAMS);
@@ -931,7 +931,7 @@ describe('Choice extensions', function () {
 				battle.choose('p2', 'move 1, move 1, move 1');
 
 				['Bulbasaur', 'Ivysaur', 'Venusaur'].forEach((species, index) => assert.species(battle.p1.active[index], species));
-				assert.strictEqual(battle.p1.active[0].lastMove, 'synthesis');
+				assert.strictEqual(battle.p1.active[0].lastMove.id, 'synthesis');
 
 				battle.destroy();
 				battle = common.createBattle({gameType: 'triples', cancel: true}, TEAMS);
@@ -942,7 +942,7 @@ describe('Choice extensions', function () {
 				battle.choose('p2', 'move 1, move 1, move 1');
 
 				['Bulbasaur', 'Ivysaur', 'Venusaur'].forEach((species, index) => assert.species(battle.p1.active[index], species));
-				assert.strictEqual(battle.p1.active[2].lastMove, 'synthesis');
+				assert.strictEqual(battle.p1.active[2].lastMove.id, 'synthesis');
 			});
 
 			it(`should disallow to ${mode} shift decisions by default`, function () {
@@ -963,7 +963,7 @@ describe('Choice extensions', function () {
 				battle.choose('p2', 'move 1, move 1, move 1');
 
 				['Ivysaur', 'Bulbasaur', 'Venusaur'].forEach((species, index) => assert.species(battle.p1.active[index], species));
-				assert.strictEqual(battle.p1.active[0].lastMove, 'growth');
+				assert.strictEqual(battle.p1.active[0].lastMove.id, 'growth');
 
 				battle.destroy();
 				battle = common.createBattle({gameType: 'triples'}, TEAMS);
@@ -974,7 +974,7 @@ describe('Choice extensions', function () {
 				battle.choose('p2', 'move 1, move 1, move 1');
 
 				['Bulbasaur', 'Venusaur', 'Ivysaur'].forEach((species, index) => assert.species(battle.p1.active[index], species));
-				assert.strictEqual(battle.p1.active[2].lastMove, 'growth');
+				assert.strictEqual(battle.p1.active[2].lastMove.id, 'growth');
 			});
 
 			it(`should support to ${mode} switch decisions on double switch requests`, function () {

--- a/test/simulator/moves/belch.js
+++ b/test/simulator/moves/belch.js
@@ -15,9 +15,9 @@ describe('Belch', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Swalot', ability: 'gluttony', item: 'lumberry', moves: ['belch', 'stockpile']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'clearbody', item: 'laggingtail', moves: ['thunderwave']}]);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'stockpile');
+		assert.strictEqual(battle.p1.active[0].lastMove.id, 'stockpile');
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'belch');
+		assert.strictEqual(battle.p1.active[0].lastMove.id, 'belch');
 	});
 
 	it('should count berries as consumed with Bug Bite or Pluck', function () {
@@ -26,8 +26,8 @@ describe('Belch', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Swalot', ability: 'gluttony', item: 'salacberry', moves: ['belch', 'pluck']}]);
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'belch');
-		assert.strictEqual(battle.p2.active[0].lastMove, 'belch');
+		assert.strictEqual(battle.p1.active[0].lastMove.id, 'belch');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'belch');
 	});
 
 	it('should count berries as consumed when they are Flung', function () {
@@ -36,7 +36,7 @@ describe('Belch', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Machamp', ability: 'noguard', item: 'salacberry', moves: ['fling']}]);
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'belch');
+		assert.strictEqual(battle.p1.active[0].lastMove.id, 'belch');
 	});
 
 	it('should still count berries as consumed after switch out', function () {
@@ -52,6 +52,6 @@ describe('Belch', function () {
 		battle.choose('p1', 'switch 2');
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'belch');
+		assert.strictEqual(battle.p1.active[0].lastMove.id, 'belch');
 	});
 });

--- a/test/simulator/moves/disable.js
+++ b/test/simulator/moves/disable.js
@@ -16,6 +16,6 @@ describe('Disable', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['teleport']}]);
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 });

--- a/test/simulator/moves/embargo.js
+++ b/test/simulator/moves/embargo.js
@@ -34,7 +34,7 @@ describe('Embargo', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['embargo']}]);
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'protect');
+		assert.strictEqual(battle.p1.active[0].lastMove.id, 'protect');
 	});
 
 	it('should cause Fling to fail', function () {

--- a/test/simulator/moves/gravity.js
+++ b/test/simulator/moves/gravity.js
@@ -33,6 +33,6 @@ describe('Gravity', function () {
 		battle.commitDecisions();
 		assert.ok(!battle.p2.active[0].volatiles['twoturnmove']);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 });

--- a/test/simulator/moves/healblock.js
+++ b/test/simulator/moves/healblock.js
@@ -33,7 +33,7 @@ describe('Heal Block', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Cresselia', ability: 'levitate', moves: ['recover']}]);
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
 	it('should prevent Pokemon from using draining moves', function () {
@@ -99,7 +99,7 @@ describe('Heal Block [Gen 5]', function () {
 		]);
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
 	it('should prevent abilities from recovering HP', function () {
@@ -152,7 +152,7 @@ describe('Heal Block [Gen 4]', function () {
 		]);
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
 	it('should block the effect of Wish', function () {

--- a/test/simulator/moves/imprison.js
+++ b/test/simulator/moves/imprison.js
@@ -18,6 +18,6 @@ describe('Imprison', function () {
 		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
 		assert.strictEqual(battle.p2.active[0].boosts['spd'], 0);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p2.active[0].lastMove, 'confusion');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'confusion');
 	});
 });

--- a/test/simulator/moves/magicroom.js
+++ b/test/simulator/moves/magicroom.js
@@ -32,7 +32,7 @@ describe('Magic Room', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['magicroom']}]);
 		battle.commitDecisions();
 		battle.commitDecisions();
-		assert.strictEqual(battle.p1.active[0].lastMove, 'protect');
+		assert.strictEqual(battle.p1.active[0].lastMove.id, 'protect');
 	});
 
 	it('should cause Fling to fail', function () {

--- a/test/simulator/moves/taunt.js
+++ b/test/simulator/moves/taunt.js
@@ -18,7 +18,7 @@ describe('Taunt', function () {
 		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
 		assert.strictEqual(battle.p2.active[0].boosts['spd'], 0);
 		battle.commitDecisions();
-		assert.strictEqual(battle.p2.active[0].lastMove, 'struggle');
+		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
 	it('should not prevent the target from using Z-Powered Status moves', function () {


### PR DESCRIPTION
Mostly this is just adding `.id`, but there are some specific changes:

- Conversion 2 now resists the move's actual type (after effects) rather than its original type
- Z-status moves can't be copied etc.
- Some extra null-checks of course (I think I got them all...)