### PR TITLE
Update format links

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -35,7 +35,6 @@ exports.Formats = [
 		name: "[Gen 7] OU",
 		desc: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3621042/">OU Metagame Discussion</a>`,
-			`&bullet; <a href="http://www.smogon.com/forums/threads/3587177/">OU Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3621329/">OU Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3626219/">OU Sample Teams</a>`,
 		],
@@ -60,7 +59,7 @@ exports.Formats = [
 		name: "[Gen 7] UU",
 		desc: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3627043/">UU Metagame Discussion</a>`,
-			`&bullet; <a href="http://www.smogon.com/forums/threads/3620980/">UU Viability Rankings</a>`,
+			`&bullet; <a href="http://www.smogon.com/forums/threads/3626124/">UU Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3621217/">UU Sample Teams</a>`,
 		],
 
@@ -86,7 +85,7 @@ exports.Formats = [
 		desc: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3628085/">NU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3622107/">NU Viability Rankings</a>`,
-			`&bullet; <a href="http://www.smogon.com/forums/threads/3606112/">NU Sample Teams</a>`,
+			`&bullet; <a href="http://www.smogon.com/forums/threads/3612396/">NU Sample Teams</a>`,
 		],
 
 		mod: 'gen7',


### PR DESCRIPTION
* The OU Banlist link is from 2016 and is heavily outdated, and it's inconsistent with other tiers
* The UU Viability Ranking thread was actually outdated
* The NU Sample Teams link was changed because the link currently leads to the NU Bazaar, which is a different thread than NU Sample Teams