### PR TITLE
Add git commit hash to battle logs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
 		"node": true
 	},
 	"globals": {
+		"__version": false,
 		"Config": false, "Monitor": false, "toId": false, "Dex": false, "LoginServer": false,
 		"Users": false, "Punishments": false, "Rooms": false, "Verifier": false, "Chat": false,
 		"Tournaments": false, "Dnsbl": false, "Sockets": false, "TeamValidator": false,

--- a/dev-tools/global.d.ts
+++ b/dev-tools/global.d.ts
@@ -61,4 +61,7 @@ declare global {
 	const Users: typeof UsersType
 	const User: typeof UsersType.User
 	const Connection: typeof UsersType.Connection
+
+	// simulator version
+	const __version: string
 }

--- a/room-battle.js
+++ b/room-battle.js
@@ -840,6 +840,10 @@ if (process.send && module === process.mainModule) {
 	const Sim = require('./sim');
 	global.Dex = require('./sim/dex');
 	global.toId = Dex.getId;
+	global.__version = require('child_process')
+		.execSync('git merge-base master HEAD')
+		.toString()
+		.trim();
 
 	if (Config.crashguard) {
 		// graceful crash - allow current battles to finish before restarting

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1754,6 +1754,11 @@ class Battle extends Dex.ModdedDex {
 		if (this.started) {
 			return;
 		}
+
+		if (typeof __version !== 'undefined') {
+			this.log.push(`>version|${__version}`);
+		}
+
 		this.activeTurns = 0;
 		this.started = true;
 		this.p2.foe = this.p1;


### PR DESCRIPTION
Should fix #3201.

This has the basic functionality but with the drawback of adding the version number to the visible battle log. I'm not sure how to fix that -- is there a log command that serves as a no-op?

[Gen7RandomBattle-2018-01-17-yuzeh-yuzehtwo.html.zip](https://github.com/Zarel/Pokemon-Showdown/files/1639781/Gen7RandomBattle-2018-01-17-yuzeh-yuzehtwo.html.zip)

Looping in @Antar1011 to check that this fixes his issue.
