### PR TITLE
Help Tickets: Call /helpticket when /report is supplied with a target

### DIFF
--- a/chat-plugins/helptickets.js
+++ b/chat-plugins/helptickets.js
@@ -446,7 +446,6 @@ exports.pages = {
 exports.commands = {
 	requesthelp: 'helpticket',
 	helprequest: 'helpticket',
-	report: 'helpticket',
 	ht: 'helpticket',
 	helpticket: {
 		'!create': true,
@@ -728,4 +727,12 @@ exports.commands = {
 		`/helpticket unban [user] - Ticket unbans a user. Requires: % @ * & ~`,
 		`/helpticket delete [user] - Deletes a user's ticket. Requires: & ~`,
 	],
+
+	report: function (target, room, user, connection) {
+		let message = toId(target);
+		if (message.includes('list') || message.includes('escalate') || message.includes('close') || message.includes('ban') || message.includes('delete')) {
+			return this.parse('/helpticket ' + target);
+		}
+		return this.parse('/helpticket');
+	},
 };


### PR DESCRIPTION
http://www.smogon.com/forums/threads/suggestions.3534365/page-66#post-7652306

"Can there be an auto-reply thing to /report? People often put /report [name] and all it tells them is that the command does not exist. Can it be changed to where it says something that specifies all they need to do is type /report and not include a name. Or maybe even make it possible to report with a name included to the command. A lot of people face this issue in the Help room i noticed."