### PR TITLE
Remove floralhealing.isViable to match Heal Pulse

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -5500,7 +5500,6 @@ exports.BattleMovedex = {
 		desc: "The target restores 1/2 of its maximum HP, rounded half up. If the terrain is Grassy Terrain, the target instead restores 2/3 of its maximum HP, rounded half down.",
 		shortDesc: "Heals the target by 50% of its max HP.",
 		id: "floralhealing",
-		isViable: true,
 		name: "Floral Healing",
 		pp: 10,
 		priority: 0,


### PR DESCRIPTION
I believe this will do what's requested in https://www.smogon.com/forums/threads/what-can-ps-do-for-you.3622358/page-5#post-7698629
In any case, this is the only real difference between Floral Healing and Heal Pulse, and therefore seems like it should be removed.