### PR TITLE
Don't trick away the Custap Berry being eaten

### DIFF
--- a/mods/gen4/items.js
+++ b/mods/gen4/items.js
@@ -54,14 +54,7 @@ exports.BattleItems = {
 		onCustap: function (pokemon) {
 			let action = this.willMove(pokemon);
 			this.debug('custap action: ' + action);
-			if (action) {
-				pokemon.eatItem();
-			}
-		},
-		onEat: function (pokemon) {
-			let action = this.willMove(pokemon);
-			this.debug('custap eaten: ' + action);
-			if (action) {
+			if (action && pokemon.eatItem()) {
 				this.cancelAction(pokemon);
 				this.add('-message', "Custap Berry activated.");
 				this.runAction(action);


### PR DESCRIPTION
Reported [here](http://www.smogon.com/forums/posts/7656866).

Tested using the following commands in a `node` REPL:

    global.Dex = require('./sim/dex');
    const common = require('./test/common');
    let battle = common.gen(4).createBattle();
    battle.join('p1', 'Guest 1', 1, [{species: 'Registeel', item: 'leftovers', moves: ['seismictoss', 'curse']}]);
    battle.join('p2', 'Guest 2', 1, [{species: 'Mesprit', item: 'custapberry', moves: ['stealthrock', 'trick']}]);
    battle.makeChoices('move seismicross', 'move stealthrock');
    battle.makeChoices('move seismicross', 'move stealthrock');
    battle.makeChoices('move seismicross', 'move stealthrock');
    battle.makeChoices('move curse', 'move trick');

Before the change, `p1.pokemon[0].item === 'custapberry'` but after the change `p2.pokemon[0].item === 'leftovers'`.