### PR TITLE
Refactor twineedle.multihit to match doublekick

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -18030,7 +18030,7 @@ exports.BattleMovedex = {
 		pp: 20,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		multihit: [2, 2],
+		multihit: 2,
 		secondary: {
 			chance: 20,
 			status: 'psn',


### PR DESCRIPTION
[16:33:09] +DoW: Hi, is there a reason that ``twineedle.multihit == [2, 2]`` whereas ``doublekick.multihit == 2``?
[16:33:09] +DoW: As far as I can tell they do the same thing
[16:39:21] ~Zarel: yeah
[16:39:25] ~Zarel: they should probably both be ``2``
[16:39:51] +DoW: Cool, thanks