### PR TITLE
Block making polls in battles

### DIFF
--- a/chat-plugins/poll.js
+++ b/chat-plugins/poll.js
@@ -184,6 +184,7 @@ exports.commands = {
 		new: function (target, room, user, connection, cmd, message) {
 			if (!target) return this.parse('/help poll new');
 			if (target.length > 1024) return this.errorReply("Poll too long.");
+			if (room.battle) return this.errorReply("This command cannot be used in battle rooms.");
 
 			const supportHTML = cmd === 'htmlcreate';
 			let separator = '';

--- a/chat-plugins/poll.js
+++ b/chat-plugins/poll.js
@@ -184,7 +184,7 @@ exports.commands = {
 		new: function (target, room, user, connection, cmd, message) {
 			if (!target) return this.parse('/help poll new');
 			if (target.length > 1024) return this.errorReply("Poll too long.");
-			if (room.battle) return this.errorReply("This command cannot be used in battle rooms.");
+			if (room.battle) return this.errorReply("Battles do not support polls.");
 
 			const supportHTML = cmd === 'htmlcreate';
 			let separator = '';


### PR DESCRIPTION
You should not be able to make polls in battle rooms (I think) even though it is somehow possible (and entirely useless since it gives an [error](https://prnt.sc/i55fze).)