### PR TITLE
Add unit test for Protective Pads/Mummy interaction

### DIFF
--- a/test/simulator/items/protectivepads.js
+++ b/test/simulator/items/protectivepads.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Protective Pads', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should prevent abilities triggered by contact from acting', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: "Cofagrigus", ability: 'mummy', moves: ['calmmind']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Hariyama", ability: 'thickfat', item: 'protectivepads', moves: ['bulletpunch']}]);
+		const attacker = battle.p2.active[0];
+		battle.commitDecisions();
+		assert.strictEqual(attacker.ability, 'thickfat');
+		const mummyActivationMessages = battle.log.filter(logStr => logStr.startsWith('|-activate|') && logStr.includes('Mummy'));
+		assert.strictEqual(mummyActivationMessages.length, 1, "Mummy should activate only once");
+		assert.ok(mummyActivationMessages[0].includes('Cofagrigus'), "Source of Mummy activation should be included");
+		assert.false(mummyActivationMessages[0].includes('Thick Fat'), "Attacker's ability should not be revealed");
+	});
+});


### PR DESCRIPTION
As per https://github.com/Zarel/Pokemon-Showdown/pull/4447#issuecomment-369892851

I wasn't sure whether to put this with the existing Mummy tests or do add it as a Protective Pads test (which is what it is atm). It tests both general Pads behavior as well as specific Mummy behavior.

I'm not sure if separate tests are wanted for specific kinds of ability effects that Pads blocks (like Iron Barbs) as well as item effects (Rocky Helmet)?