### PR TITLE
Optimize no-op effects; 11% overall perf win

### DIFF
--- a/sim/dex.js
+++ b/sim/dex.js
@@ -61,6 +61,8 @@ const DATA_FILES = {
 	'Natures': 'natures',
 };
 
+const nullEffect = new Data.PureEffect({name: '', exists: false});
+
 /** @typedef {{id: string, name: string, [k: string]: any}} DexTemplate */
 /** @typedef {{[id: string]: AnyObject}} DexTable */
 
@@ -455,30 +457,33 @@ class ModdedDex {
 	 * @return {Effect}
 	 */
 	getEffect(name) {
-		if (name && typeof name !== 'string') {
+		if (!name) {
+			return nullEffect;
+		}
+		if (typeof name !== 'string') {
 			return name;
 		}
-		if (name && name.startsWith('move:')) {
+		if (name.startsWith('move:')) {
 			return this.getMove(name.slice(5));
-		} else if (name && name.startsWith('item:')) {
+		} else if (name.startsWith('item:')) {
 			return this.getItem(name.slice(5));
-		} else if (name && name.startsWith('ability:')) {
+		} else if (name.startsWith('ability:')) {
 			return this.getAbility(name.slice(8));
 		}
 		let id = toId(name);
 		let effect;
-		if (id && this.data.Statuses.hasOwnProperty(id)) {
+		if (this.data.Statuses.hasOwnProperty(id)) {
 			effect = new Data.PureEffect({name}, this.data.Statuses[id]);
-		} else if (id && this.data.Movedex.hasOwnProperty(id) && this.data.Movedex[id].effect) {
+		} else if (this.data.Movedex.hasOwnProperty(id) && this.data.Movedex[id].effect) {
 			name = this.data.Movedex[id].name || name;
 			effect = new Data.PureEffect({name}, this.data.Movedex[id].effect);
-		} else if (id && this.data.Abilities.hasOwnProperty(id) && this.data.Abilities[id].effect) {
+		} else if (this.data.Abilities.hasOwnProperty(id) && this.data.Abilities[id].effect) {
 			name = this.data.Abilities[id].name || name;
 			effect = new Data.PureEffect({name}, this.data.Abilities[id].effect);
-		} else if (id && this.data.Items.hasOwnProperty(id) && this.data.Items[id].effect) {
+		} else if (this.data.Items.hasOwnProperty(id) && this.data.Items[id].effect) {
 			name = this.data.Items[id].name || name;
 			effect = new Data.PureEffect({name}, this.data.Items[id].effect);
-		} else if (id && this.data.Formats.hasOwnProperty(id)) {
+		} else if (this.data.Formats.hasOwnProperty(id)) {
 			effect = new Data.Format({name}, this.data.Formats[id]);
 		} else if (id === 'recoil') {
 			effect = new Data.PureEffect({name: 'Recoil', effectType: 'Recoil'});


### PR DESCRIPTION
Various functions call ModdedDex#getEffect with null, undefined, or an empty string. For example, in the common case, Battle#getWeather calls getEffect with an empty string. In these cases, getEffect basically returns the same object each time: a PureEffect indicating that no effect with the given name exists.

Creating the dummy PureEffect is expensive and puts pressure on the JavaScript garbage collector. Memoize the creation in getEffect to improve performance.

(As a bonus, special-casing null, undefined, and empty strings also lets us drop some noisy truthiness checks in getEffect.)

On my machine, this commit speeds up Pokemon Showdown's tests by 11%.

Methodology: With and without this commit, I ran mocha four times with zsh' 'time' builtin, dropped the first result, and averaged the wall times:

    mocha times before this commit:
    18.20s user 0.33s system 118% cpu 15.704 total
    17.91s user 0.34s system 118% cpu 15.454 total
    18.11s user 0.33s system 118% cpu 15.558 total

    mocha times after this commit:
    16.53s user 0.35s system 120% cpu 13.994 total
    16.43s user 0.34s system 120% cpu 13.918 total
    16.54s user 0.32s system 120% cpu 14.009 total

    Hardware:
    Mid 2012 MacBook Pro
    2.6 GHz Intel Core i7

    Software:
    Node v9.0.0
    macOS 10.10.5