### PR TITLE
Fix Mimikyu-Busted-Totem's tiering

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -6960,6 +6960,8 @@ exports.BattleFormatsData = {
 	mimikyubustedtotem: {
 		requiredAbility: 'Disguise',
 		battleOnly: true,
+		tier: "OU",
+		doublesTier: "OU",
 	},
 	bruxish: {
 		randomBattleMoves: ["psychicfangs", "crunch", "liquidation", "icefang", "aquajet", "swordsdance"],


### PR DESCRIPTION
I'm not sure if it inherits its tiering from Mimikyu-Busted or Mimikyu-Totem, but the fact that either already inherit their tiering from Mimikyu seems to have made Mimikyu-Busted-Totem's tiering to "undefined" (http://www.smogon.com/forums/threads/bug-reports-v2-0-read-op-before-posting.3469932/post-7669587).