### PR TITLE
Optimize species-specific effects (e.g. Arceus); 20% overall perf win

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1098,11 +1098,11 @@ class Battle extends Dex.ModdedDex {
 			statuses.push({status: item, callback: item[callbackType], statusData: thing.itemData, end: thing.clearItem, thing: thing});
 			this.resolveLastPriority(statuses, callbackType);
 		}
-		let baseSpecies = this.getEffect(thing.template.baseSpecies);
+		let species = thing.baseTemplate;
 		// @ts-ignore
-		if (baseSpecies[callbackType] !== undefined) {
+		if (species[callbackType] !== undefined) {
 			// @ts-ignore
-			statuses.push({status: baseSpecies, callback: baseSpecies[callbackType], statusData: thing.speciesData, end: function () {}, thing: thing});
+			statuses.push({status: species, callback: species[callbackType], statusData: thing.speciesData, end: function () {}, thing: thing});
 			this.resolveLastPriority(statuses, callbackType);
 		}
 

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -369,6 +369,11 @@ class ModdedDex {
 		}
 		if (id && this.data.Pokedex.hasOwnProperty(id)) {
 			template = new Data.Template({name}, this.data.Pokedex[id], this.data.FormatsData[id], this.data.Learnsets[id]);
+			// Inherit any statuses from the base species (Arceus, Silvally).
+			const baseSpeciesStatuses = this.data.Statuses[toId(template.baseSpecies)];
+			if (baseSpeciesStatuses !== undefined) {
+				Object.assign(template, baseSpeciesStatuses);
+			}
 			if (!template.tier && !template.doublesTier && template.baseSpecies !== template.species) {
 				if (template.baseSpecies === 'Mimikyu') {
 					template.tier = this.data.FormatsData[toId(template.baseSpecies)].tier;

--- a/test/simulator/misc/arceus.js
+++ b/test/simulator/misc/arceus.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('./../../common');
+
+const unimportantPokemon = {species: 'magikarp', moves: ['splash']};
+
+describe(`[Hackmons] Arceus`, function () {
+	it(`in untyped forme should change its type to match the plate held`, function () {
+		const battle = common.gen(4).createBattle([
+			[{species: 'arceus', ability: 'multitype', item: 'flameplate', moves: ['rest']}],
+			[unimportantPokemon],
+		]);
+		assert.deepStrictEqual(battle.p1.active[0].getTypes(), ["Fire"]);
+	});
+
+	it(`in Steel forme should should be Water-typed to match the held Splash Plate`, function () {
+		const battle = common.gen(4).createBattle([
+			[{species: 'arceussteel', ability: 'multitype', item: 'splashplate', moves: ['rest']}],
+			[unimportantPokemon],
+		]);
+		assert.deepStrictEqual(battle.p1.active[0].getTypes(), ["Water"]);
+	});
+
+	it(`in a typed forme should be Normal-typed if no plate is held`, function () {
+		const battle = common.gen(4).createBattle([
+			[{species: 'Arceusfire', ability: 'multitype', item: 'leftovers', moves: ['rest']}],
+			[unimportantPokemon],
+		]);
+		assert.deepStrictEqual(battle.p1.active[0].getTypes(), ["Normal"]);
+	});
+
+	it(`in a typed forme should be Normal-typed despite holding a plate if Arceus does not have the Multitype ability`, function () {
+		const battle = common.gen(4).createBattle([
+			[{species: 'arceusfire', ability: 'truant', item: 'flameplate', moves: ['rest']}],
+			[unimportantPokemon],
+		]);
+		assert.deepStrictEqual(battle.p1.active[0].getTypes(), ["Normal"]);
+	});
+});


### PR DESCRIPTION
Battle#getRelevantEffectsInner performs a lookup for the base species of every Pokemon with ModdedDex#getEffect, then invokes callbacks. The lookup is expensive, and callbacks very rare. In fact, there are only ever two callbacks: one for Arceus (SwitchIn) and one for Silvally (SwitchIn).

Instead of an expensive ModdedDex#getEffect lookup for the callbacks, put the callbacks directly on the Pokemon's Template object.

On my machine, this commit speeds up Pokemon Showdown's tests by 20%.

Methodology: With and without this commit, I ran mocha four times with zsh' 'time' builtin, dropped the first result, and averaged the wall times:

    mocha times before this commit:
    18.20s user 0.33s system 118% cpu 15.704 total
    17.91s user 0.34s system 118% cpu 15.454 total
    18.11s user 0.33s system 118% cpu 15.558 total

    mocha times after this commit:
    15.58s user 0.33s system 122% cpu 13.028 total
    15.32s user 0.33s system 121% cpu 12.890 total
    15.56s user 0.32s system 121% cpu 13.068 total

    Hardware:
    Mid 2012 MacBook Pro
    2.6 GHz Intel Core i7

    Software:
    Node v9.0.0
    macOS 10.10.5
