### PR TITLE
Allow UU's suspect test to be playable via challenge

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -73,7 +73,6 @@ exports.Formats = [
 		desc: [`&bullet; <a href="http://www.smogon.com/forums/threads/3630113/">UU Suspect Test</a>`],
 
 		mod: 'gen7',
-		challengeShow: false,
 		ruleset: ['[Gen 7] UU'],
 		unbanlist: ['Slowbro-Mega'],
 	},


### PR DESCRIPTION
@TheImmortal 
this seems to be the case with all suspect ladders that unban a Pokemon for their suspect.