### PR TITLE
Fix movesearch for trapping moves

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -1152,7 +1152,8 @@ function runMovesearch(target, cmd, canAll, message) {
 
 			for (let searchStatus in alts.volatileStatus) {
 				let canStatus = !!((dex[move].secondary && dex[move].secondary.volatileStatus === searchStatus) ||
-								   (dex[move].secondaries && dex[move].secondaries.some(entry => entry.volatileStatus === searchStatus)));
+								   (dex[move].secondaries && dex[move].secondaries.some(entry => entry.volatileStatus === searchStatus)) ||
+								   (dex[move].volatileStatus === searchStatus));
 				if (canStatus === alts.volatileStatus[searchStatus]) {
 					matched = true;
 					break;


### PR DESCRIPTION
It was only looking for it in the secondary effects of the move, which partial trapping isn't.