### PR TITLE
Allow formats to override checkLearnset

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1457,7 +1457,7 @@ exports.commands = {
 				if (format.restrictedStones && format.restrictedStones.length) rules.push("<b>Restricted Mega Stones</b> - " + Chat.escapeHTML(format.restrictedStones.join(", ")));
 				if (format.cannotMega && format.cannotMega.length) rules.push("<b>Can't Mega Evolve non-natively</b> - " + Chat.escapeHTML(format.cannotMega.join(", ")));
 				if (format.restrictedAbilities && format.restrictedAbilities.length) rules.push("<b>Restricted abilities</b> - " + Chat.escapeHTML(format.restrictedAbilities.join(", ")));
-				if (format.noLearn && format.noLearn.length) rules.push("<b>Restricted moves</b> - " + Chat.escapeHTML(format.noLearn.join(", ")));
+				if (format.restrictedMoves && format.restrictedMoves.length) rules.push("<b>Restricted moves</b> - " + Chat.escapeHTML(format.restrictedMoves.join(", ")));
 				if (rules.length > 0) {
 					rulesetHtml = `<details><summary>Banlist/Ruleset</summary>${rules.join("<br />")}</details>`;
 				} else {

--- a/config/formats.js
+++ b/config/formats.js
@@ -524,7 +524,11 @@ exports.Formats = [
 
 		mod: 'gen7',
 		ruleset: ['[Gen 7] OU'],
-		noLearn: ['Geomancy', 'Shell Smash', 'Sketch'],
+		restrictedMoves: ['Geomancy', 'Shell Smash', 'Sketch'],
+		checkLearnset: function (move, template, lsetData, set) {
+			if (!move.isZ && !this.format.restrictedMoves.includes(move.name) && move.id[0] === template.speciesid[0]) return false;
+			return this.checkLearnset(move, template, lsetData, set);
+		},
 		onValidateTeam: function (team) {
 			let alphabetTable = {};
 			for (const set of team) {
@@ -693,9 +697,22 @@ exports.Formats = [
 
 		mod: 'gen7',
 		searchShow: false,
-		ruleset: ['[Gen 7] OU', 'Ignore STAB Moves'],
+		ruleset: ['[Gen 7] OU'],
 		banlist: ['Kartana', 'Komala', 'Kyurem-Black', 'Silvally', 'Tapu Koko', 'Tapu Lele', 'Aerodactylite', 'King\'s Rock', 'Metagrossite', 'Razor Fang'],
-		noLearn: ['Acupressure', 'Belly Drum', 'Chatter', 'Geomancy', 'Lovely Kiss', 'Shell Smash', 'Shift Gear', 'Thousand Arrows'],
+		restrictedMoves: ['Acupressure', 'Belly Drum', 'Chatter', 'Geomancy', 'Lovely Kiss', 'Shell Smash', 'Shift Gear', 'Thousand Arrows'],
+		checkLearnset: function (move, template, lsetData, set) {
+			if (!move.isZ && !this.format.restrictedMoves.includes(move.name)) {
+				let types = template.types;
+				if (template.prevo) types = types.concat(this.dex.getTemplate(this.dex.getTemplate(template.prevo).prevo || template.prevo).types);
+				if (template.baseSpecies === 'Rotom') types = ['Electric', 'Ghost', 'Fire', 'Water', 'Ice', 'Flying', 'Grass'];
+				if (template.baseSpecies === 'Shaymin') types = ['Grass', 'Flying'];
+				if (template.baseSpecies === 'Hoopa') types = ['Psychic', 'Ghost', 'Dark'];
+				if (template.baseSpecies === 'Oricorio') types = ['Fire', 'Flying', 'Electric', 'Psychic', 'Ghost'];
+				if (template.baseSpecies === 'Necrozma') types = ['Psychic', 'Steel', 'Ghost'];
+				if (template.baseSpecies === 'Arceus' || template.baseSpecies === 'Silvally' || types.includes(move.type)) return false;
+			}
+			return this.checkLearnset(move, template, lsetData, set);
+		},
 	},
 	{
 		name: "[Gen 7] 2v2 Doubles",

--- a/sim/dex-data.js
+++ b/sim/dex-data.js
@@ -372,6 +372,10 @@ class Format extends Effect {
 		 */
 		this.validateSet = this.validateSet;
 		/**
+		 * @type {((this: Validator, move: Move, template: Template, lsetData: PokemonSources, set: PokemonSet) => string | false)?}
+		 */
+		this.checkLearnset = this.checkLearnset;
+		/**
 		 * @type {((this: Validator, team: PokemonSet[], removeNicknames: boolean) => string[] | false)?}
 		 */
 		this.validateTeam = this.validateTeam;

--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -356,7 +356,7 @@ class Validator {
 			}
 
 			if (ruleTable.has('-illegal')) {
-				let problem = this.checkLearnset(move, template, lsetData, set);
+				let problem = (format.checkLearnset || this.checkLearnset).call(this, move, template, lsetData, set);
 				if (problem) {
 					let problemString = `${name} can't learn ${move.name}`;
 					if (problem.type === 'incompatibleAbility') {
@@ -921,22 +921,6 @@ class Validator {
 		while (template && template.species && !alreadyChecked[template.speciesid]) {
 			alreadyChecked[template.speciesid] = true;
 			if (dex.gen === 2 && template.gen === 1) tradebackEligible = true;
-			// STABmons hack to avoid copying all of validateSet to formats
-			// @ts-ignore
-			let noLearn = format.noLearn || [];
-			if (ruleTable.has('ignorestabmoves') && !noLearn.includes(move.name) && !move.isZ) {
-				let types = template.types;
-				if (template.baseSpecies === 'Rotom') types = ['Electric', 'Ghost', 'Fire', 'Water', 'Ice', 'Flying', 'Grass'];
-				if (template.baseSpecies === 'Shaymin') types = ['Grass', 'Flying'];
-				if (template.baseSpecies === 'Hoopa') types = ['Psychic', 'Ghost', 'Dark'];
-				if (template.baseSpecies === 'Oricorio') types = ['Fire', 'Flying', 'Electric', 'Psychic', 'Ghost'];
-				if (template.baseSpecies === 'Necrozma') types = ['Psychic', 'Steel', 'Ghost'];
-				if (template.baseSpecies === 'Arceus' || template.baseSpecies === 'Silvally' || types.includes(move.type)) return false;
-			}
-			if (format.id === 'gen7alphabetcup' && Object.keys(alreadyChecked).length < 2) {
-				const letter = template.id.slice(0, 1);
-				if (move.id.slice(0, 1) === letter && !move.isZ && !noLearn.includes(move.name)) return false;
-			}
 			if (!template.learnset) {
 				if (template.baseSpecies !== template.species) {
 					// forme without its own learnset


### PR DESCRIPTION
This avoids special hacks for Alphabet Cup and STABmons, but could also be used for Sketchmons and potentially other OMs (ORAS OM examples: Genmons; Move Pass LC; Multitype Mansion; Setupmons; Super-Effectivemons; The Power Within).