### PR TITLE
Dexsearch: fix error in old gen ds

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -719,7 +719,7 @@ function runDexsearch(target, cmd, canAll, message) {
 		}
 	}
 	let results = [];
-	for (let mon in dex) {
+	for (const mon of Object.keys(dex).sort()) {
 		if (dex[mon].baseSpecies && results.includes(dex[mon].baseSpecies)) continue;
 		results.push(dex[mon].species);
 	}


### PR DESCRIPTION
Currently, for some old gens ds, it is possible to a mon and the base form to appear, such as
![image](https://user-images.githubusercontent.com/22896712/37636764-28bfa280-2bc1-11e8-98af-ddcbb98d690a.png)
This is due to the mods/gen6/pokedex.js file having only a few mons (the lati@s-mega pair being one), and those mons appear earlier in the dex than the base forms, which normally doesn't happen.  This commit sorts the mons before checking for base forms, so it should fix this, and results are sorted at the end anyways so it shouldn't change the order of results.