### PR TITLE
Disable, Mirror Move and Spite should fail against a Z-move

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -3413,6 +3413,11 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1, authentic: 1},
 		volatileStatus: 'disable',
+		onTryHit: function (target) {
+			if (!target.lastMove || target.lastMove.isZ) {
+				return false;
+			}
+		},
 		effect: {
 			duration: 4,
 			noCopy: true, // doesn't get copied by Baton Pass
@@ -10550,7 +10555,7 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		onTryHit: function (target, pokemon) {
-			if (!target.lastMove || !target.lastMove.flags['mirror']) {
+			if (!target.lastMove || !target.lastMove.flags['mirror'] || target.lastMove.isZ) {
 				return false;
 			}
 			this.useMove(target.lastMove.id, pokemon, target);
@@ -15957,7 +15962,7 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1, authentic: 1},
 		onHit: function (target) {
-			if (target.lastMove) {
+			if (target.lastMove && !target.lastMove.isZ) {
 				let ppDeducted = target.deductPP(target.lastMove.id, 4);
 				if (ppDeducted) {
 					this.add("-activate", target, 'move: Spite', this.getMove(target.lastMove.id).name, ppDeducted);


### PR DESCRIPTION
This includes when the move is a Z-Status move, in which case we'd be able to find the move's id in the target's learnset.

Thanks to Merritt from the Smogon forums for testing this for me, and also verifying the results of the other relevant moves, although their effect on Z-Status moves has already been fixed by #4298.

> Conversion 2: Z-Will-o-Wisp was used, Conversion 2 was used, Porygon-Z transformed into a Water type (move worked).  
> Copycat: Z-Will-o-Wisp was used, Copycat was attempted without animation, text displayed "But it failed!"  
> Disable: Z-Will-o-Wisp was used, Disable was attempted without animation, text displayed "But it failed!"  
> Instruct: Z-Will-o-Wisp was used, Instruct was attempted without animation, text displayed "But it failed!"  
> Mimic: Z-Will-o-Wisp was used, Mimic was attempted without animation, text displayed "But it failed!"  
> Mirror Move: Z-Will-o-Wisp was used, Mirror Move was attempted without animation, text displayed "But it failed!"  
> Sketch: Z-Will-o-Wisp was used, Sketch was attempted without animation, text displayed "But it failed!"  
> Spite: Z-Will-o-Wisp was used, Spite was attempted without animation, text displayed "But it failed!"  