### PR TITLE
Set source of ability change on Mummy activation

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2027,7 +2027,7 @@ exports.BattleAbilities = {
 		name: "Mummy",
 		onAfterDamage: function (damage, target, source, move) {
 			if (source && source !== target && move && move.flags['contact'] && source.ability !== 'mummy') {
-				let oldAbility = source.setAbility('mummy');
+				let oldAbility = source.setAbility('mummy', target);
 				if (oldAbility) {
 					this.add('-activate', target, 'ability: Mummy', this.getAbility(oldAbility).name, '[of] ' + source);
 				}


### PR DESCRIPTION
This is (so far) only relevant for the specific case of Protective Pads blocking Mummy, because it has an `onSetAbility` handler that uses the source of the change. Since it wasn't set, it caused this: https://replay.pokemonshowdown.com/gen7hackmonscup-708439558 (turn 7-9).

There are a whole lot of calls to `setAbility `without a source, but there are no further `onSetAbility`s so it doesn't matter yet - is it worth bothering to add sources to them all?