### PR TITLE
Don't protect against contrary spectral thief stat drops

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -455,7 +455,7 @@ exports.BattleScripts = {
 			if (stolen) {
 				this.attrLastMove('[still]');
 				this.add('-clearpositiveboost', target, pokemon, 'move: ' + move.name);
-				this.boost(boosts, pokemon);
+				this.boost(boosts, pokemon, pokemon);
 
 				for (let statName in boosts) {
 					boosts[statName] = 0;


### PR DESCRIPTION
I haven't researched this so feel free to prove me wrong but I suspect that Spectral Thief's stat boosts should be self-inflicted, so that Protective Pads shouldn't protect against its Contrary stat drops.