### PR TITLE
Send poll info to users in onJoin

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -1195,6 +1195,7 @@ class BasicChatRoom extends BasicRoom {
 		this.users[user.userid] = user;
 		this.userCount++;
 
+		if (this.poll) this.poll.onConnect(user, connection);
 		if (this.game && this.game.onJoin) this.game.onJoin(user, connection);
 		return true;
 	}


### PR DESCRIPTION
Currently, if you vote for a poll on one IP, let your user object expire, and join PS! on a different IP, the following will occur:
![image](https://user-images.githubusercontent.com/22896712/36625717-dbb86124-18d9-11e8-9fac-7895092924d0.png)
telling you that you have already voted for the poll, even though the poll results did not display.
This is since the poll is sent to the user in onConnect, but onConnect is called before the user is actually logged in (while onJoin is called after the user is logged in).