### PR TITLE
Nature Swap: Correctly calculate nature.minus

### DIFF
--- a/mods/natureswap/scripts.js
+++ b/mods/natureswap/scripts.js
@@ -6,7 +6,17 @@ exports.BattleScripts = {
 		let nature = this.getNature(set.nature);
 		for (let statName in modStats) {
 			let stat = stats[statName];
-			modStats[statName] = Math.floor(Math.floor(2 * stat + (nature.plus && statName === nature.minus ? set.ivs[nature.plus] : set.ivs[statName]) + Math.floor((nature.plus && statName === nature.minus ? set.evs[nature.plus] : set.evs[statName]) / 4)) * set.level / 100 + 5);
+			let usedStat = statName;
+			if (nature.plus) {
+				if (statName === nature.minus) {
+					usedStat = nature.plus;
+				} else if (statName === nature.plus) {
+					usedStat = nature.minus;
+				} else {
+					usedStat = statName;
+				}
+			}
+			modStats[statName] = Math.floor(Math.floor(2 * stat + set.ivs[usedStat] + Math.floor(set.evs[usedStat] / 4)) * set.level / 100 + 5);
 		}
 		if ('hp' in stats) {
 			let stat = stats['hp'];

--- a/mods/natureswap/scripts.js
+++ b/mods/natureswap/scripts.js
@@ -12,8 +12,6 @@ exports.BattleScripts = {
 					usedStat = nature.plus;
 				} else if (statName === nature.plus) {
 					usedStat = nature.minus;
-				} else {
-					usedStat = statName;
 				}
 			}
 			modStats[statName] = Math.floor(Math.floor(2 * stat + set.ivs[usedStat] + Math.floor(set.evs[usedStat] / 4)) * set.level / 100 + 5);


### PR DESCRIPTION
This is honestly my fault for only paying attention to the modified `nature.plus` stat, but currently, calculating stats will use the EVs and IVs for `nature.plus` in both the `nature.plus` and `nature.minus` stats