### PR TITLE
Unit tests: prevent expired battle warning message

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -42,4 +42,6 @@ before('initialization', function () {
 	require('../app');
 
 	LoginServer.disabled = true;
+
+	Ladders.disabled = true;
 });


### PR DESCRIPTION
Every time I run this unit test, as part of the whole suite or separately, I get a warning message and TypeErrors because the battle is destroyed before ``updateRating()`` is done with it (or probably before it's even called).
Adding a slight delay before destroying the battle fixes it for me, but of course it is a rather ugly solution. I'd very much like to enforce the sequence of events programmatically, but there doesn't seem to be a way to have updateRating be called synchronously.