### PR TITLE
Fix last item handling

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1268,6 +1268,7 @@ exports.BattleAbilities = {
 			if (this.isWeather(['sunnyday', 'desolateland']) || this.random(2) === 0) {
 				if (pokemon.hp && !pokemon.item && this.getItem(pokemon.lastItem).isBerry) {
 					pokemon.setItem(pokemon.lastItem);
+					pokemon.lastItem = '';
 					this.add('-item', pokemon, pokemon.getItem(), '[from] ability: Harvest');
 				}
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -5481,6 +5481,8 @@ exports.BattleMovedex = {
 				}
 			}
 			source.setItem('');
+			source.lastItem = item.id;
+			source.usedItemThisTurn = true;
 			this.add("-enditem", source, item.name, '[from] move: Fling');
 			this.runEvent('AfterUseItem', source, null, null, item);
 		},
@@ -10988,6 +10990,8 @@ exports.BattleMovedex = {
 			move.basePower = item.naturalGift.basePower;
 			move.type = item.naturalGift.type;
 			pokemon.setItem('');
+			pokemon.lastItem = item.id;
+			pokemon.usedItemThisTurn = true;
 			this.runEvent('AfterUseItem', pokemon, null, null, item);
 		},
 		secondary: false,
@@ -13133,6 +13137,7 @@ exports.BattleMovedex = {
 		onHit: function (pokemon) {
 			if (pokemon.item || !pokemon.lastItem) return false;
 			pokemon.setItem(pokemon.lastItem);
+			pokemon.lastItem = '';
 			this.add('-item', pokemon, pokemon.getItem(), '[from] move: Recycle');
 		},
 		secondary: false,

--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -504,6 +504,7 @@ exports.BattleAbilities = {
 			if (!pokemon.gluttonyFlag && !pokemon.item && this.getItem(pokemon.lastItem).isBerry) {
 				pokemon.gluttonyFlag = true;
 				pokemon.setItem(pokemon.lastItem);
+				pokemon.lastItem = '';
 				this.add("-item", pokemon, pokemon.item, '[from] ability: Gluttony');
 			}
 		},

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -1227,13 +1227,11 @@ class Pokemon {
 			this.isStale = 2;
 			this.isStaleSource = 'getleppa';
 		}
-		this.lastItem = this.item;
 		this.item = item.id;
 		this.itemData = {id: item.id, target: this};
 		if (item.id) {
 			this.battle.singleEvent('Start', item, this.itemData, this, source, effect);
 		}
-		if (this.lastItem) this.usedItemThisTurn = true;
 		return true;
 	}
 


### PR DESCRIPTION
Bestow, Pickup, Switcheroo and Trick do not change a Pokémon's consumed item. In the case of Pickup, this lets two Pokémon pick up each other's item consumed the same turn. This bug was originally reported in this [video](https://www.youtube.com/watch?v=RrBkz1QQYG4) which was subsequently mentioned in the Gen 7 mechanics forum.
To achieve this, I removed the `lastItem` handling code from `setItem` and moved it to those effects that don't already alter the consumed item, which are Fling, Harvest, Natural Gift and Recycle.