### PR TITLE
Report imported battles when players join

### DIFF
--- a/room-battle.js
+++ b/room-battle.js
@@ -882,7 +882,10 @@ class Battle {
 		}
 		this.stream.write(`>player ${slot} ` + JSON.stringify(options));
 		if (this.started) this.onUpdateConnection(user);
-		if (this.p1 && this.p2) this.started = true;
+		if (this.p1 && this.p2) {
+			this.started = true;
+			Rooms.global.onCreateBattleRoom(Users(this.p1.userid), Users(this.p2.userid), this.room, {rated: this.rated});
+		}
 		return player;
 	}
 

--- a/rooms.js
+++ b/rooms.js
@@ -1554,7 +1554,6 @@ let Rooms = Object.assign(getRoom, {
 		if (p2) p2.joinRoom(room);
 		if (p1) Monitor.countBattle(p1.latestIp, p1.name);
 		if (p2) Monitor.countBattle(p2.latestIp, p2.name);
-		if (p1 && p2) Rooms.global.onCreateBattleRoom(p1, p2, room, options);
 		return room;
 	},
 


### PR DESCRIPTION
This was requested by the smogon tournament directors.
Normally when a battle is created, and `Config.reportbattles` is set to a truthy value, it is reported in lobby or the the room `Config.reportbattles` specifies. Battles created with `/importinputlog` are not logged though. This attempts to fix that by calling `Rooms.global.onCreateBattleRoom` when the battle gets both of its players.