### PR TITLE
VGC: Update bans

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -303,7 +303,7 @@ exports.Formats = [
 		},
 		timer: {starting: 6 * 60 + 30 - 10, perTurn: 10, maxPerTurn: 55, maxFirstTurn: 90, timeoutAutoChoose: true},
 		ruleset: ['Pokemon', 'Standard GBU'],
-		banlist: ['Unown'],
+		banlist: ['Unown', 'Curse', 'String Shot', 'Forests Curse', 'Power Trick'],
 		requirePlus: true,
 	},
 	{


### PR DESCRIPTION
Curse, String Shot, Forest's Curse, and Power Trick have been temporarily banned from VGC 2018 (Until the 1.2 patch for Ultra Sun and Ultra Moon).

https://assets.pokemon.com//assets/cms2/pdf/play-pokemon/rules/play-pokemon-vg-rules-formats-and-penalty-guidelines-en.pdf Section 1.4