### PR TITLE
Nature Swap: Correctly fix EVs and IVs

### DIFF
--- a/mods/natureswap/scripts.js
+++ b/mods/natureswap/scripts.js
@@ -4,19 +4,9 @@ exports.BattleScripts = {
 	spreadModify: function (stats, set) {
 		const modStats = {atk: 10, def: 10, spa: 10, spd: 10, spe: 10};
 		let nature = this.getNature(set.nature);
-		if (nature.plus) {
-			let minusEVs = set.evs[nature.minus];
-			let plusEVs = set.evs[nature.plus];
-			let minusIVs = set.ivs[nature.minus];
-			let plusIVs = set.ivs[nature.plus];
-			set.evs[nature.minus] = plusEVs;
-			set.evs[nature.plus] = minusEVs;
-			set.ivs[nature.minus] = plusIVs;
-			set.ivs[nature.plus] = minusIVs;
-		}
 		for (let statName in modStats) {
 			let stat = stats[statName];
-			modStats[statName] = Math.floor(Math.floor(2 * stat + set.ivs[statName] + Math.floor(set.evs[statName] / 4)) * set.level / 100 + 5);
+			modStats[statName] = Math.floor(Math.floor(2 * stat + (nature.plus && statName === nature.minus ? set.ivs[nature.plus] : set.ivs[statName]) + Math.floor((nature.plus && statName === nature.minus ? set.evs[nature.plus] : set.evs[statName]) / 4)) * set.level / 100 + 5);
 		}
 		if ('hp' in stats) {
 			let stat = stats['hp'];


### PR DESCRIPTION
The previous method would cause the EVs and IVs in a stat to swap every time a Pokemon switched out.