### PR TITLE
Fix Flash Fire + Freeze in Gens 3 and 4

### DIFF
--- a/mods/gen3/abilities.js
+++ b/mods/gen3/abilities.js
@@ -49,6 +49,9 @@ exports.BattleAbilities = {
 				if (move.id === 'willowisp' && (target.hasType('Fire') || target.status || target.volatiles['substitute'])) {
 					return;
 				}
+				if (target.status === 'frz') {
+					return;
+				}
 				if (!target.addVolatile('flashfire')) {
 					this.add('-immune', target, '[msg]');
 				}

--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -61,7 +61,6 @@ exports.BattleAbilities = {
 		inherit: true,
 		onTryHit: function (target, source, move) {
 			if (target !== source && move.type === 'Fire') {
-				move.accuracy = true;
 				if (target.status === 'frz') {
 					return;
 				}

--- a/mods/gen4/abilities.js
+++ b/mods/gen4/abilities.js
@@ -59,6 +59,18 @@ exports.BattleAbilities = {
 	},
 	"flashfire": {
 		inherit: true,
+		onTryHit: function (target, source, move) {
+			if (target !== source && move.type === 'Fire') {
+				move.accuracy = true;
+				if (target.status === 'frz') {
+					return;
+				}
+				if (!target.addVolatile('flashfire')) {
+					this.add('-immune', target, '[msg]', '[from] ability: Flash Fire');
+				}
+				return null;
+			}
+		},
 		effect: {
 			noCopy: true, // doesn't get copied by Baton Pass
 			onStart: function (target) {


### PR DESCRIPTION
If a Pokemon with Flash Fire is frozen in Gens 3 and 4, Flash Fire shouldn't activate.