### PR TITLE
Fix reporting of punished alts

### DIFF
--- a/users.js
+++ b/users.js
@@ -1237,12 +1237,14 @@ class User {
 		this.inRooms.clear();
 	}
 	/**
+	 * If this user is included in the returned list of alts (i.e. when forPunishment is true), they will always be the first element of that list.
 	 * @param {boolean} includeTrusted
 	 * @param {boolean} forPunishment
 	 */
 	getAltUsers(includeTrusted, forPunishment) {
 		let alts = findUsers([this.getLastId()], Object.keys(this.ips), {includeTrusted: includeTrusted, forPunishment: forPunishment});
-		if (!forPunishment) alts = alts.filter(user => user !== this);
+		alts = alts.filter(user => user !== this);
+		if (forPunishment) alts.unshift(this);
 		return alts;
 	}
 	getLastName() {


### PR DESCRIPTION
The punishment methods do not impose any order on the affected alts that are returned from them. In particular, the first element is not always the original target user, which the alt list reporting wrongly assumes to always be the case. This can lead to the target user being reported as an alt of itself while an actual alt is missing.

Another possibility would be refactoring the punishents to return {targetUser, alts}, that way the separation would be somewhat enforced and documented.