### PR TITLE
Refactor random booleans into randomChance function

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -511,7 +511,7 @@ exports.BattleAbilities = {
 		onAfterDamage: function (damage, target, source, move) {
 			if (!source || source.volatiles['disable']) return;
 			if (source !== target && move && move.effectType === 'Move' && !move.isFutureMove) {
-				if (this.random(10) < 3) {
+				if (this.randomChance(3, 10)) {
 					source.addVolatile('disable', this.effectData.target);
 				}
 			}
@@ -526,7 +526,7 @@ exports.BattleAbilities = {
 		shortDesc: "30% chance of infatuating Pokemon of the opposite gender if they make contact.",
 		onAfterDamage: function (damage, target, source, move) {
 			if (move && move.flags['contact']) {
-				if (this.random(10) < 3) {
+				if (this.randomChance(3, 10)) {
 					source.addVolatile('attract', this.effectData.target);
 				}
 			}
@@ -905,7 +905,7 @@ exports.BattleAbilities = {
 		shortDesc: "30% chance a Pokemon making contact with this Pokemon will be burned.",
 		onAfterDamage: function (damage, target, source, move) {
 			if (move && move.flags['contact']) {
-				if (this.random(10) < 3) {
+				if (this.randomChance(3, 10)) {
 					source.trySetStatus('brn', target);
 				}
 			}
@@ -1266,7 +1266,7 @@ exports.BattleAbilities = {
 		onResidualOrder: 26,
 		onResidualSubOrder: 1,
 		onResidual: function (pokemon) {
-			if (this.isWeather(['sunnyday', 'desolateland']) || this.random(2) === 0) {
+			if (this.isWeather(['sunnyday', 'desolateland']) || this.randomChance(1, 2)) {
 				if (pokemon.hp && !pokemon.item && this.getItem(pokemon.lastItem).isBerry) {
 					pokemon.setItem(pokemon.lastItem);
 					pokemon.lastItem = '';
@@ -1290,7 +1290,7 @@ exports.BattleAbilities = {
 				return;
 			}
 			for (let i = 0; i < allyActive.length; i++) {
-				if (allyActive[i] && allyActive[i].hp && this.isAdjacent(pokemon, allyActive[i]) && allyActive[i].status && this.random(10) < 3) {
+				if (allyActive[i] && allyActive[i].hp && this.isAdjacent(pokemon, allyActive[i]) && allyActive[i].status && this.randomChance(3, 10)) {
 					this.add('-activate', pokemon, 'ability: Healer');
 					allyActive[i].cureStatus();
 				}
@@ -2389,7 +2389,7 @@ exports.BattleAbilities = {
 		shortDesc: "30% chance a Pokemon making contact with this Pokemon will be poisoned.",
 		onAfterDamage: function (damage, target, source, move) {
 			if (move && move.flags['contact']) {
-				if (this.random(10) < 3) {
+				if (this.randomChance(3, 10)) {
 					source.trySetStatus('psn', target);
 				}
 			}
@@ -2940,7 +2940,7 @@ exports.BattleAbilities = {
 		onResidualOrder: 5,
 		onResidualSubOrder: 1,
 		onResidual: function (pokemon) {
-			if (pokemon.hp && pokemon.status && this.random(3) === 0) {
+			if (pokemon.hp && pokemon.status && this.randomChance(1, 3)) {
 				this.debug('shed skin');
 				this.add('-activate', pokemon, 'ability: Shed Skin');
 				pokemon.cureStatus();
@@ -3290,7 +3290,7 @@ exports.BattleAbilities = {
 		shortDesc: "30% chance a Pokemon making contact with this Pokemon will be paralyzed.",
 		onAfterDamage: function (damage, target, source, move) {
 			if (move && move.flags['contact']) {
-				if (this.random(10) < 3) {
+				if (this.randomChance(3, 10)) {
 					source.trySetStatus('par', target);
 				}
 			}

--- a/data/items.js
+++ b/data/items.js
@@ -1874,7 +1874,7 @@ exports.BattleItems = {
 			basePower: 10,
 		},
 		onDamage: function (damage, target, source, effect) {
-			if (this.random(10) === 0 && damage >= target.hp && effect && effect.effectType === 'Move') {
+			if (this.randomChance(1, 10) && damage >= target.hp && effect && effect.effectType === 'Move') {
 				this.add("-activate", target, "item: Focus Band");
 				return target.hp - 1;
 			}
@@ -4337,7 +4337,7 @@ exports.BattleItems = {
 		id: "quickclaw",
 		onModifyPriorityPriority: -1,
 		onModifyPriority: function (priority, pokemon) {
-			if (this.random(5) === 0) {
+			if (this.randomChance(1, 5)) {
 				this.add('-activate', pokemon, 'item: Quick Claw');
 				return Math.round(priority) + 0.1;
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -784,7 +784,7 @@ exports.BattleMovedex = {
 			onBeforeMovePriority: 2,
 			onBeforeMove: function (pokemon, target, move) {
 				this.add('-activate', pokemon, 'move: Attract', '[of] ' + this.effectData.source);
-				if (this.random(2) === 0) {
+				if (this.randomChance(1, 2)) {
 					this.add('cant', pokemon, 'Attract');
 					return false;
 				}

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1133,12 +1133,12 @@ class RandomTeams extends Dex.ModdedDex {
 		let ability1 = this.getAbility(abilities[1]);
 		let ability2 = this.getAbility(abilities[2]);
 		if (abilities[1]) {
-			if (abilities[2] && ability1.rating <= ability2.rating && !this.randomChance(1, 2)) {
+			if (abilities[2] && ability1.rating <= ability2.rating && this.randomChance(1, 2)) {
 				[ability1, ability2] = [ability2, ability1];
 			}
-			if (ability0.rating <= ability1.rating && !this.randomChance(1, 2)) {
+			if (ability0.rating <= ability1.rating && this.randomChance(1, 2)) {
 				[ability0, ability1] = [ability1, ability0];
-			} else if (ability0.rating - 0.6 <= ability1.rating && !this.randomChance(1, 3)) {
+			} else if (ability0.rating - 0.6 <= ability1.rating && this.randomChance(2, 3)) {
 				[ability0, ability1] = [ability1, ability0];
 			}
 			ability = ability0.name;
@@ -1261,7 +1261,7 @@ class RandomTeams extends Dex.ModdedDex {
 				ability = 'Pickup';
 			} else if (template.baseSpecies === 'Basculin') {
 				ability = 'Adaptability';
-			} else if (template.species === 'Lopunny' && hasMove['switcheroo'] && !this.randomChance(1, 3)) {
+			} else if (template.species === 'Lopunny' && hasMove['switcheroo'] && this.randomChance(2, 3)) {
 				ability = 'Klutz';
 			} else if ((template.species === 'Rampardos' && !hasMove['headsmash']) || hasMove['rockclimb']) {
 				ability = 'Sheer Force';
@@ -1340,7 +1340,7 @@ class RandomTeams extends Dex.ModdedDex {
 			// To perma-taunt a Pokemon by giving it Assault Vest
 			item = 'Assault Vest';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomBool = !this.randomChance(1, 3);
+			let randomBool = this.randomChance(2, 3);
 			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
@@ -1363,7 +1363,7 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (hasMove['bellydrum']) {
 			if (ability === 'Gluttony') {
 				item = ['Aguav', 'Figy', 'Iapapa', 'Mago', 'Wiki'][this.random(5)] + ' Berry';
-			} else if (template.baseStats.spe <= 50 && !teamDetails.zMove && !this.randomChance(1, 2)) {
+			} else if (template.baseStats.spe <= 50 && !teamDetails.zMove && this.randomChance(1, 2)) {
 				item = 'Normalium Z';
 			} else {
 				item = 'Sitrus Berry';
@@ -1401,10 +1401,10 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (template.baseStats.spe <= 50 && hasMove['sleeppowder'] && counter.setupType && !teamDetails.zMove) {
 			item = 'Grassium Z';
 		} else if (counter.Physical >= 4 && !hasMove['bodyslam'] && !hasMove['dragontail'] && !hasMove['fakeout'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = template.baseStats.atk >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Band';
+			item = template.baseStats.atk >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Band';
 		} else if (counter.Special >= 4 && !hasMove['acidspray'] && !hasMove['chargebeam'] && !hasMove['clearsmog'] && !hasMove['fierydance']) {
-			item = template.baseStats.spa >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Specs';
-		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['uturn'])) && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3)) {
+			item = template.baseStats.spa >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Specs';
+		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['uturn'])) && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3)) {
 			item = 'Choice Scarf';
 		} else if (ability === 'Defeatist' || hasMove['eruption'] || hasMove['waterspout']) {
 			item = counter.Status <= 1 ? 'Expert Belt' : 'Leftovers';
@@ -1420,7 +1420,7 @@ class RandomTeams extends Dex.ModdedDex {
 			item = 'Leftovers';
 		} else if (hasMove['substitute']) {
 			item = !counter['drain'] || counter.damagingMoves.length < 2 ? 'Leftovers' : 'Life Orb';
-		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && !this.randomChance(1, 2)) {
+		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && this.randomChance(1, 2)) {
 			item = 'Rocky Helmet';
 		} else if (counter.Physical + counter.Special >= 4 && template.baseStats.spd >= 65 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd >= 235) {
 			item = 'Assault Vest';
@@ -1592,33 +1592,33 @@ class RandomTeams extends Dex.ModdedDex {
 			switch (tier) {
 			case 'Uber':
 				// Ubers are limited to 2 but have a 20% chance of being added anyway.
-				if (uberCount > 1 && !this.randomChance(1, 5)) continue;
+				if (uberCount > 1 && this.randomChance(4, 5)) continue;
 				break;
 			case 'PU':
 				// PUs are limited to 2 but have a 20% chance of being added anyway.
-				if (puCount > 1 && !this.randomChance(1, 5)) continue;
+				if (puCount > 1 && this.randomChance(4, 5)) continue;
 				break;
 			case 'Unreleased': case 'CAP':
 				// Unreleased and CAP have 20% the normal rate
-				if (!this.randomChance(1, 5)) continue;
+				if (this.randomChance(4, 5)) continue;
 			}
 
 			// Adjust rate for species with multiple formes
 			switch (template.baseSpecies) {
 			case 'Arceus': case 'Silvally':
-				if (!this.randomChance(1, 18)) continue;
+				if (this.randomChance(17, 18)) continue;
 				break;
 			case 'Pikachu':
-				if (!this.randomChance(1, 7)) continue;
+				if (this.randomChance(6, 7)) continue;
 				continue;
 			case 'Genesect':
-				if (!this.randomChance(1, 5)) continue;
+				if (this.randomChance(4, 5)) continue;
 				break;
 			case 'Castform': case 'Gourgeist': case 'Oricorio':
-				if (!this.randomChance(1, 4)) continue;
+				if (this.randomChance(3, 4)) continue;
 				break;
 			case 'Basculin': case 'Cherrim': case 'Greninja': case 'Hoopa': case 'Meloetta': case 'Meowstic':
-				if (!this.randomChance(1, 2)) continue;
+				if (this.randomChance(1, 2)) continue;
 				break;
 			}
 
@@ -1642,7 +1642,7 @@ class RandomTeams extends Dex.ModdedDex {
 				// Limit 2 of any type
 				let skip = false;
 				for (let t = 0; t < types.length; t++) {
-					if (typeCount[types[t]] > 1 && !this.randomChance(1, 5)) {
+					if (typeCount[types[t]] > 1 && this.randomChance(4, 5)) {
 						skip = true;
 						break;
 					}
@@ -1729,7 +1729,7 @@ class RandomTeams extends Dex.ModdedDex {
 			species = template.baseSpecies;
 		}
 		let battleForme = this.checkBattleForme(template);
-		if (battleForme && (battleForme.isMega ? !teamDetails.megaStone : !this.randomChance(1, 2))) {
+		if (battleForme && (battleForme.isMega ? !teamDetails.megaStone : this.randomChance(1, 2))) {
 			template = this.getTemplate(template.otherFormes.length >= 2 ? template.otherFormes[this.random(template.otherFormes.length)] : template.otherFormes[0]);
 		}
 
@@ -2183,10 +2183,10 @@ class RandomTeams extends Dex.ModdedDex {
 		ability = ability0.name;
 		if (abilities[1]) {
 			if (abilities[2] && ability2.rating === ability1.rating) {
-				if (!this.randomChance(1, 2)) ability1 = ability2;
+				if (this.randomChance(1, 2)) ability1 = ability2;
 			}
 			if (ability0.rating <= ability1.rating) {
-				if (!this.randomChance(1, 2)) ability = ability1.name;
+				if (this.randomChance(1, 2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
 				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
@@ -2328,7 +2328,7 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (template.species === 'Unown') {
 			item = 'Choice Specs';
 		} else if (hasMove['trick'] || hasMove['switcheroo']) {
-			let randomBool = !this.randomChance(1, 2);
+			let randomBool = this.randomChance(1, 2);
 			if (counter.Physical >= 3 && (template.baseStats.spe >= 95 || randomBool)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe >= 95 || randomBool)) {
@@ -2339,7 +2339,7 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (ability === 'Gluttony' || ability === 'Schooling') {
 			item = ['Aguav', 'Figy', 'Iapapa', 'Mago', 'Wiki'][this.random(5)] + ' Berry';
 		} else if (hasMove['bellydrum']) {
-			if (template.baseStats.spe <= 50 && !teamDetails.zMove && !this.randomChance(1, 2)) {
+			if (template.baseStats.spe <= 50 && !teamDetails.zMove && this.randomChance(1, 2)) {
 				item = 'Normalium Z';
 			} else {
 				item = 'Sitrus Berry';
@@ -2625,7 +2625,7 @@ class RandomTeams extends Dex.ModdedDex {
 		return {
 			name: setData.set.name || template.baseSpecies,
 			species: setData.set.species,
-			gender: setData.set.gender || template.gender || (!this.randomChance(1, 2) ? 'M' : 'F'),
+			gender: setData.set.gender || template.gender || (this.randomChance(1, 2) ? 'M' : 'F'),
 			item: items + '' || setData.set.item || '',
 			ability: abilities + '' || setData.set.ability || template.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
@@ -2691,7 +2691,7 @@ class RandomTeams extends Dex.ModdedDex {
 			// If not Monotype, limit to two of each type
 				let skip = false;
 				for (let t = 0; t < types.length; t++) {
-					if (teamData.typeCount[types[t]] > 1 && !this.randomChance(1, 5)) {
+					if (teamData.typeCount[types[t]] > 1 && this.randomChance(4, 5)) {
 						skip = true;
 						break;
 					}
@@ -2849,7 +2849,7 @@ class RandomTeams extends Dex.ModdedDex {
 		return {
 			name: setData.set.name || template.baseSpecies,
 			species: setData.set.species,
-			gender: setData.set.gender || template.gender || (!this.randomChance(1, 2) ? 'M' : 'F'),
+			gender: setData.set.gender || template.gender || (this.randomChance(1, 2) ? 'M' : 'F'),
 			item: setData.set.item || '',
 			ability: setData.set.ability || template.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
@@ -2903,7 +2903,7 @@ class RandomTeams extends Dex.ModdedDex {
 			let types = template.types;
 			let skip = false;
 			for (let t = 0; t < types.length; t++) {
-				if (teamData.typeCount[types[t]] > 1 && !this.randomChance(1, 5)) {
+				if (teamData.typeCount[types[t]] > 1 && this.randomChance(4, 5)) {
 					skip = true;
 					break;
 				}
@@ -3062,7 +3062,7 @@ class RandomTeams extends Dex.ModdedDex {
 		return {
 			name: setData.set.nickname || setData.set.name || template.baseSpecies,
 			species: setData.set.species,
-			gender: setData.set.gender || template.gender || (!this.randomChance(1, 2) ? 'M' : 'F'),
+			gender: setData.set.gender || template.gender || (this.randomChance(1, 2) ? 'M' : 'F'),
 			item: setData.set.item || '',
 			ability: setData.set.ability || template.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
@@ -3112,7 +3112,7 @@ class RandomTeams extends Dex.ModdedDex {
 			let types = template.types;
 			let skip = false;
 			for (let t = 0; t < types.length; t++) {
-				if (teamData.typeCount[types[t]] > 1 && !this.randomChance(1, 5)) {
+				if (teamData.typeCount[types[t]] > 1 && this.randomChance(4, 5)) {
 					skip = true;
 					break;
 				}

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1340,10 +1340,10 @@ class RandomTeams extends Dex.ModdedDex {
 			// To perma-taunt a Pokemon by giving it Assault Vest
 			item = 'Assault Vest';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomNum = !this.randomChance(1, 3);
-			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
+			let randomBool = !this.randomChance(1, 3);
+			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Band';
-			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
+			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Specs';
 			} else {
 				item = 'Choice Scarf';
@@ -2328,10 +2328,10 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (template.species === 'Unown') {
 			item = 'Choice Specs';
 		} else if (hasMove['trick'] || hasMove['switcheroo']) {
-			let randomNum = !this.randomChance(1, 2);
-			if (counter.Physical >= 3 && (template.baseStats.spe >= 95 || randomNum)) {
+			let randomBool = !this.randomChance(1, 2);
+			if (counter.Physical >= 3 && (template.baseStats.spe >= 95 || randomBool)) {
 				item = 'Choice Band';
-			} else if (counter.Special >= 3 && (template.baseStats.spe >= 95 || randomNum)) {
+			} else if (counter.Special >= 3 && (template.baseStats.spe >= 95 || randomBool)) {
 				item = 'Choice Specs';
 			} else {
 				item = 'Choice Scarf';

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1133,12 +1133,12 @@ class RandomTeams extends Dex.ModdedDex {
 		let ability1 = this.getAbility(abilities[1]);
 		let ability2 = this.getAbility(abilities[2]);
 		if (abilities[1]) {
-			if (abilities[2] && ability1.rating <= ability2.rating && this.random(2)) {
+			if (abilities[2] && ability1.rating <= ability2.rating && !this.randomChance(1, 2)) {
 				[ability1, ability2] = [ability2, ability1];
 			}
-			if (ability0.rating <= ability1.rating && this.random(2)) {
+			if (ability0.rating <= ability1.rating && !this.randomChance(1, 2)) {
 				[ability0, ability1] = [ability1, ability0];
-			} else if (ability0.rating - 0.6 <= ability1.rating && this.random(3)) {
+			} else if (ability0.rating - 0.6 <= ability1.rating && !this.randomChance(1, 3)) {
 				[ability0, ability1] = [ability1, ability0];
 			}
 			ability = ability0.name;
@@ -1261,7 +1261,7 @@ class RandomTeams extends Dex.ModdedDex {
 				ability = 'Pickup';
 			} else if (template.baseSpecies === 'Basculin') {
 				ability = 'Adaptability';
-			} else if (template.species === 'Lopunny' && hasMove['switcheroo'] && this.random(3)) {
+			} else if (template.species === 'Lopunny' && hasMove['switcheroo'] && !this.randomChance(1, 3)) {
 				ability = 'Klutz';
 			} else if ((template.species === 'Rampardos' && !hasMove['headsmash']) || hasMove['rockclimb']) {
 				ability = 'Sheer Force';
@@ -1340,7 +1340,7 @@ class RandomTeams extends Dex.ModdedDex {
 			// To perma-taunt a Pokemon by giving it Assault Vest
 			item = 'Assault Vest';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomNum = this.random(3);
+			let randomNum = !this.randomChance(1, 3);
 			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
@@ -1363,7 +1363,7 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (hasMove['bellydrum']) {
 			if (ability === 'Gluttony') {
 				item = ['Aguav', 'Figy', 'Iapapa', 'Mago', 'Wiki'][this.random(5)] + ' Berry';
-			} else if (template.baseStats.spe <= 50 && !teamDetails.zMove && this.random(2)) {
+			} else if (template.baseStats.spe <= 50 && !teamDetails.zMove && !this.randomChance(1, 2)) {
 				item = 'Normalium Z';
 			} else {
 				item = 'Sitrus Berry';
@@ -1401,10 +1401,10 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (template.baseStats.spe <= 50 && hasMove['sleeppowder'] && counter.setupType && !teamDetails.zMove) {
 			item = 'Grassium Z';
 		} else if (counter.Physical >= 4 && !hasMove['bodyslam'] && !hasMove['dragontail'] && !hasMove['fakeout'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = template.baseStats.atk >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.random(3) ? 'Choice Scarf' : 'Choice Band';
+			item = template.baseStats.atk >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Band';
 		} else if (counter.Special >= 4 && !hasMove['acidspray'] && !hasMove['chargebeam'] && !hasMove['clearsmog'] && !hasMove['fierydance']) {
-			item = template.baseStats.spa >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.random(3) ? 'Choice Scarf' : 'Choice Specs';
-		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['uturn'])) && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.random(3)) {
+			item = template.baseStats.spa >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Specs';
+		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['uturn'])) && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3)) {
 			item = 'Choice Scarf';
 		} else if (ability === 'Defeatist' || hasMove['eruption'] || hasMove['waterspout']) {
 			item = counter.Status <= 1 ? 'Expert Belt' : 'Leftovers';
@@ -1420,7 +1420,7 @@ class RandomTeams extends Dex.ModdedDex {
 			item = 'Leftovers';
 		} else if (hasMove['substitute']) {
 			item = !counter['drain'] || counter.damagingMoves.length < 2 ? 'Leftovers' : 'Life Orb';
-		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && this.random(2)) {
+		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && !this.randomChance(1, 2)) {
 			item = 'Rocky Helmet';
 		} else if (counter.Physical + counter.Special >= 4 && template.baseStats.spd >= 65 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd >= 235) {
 			item = 'Assault Vest';
@@ -1729,7 +1729,7 @@ class RandomTeams extends Dex.ModdedDex {
 			species = template.baseSpecies;
 		}
 		let battleForme = this.checkBattleForme(template);
-		if (battleForme && (battleForme.isMega ? !teamDetails.megaStone : this.random(2))) {
+		if (battleForme && (battleForme.isMega ? !teamDetails.megaStone : !this.randomChance(1, 2))) {
 			template = this.getTemplate(template.otherFormes.length >= 2 ? template.otherFormes[this.random(template.otherFormes.length)] : template.otherFormes[0]);
 		}
 
@@ -2183,10 +2183,10 @@ class RandomTeams extends Dex.ModdedDex {
 		ability = ability0.name;
 		if (abilities[1]) {
 			if (abilities[2] && ability2.rating === ability1.rating) {
-				if (this.random(2)) ability1 = ability2;
+				if (!this.randomChance(1, 2)) ability1 = ability2;
 			}
 			if (ability0.rating <= ability1.rating) {
-				if (this.random(2)) ability = ability1.name;
+				if (!this.randomChance(1, 2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
 				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
@@ -2328,7 +2328,7 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (template.species === 'Unown') {
 			item = 'Choice Specs';
 		} else if (hasMove['trick'] || hasMove['switcheroo']) {
-			let randomNum = this.random(2);
+			let randomNum = !this.randomChance(1, 2);
 			if (counter.Physical >= 3 && (template.baseStats.spe >= 95 || randomNum)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe >= 95 || randomNum)) {
@@ -2339,7 +2339,7 @@ class RandomTeams extends Dex.ModdedDex {
 		} else if (ability === 'Gluttony' || ability === 'Schooling') {
 			item = ['Aguav', 'Figy', 'Iapapa', 'Mago', 'Wiki'][this.random(5)] + ' Berry';
 		} else if (hasMove['bellydrum']) {
-			if (template.baseStats.spe <= 50 && !teamDetails.zMove && this.random(2)) {
+			if (template.baseStats.spe <= 50 && !teamDetails.zMove && !this.randomChance(1, 2)) {
 				item = 'Normalium Z';
 			} else {
 				item = 'Sitrus Berry';
@@ -2536,7 +2536,7 @@ class RandomTeams extends Dex.ModdedDex {
 			ivs: ivs,
 			item: item,
 			level: level,
-			shiny: !this.random(template.id === 'missingno' ? 4 : 1024),
+			shiny: this.randomChance(1, template.id === 'missingno' ? 4 : 1024),
 		};
 	}
 	randomFactorySet(template, slot, teamData, tier) {
@@ -2625,7 +2625,7 @@ class RandomTeams extends Dex.ModdedDex {
 		return {
 			name: setData.set.name || template.baseSpecies,
 			species: setData.set.species,
-			gender: setData.set.gender || template.gender || (this.random(2) ? 'M' : 'F'),
+			gender: setData.set.gender || template.gender || (!this.randomChance(1, 2) ? 'M' : 'F'),
 			item: items + '' || setData.set.item || '',
 			ability: abilities + '' || setData.set.ability || template.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
@@ -2691,7 +2691,7 @@ class RandomTeams extends Dex.ModdedDex {
 			// If not Monotype, limit to two of each type
 				let skip = false;
 				for (let t = 0; t < types.length; t++) {
-					if (teamData.typeCount[types[t]] > 1 && this.random(5)) {
+					if (teamData.typeCount[types[t]] > 1 && !this.randomChance(1, 5)) {
 						skip = true;
 						break;
 					}
@@ -2849,7 +2849,7 @@ class RandomTeams extends Dex.ModdedDex {
 		return {
 			name: setData.set.name || template.baseSpecies,
 			species: setData.set.species,
-			gender: setData.set.gender || template.gender || (this.random(2) ? 'M' : 'F'),
+			gender: setData.set.gender || template.gender || (!this.randomChance(1, 2) ? 'M' : 'F'),
 			item: setData.set.item || '',
 			ability: setData.set.ability || template.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
@@ -2903,7 +2903,7 @@ class RandomTeams extends Dex.ModdedDex {
 			let types = template.types;
 			let skip = false;
 			for (let t = 0; t < types.length; t++) {
-				if (teamData.typeCount[types[t]] > 1 && this.random(5)) {
+				if (teamData.typeCount[types[t]] > 1 && !this.randomChance(1, 5)) {
 					skip = true;
 					break;
 				}
@@ -3062,7 +3062,7 @@ class RandomTeams extends Dex.ModdedDex {
 		return {
 			name: setData.set.nickname || setData.set.name || template.baseSpecies,
 			species: setData.set.species,
-			gender: setData.set.gender || template.gender || (this.random(2) ? 'M' : 'F'),
+			gender: setData.set.gender || template.gender || (!this.randomChance(1, 2) ? 'M' : 'F'),
 			item: setData.set.item || '',
 			ability: setData.set.ability || template.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
@@ -3112,7 +3112,7 @@ class RandomTeams extends Dex.ModdedDex {
 			let types = template.types;
 			let skip = false;
 			for (let t = 0; t < types.length; t++) {
-				if (teamData.typeCount[types[t]] > 1 && this.random(5)) {
+				if (teamData.typeCount[types[t]] > 1 && !this.randomChance(1, 5)) {
 					skip = true;
 					break;
 				}

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -23,6 +23,9 @@ class RandomTeams extends Dex.ModdedDex {
 		const generatorName = typeof this.format.team === 'string' && this.format.team.startsWith('random') ? this.format.team + 'Team' : '';
 		return this[generatorName || 'randomTeam']();
 	}
+	randomChance(numerator, denominator) {
+		return this.prng.randomChance(numerator, denominator);
+	}
 	random(m, n) {
 		return this.prng.next(m, n);
 	}
@@ -194,7 +197,7 @@ class RandomTeams extends Dex.ModdedDex {
 			let happiness = this.random(256);
 
 			// Random shininess
-			let shiny = !this.random(1024);
+			let shiny = this.randomChance(1, 1024);
 
 			team.push({
 				name: template.baseSpecies,
@@ -331,7 +334,7 @@ class RandomTeams extends Dex.ModdedDex {
 			let happiness = this.random(256);
 
 			// Random shininess
-			let shiny = !this.random(1024);
+			let shiny = this.randomChance(1, 1024);
 
 			team.push({
 				name: template.baseSpecies,
@@ -1325,7 +1328,7 @@ class RandomTeams extends Dex.ModdedDex {
 			item = 'Choice Specs';
 		} else if (template.species === 'Wobbuffet') {
 			item = hasMove['destinybond'] ? 'Custap Berry' : ['Leftovers', 'Sitrus Berry'][this.random(2)];
-		} else if (template.species === 'Raichu-Alola' && hasMove['thunderbolt'] && !teamDetails.zMove && this.random(4) < 1) {
+		} else if (template.species === 'Raichu-Alola' && hasMove['thunderbolt'] && !teamDetails.zMove && this.randomChance(1, 4)) {
 			item = 'Aloraichium Z';
 		} else if (template.species === 'Zygarde-10%' && hasMove['substitute'] && !teamDetails.zMove) {
 			item = hasMove['outrage'] ? 'Dragonium Z' : 'Groundium Z';
@@ -1535,7 +1538,7 @@ class RandomTeams extends Dex.ModdedDex {
 			ivs: ivs,
 			item: item,
 			level: level,
-			shiny: !this.random(1024),
+			shiny: this.randomChance(1, 1024),
 		};
 	}
 	randomTeam() {
@@ -1589,33 +1592,33 @@ class RandomTeams extends Dex.ModdedDex {
 			switch (tier) {
 			case 'Uber':
 				// Ubers are limited to 2 but have a 20% chance of being added anyway.
-				if (uberCount > 1 && this.random(5) >= 1) continue;
+				if (uberCount > 1 && !this.randomChance(1, 5)) continue;
 				break;
 			case 'PU':
 				// PUs are limited to 2 but have a 20% chance of being added anyway.
-				if (puCount > 1 && this.random(5) >= 1) continue;
+				if (puCount > 1 && !this.randomChance(1, 5)) continue;
 				break;
 			case 'Unreleased': case 'CAP':
 				// Unreleased and CAP have 20% the normal rate
-				if (this.random(5) >= 1) continue;
+				if (!this.randomChance(1, 5)) continue;
 			}
 
 			// Adjust rate for species with multiple formes
 			switch (template.baseSpecies) {
 			case 'Arceus': case 'Silvally':
-				if (this.random(18) >= 1) continue;
+				if (!this.randomChance(1, 18)) continue;
 				break;
 			case 'Pikachu':
-				if (this.random(7) >= 1) continue;
+				if (!this.randomChance(1, 7)) continue;
 				continue;
 			case 'Genesect':
-				if (this.random(5) >= 1) continue;
+				if (!this.randomChance(1, 5)) continue;
 				break;
 			case 'Castform': case 'Gourgeist': case 'Oricorio':
-				if (this.random(4) >= 1) continue;
+				if (!this.randomChance(1, 4)) continue;
 				break;
 			case 'Basculin': case 'Cherrim': case 'Greninja': case 'Hoopa': case 'Meloetta': case 'Meowstic':
-				if (this.random(2) >= 1) continue;
+				if (!this.randomChance(1, 2)) continue;
 				break;
 			}
 
@@ -1639,7 +1642,7 @@ class RandomTeams extends Dex.ModdedDex {
 				// Limit 2 of any type
 				let skip = false;
 				for (let t = 0; t < types.length; t++) {
-					if (typeCount[types[t]] > 1 && this.random(5) >= 1) {
+					if (typeCount[types[t]] > 1 && !this.randomChance(1, 5)) {
 						skip = true;
 						break;
 					}
@@ -2185,7 +2188,7 @@ class RandomTeams extends Dex.ModdedDex {
 			if (ability0.rating <= ability1.rating) {
 				if (this.random(2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
-				if (!this.random(3)) ability = ability1.name;
+				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
 
 			let rejectAbility = false;
@@ -2369,7 +2372,7 @@ class RandomTeams extends Dex.ModdedDex {
 			item = 'Petaya Berry';
 		} else if (template.species === 'Wobbuffet') {
 			item = hasMove['destinybond'] ? 'Custap Berry' : 'Sitrus Berry';
-		} else if (template.species === 'Raichu-Alola' && hasMove['thunderbolt'] && !teamDetails.zMove && this.random(4) < 1) {
+		} else if (template.species === 'Raichu-Alola' && hasMove['thunderbolt'] && !teamDetails.zMove && this.randomChance(1, 4)) {
 			item = 'Aloraichium Z';
 		} else if (hasMove['focusenergy'] || (template.species === 'Unfezant' && counter['Physical'] >= 2)) {
 			item = 'Scope Lens';
@@ -2625,7 +2628,7 @@ class RandomTeams extends Dex.ModdedDex {
 			gender: setData.set.gender || template.gender || (this.random(2) ? 'M' : 'F'),
 			item: items + '' || setData.set.item || '',
 			ability: abilities + '' || setData.set.ability || template.abilities['0'],
-			shiny: typeof setData.set.shiny === 'undefined' ? !this.random(1024) : setData.set.shiny,
+			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
 			level: setData.set.level || 100,
 			happiness: typeof setData.set.happiness === 'undefined' ? 255 : setData.set.happiness,
 			evs: setData.set.evs || {hp: 84, atk: 84, def: 84, spa: 84, spd: 84, spe: 84},
@@ -2849,7 +2852,7 @@ class RandomTeams extends Dex.ModdedDex {
 			gender: setData.set.gender || template.gender || (this.random(2) ? 'M' : 'F'),
 			item: setData.set.item || '',
 			ability: setData.set.ability || template.abilities['0'],
-			shiny: typeof setData.set.shiny === 'undefined' ? !this.random(1024) : setData.set.shiny,
+			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
 			level: 100,
 			happiness: typeof setData.set.happiness === 'undefined' ? 255 : setData.set.happiness,
 			evs: setData.set.evs || {hp: 84, atk: 84, def: 84, spa: 84, spd: 84, spe: 84},
@@ -3062,7 +3065,7 @@ class RandomTeams extends Dex.ModdedDex {
 			gender: setData.set.gender || template.gender || (this.random(2) ? 'M' : 'F'),
 			item: setData.set.item || '',
 			ability: setData.set.ability || template.abilities['0'],
-			shiny: typeof setData.set.shiny === 'undefined' ? !this.random(1024) : setData.set.shiny,
+			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
 			level: setData.set.level || 50,
 			happiness: typeof setData.set.happiness === 'undefined' ? 255 : setData.set.happiness,
 			evs: setData.set.evs || {hp: 84, atk: 84, def: 84, spa: 84, spd: 84, spe: 84},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -417,7 +417,7 @@ exports.BattleScripts = {
 		} else {
 			accuracy = this.runEvent('Accuracy', target, pokemon, move, accuracy);
 		}
-		if (accuracy !== true && this.random(100) >= accuracy) {
+		if (accuracy !== true && !this.randomChance(accuracy, 100)) {
 			if (!move.spreadHit) this.attrLastMove('[miss]');
 			this.add('-miss', pokemon, target);
 			return false;
@@ -516,7 +516,7 @@ exports.BattleScripts = {
 					accuracy = this.runEvent('ModifyAccuracy', target, pokemon, move, accuracy);
 					if (!move.alwaysHit) {
 						accuracy = this.runEvent('Accuracy', target, pokemon, move, accuracy);
-						if (accuracy !== true && this.random(100) >= accuracy) break;
+						if (accuracy !== true && !this.randomChance(accuracy, 100)) break;
 					}
 				}
 

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -168,7 +168,7 @@ exports.BattleStatuses = {
 				return;
 			}
 			this.add('-activate', pokemon, 'confusion');
-			if (this.random(3) > 0) {
+			if (!this.randomChance(1, 3)) {
 				return;
 			}
 			this.activeTarget = pokemon;
@@ -404,7 +404,7 @@ exports.BattleStatuses = {
 			// However, just in case, use 1 if it is undefined.
 			let counter = this.effectData.counter || 1;
 			this.debug("Success chance: " + Math.round(100 / counter) + "%");
-			return (this.random(counter) === 0);
+			return this.randomChance(1, counter);
 		},
 		onRestart: function () {
 			if (this.effectData.counter < this.effect.counterMax) {

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -34,7 +34,7 @@ exports.BattleStatuses = {
 		},
 		onBeforeMovePriority: 1,
 		onBeforeMove: function (pokemon) {
-			if (this.random(4) === 0) {
+			if (this.randomChance(1, 4)) {
 				this.add('cant', pokemon, 'par');
 				return false;
 			}
@@ -91,7 +91,7 @@ exports.BattleStatuses = {
 		onBeforeMovePriority: 10,
 		onBeforeMove: function (pokemon, target, move) {
 			if (move.flags['defrost']) return;
-			if (this.random(5) === 0) {
+			if (this.randomChance(1, 5)) {
 				pokemon.cureStatus();
 				return;
 			}

--- a/mods/gen1/random-teams.js
+++ b/mods/gen1/random-teams.js
@@ -168,7 +168,7 @@ class RandomGen1Teams extends RandomGen2Teams {
 			// Limit 2 of any type as well. Diversity and minor weakness count.
 			// The second of a same type has halved chance of being added.
 			for (const type of template.types) {
-				if (typeCount[type] > 1 || (typeCount[type] === 1 && this.random(2) && pokemonPool.length > 1)) {
+				if (typeCount[type] > 1 || (typeCount[type] === 1 && !this.randomChance(1, 2) && pokemonPool.length > 1)) {
 					skip = true;
 					break;
 				}

--- a/mods/gen1/random-teams.js
+++ b/mods/gen1/random-teams.js
@@ -160,7 +160,7 @@ class RandomGen1Teams extends RandomGen2Teams {
 				break;
 			default:
 				// OUs are fine. Otherwise 50% chance to skip mon if already 4 or more non-OUs.
-				if (uuTiers.includes(tier) && pokemonPool.length > 1 && (nuCount > 3 && !this.randomChance(1, 2))) continue;
+				if (uuTiers.includes(tier) && pokemonPool.length > 1 && (nuCount > 3 && this.randomChance(1, 2))) continue;
 			}
 
 			let skip = false;
@@ -168,7 +168,7 @@ class RandomGen1Teams extends RandomGen2Teams {
 			// Limit 2 of any type as well. Diversity and minor weakness count.
 			// The second of a same type has halved chance of being added.
 			for (const type of template.types) {
-				if (typeCount[type] > 1 || (typeCount[type] === 1 && !this.randomChance(1, 2) && pokemonPool.length > 1)) {
+				if (typeCount[type] > 1 || (typeCount[type] === 1 && this.randomChance(1, 2) && pokemonPool.length > 1)) {
 					skip = true;
 					break;
 				}

--- a/mods/gen1/random-teams.js
+++ b/mods/gen1/random-teams.js
@@ -152,7 +152,7 @@ class RandomGen1Teams extends RandomGen2Teams {
 			case 'NFE':
 				// Don't add pre-evo mon if already 4 or more non-OUs, or if already 3 or more non-OUs with one being a shitmon
 				// Regardless, pre-evo mons are slightly less common.
-				if (nuCount > 3 || (hasShitmon && nuCount > 2) || this.random(3) === 0) continue;
+				if (nuCount > 3 || (hasShitmon && nuCount > 2) || this.randomChance(1, 3)) continue;
 				break;
 			case 'Uber':
 				// If you have one of the worst mons we allow luck to give you all Ubers.
@@ -160,7 +160,7 @@ class RandomGen1Teams extends RandomGen2Teams {
 				break;
 			default:
 				// OUs are fine. Otherwise 50% chance to skip mon if already 4 or more non-OUs.
-				if (uuTiers.includes(tier) && pokemonPool.length > 1 && (nuCount > 3 && this.random(2) >= 1)) continue;
+				if (uuTiers.includes(tier) && pokemonPool.length > 1 && (nuCount > 3 && !this.randomChance(1, 2))) continue;
 			}
 
 			let skip = false;
@@ -246,7 +246,7 @@ class RandomGen1Teams extends RandomGen2Teams {
 
 		// Either add all moves or add none
 		if (template.comboMoves) {
-			if (this.random(2) === 0) {
+			if (this.randomChance(1, 2)) {
 				moves = moves.concat(template.comboMoves);
 			}
 		}

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -292,7 +292,7 @@ exports.BattleScripts = {
 		if (move.target === 'self' && accuracy !== true) accuracy++;
 
 		// 1/256 chance of missing always, no matter what. Besides the aforementioned exceptions.
-		if (accuracy !== true && this.random(256) >= accuracy) {
+		if (accuracy !== true && !this.randomChance(accuracy, 256)) {
 			this.attrLastMove('[miss]');
 			this.add('-miss', pokemon);
 			damage = false;
@@ -571,7 +571,7 @@ exports.BattleScripts = {
 				// If a move that was not fire-type would exist on Gen 1, it could burn a Pokémon.
 				if (!(secondary.status && ['par', 'brn', 'frz'].includes(secondary.status) && target && target.hasType(move.type))) {
 					let effectChance = Math.ceil(secondary.chance * 256 / 100);
-					if (typeof secondary.chance === 'undefined' || this.random(256) < effectChance) {
+					if (typeof secondary.chance === 'undefined' || this.randomChance(effectChance, 256)) {
 						this.moveHit(target, pokemon, move, secondary, true, isSelf);
 					}
 				}
@@ -832,7 +832,7 @@ exports.BattleScripts = {
 			// We compare our critical hit chance against a random number between 0 and 255.
 			// If the random number is lower, we get a critical hit. This means there is always a 1/255 chance of not hitting critically.
 			if (critChance > 0) {
-				move.crit = (this.random(256) < critChance);
+				move.crit = this.randomChance(critChance, 256);
 			}
 		}
 

--- a/mods/gen1/statuses.js
+++ b/mods/gen1/statuses.js
@@ -255,7 +255,7 @@ exports.BattleStatuses = {
 				return (this.random() * 4294967296 < 1);
 			}
 			this.debug("Success chance: " + Math.round(100 / counter) + "%");
-			return (this.random(counter) === 0);
+			return this.randomChance(1, counter);
 		},
 		onRestart: function () {
 			if (this.effectData.counter < this.effect.counterMax) {

--- a/mods/gen1/statuses.js
+++ b/mods/gen1/statuses.js
@@ -41,7 +41,7 @@ exports.BattleStatuses = {
 		},
 		onBeforeMovePriority: 2,
 		onBeforeMove: function (pokemon) {
-			if (this.random(256) < 63) {
+			if (this.randomChance(63, 256)) {
 				this.add('cant', pokemon, 'par');
 				pokemon.removeVolatile('bide');
 				pokemon.removeVolatile('twoturnmove');
@@ -154,7 +154,7 @@ exports.BattleStatuses = {
 				return;
 			}
 			this.add('-activate', pokemon, 'confusion');
-			if (this.random(256) >= 128) {
+			if (!this.randomChance(128, 256)) {
 				// We check here to implement the substitute bug since otherwise we need to change directDamage to take target.
 				let damage = Math.floor(Math.floor(((Math.floor(2 * pokemon.level / 5) + 2) * pokemon.getStat('atk') * 40) / pokemon.getStat('def', false, false, true)) / 50) + 2;
 				if (pokemon.volatiles['substitute']) {

--- a/mods/gen2/items.js
+++ b/mods/gen2/items.js
@@ -23,7 +23,7 @@ exports.BattleItems = {
 		inherit: true,
 		desc: "Holder has a ~11.7% chance to survive an attack that would KO it with 1 HP.",
 		onDamage: function (damage, target, source, effect) {
-			if (this.random(256) < 30 && damage >= target.hp && effect && effect.effectType === 'Move') {
+			if (this.randomChance(30, 256) && damage >= target.hp && effect && effect.effectType === 'Move') {
 				this.add('-activate', target, 'item: Focus Band');
 				return target.hp - 1;
 			}
@@ -55,7 +55,7 @@ exports.BattleItems = {
 		inherit: true,
 		desc: "Each turn, holder has a ~23.4% chance to move first in its priority bracket.",
 		onModifyPriority: function (priority, pokemon) {
-			if (this.random(256) < 60) {
+			if (this.randomChance(60, 256)) {
 				return Math.round(priority) + 0.1;
 			}
 		},

--- a/mods/gen2/random-teams.js
+++ b/mods/gen2/random-teams.js
@@ -56,7 +56,7 @@ class RandomGen2Teams extends RandomGen3Teams {
 				if (typeCount[types[0]] && this.randomChance(1, 3)) skip = true;
 			} else if (types.length === 2) {
 				if (typeCount[types[0]] > 1 || typeCount[types[1]] > 1) skip = true;
-				if (typeCount[types[0]] && typeCount[types[1]] && !this.randomChance(1, 3)) skip = true;
+				if (typeCount[types[0]] && typeCount[types[1]] && this.randomChance(2, 3)) skip = true;
 			}
 
 			// Ensure the weakness-resistance balance is 2 points or lower for all types,

--- a/mods/gen2/random-teams.js
+++ b/mods/gen2/random-teams.js
@@ -56,7 +56,7 @@ class RandomGen2Teams extends RandomGen3Teams {
 				if (typeCount[types[0]] && this.randomChance(1, 3)) skip = true;
 			} else if (types.length === 2) {
 				if (typeCount[types[0]] > 1 || typeCount[types[1]] > 1) skip = true;
-				if (typeCount[types[0]] && typeCount[types[1]] && this.random(3) > 0) skip = true;
+				if (typeCount[types[0]] && typeCount[types[1]] && !this.randomChance(1, 3)) skip = true;
 			}
 
 			// Ensure the weakness-resistance balance is 2 points or lower for all types,

--- a/mods/gen2/random-teams.js
+++ b/mods/gen2/random-teams.js
@@ -53,7 +53,7 @@ class RandomGen2Teams extends RandomGen3Teams {
 			let types = template.types;
 			if (types.length === 1) {
 				if (typeCount[types[0]] > 1) skip = true;
-				if (typeCount[types[0]] && this.random(3) === 0) skip = true;
+				if (typeCount[types[0]] && this.randomChance(1, 3)) skip = true;
 			} else if (types.length === 2) {
 				if (typeCount[types[0]] > 1 || typeCount[types[1]] > 1) skip = true;
 				if (typeCount[types[0]] && typeCount[types[1]] && this.random(3) > 0) skip = true;
@@ -206,7 +206,7 @@ class RandomGen2Teams extends RandomGen3Teams {
 				if (isSleepMove(moveid) && restrictMoves['sleeping'] > 1) { discourage = false; break; }
 			}
 		}
-		if (discourage && this.random(2) === 0) discard = true;
+		if (discourage && this.randomChance(1, 2)) discard = true;
 
 		// Add the held item
 		// TODO: for some reason, items like Thick Club are not working in randbats

--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -197,7 +197,7 @@ exports.BattleScripts = {
 		} else {
 			accuracy = this.runEvent('Accuracy', target, pokemon, move, accuracy);
 		}
-		if (accuracy !== true && accuracy !== 255 && this.random(256) >= accuracy) {
+		if (accuracy !== true && accuracy !== 255 && !this.randomChance(accuracy, 256)) {
 			this.attrLastMove('[miss]');
 			this.add('-miss', pokemon);
 			damage = false;
@@ -400,7 +400,7 @@ exports.BattleScripts = {
 				// Unlike gen 1, though, paralysis works for all unless the target is immune to direct move (ie. ground-types and t-wave).
 				if (!(secondary.status && ['brn', 'frz'].includes(secondary.status) && target && target.hasType(move.type))) {
 					let effectChance = Math.floor(secondary.chance * 255 / 100);
-					if (typeof secondary.chance === 'undefined' || this.random(256) < effectChance) {
+					if (typeof secondary.chance === 'undefined' || this.randomChance(effectChance, 256)) {
 						this.moveHit(target, pokemon, move, secondary, true, isSelf);
 					}
 				}
@@ -485,7 +485,7 @@ exports.BattleScripts = {
 		move.crit = move.willCrit || false;
 		if (typeof move.willCrit === 'undefined') {
 			if (move.critRatio) {
-				move.crit = (this.random(critMult[move.critRatio]) === 0);
+				move.crit = this.randomChance(1, critMult[move.critRatio]);
 			}
 		}
 

--- a/mods/gen2/statuses.js
+++ b/mods/gen2/statuses.js
@@ -183,7 +183,7 @@ exports.BattleStatuses = {
 		onStallMove: function () {
 			let counter = Math.floor(this.effectData.counter) || 127;
 			this.debug("Success chance: " + Math.round(counter * 1000 / 255) / 10 + "% (" + counter + "/255)");
-			return (this.random(255) < counter);
+			return this.randomChance(counter, 255);
 		},
 		onRestart: function () {
 			this.effectData.counter /= 2;

--- a/mods/gen2/statuses.js
+++ b/mods/gen2/statuses.js
@@ -18,7 +18,7 @@ exports.BattleStatuses = {
 		inherit: true,
 		onBeforeMovePriority: 2,
 		onBeforeMove: function (pokemon) {
-			if (this.random(4) === 0) {
+			if (this.randomChance(1, 4)) {
 				this.add('cant', pokemon, 'par');
 				return false;
 			}
@@ -57,7 +57,7 @@ exports.BattleStatuses = {
 			if (move.flags['defrost']) pokemon.cureStatus();
 		},
 		onResidual: function (pokemon) {
-			if (this.random(256) < 25) pokemon.cureStatus();
+			if (this.randomChance(25, 256)) pokemon.cureStatus();
 		},
 	},
 	psn: {
@@ -116,7 +116,7 @@ exports.BattleStatuses = {
 				return;
 			}
 			this.add('-activate', pokemon, 'confusion');
-			if (this.random(2) === 0) {
+			if (this.randomChance(1, 2)) {
 				return;
 			}
 			move = {

--- a/mods/gen3/abilities.js
+++ b/mods/gen3/abilities.js
@@ -7,7 +7,7 @@ exports.BattleAbilities = {
 		shortDesc: "1/3 chance of infatuating Pokemon of the opposite gender if they make contact.",
 		onAfterDamage: function (damage, target, source, move) {
 			if (move && move.flags['contact']) {
-				if (this.random(3) < 1) {
+				if (this.randomChance(1, 3)) {
 					source.addVolatile('attract', target);
 				}
 			}
@@ -35,7 +35,7 @@ exports.BattleAbilities = {
 		shortDesc: "1/3 chance a Pokemon making contact with this Pokemon will be burned.",
 		onAfterDamage: function (damage, target, source, move) {
 			if (move && move.flags['contact']) {
-				if (this.random(3) < 1) {
+				if (this.randomChance(1, 3)) {
 					source.trySetStatus('brn', target);
 				}
 			}
@@ -104,7 +104,7 @@ exports.BattleAbilities = {
 		shortDesc: "1/3 chance a Pokemon making contact with this Pokemon will be poisoned.",
 		onAfterDamage: function (damage, target, source, move) {
 			if (move && move.flags['contact']) {
-				if (this.random(3) < 1) {
+				if (this.randomChance(1, 3)) {
 					source.trySetStatus('psn', target);
 				}
 			}
@@ -137,7 +137,7 @@ exports.BattleAbilities = {
 		shortDesc: "1/3 chance a Pokemon making contact with this Pokemon will be paralyzed.",
 		onAfterDamage: function (damage, target, source, effect) {
 			if (effect && effect.flags['contact']) {
-				if (this.random(3) < 1) {
+				if (this.randomChance(1, 3)) {
 					source.trySetStatus('par', target);
 				}
 			}

--- a/mods/gen3/items.js
+++ b/mods/gen3/items.js
@@ -143,7 +143,7 @@ exports.BattleItems = {
 	"quickclaw": {
 		inherit: true,
 		onModifyPriority: function (priority, pokemon) {
-			if (this.random(5) === 0) {
+			if (this.randomChance(1, 5)) {
 				return Math.round(priority) + 0.1;
 			}
 		},

--- a/mods/gen3/random-teams.js
+++ b/mods/gen3/random-teams.js
@@ -430,7 +430,7 @@ class RandomGen3Teams extends RandomGen4Teams {
 		if (ability0.gen !== 3) ability = ability1.name;
 		if (ability0.gen === 3 && ability1.gen === 3) {
 			if (ability0.rating <= ability1.rating) {
-				if (this.random(2)) ability = ability1.name;
+				if (!this.randomChance(1, 2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
 				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
@@ -512,15 +512,15 @@ class RandomGen3Teams extends RandomGen4Teams {
 		} else if (hasMove['leechseed']) {
 			item = 'Leftovers';
 		} else if (hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal'] || hasMove['endure'] ||
-			hasMove['substitute'] && counter.Status < 3 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd < 250 && this.random(2)) {
+			hasMove['substitute'] && counter.Status < 3 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd < 250 && !this.randomChance(1, 2)) {
 			if (template.baseStats.spe <= 90 && !counter['speedsetup'] && !hasMove['focuspunch']) {
 				item = 'Salac Berry';
-			} else if (counter.Physical > counter.Special || counter.Physical === counter.Special && this.random(2)) {
+			} else if (counter.Physical > counter.Special || counter.Physical === counter.Special && !this.randomChance(1, 2)) {
 				item = 'Liechi Berry';
 			} else {
 				item = 'Petaya Berry';
 			}
-		} else if ((counter.Physical >= 4 || counter.Physical >= 3 && counter.Special === 1 && this.random(2)) && !(hasMove['bodyslam'] && hasAbility['Serene Grace']) && !hasMove['fakeout'] && !hasMove['rapidspin']) {
+		} else if ((counter.Physical >= 4 || counter.Physical >= 3 && counter.Special === 1 && !this.randomChance(1, 2)) && !(hasMove['bodyslam'] && hasAbility['Serene Grace']) && !hasMove['fakeout'] && !hasMove['rapidspin']) {
 			item = 'Choice Band';
 		} else if (hasMove['curse'] || hasMove['protect'] || hasMove['sleeptalk'] || hasMove['substitute']) {
 			item = 'Leftovers';

--- a/mods/gen3/random-teams.js
+++ b/mods/gen3/random-teams.js
@@ -430,7 +430,7 @@ class RandomGen3Teams extends RandomGen4Teams {
 		if (ability0.gen !== 3) ability = ability1.name;
 		if (ability0.gen === 3 && ability1.gen === 3) {
 			if (ability0.rating <= ability1.rating) {
-				if (!this.randomChance(1, 2)) ability = ability1.name;
+				if (this.randomChance(1, 2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
 				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
@@ -512,15 +512,15 @@ class RandomGen3Teams extends RandomGen4Teams {
 		} else if (hasMove['leechseed']) {
 			item = 'Leftovers';
 		} else if (hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal'] || hasMove['endure'] ||
-			hasMove['substitute'] && counter.Status < 3 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd < 250 && !this.randomChance(1, 2)) {
+			hasMove['substitute'] && counter.Status < 3 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd < 250 && this.randomChance(1, 2)) {
 			if (template.baseStats.spe <= 90 && !counter['speedsetup'] && !hasMove['focuspunch']) {
 				item = 'Salac Berry';
-			} else if (counter.Physical > counter.Special || counter.Physical === counter.Special && !this.randomChance(1, 2)) {
+			} else if (counter.Physical > counter.Special || counter.Physical === counter.Special && this.randomChance(1, 2)) {
 				item = 'Liechi Berry';
 			} else {
 				item = 'Petaya Berry';
 			}
-		} else if ((counter.Physical >= 4 || counter.Physical >= 3 && counter.Special === 1 && !this.randomChance(1, 2)) && !(hasMove['bodyslam'] && hasAbility['Serene Grace']) && !hasMove['fakeout'] && !hasMove['rapidspin']) {
+		} else if ((counter.Physical >= 4 || counter.Physical >= 3 && counter.Special === 1 && this.randomChance(1, 2)) && !(hasMove['bodyslam'] && hasAbility['Serene Grace']) && !hasMove['fakeout'] && !hasMove['rapidspin']) {
 			item = 'Choice Band';
 		} else if (hasMove['curse'] || hasMove['protect'] || hasMove['sleeptalk'] || hasMove['substitute']) {
 			item = 'Leftovers';
@@ -620,20 +620,20 @@ class RandomGen3Teams extends RandomGen4Teams {
 			switch (tier) {
 			case 'Uber':
 				// Ubers are limited to 2 but have a 20% chance of being added anyway.
-				if (uberCount > 1 && !this.randomChance(1, 5)) continue;
+				if (uberCount > 1 && this.randomChance(4, 5)) continue;
 				break;
 			case 'NU':
 				// NUs are limited to 2 but have a 20% chance of being added anyway.
-				if (nuCount > 1 && !this.randomChance(1, 5)) continue;
+				if (nuCount > 1 && this.randomChance(4, 5)) continue;
 			}
 
 			// Adjust rate for castform
-			if (template.baseSpecies === 'Castform' && !this.randomChance(1, 4)) continue;
+			if (template.baseSpecies === 'Castform' && this.randomChance(3, 4)) continue;
 
 			// Limit 2 of any type
 			let skip = false;
 			for (const type of template.types) {
-				if (typeCount[type] > 1 && !this.randomChance(1, 5)) {
+				if (typeCount[type] > 1 && this.randomChance(4, 5)) {
 					skip = true;
 					break;
 				}

--- a/mods/gen3/random-teams.js
+++ b/mods/gen3/random-teams.js
@@ -432,7 +432,7 @@ class RandomGen3Teams extends RandomGen4Teams {
 			if (ability0.rating <= ability1.rating) {
 				if (this.random(2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
-				if (!this.random(3)) ability = ability1.name;
+				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
 
 			let rejectAbility = false;
@@ -574,7 +574,7 @@ class RandomGen3Teams extends RandomGen4Teams {
 			ivs: ivs,
 			item: item,
 			level: level,
-			shiny: !this.random(1024),
+			shiny: this.randomChance(1, 1024),
 		};
 	}
 	randomTeam(side) {
@@ -620,20 +620,20 @@ class RandomGen3Teams extends RandomGen4Teams {
 			switch (tier) {
 			case 'Uber':
 				// Ubers are limited to 2 but have a 20% chance of being added anyway.
-				if (uberCount > 1 && this.random(5) >= 1) continue;
+				if (uberCount > 1 && !this.randomChance(1, 5)) continue;
 				break;
 			case 'NU':
 				// NUs are limited to 2 but have a 20% chance of being added anyway.
-				if (nuCount > 1 && this.random(5) >= 1) continue;
+				if (nuCount > 1 && !this.randomChance(1, 5)) continue;
 			}
 
 			// Adjust rate for castform
-			if (template.baseSpecies === 'Castform' && this.random(4) >= 1) continue;
+			if (template.baseSpecies === 'Castform' && !this.randomChance(1, 4)) continue;
 
 			// Limit 2 of any type
 			let skip = false;
 			for (const type of template.types) {
-				if (typeCount[type] > 1 && this.random(5) >= 1) {
+				if (typeCount[type] > 1 && !this.randomChance(1, 5)) {
 					skip = true;
 					break;
 				}

--- a/mods/gen4/random-teams.js
+++ b/mods/gen4/random-teams.js
@@ -450,7 +450,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 		ability = ability0.name;
 		if (abilities[1]) {
 			if (ability0.rating <= ability1.rating) {
-				if (this.random(2)) ability = ability1.name;
+				if (!this.randomChance(1, 2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
 				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
@@ -539,7 +539,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 		} else if (template.species === 'Wobbuffet') {
 			item = hasMove['destinybond'] ? 'Custap Berry' : ['Leftovers', 'Sitrus Berry'][this.random(2)];
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomNum = this.random(3);
+			let randomNum = !this.randomChance(1, 3);
 			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
@@ -568,9 +568,9 @@ class RandomGen4Teams extends RandomGen5Teams {
 
 		// Medium priority
 		} else if (counter.Physical >= 4 && !(hasMove['bodyslam'] && hasAbility['Serene Grace']) && !hasMove['fakeout'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !hasMove['bodyslam'] && this.random(3) ? 'Choice Scarf' : 'Choice Band';
+			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !hasMove['bodyslam'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Band';
 		} else if ((counter.Special >= 4 || (counter.Special >= 3 && (hasMove['batonpass'] || hasMove['uturn'] || hasMove['waterspout'] && hasMove['selfdestruct']))) && !hasMove['chargebeam']) {
-			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && ability !== 'Speed Boost' && !counter['priority'] && this.random(3) ? 'Choice Scarf' : 'Choice Specs';
+			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && ability !== 'Speed Boost' && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Specs';
 		} else if (hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal']) {
 			item = 'Focus Sash';
 		} else if (ability === 'Slow Start' || hasMove['curse'] || hasMove['detect'] || hasMove['leechseed'] || hasMove['protect'] || hasMove['roar'] || hasMove['sleeptalk'] || hasMove['whirlwind']) {

--- a/mods/gen4/random-teams.js
+++ b/mods/gen4/random-teams.js
@@ -452,7 +452,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 			if (ability0.rating <= ability1.rating) {
 				if (this.random(2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
-				if (!this.random(3)) ability = ability1.name;
+				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
 
 			let rejectAbility = false;
@@ -666,7 +666,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 			ivs: ivs,
 			item: item,
 			level: level,
-			shiny: !this.random(1024),
+			shiny: this.randomChance(1, 1024),
 		};
 	}
 }

--- a/mods/gen4/random-teams.js
+++ b/mods/gen4/random-teams.js
@@ -450,7 +450,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 		ability = ability0.name;
 		if (abilities[1]) {
 			if (ability0.rating <= ability1.rating) {
-				if (!this.randomChance(1, 2)) ability = ability1.name;
+				if (this.randomChance(1, 2)) ability = ability1.name;
 			} else if (ability0.rating - 0.6 <= ability1.rating) {
 				if (this.randomChance(1, 3)) ability = ability1.name;
 			}
@@ -539,7 +539,7 @@ class RandomGen4Teams extends RandomGen5Teams {
 		} else if (template.species === 'Wobbuffet') {
 			item = hasMove['destinybond'] ? 'Custap Berry' : ['Leftovers', 'Sitrus Berry'][this.random(2)];
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomBool = !this.randomChance(1, 3);
+			let randomBool = this.randomChance(1, 3);
 			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
@@ -568,9 +568,9 @@ class RandomGen4Teams extends RandomGen5Teams {
 
 		// Medium priority
 		} else if (counter.Physical >= 4 && !(hasMove['bodyslam'] && hasAbility['Serene Grace']) && !hasMove['fakeout'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !hasMove['bodyslam'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Band';
+			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !hasMove['bodyslam'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Band';
 		} else if ((counter.Special >= 4 || (counter.Special >= 3 && (hasMove['batonpass'] || hasMove['uturn'] || hasMove['waterspout'] && hasMove['selfdestruct']))) && !hasMove['chargebeam']) {
-			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && ability !== 'Speed Boost' && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Specs';
+			item = template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && ability !== 'Speed Boost' && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Specs';
 		} else if (hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal']) {
 			item = 'Focus Sash';
 		} else if (ability === 'Slow Start' || hasMove['curse'] || hasMove['detect'] || hasMove['leechseed'] || hasMove['protect'] || hasMove['roar'] || hasMove['sleeptalk'] || hasMove['whirlwind']) {

--- a/mods/gen4/random-teams.js
+++ b/mods/gen4/random-teams.js
@@ -539,10 +539,10 @@ class RandomGen4Teams extends RandomGen5Teams {
 		} else if (template.species === 'Wobbuffet') {
 			item = hasMove['destinybond'] ? 'Custap Berry' : ['Leftovers', 'Sitrus Berry'][this.random(2)];
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomNum = !this.randomChance(1, 3);
-			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
+			let randomBool = !this.randomChance(1, 3);
+			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Band';
-			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
+			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Specs';
 			} else {
 				item = 'Choice Scarf';

--- a/mods/gen4/statuses.js
+++ b/mods/gen4/statuses.js
@@ -4,7 +4,7 @@ exports.BattleStatuses = {
 	par: {
 		inherit: true,
 		onBeforeMove: function (pokemon) {
-			if (!pokemon.hasAbility('magicguard') && this.random(4) === 0) {
+			if (!pokemon.hasAbility('magicguard') && this.randomChance(1, 4)) {
 				this.add('cant', pokemon, 'par');
 				return false;
 			}
@@ -37,7 +37,7 @@ exports.BattleStatuses = {
 	frz: {
 		inherit: true,
 		onBeforeMove: function (pokemon, target, move) {
-			if (this.random(5) === 0) {
+			if (this.randomChance(1, 5)) {
 				pokemon.cureStatus();
 				return;
 			}

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -757,7 +757,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 1,
 			onAfterMoveSecondarySelf: function (source, target, move) {
-				if (this.random(10) < 3) {
+				if (this.randomChance(3, 10)) {
 					this.boost({accuracy: -1}, target, source);
 				}
 				source.removeVolatile('secretpower');

--- a/mods/gen5/random-teams.js
+++ b/mods/gen5/random-teams.js
@@ -617,7 +617,7 @@ class RandomGen5Teams extends RandomGen6Teams {
 			ivs: ivs,
 			item: item,
 			level: level,
-			shiny: !this.random(1024),
+			shiny: this.randomChance(1, 1024),
 		};
 	}
 
@@ -651,36 +651,36 @@ class RandomGen5Teams extends RandomGen6Teams {
 			switch (tier) {
 			case 'Uber':
 				// Ubers are limited to 2 but have a 20% chance of being added anyway.
-				if (uberCount > 1 && this.random(5) >= 1) continue;
+				if (uberCount > 1 && !this.randomChance(1, 5)) continue;
 				break;
 			case 'NU':
 				// NUs are limited to 2 but have a 20% chance of being added anyway.
-				if (nuCount > 1 && this.random(5) >= 1) continue;
+				if (nuCount > 1 && !this.randomChance(1, 5)) continue;
 			}
 
 			// Adjust rate for species with multiple formes
 			switch (template.baseSpecies) {
 			case 'Arceus':
-				if (this.random(17) >= 1) continue;
+				if (!this.randomChance(1, 17)) continue;
 				break;
 			case 'Rotom':
-				if (this.random(6) >= 1) continue;
+				if (!this.randomChance(1, 6)) continue;
 				break;
 			case 'Genesect':
-				if (this.random(5) >= 1) continue;
+				if (!this.randomChance(1, 5)) continue;
 				break;
 			case 'Castform':
-				if (this.random(4) >= 1) continue;
+				if (!this.randomChance(1, 4)) continue;
 				break;
 			case 'Basculin': case 'Cherrim': case 'Meloetta':
-				if (this.random(2) >= 1) continue;
+				if (!this.randomChance(1, 2)) continue;
 				break;
 			}
 
 			// Limit 2 of any type
 			let skip = false;
 			for (const type of template.types) {
-				if (typeCount[type] > 1 && this.random(5) >= 1) {
+				if (typeCount[type] > 1 && !this.randomChance(1, 5)) {
 					skip = true;
 					break;
 				}

--- a/mods/gen5/random-teams.js
+++ b/mods/gen5/random-teams.js
@@ -481,10 +481,10 @@ class RandomGen5Teams extends RandomGen6Teams {
 		} else if (hasMove['trick'] && hasMove['gyroball']) {
 			item = 'Iron Ball';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomNum = !this.randomChance(1, 2);
-			if (counter.Physical >= 3 && (template.baseStats.spe >= 95 || randomNum)) {
+			let randomBool = !this.randomChance(1, 2);
+			if (counter.Physical >= 3 && (template.baseStats.spe >= 95 || randomBool)) {
 				item = 'Choice Band';
-			} else if (counter.Special >= 3 && (template.baseStats.spe >= 95 || randomNum)) {
+			} else if (counter.Special >= 3 && (template.baseStats.spe >= 95 || randomBool)) {
 				item = 'Choice Specs';
 			} else {
 				item = 'Choice Scarf';

--- a/mods/gen5/random-teams.js
+++ b/mods/gen5/random-teams.js
@@ -371,12 +371,12 @@ class RandomGen5Teams extends RandomGen6Teams {
 		let ability1 = this.getAbility(abilities[1]);
 		let ability2 = this.getAbility(abilities[2]);
 		if (abilities[1]) {
-			if (abilities[2] && ability1.rating <= ability2.rating && !this.randomChance(1, 2)) {
+			if (abilities[2] && ability1.rating <= ability2.rating && this.randomChance(1, 2)) {
 				[ability1, ability2] = [ability2, ability1];
 			}
-			if (ability0.rating <= ability1.rating && !this.randomChance(1, 2)) {
+			if (ability0.rating <= ability1.rating && this.randomChance(1, 2)) {
 				[ability0, ability1] = [ability1, ability0];
-			} else if (ability0.rating - 0.6 <= ability1.rating && !this.randomChance(1, 3)) {
+			} else if (ability0.rating - 0.6 <= ability1.rating && this.randomChance(2, 3)) {
 				[ability0, ability1] = [ability1, ability0];
 			}
 			ability = ability0.name;
@@ -472,7 +472,7 @@ class RandomGen5Teams extends RandomGen6Teams {
 			item = 'Focus Sash';
 		} else if (template.species === 'Unown') {
 			item = 'Choice Specs';
-		} else if (template.species === 'Wobbuffet' && hasMove['destinybond'] && !this.randomChance(1, 2)) {
+		} else if (template.species === 'Wobbuffet' && hasMove['destinybond'] && this.randomChance(1, 2)) {
 			item = 'Custap Berry';
 		} else if (ability === 'Imposter') {
 			item = 'Choice Scarf';
@@ -481,7 +481,7 @@ class RandomGen5Teams extends RandomGen6Teams {
 		} else if (hasMove['trick'] && hasMove['gyroball']) {
 			item = 'Iron Ball';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomBool = !this.randomChance(1, 2);
+			let randomBool = this.randomChance(1, 2);
 			if (counter.Physical >= 3 && (template.baseStats.spe >= 95 || randomBool)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe >= 95 || randomBool)) {
@@ -531,9 +531,9 @@ class RandomGen5Teams extends RandomGen6Teams {
 		} else if (hasMove['lightscreen'] || hasMove['reflect']) {
 			item = 'Light Clay';
 		} else if (counter.Physical >= 4 && !hasMove['fakeout'] && !hasMove['suckerpunch'] && !hasMove['flamecharge'] && !hasMove['rapidspin']) {
-			item = !this.randomChance(1, 3) ? 'Choice Band' : 'Expert Belt';
+			item = this.randomChance(2, 3) ? 'Choice Band' : 'Expert Belt';
 		} else if (counter.Special >= 4) {
-			item = !this.randomChance(1, 3) ? 'Choice Specs' : 'Expert Belt';
+			item = this.randomChance(2, 3) ? 'Choice Specs' : 'Expert Belt';
 		} else if (this.getEffectiveness('Ground', template) >= 2 && ability !== 'Levitate' && !hasMove['magnetrise']) {
 			item = 'Air Balloon';
 		} else if ((hasMove['eruption'] || hasMove['waterspout']) && !counter['Status']) {
@@ -651,36 +651,36 @@ class RandomGen5Teams extends RandomGen6Teams {
 			switch (tier) {
 			case 'Uber':
 				// Ubers are limited to 2 but have a 20% chance of being added anyway.
-				if (uberCount > 1 && !this.randomChance(1, 5)) continue;
+				if (uberCount > 1 && this.randomChance(4, 5)) continue;
 				break;
 			case 'NU':
 				// NUs are limited to 2 but have a 20% chance of being added anyway.
-				if (nuCount > 1 && !this.randomChance(1, 5)) continue;
+				if (nuCount > 1 && this.randomChance(4, 5)) continue;
 			}
 
 			// Adjust rate for species with multiple formes
 			switch (template.baseSpecies) {
 			case 'Arceus':
-				if (!this.randomChance(1, 17)) continue;
+				if (this.randomChance(16, 17)) continue;
 				break;
 			case 'Rotom':
-				if (!this.randomChance(1, 6)) continue;
+				if (this.randomChance(5, 6)) continue;
 				break;
 			case 'Genesect':
-				if (!this.randomChance(1, 5)) continue;
+				if (this.randomChance(4, 5)) continue;
 				break;
 			case 'Castform':
-				if (!this.randomChance(1, 4)) continue;
+				if (this.randomChance(3, 4)) continue;
 				break;
 			case 'Basculin': case 'Cherrim': case 'Meloetta':
-				if (!this.randomChance(1, 2)) continue;
+				if (this.randomChance(1, 2)) continue;
 				break;
 			}
 
 			// Limit 2 of any type
 			let skip = false;
 			for (const type of template.types) {
-				if (typeCount[type] > 1 && !this.randomChance(1, 5)) {
+				if (typeCount[type] > 1 && this.randomChance(4, 5)) {
 					skip = true;
 					break;
 				}

--- a/mods/gen5/random-teams.js
+++ b/mods/gen5/random-teams.js
@@ -371,12 +371,12 @@ class RandomGen5Teams extends RandomGen6Teams {
 		let ability1 = this.getAbility(abilities[1]);
 		let ability2 = this.getAbility(abilities[2]);
 		if (abilities[1]) {
-			if (abilities[2] && ability1.rating <= ability2.rating && this.random(2)) {
+			if (abilities[2] && ability1.rating <= ability2.rating && !this.randomChance(1, 2)) {
 				[ability1, ability2] = [ability2, ability1];
 			}
-			if (ability0.rating <= ability1.rating && this.random(2)) {
+			if (ability0.rating <= ability1.rating && !this.randomChance(1, 2)) {
 				[ability0, ability1] = [ability1, ability0];
-			} else if (ability0.rating - 0.6 <= ability1.rating && this.random(3)) {
+			} else if (ability0.rating - 0.6 <= ability1.rating && !this.randomChance(1, 3)) {
 				[ability0, ability1] = [ability1, ability0];
 			}
 			ability = ability0.name;
@@ -472,7 +472,7 @@ class RandomGen5Teams extends RandomGen6Teams {
 			item = 'Focus Sash';
 		} else if (template.species === 'Unown') {
 			item = 'Choice Specs';
-		} else if (template.species === 'Wobbuffet' && hasMove['destinybond'] && this.random(2)) {
+		} else if (template.species === 'Wobbuffet' && hasMove['destinybond'] && !this.randomChance(1, 2)) {
 			item = 'Custap Berry';
 		} else if (ability === 'Imposter') {
 			item = 'Choice Scarf';
@@ -481,7 +481,7 @@ class RandomGen5Teams extends RandomGen6Teams {
 		} else if (hasMove['trick'] && hasMove['gyroball']) {
 			item = 'Iron Ball';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomNum = this.random(2);
+			let randomNum = !this.randomChance(1, 2);
 			if (counter.Physical >= 3 && (template.baseStats.spe >= 95 || randomNum)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe >= 95 || randomNum)) {
@@ -531,9 +531,9 @@ class RandomGen5Teams extends RandomGen6Teams {
 		} else if (hasMove['lightscreen'] || hasMove['reflect']) {
 			item = 'Light Clay';
 		} else if (counter.Physical >= 4 && !hasMove['fakeout'] && !hasMove['suckerpunch'] && !hasMove['flamecharge'] && !hasMove['rapidspin']) {
-			item = this.random(3) ? 'Choice Band' : 'Expert Belt';
+			item = !this.randomChance(1, 3) ? 'Choice Band' : 'Expert Belt';
 		} else if (counter.Special >= 4) {
-			item = this.random(3) ? 'Choice Specs' : 'Expert Belt';
+			item = !this.randomChance(1, 3) ? 'Choice Specs' : 'Expert Belt';
 		} else if (this.getEffectiveness('Ground', template) >= 2 && ability !== 'Levitate' && !hasMove['magnetrise']) {
 			item = 'Air Balloon';
 		} else if ((hasMove['eruption'] || hasMove['waterspout']) && !counter['Status']) {

--- a/mods/gen5/statuses.js
+++ b/mods/gen5/statuses.js
@@ -37,7 +37,7 @@ exports.BattleStatuses = {
 				return (this.random() * 4294967296 < 1);
 			}
 			this.debug("Success chance: " + Math.round(100 / counter) + "%");
-			return (this.random(counter) === 0);
+			return this.randomChance(1, counter);
 		},
 		onRestart: function () {
 			if (this.effectData.counter < this.effect.counterMax) {

--- a/mods/gen6/random-teams.js
+++ b/mods/gen6/random-teams.js
@@ -948,7 +948,7 @@ class RandomGen6Teams extends RandomTeams {
 			ivs: ivs,
 			item: item,
 			level: level,
-			shiny: !this.random(1024),
+			shiny: this.randomChance(1, 1024),
 		};
 	}
 }

--- a/mods/gen6/random-teams.js
+++ b/mods/gen6/random-teams.js
@@ -758,10 +758,10 @@ class RandomGen6Teams extends RandomTeams {
 			// To perma-taunt a Pokemon by giving it Assault Vest
 			item = 'Assault Vest';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomNum = !this.randomChance(1, 3);
-			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
+			let randomBool = !this.randomChance(1, 3);
+			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Band';
-			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
+			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Specs';
 			} else {
 				item = 'Choice Scarf';

--- a/mods/gen6/random-teams.js
+++ b/mods/gen6/random-teams.js
@@ -23,7 +23,7 @@ class RandomGen6Teams extends RandomTeams {
 			species = template.baseSpecies;
 		}
 		let battleForme = this.checkBattleForme(template);
-		if (battleForme && battleForme.tier !== 'AG' && (battleForme.isMega ? !teamDetails.megaStone : !this.randomChance(1, 2))) {
+		if (battleForme && battleForme.tier !== 'AG' && (battleForme.isMega ? !teamDetails.megaStone : this.randomChance(1, 2))) {
 			template = this.getTemplate(template.otherFormes.length >= 2 ? template.otherFormes[this.random(template.otherFormes.length)] : template.otherFormes[0]);
 		}
 
@@ -604,12 +604,12 @@ class RandomGen6Teams extends RandomTeams {
 		let ability1 = this.getAbility(abilities[1]);
 		let ability2 = this.getAbility(abilities[2]);
 		if (abilities[1]) {
-			if (abilities[2] && ability1.rating <= ability2.rating && !this.randomChance(1, 2)) {
+			if (abilities[2] && ability1.rating <= ability2.rating && this.randomChance(1, 2)) {
 				[ability1, ability2] = [ability2, ability1];
 			}
-			if (ability0.rating <= ability1.rating && !this.randomChance(1, 2)) {
+			if (ability0.rating <= ability1.rating && this.randomChance(1, 2)) {
 				[ability0, ability1] = [ability1, ability0];
-			} else if (ability0.rating - 0.6 <= ability1.rating && !this.randomChance(1, 3)) {
+			} else if (ability0.rating - 0.6 <= ability1.rating && this.randomChance(2, 3)) {
 				[ability0, ability1] = [ability1, ability0];
 			}
 			ability = ability0.name;
@@ -716,7 +716,7 @@ class RandomGen6Teams extends RandomTeams {
 				ability = 'Pickup';
 			} else if (template.baseSpecies === 'Basculin') {
 				ability = 'Adaptability';
-			} else if (template.species === 'Lopunny' && hasMove['switcheroo'] && !this.randomChance(1, 3)) {
+			} else if (template.species === 'Lopunny' && hasMove['switcheroo'] && this.randomChance(2, 3)) {
 				ability = 'Klutz';
 			} else if ((template.species === 'Rampardos' && !hasMove['headsmash']) || hasMove['rockclimb']) {
 				ability = 'Sheer Force';
@@ -758,7 +758,7 @@ class RandomGen6Teams extends RandomTeams {
 			// To perma-taunt a Pokemon by giving it Assault Vest
 			item = 'Assault Vest';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomBool = !this.randomChance(1, 3);
+			let randomBool = this.randomChance(2, 3);
 			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomBool)) {
@@ -814,10 +814,10 @@ class RandomGen6Teams extends RandomTeams {
 		} else if (((ability === 'Speed Boost' && !hasMove['substitute']) || (ability === 'Stance Change')) && counter.Physical + counter.Special > 2) {
 			item = 'Life Orb';
 		} else if (counter.Physical >= 4 && !hasMove['bodyslam'] && !hasMove['dragontail'] && !hasMove['fakeout'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = template.baseStats.atk >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Band';
+			item = template.baseStats.atk >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Band';
 		} else if (counter.Special >= 4 && !hasMove['acidspray'] && !hasMove['chargebeam'] && !hasMove['clearsmog'] && !hasMove['fierydance']) {
-			item = template.baseStats.spa >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Specs';
-		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['uturn'])) && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3)) {
+			item = template.baseStats.spa >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Specs';
+		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['uturn'])) && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3)) {
 			item = 'Choice Scarf';
 		} else if (ability === 'Defeatist' || hasMove['eruption'] || hasMove['waterspout']) {
 			item = counter.Status <= 1 ? 'Expert Belt' : 'Leftovers';
@@ -831,7 +831,7 @@ class RandomGen6Teams extends RandomTeams {
 			item = 'Leftovers';
 		} else if (hasMove['substitute']) {
 			item = !counter['drain'] || counter.damagingMoves.length < 2 ? 'Leftovers' : 'Life Orb';
-		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && !this.randomChance(1, 2)) {
+		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && this.randomChance(1, 2)) {
 			item = 'Rocky Helmet';
 		} else if (counter.Physical + counter.Special >= 4 && template.baseStats.spd >= 65 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd >= 235) {
 			item = 'Assault Vest';

--- a/mods/gen6/random-teams.js
+++ b/mods/gen6/random-teams.js
@@ -23,7 +23,7 @@ class RandomGen6Teams extends RandomTeams {
 			species = template.baseSpecies;
 		}
 		let battleForme = this.checkBattleForme(template);
-		if (battleForme && battleForme.tier !== 'AG' && (battleForme.isMega ? !teamDetails.megaStone : this.random(2))) {
+		if (battleForme && battleForme.tier !== 'AG' && (battleForme.isMega ? !teamDetails.megaStone : !this.randomChance(1, 2))) {
 			template = this.getTemplate(template.otherFormes.length >= 2 ? template.otherFormes[this.random(template.otherFormes.length)] : template.otherFormes[0]);
 		}
 
@@ -604,12 +604,12 @@ class RandomGen6Teams extends RandomTeams {
 		let ability1 = this.getAbility(abilities[1]);
 		let ability2 = this.getAbility(abilities[2]);
 		if (abilities[1]) {
-			if (abilities[2] && ability1.rating <= ability2.rating && this.random(2)) {
+			if (abilities[2] && ability1.rating <= ability2.rating && !this.randomChance(1, 2)) {
 				[ability1, ability2] = [ability2, ability1];
 			}
-			if (ability0.rating <= ability1.rating && this.random(2)) {
+			if (ability0.rating <= ability1.rating && !this.randomChance(1, 2)) {
 				[ability0, ability1] = [ability1, ability0];
-			} else if (ability0.rating - 0.6 <= ability1.rating && this.random(3)) {
+			} else if (ability0.rating - 0.6 <= ability1.rating && !this.randomChance(1, 3)) {
 				[ability0, ability1] = [ability1, ability0];
 			}
 			ability = ability0.name;
@@ -716,7 +716,7 @@ class RandomGen6Teams extends RandomTeams {
 				ability = 'Pickup';
 			} else if (template.baseSpecies === 'Basculin') {
 				ability = 'Adaptability';
-			} else if (template.species === 'Lopunny' && hasMove['switcheroo'] && this.random(3)) {
+			} else if (template.species === 'Lopunny' && hasMove['switcheroo'] && !this.randomChance(1, 3)) {
 				ability = 'Klutz';
 			} else if ((template.species === 'Rampardos' && !hasMove['headsmash']) || hasMove['rockclimb']) {
 				ability = 'Sheer Force';
@@ -758,7 +758,7 @@ class RandomGen6Teams extends RandomTeams {
 			// To perma-taunt a Pokemon by giving it Assault Vest
 			item = 'Assault Vest';
 		} else if (hasMove['switcheroo'] || hasMove['trick']) {
-			let randomNum = this.random(3);
+			let randomNum = !this.randomChance(1, 3);
 			if (counter.Physical >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
 				item = 'Choice Band';
 			} else if (counter.Special >= 3 && (template.baseStats.spe < 60 || template.baseStats.spe > 108 || randomNum)) {
@@ -814,10 +814,10 @@ class RandomGen6Teams extends RandomTeams {
 		} else if (((ability === 'Speed Boost' && !hasMove['substitute']) || (ability === 'Stance Change')) && counter.Physical + counter.Special > 2) {
 			item = 'Life Orb';
 		} else if (counter.Physical >= 4 && !hasMove['bodyslam'] && !hasMove['dragontail'] && !hasMove['fakeout'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = template.baseStats.atk >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.random(3) ? 'Choice Scarf' : 'Choice Band';
+			item = template.baseStats.atk >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Band';
 		} else if (counter.Special >= 4 && !hasMove['acidspray'] && !hasMove['chargebeam'] && !hasMove['clearsmog'] && !hasMove['fierydance']) {
-			item = template.baseStats.spa >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.random(3) ? 'Choice Scarf' : 'Choice Specs';
-		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['uturn'])) && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && this.random(3)) {
+			item = template.baseStats.spa >= 100 && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3) ? 'Choice Scarf' : 'Choice Specs';
+		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['uturn'])) && template.baseStats.spe >= 60 && template.baseStats.spe <= 108 && !counter['priority'] && !this.randomChance(1, 3)) {
 			item = 'Choice Scarf';
 		} else if (ability === 'Defeatist' || hasMove['eruption'] || hasMove['waterspout']) {
 			item = counter.Status <= 1 ? 'Expert Belt' : 'Leftovers';
@@ -831,7 +831,7 @@ class RandomGen6Teams extends RandomTeams {
 			item = 'Leftovers';
 		} else if (hasMove['substitute']) {
 			item = !counter['drain'] || counter.damagingMoves.length < 2 ? 'Leftovers' : 'Life Orb';
-		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && this.random(2)) {
+		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && !this.randomChance(1, 2)) {
 			item = 'Rocky Helmet';
 		} else if (counter.Physical + counter.Special >= 4 && template.baseStats.spd >= 65 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd >= 235) {
 			item = 'Assault Vest';

--- a/mods/gen6/statuses.js
+++ b/mods/gen6/statuses.js
@@ -24,7 +24,7 @@ exports.BattleStatuses = {
 				return;
 			}
 			this.add('-activate', pokemon, 'confusion');
-			if (this.random(2) === 0) {
+			if (this.randomChance(1, 2)) {
 				return;
 			}
 			this.damage(this.getDamage(pokemon, pokemon, 40), pokemon, pokemon, {

--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -124,7 +124,7 @@ exports.BattleAbilities = {
 		},
 		onAfterDamage: function (damage, target, source, move) {
 			if (move && move.flags['contact'] && this.isWeather('hail')) {
-				if (this.random(10) < 3) {
+				if (this.randomChance(3, 10)) {
 					source.trySetStatus('frz', target);
 				}
 			}

--- a/mods/stadium/scripts.js
+++ b/mods/stadium/scripts.js
@@ -172,7 +172,7 @@ exports.BattleScripts = {
 		accuracy = this.runEvent('Accuracy', target, pokemon, move, accuracy);
 
 		// Stadium fixes the 1/256 accuracy bug.
-		if (accuracy !== true && this.random(256) > accuracy) {
+		if (accuracy !== true && !this.randomChance(accuracy + 1, 256)) {
 			this.attrLastMove('[miss]');
 			this.add('-miss', pokemon);
 			damage = false;
@@ -389,7 +389,7 @@ exports.BattleScripts = {
 				// If a move that was not fire-type would exist on Gen 1, it could burn a Pokémon.
 				if (!(secondary.status && ['par', 'brn', 'frz'].includes(secondary.status) && target && target.hasType(move.type))) {
 					let effectChance = Math.floor(secondary.chance * 255 / 100);
-					if (typeof secondary.chance === 'undefined' || this.random(256) <= effectChance) {
+					if (typeof secondary.chance === 'undefined' || this.randomChance(effectChance + 1, 256)) {
 						this.moveHit(target, pokemon, move, secondary, true, isSelf);
 					}
 				}
@@ -508,7 +508,7 @@ exports.BattleScripts = {
 			// We compare our critical hit chance against a random number between 0 and 255.
 			// If the random number is lower, we get a critical hit. This means there is always a 1/255 chance of not hitting critically.
 			if (critChance > 0) {
-				move.crit = (this.random(256) < critChance);
+				move.crit = this.randomChance(critChance, 256);
 			}
 		}
 		// There is a critical hit.

--- a/mods/stadium/statuses.js
+++ b/mods/stadium/statuses.js
@@ -21,7 +21,7 @@ exports.BattleStatuses = {
 		},
 		onBeforeMovePriority: 2,
 		onBeforeMove: function (pokemon) {
-			if (this.random(256) < 63) {
+			if (this.randomChance(63, 256)) {
 				this.add('cant', pokemon, 'par');
 				pokemon.removeVolatile('bide');
 				pokemon.removeVolatile('lockedmovee');

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -2211,7 +2211,7 @@ class Battle extends Dex.ModdedDex {
 		move.crit = move.willCrit || false;
 		if (move.willCrit === undefined) {
 			if (critRatio) {
-				move.crit = (this.random(critMult[critRatio]) === 0);
+				move.crit = this.randomChance(1, critMult[critRatio]);
 			}
 		}
 

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -222,6 +222,14 @@ class Battle extends Dex.ModdedDex {
 		return this.prng.next(m, n);
 	}
 
+	/**
+	 * @param {number} numerator
+	 * @param {number} denominator
+	 */
+	randomChance(numerator, denominator) {
+		return this.prng.randomChance(numerator, denominator);
+	}
+
 	resetRNG() {
 		this.prng = new PRNG(this.prng.startingSeed);
 	}

--- a/sim/prng.js
+++ b/sim/prng.js
@@ -79,6 +79,24 @@ class PRNG {
 	}
 
 	/**
+	 * Flip a coin (two-sided die), returning true or false.
+	 *
+	 * This function returns true with probability `P`, where `P = numerator
+	 * / denominator`. This function returns false with probability `1 - P`.
+         *
+         * The numerator must be a non-negative integer (`>= 0`).
+         *
+         * The denominator must be a positive integer (`> 0`).
+	 *
+	 * @param {number} numerator - the top part of the probability fraction
+	 * @param {number} denominator - the bottom part of the probability fraction
+	 * @return {boolean} - randomly true or false
+	 */
+	randomChance(numerator, denominator) {
+		return this.next(denominator) < numerator;
+	}
+
+	/**
 		The RNG is a Linear Congruential Generator (LCG) in the form: `x_{n + 1} = (a x_n + c) % m`
 
 		Where: `x_0` is the seed, `x_n` is the random number after n iterations,

--- a/test/simulator/misc/prng.js
+++ b/test/simulator/misc/prng.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const PRNG = require('../../../sim/prng');
+const assert = require('../../assert');
+
+const testSeed = [1, 2, 3, 4];
+
+describe(`PRNG`, function () {
+	describe(`randomChance(numerator=0, denominator=1)`, function () {
+		it(`should always return false`, function () {
+			const prng = new PRNG(testSeed);
+			for (let i = 0; i < 100; ++i) {
+				assert.strictEqual(prng.randomChance(0, 1), false);
+			}
+		});
+	});
+	describe(`randomChance(numerator=1, denominator=1)`, function () {
+		it(`should always return true`, function () {
+			const prng = new PRNG(testSeed);
+			for (let i = 0; i < 100; ++i) {
+				assert.strictEqual(prng.randomChance(1, 1), true);
+			}
+		});
+	});
+	describe(`randomChance(numerator=256, denominator=256)`, function () {
+		it(`should always return true`, function () {
+			const prng = new PRNG(testSeed);
+			for (let i = 0; i < 100; ++i) {
+				assert.strictEqual(prng.randomChance(256, 256), true);
+			}
+		});
+	});
+	describe(`randomChance(numerator=1, denominator=2)`, function () {
+		it(`should return true 45-55% of the time`, function () {
+			const prng = new PRNG(testSeed);
+			let trueCount = 0;
+			for (let i = 0; i < 100; ++i) {
+				if (prng.randomChance(1, 2)) {
+					trueCount += 1;
+				}
+			}
+			assert.bounded(trueCount, [45, 55]);
+		});
+		it(`should be identical to (next(2) == 0)`, function () {
+			// This invariant is important for battle logs.
+			const coinPRNG = new PRNG(testSeed);
+			const numberPRNG = new PRNG(testSeed);
+			for (let i = 0; i < 10; ++i) {
+				assert.strictEqual(numberPRNG.next(2) === 0, coinPRNG.randomChance(1, 2));
+			}
+		});
+	});
+	describe(`randomChance(numerator=217, denominator=256)`, function () {
+		it(`should return true 80%-90% of the time`, function () {
+			const prng = new PRNG(testSeed);
+			let trueCount = 0;
+			for (let i = 0; i < 100; ++i) {
+				if (prng.randomChance(217, 256)) {
+					trueCount += 1;
+				}
+			}
+			assert.bounded(trueCount, [80, 90]);
+		});
+		it(`should be identical to (next(256) < 217)`, function () {
+			// This invariant is important for battle logs.
+			const coinPRNG = new PRNG(testSeed);
+			const numberPRNG = new PRNG(testSeed);
+			for (let i = 0; i < 10; ++i) {
+				assert.strictEqual(numberPRNG.next(256) < 217, coinPRNG.randomChance(217, 256));
+			}
+		});
+	});
+});


### PR DESCRIPTION
Often, you just need a random boolean. Throughout Pokemon Showdown's code, there are many creative ways of requesting random booleans. For example:

```js
if (this.random(10) < 3) {
if (this.isWeather(['sunnyday', 'desolateland']) || this.random(2) === 0) {
let shiny = !this.random(1024);
if (uberCount > 1 && this.random(5) >= 1) continue;
if (!this.random(3)) ability = ability1.name;
} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && this.random(2)) {
if (typeof secondary.chance === 'undefined' || this.random(256) <= effectChance) {
if (accuracy !== true && this.random(256) > accuracy) {
```

Enable these methods to converge by introducing the PRNG#randomChance function. It accepts a probability and returns true with that probability.

Notes for reviewers:

* Commits are separated to improve archaeology and bug-finding. For example, the changes made in 8612729 and 6e3ffaf should be behaviour-preserving, but the changes made in 4f3059e possibly affect behaviour. Commit 8612729 contains scripted code modifications which should be safe, but commits 6e3ffaf and 4f3059e were made by hand and and are prone to human error. I recommend rebasing or merging these commits as-is and *not* squashing them into a single commit.
