### PR TITLE
Don't generate female Greninja-Ash in randbats

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -188,8 +188,6 @@ class RandomTeams extends Dex.ModdedDex {
 				level++;
 			}
 
-			// Random gender--already handled by PS
-
 			// Random happiness
 			let happiness = this.random(256);
 
@@ -199,6 +197,7 @@ class RandomTeams extends Dex.ModdedDex {
 			team.push({
 				name: template.baseSpecies,
 				species: template.species,
+				gender: template.gender,
 				item: item,
 				ability: ability,
 				moves: moves,
@@ -335,6 +334,7 @@ class RandomTeams extends Dex.ModdedDex {
 			team.push({
 				name: template.baseSpecies,
 				species: template.species,
+				gender: template.gender,
 				item: item,
 				ability: ability,
 				moves: m,
@@ -1515,6 +1515,7 @@ class RandomTeams extends Dex.ModdedDex {
 		return {
 			name: template.baseSpecies,
 			species: species,
+			gender: template.gender,
 			moves: moves,
 			ability: ability,
 			evs: evs,
@@ -2512,6 +2513,7 @@ class RandomTeams extends Dex.ModdedDex {
 		return {
 			name: template.baseSpecies,
 			species: species,
+			gender: template.gender,
 			moves: moves,
 			ability: ability,
 			evs: evs,


### PR DESCRIPTION
The randbats generators (except Battle/BSS Factory) let the sim pick a random gender. This doesn't work for Ash Greninja because it starts off with the regular Greninja template which isn't gender limited, so I'm adding the gender manually to all the random sets to handle this case.