### PR TITLE
Fix double shared power activation

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -414,34 +414,32 @@ exports.Formats = [
 			'Mold Breaker', 'Protean', 'Pure Power', 'Quick Feet', 'Rattled', 'Sand Rush', 'Simple', 'Skill Link', 'Slush Rush',
 			'Speed Boost', 'Surge Surfer', 'Swift Swim', 'Teravolt', 'Tinted Lens', 'Trace', 'Unburden', 'Water Bubble', 'Weak Armor',
 		],
+		getSharedPower: function (pokemon) {
+			let sharedPower = new Set();
+			for (const ally of pokemon.side.pokemon) sharedPower.add(ally.baseAbility);
+			for (const ability of this.restrictedAbilities) sharedPower.delete(toId(ability));
+			sharedPower.delete(pokemon.baseAbility);
+			return sharedPower;
+		},
 		onBeforeSwitchIn: function (pokemon) {
-			let restrictedAbilities = this.getFormat().restrictedAbilities.map(toId);
-			for (const ally of pokemon.side.pokemon) {
-				if (ally.baseAbility !== pokemon.baseAbility && !restrictedAbilities.includes(ally.baseAbility)) {
-					let effect = 'ability' + ally.baseAbility;
-					pokemon.volatiles[effect] = {id: effect, target: pokemon};
-				}
+			for (const ability of this.getFormat().getSharedPower(pokemon)) {
+				let effect = 'ability' + ability;
+				pokemon.volatiles[effect] = {id: effect, target: pokemon};
 			}
 		},
 		onSwitchInPriority: 2,
 		onSwitchIn: function (pokemon) {
-			let restrictedAbilities = this.getFormat().restrictedAbilities.map(toId);
-			for (const ally of pokemon.side.pokemon) {
-				if (ally.baseAbility !== pokemon.baseAbility && !restrictedAbilities.includes(ally.baseAbility)) {
-					let effect = 'ability' + ally.baseAbility;
-					delete pokemon.volatiles[effect];
-					pokemon.addVolatile(effect);
-				}
+			for (const ability of this.getFormat().getSharedPower(pokemon)) {
+				let effect = 'ability' + ability;
+				delete pokemon.volatiles[effect];
+				pokemon.addVolatile(effect);
 			}
 		},
 		onAfterMega: function (pokemon) {
-			let restrictedAbilities = this.getFormat().restrictedAbilities.map(toId);
 			pokemon.removeVolatile('ability' + pokemon.baseAbility);
-			for (const ally of pokemon.side.pokemon) {
-				if (ally.baseAbility !== pokemon.baseAbility && !restrictedAbilities.includes(ally.baseAbility)) {
-					let effect = 'ability' + ally.baseAbility;
-					pokemon.addVolatile(effect);
-				}
+			for (const ability of this.getFormat().getSharedPower(pokemon)) {
+				let effect = 'ability' + ability;
+				pokemon.addVolatile(effect);
 			}
 		},
 	},


### PR DESCRIPTION
Shared abilities were activating once per switch in for every shared user, even if two allies had the same ability. This fixes that by calculating the list of shared abilities in a set. I reused the code for the before switch / after mega cases too although they're not affected.