### PR TITLE
Gen 1 1v1, adding Team Preview

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -751,7 +751,7 @@ exports.Formats = [
 			validate: [1, 3],
 			battle: 1,
 		},
-		ruleset: ['[Gen 1] OU'],
+		ruleset: ['[Gen 1] OU', 'Team Preview'],
 		banlist: [
 			'Flash', 'Kinesis', 'Sand Attack', 'Smokescreen',
 			'Bind', 'Clamp', 'Fire Spin', 'Wrap',


### PR DESCRIPTION
Gen 1 1v1 does not have Gen 1 preview. I've discussed this with others, and removing the team preview also further removes and strategy by choosing the first Pokemon in your team. This makes the type match ups completely random.