### PR TITLE
Typescript data/ and config/formats

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -1482,14 +1482,16 @@ exports.commands = {
 			}
 			let formatType = (format.gameType || "singles");
 			formatType = formatType.charAt(0).toUpperCase() + formatType.slice(1).toLowerCase();
-			if (!format.desc) {
+			if (!format.desc && !format.threads) {
 				if (format.effectType === 'Format') {
 					return this.sendReplyBox("No description found for this " + formatType + " " + format.section + " format." + "<br />" + rulesetHtml);
 				} else {
 					return this.sendReplyBox("No description found for this rule." + "<br />" + rulesetHtml);
 				}
 			}
-			return this.sendReplyBox(format.desc.join("<br />") + "<br />" + rulesetHtml);
+			let descHtml = format.desc ? [format.desc] : [];
+			if (format.threads) descHtml = descHtml.concat(format.threads);
+			return this.sendReplyBox(descHtml.join("<br />") + "<br />" + rulesetHtml);
 		}
 
 		let tableStyle = `border:1px solid gray; border-collapse:collapse`;
@@ -1506,7 +1508,9 @@ exports.commands = {
 			for (const section of sections[sectionId].formats) {
 				let format = Dex.getFormat(section);
 				let nameHTML = Chat.escapeHTML(format.name);
-				let descHTML = format.desc ? format.desc.join("<br />") : "&mdash;";
+				let desc = format.desc ? [format.desc] : [];
+				if (format.threads) desc = desc.concat(format.threads);
+				let descHTML = desc.length ? desc.join("<br />") : "&mdash;";
 				buf.push(`<tr><td style="border:1px solid gray">${nameHTML}</td><td style="border: 1px solid gray; margin-left:10px">${descHTML}</td></tr>`);
 			}
 		}

--- a/chat.js
+++ b/chat.js
@@ -1445,6 +1445,7 @@ Chat.getDataPokemonHTML = function (template, gen = 7, tier = '') {
 	}
 	let bst = 0;
 	for (let i in template.baseStats) {
+		// @ts-ignore
 		bst += template.baseStats[i];
 	}
 	buf += '<span style="float:left;min-height:26px">';

--- a/config/formats.js
+++ b/config/formats.js
@@ -3,7 +3,8 @@
 // Note: This is the list of formats
 // The rules that formats use are stored in data/rulesets.js
 
-exports.Formats = [
+/**@type {(FormatsData | {section: string, column?: number})[]} */
+let Formats = [
 
 	// US/UM Singles
 	///////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Random Battle",
-		desc: [
-			`Randomized teams of level-balanced Pok&eacute;mon with sets that are generated to be competitively viable.`,
+		desc: `Randomized teams of level-balanced Pok&eacute;mon with sets that are generated to be competitively viable.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3591157/">Sets and Suggestions</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3616946/">Role Compendium</a>`,
 		],
@@ -33,7 +34,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3621042/">OU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3621329/">OU Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3626219/">OU Sample Teams</a>`,
@@ -45,7 +46,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Ubers",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3587184/">Ubers Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3623296/">Ubers Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3599816/">Ubers Sample Teams</a>`,
@@ -57,7 +58,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] UU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3630113/">UU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3626124/">UU Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3621217/">UU Sample Teams</a>`,
@@ -69,7 +70,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] RU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3625382/">RU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3622740/">RU Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3622057/">RU Sample Teams</a>`,
@@ -82,7 +83,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] NU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3628085/">NU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3622107/">NU Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3612396/">NU Sample Teams</a>`,
@@ -94,7 +95,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] PU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3625646/">PU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3614892/">PU Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3614470/">PU Sample Teams</a>`,
@@ -106,7 +107,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] LC",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3629645/">LC Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/dex/sm/formats/lc/">LC Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3621440/">LC Viability Rankings</a>`,
@@ -123,7 +124,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Monotype",
-		desc: [
+		threads: [
 			`All the Pok&eacute;mon on a team must share a type.`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3621036/">Monotype Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3622349">Monotype Viability Rankings</a>`,
@@ -142,7 +143,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Anything Goes",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3587441/">Anything Goes</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3591711/">AG Resources</a>`,
 		],
@@ -153,7 +154,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] CAP",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3587865/">CAP Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3597893/">CAP Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/7203358/">CAP Sample Teams</a>`,
@@ -165,7 +166,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] CAP LC",
-		desc: [`&bullet; <a href="http://www.smogon.com/forums/threads/3599594/">CAP LC</a>`],
+		threads: [`&bullet; <a href="http://www.smogon.com/forums/threads/3599594/">CAP LC</a>`],
 
 		mod: 'gen7',
 		searchShow: false,
@@ -174,7 +175,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Battle Spot Singles",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3601012/">Introduction to Battle Spot Singles</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3605970/">Battle Spot Singles Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3601658/">Battle Spot Singles Roles Compendium</a>`,
@@ -215,7 +216,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Random Doubles Battle",
-		desc: [`&bullet; <a href="http://www.smogon.com/forums/threads/3601525/">Sets and Suggestions</a>`],
+		threads: [`&bullet; <a href="http://www.smogon.com/forums/threads/3601525/">Sets and Suggestions</a>`],
 
 		mod: 'gen7',
 		gameType: 'doubles',
@@ -224,7 +225,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Doubles OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3629155/">Doubles OU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3623347/">Doubles OU Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3590987/">Doubles OU Sample Teams</a>`,
@@ -245,7 +246,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Doubles UU",
-		desc: [`&bullet; <a href="http://www.smogon.com/forums/threads/3598014/">Doubles UU Metagame Discussion</a>`],
+		threads: [`&bullet; <a href="http://www.smogon.com/forums/threads/3598014/">Doubles UU Metagame Discussion</a>`],
 
 		mod: 'gen7',
 		gameType: 'doubles',
@@ -269,7 +270,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] VGC 2017",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3583926/">VGC 2017 Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3591794/">VGC 2017 Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3590391/">VGC 2017 Sample Teams</a>`,
@@ -290,7 +291,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Battle Spot Doubles",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3595001/">Battle Spot Doubles Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3593890/">Battle Spot Doubles Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3595859/">Battle Spot Doubles Sample Teams</a>`,
@@ -308,7 +309,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Battle Spot Special 9",
-		desc: [`&bullet; <a href="http://www.smogon.com/forums/threads/3629823/">Battle Spot Special 9</a>`],
+		threads: [`&bullet; <a href="http://www.smogon.com/forums/threads/3629823/">Battle Spot Special 9</a>`],
 
 		mod: 'gen7',
 		gameType: 'doubles',
@@ -353,8 +354,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] 2v2 Doubles",
-		desc: [
-			`Double battle where you bring four Pok&eacute;mon to Team Preview and choose only two.`,
+		desc: `Double battle where you bring four Pok&eacute;mon to Team Preview and choose only two.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3606989/">2v2 Doubles</a>`,
 		],
 
@@ -370,8 +371,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Nature Swap",
-		desc: [
-			`Pok&eacute;mon have their base stats swapped depending on their nature.`,
+		desc: `Pok&eacute;mon have their base stats swapped depending on their nature.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3612727/">Nature Swap</a>`,
 		],
 
@@ -385,8 +386,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Balanced Hackmons",
-		desc: [
-			`Anything that can be hacked in-game and is usable in local battles is allowed.`,
+		desc: `Anything that can be hacked in-game and is usable in local battles is allowed.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3587475/">Balanced Hackmons</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3588586/">BH Suspects and Bans Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3593766/">BH Resources</a>`,
@@ -398,8 +399,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] 1v1",
-		desc: [
-			`Bring three Pok&eacute;mon to Team Preview and choose one to battle.`,
+		desc: `Bring three Pok&eacute;mon to Team Preview and choose one to battle.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3587523/">1v1</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3592842/">1v1 Resources</a>`,
 		],
@@ -420,8 +421,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Mix and Mega",
-		desc: [
-			`Mega Stones and Primal Orbs can be used on almost any fully evolved Pok&eacute;mon with no Mega Evolution limit.`,
+		desc: `Mega Stones and Primal Orbs can be used on almost any fully evolved Pok&eacute;mon with no Mega Evolution limit.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3587740/">Mix and Mega</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3591580/">Mix and Mega Resources</a>`,
 		],
@@ -440,9 +441,9 @@ exports.Formats = [
 			for (const set of team) {
 				let item = this.getItem(set.item);
 				if (!item) continue;
-				if (itemTable[item] && item.megaStone) return ["You are limited to one of each Mega Stone.", "(You have more than one " + this.getItem(item).name + ")"];
-				if (itemTable[item] && (item.id === 'blueorb' || item.id === 'redorb')) return ["You are limited to one of each Primal Orb.", "(You have more than one " + this.getItem(item).name + ")"];
-				itemTable[item] = true;
+				if (itemTable[item.id] && item.megaStone) return ["You are limited to one of each Mega Stone.", "(You have more than one " + this.getItem(item).name + ")"];
+				if (itemTable[item.id] && (item.id === 'blueorb' || item.id === 'redorb')) return ["You are limited to one of each Primal Orb.", "(You have more than one " + this.getItem(item).name + ")"];
+				itemTable[item.id] = true;
 			}
 		},
 		onValidateSet: function (set, format) {
@@ -480,8 +481,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Almost Any Ability",
-		desc: [
-			`Pok&eacute;mon can use any ability, barring the few that are restricted to their natural users.`,
+		desc: `Pok&eacute;mon can use any ability, barring the few that are restricted to their natural users.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3587901/">Almost Any Ability</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3595753/">AAA Resources</a>`,
 		],
@@ -500,6 +501,7 @@ exports.Formats = [
 				let template = this.getTemplate(set.species || set.name);
 				let legalAbility = false;
 				for (let i in template.abilities) {
+					// @ts-ignore
 					if (set.ability === template.abilities[i]) legalAbility = true;
 				}
 				if (!legalAbility) return ['The ability ' + set.ability + ' is banned on Pok\u00e9mon that do not naturally have it.'];
@@ -508,8 +510,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Camomons",
-		desc: [
-			`Pok&eacute;mon change type to match their first two moves.`,
+		desc: `Pok&eacute;mon change type to match their first two moves.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3598418/">Camomons</a>`,
 		],
 		mod: 'gen7',
@@ -530,8 +532,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] STABmons",
-		desc: [
-			`Pok&eacute;mon can use any move of their typing, in addition to the moves they can normally learn.`,
+		desc: `Pok&eacute;mon can use any move of their typing, in addition to the moves they can normally learn.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3587949/">STABmons</a>`,
 		],
 
@@ -559,7 +561,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Battle Factory",
-		desc: [`Randomized teams of Pok&eacute;mon for a generated Smogon tier with sets that are competitively viable.`],
+		desc: `Randomized teams of Pok&eacute;mon for a generated Smogon tier with sets that are competitively viable.`,
 
 		mod: 'gen7',
 		team: 'randomFactory',
@@ -567,8 +569,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] BSS Factory",
-		desc: [
-			`Randomized 3v3 Singles featuring Pok&eacute;mon and movesets popular in Battle Spot Singles.`,
+		desc: `Randomized 3v3 Singles featuring Pok&eacute;mon and movesets popular in Battle Spot Singles.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3604845/">Information and Suggestions Thread</a>`,
 		],
 
@@ -612,7 +614,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 7] Hackmons Cup",
-		desc: [`Randomized teams of level-balanced Pok&eacute;mon with absolutely any ability, moves, and item.`],
+		desc: `Randomized teams of level-balanced Pok&eacute;mon with absolutely any ability, moves, and item.`,
 
 		mod: 'gen7',
 		team: 'randomHC',
@@ -636,7 +638,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] Battle Factory",
-		desc: [`Randomized teams of Pok&eacute;mon for a generated Smogon tier with sets that are competitively viable.`],
+		desc: `Randomized teams of Pok&eacute;mon for a generated Smogon tier with sets that are competitively viable.`,
 
 		mod: 'gen6',
 		team: 'randomFactory',
@@ -697,7 +699,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 1] 1v1",
-		desc: [`&bullet; <a href="http://www.smogon.com/forums/posts/7523781/">RBY 1v1</a>`],
+		threads: [`&bullet; <a href="http://www.smogon.com/forums/posts/7523781/">RBY 1v1</a>`],
 
 		mod: 'gen1',
 		teamLength: {
@@ -714,7 +716,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 4] UU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3532624/">DPP UU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3503638/">DPP UU Viability Ranking</a>`,
 		],
@@ -741,7 +743,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/dex/xy/tags/ou/">ORAS OU Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3623399/">ORAS OU Viability Rankings</a>`,
 		],
@@ -752,7 +754,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 5] OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3599678/">BW2 OU Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431094/">BW2 Sample Teams</a>`,
 		],
@@ -763,7 +765,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 4] OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3506147/">DPP OU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3551992/">DPP OU Viability Ranking</a>`,
 		],
@@ -774,7 +776,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 3] OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3503019/">ADV OU Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431087/">ADV Sample Teams</a>`,
 		],
@@ -785,7 +787,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 2] OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3556533/">GSC OU Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431086/">GSC Sample Teams</a>`,
 		],
@@ -796,7 +798,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 1] OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3572352/">RBY OU Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431045/">RBY Sample Teams</a>`,
 		],
@@ -815,7 +817,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] Ubers",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3522911/">ORAS Ubers</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3535106/">ORAS Ubers Viability Rankings</a>`,
 		],
@@ -826,7 +828,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] UU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/dex/xy/tags/uu/">ORAS UU Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3598164/">ORAS UU Viability Rankings</a>`,
 		],
@@ -838,7 +840,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] RU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/dex/xy/tags/ru/">ORAS RU Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3574583/">ORAS RU Viability Rankings</a>`,
 		],
@@ -850,7 +852,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] NU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/dex/xy/tags/nu/">ORAS NU Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3555650/">ORAS NU Viability Rankings</a>`,
 		],
@@ -862,7 +864,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] PU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/dex/xy/tags/pu/">ORAS PU Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3528743/">ORAS PU Viability Rankings</a>`,
 		],
@@ -875,7 +877,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] LC",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/dex/xy/formats/lc/">ORAS LC Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3547566/">ORAS LC Viability Rankings</a>`,
 		],
@@ -888,7 +890,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] Monotype",
-		desc: [`&bullet; <a href="http://www.smogon.com/forums/posts/7421332/">ORAS Monotype</a>`],
+		threads: [`&bullet; <a href="http://www.smogon.com/forums/posts/7421332/">ORAS Monotype</a>`],
 
 		mod: 'gen6',
 		searchShow: false,
@@ -902,7 +904,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] Anything Goes",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3523229/">ORAS Anything Goes</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3548945/">ORAS AG Resources</a>`,
 		],
@@ -914,7 +916,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] CAP",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3537407/">ORAS CAP Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3545628/">ORAS CAP Viability Rankings</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/5594694/">ORAS CAP Sample Teams</a>`,
@@ -926,7 +928,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] Battle Spot Singles",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3527960/">ORAS Battle Spot Singles</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3554616/">ORAS BSS Viability Rankings</a>`,
 		],
@@ -962,7 +964,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] Doubles OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3498688/">ORAS Doubles OU Banlist</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3535930/">ORAS Doubles OU Viability Rankings</a>`,
 		],
@@ -975,7 +977,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] VGC 2016",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3558332/">VGC 2016 Rules</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3580592/">VGC 2016 Viability Rankings</a>`,
 		],
@@ -1006,7 +1008,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] Battle Spot Doubles",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3560820/">ORAS Battle Spot Doubles Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3560824/">ORAS BSD Viability Rankings</a>`,
 		],
@@ -1037,7 +1039,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 6] Battle Spot Triples",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3533914/">ORAS Battle Spot Triples Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3549201/">ORAS BST Viability Rankings</a>`,
 		],
@@ -1075,7 +1077,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 5] Ubers",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3550881/">BW2 Ubers Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6446463/">BW2 Ubers Sample Teams</a>`,
 		],
@@ -1086,7 +1088,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 5] UU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3474024/">BW2 UU Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431094/">BW2 Sample Teams</a>`,
 		],
@@ -1098,7 +1100,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 5] RU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3473124/">BW2 RU Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431094/">BW2 Sample Teams</a>`,
 		],
@@ -1110,7 +1112,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 5] NU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3484121/">BW2 NU Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431094/">BW2 Sample Teams</a>`,
 		],
@@ -1122,7 +1124,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 5] LC",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3485860/">BW2 LC Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431094/">BW2 Sample Teams</a>`,
 		],
@@ -1168,7 +1170,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 5] Doubles OU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3533424/">BW2 Doubles Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3533421/">BW2 Doubles Viability Ranking</a>`,
 		],
@@ -1219,7 +1221,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 4] Ubers",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/posts/7433831/">DPP Ubers Information &amp; Resources</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3505128/">DPP Ubers Viability Ranking</a>`,
 		],
@@ -1231,7 +1233,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 4] NU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3583742/">DPP NU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/3512254/">DPP NU Viability Ranking</a>`,
 		],
@@ -1243,7 +1245,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 4] LC",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/dp/articles/little_cup_guide">DPP LC Guide</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/7336500/">DPP LC Viability Ranking</a>`,
 		],
@@ -1276,7 +1278,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 4] Doubles OU",
-		desc: [`&bullet; <a href="http://www.smogon.com/forums/threads/3618411/">DPP Doubles</a>`],
+		threads: [`&bullet; <a href="http://www.smogon.com/forums/threads/3618411/">DPP Doubles</a>`],
 
 		mod: 'gen4',
 		gameType: 'doubles',
@@ -1308,7 +1310,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 3] Ubers",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/posts/7433832/">ADV Ubers Information &amp; Resources</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3536426/">ADV Ubers Viability Ranking</a>`,
 		],
@@ -1320,7 +1322,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 3] UU",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3585923/">ADV UU Metagame Discussion</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3548578/">ADV UU Viability Rankings</a>`,
 		],
@@ -1349,7 +1351,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 2] Ubers",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/posts/7433879/">GSC Ubers Information &amp; Resources</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431086/">GSC Sample Teams</a>`,
 		],
@@ -1360,7 +1362,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 2] UU",
-		desc: [`&bullet; <a href="http://www.smogon.com/forums/threads/3576710/">GSC UU</a>`],
+		threads: [`&bullet; <a href="http://www.smogon.com/forums/threads/3576710/">GSC UU</a>`],
 
 		mod: 'gen2',
 		searchShow: false,
@@ -1377,7 +1379,7 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 1] Ubers",
-		desc: [
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/forums/threads/3541329/">RBY Ubers Viability Ranking</a>`,
 			`&bullet; <a href="http://www.smogon.com/forums/posts/6431045/">RBY Sample Teams</a>`,
 		],
@@ -1388,8 +1390,8 @@ exports.Formats = [
 	},
 	{
 		name: "[Gen 1] OU (tradeback)",
-		desc: [
-			`RBY OU with movepool additions from the Time Capsule.`,
+		desc: `RBY OU with movepool additions from the Time Capsule.`,
+		threads: [
 			`&bullet; <a href="http://www.smogon.com/articles/rby-tradebacks-ou/">Information</a>`,
 		],
 
@@ -1421,3 +1423,5 @@ exports.Formats = [
 		ruleset: ['Pokemon', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 ];
+
+exports.Formats = Formats;

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -38,7 +38,8 @@ Ratings and how they work:
 
 'use strict';
 
-exports.BattleAbilities = {
+/**@type {{[k: string]: AbilityData}} */
+let BattleAbilities = {
 	"adaptability": {
 		desc: "This Pokemon's moves that match one of its types have a same-type attack bonus (STAB) of 2 instead of 1.5.",
 		shortDesc: "This Pokemon's same-type attack bonus (STAB) is 2 instead of 1.5.",
@@ -309,8 +310,8 @@ exports.BattleAbilities = {
 		shortDesc: "Prevents other Pokemon from lowering this Pokemon's Defense stat stage.",
 		onBoost: function (boost, target, source, effect) {
 			if (source && target === source) return;
-			if (boost['def'] && boost['def'] < 0) {
-				delete boost['def'];
+			if (boost.def && boost.def < 0) {
+				delete boost.def;
 				if (!effect.secondaries) this.add("-fail", target, "unboost", "Defense", "[from] ability: Big Pecks", "[of] " + target);
 			}
 		},
@@ -384,7 +385,9 @@ exports.BattleAbilities = {
 			if (source && target === source) return;
 			let showMsg = false;
 			for (let i in boost) {
+				// @ts-ignore
 				if (boost[i] < 0) {
+					// @ts-ignore
 					delete boost[i];
 					showMsg = true;
 				}
@@ -458,6 +461,7 @@ exports.BattleAbilities = {
 			}
 			let statsLowered = false;
 			for (let i in boost) {
+				// @ts-ignore
 				if (boost[i] < 0) {
 					statsLowered = true;
 				}
@@ -488,6 +492,7 @@ exports.BattleAbilities = {
 		onBoost: function (boost, target, source, effect) {
 			if (effect && effect.id === 'zpower') return;
 			for (let i in boost) {
+				// @ts-ignore
 				boost[i] *= -1;
 			}
 		},
@@ -625,6 +630,7 @@ exports.BattleAbilities = {
 			}
 			let statsLowered = false;
 			for (let i in boost) {
+				// @ts-ignore
 				if (boost[i] < 0) {
 					statsLowered = true;
 				}
@@ -1014,7 +1020,9 @@ exports.BattleAbilities = {
 			if ((source && target === source) || !target.hasType('Grass')) return;
 			let showMsg = false;
 			for (let i in boost) {
+				// @ts-ignore
 				if (boost[i] < 0) {
+					// @ts-ignore
 					delete boost[i];
 					showMsg = true;
 				}
@@ -1083,6 +1091,7 @@ exports.BattleAbilities = {
 		desc: "On switch-in, this Pokemon is alerted to the move with the highest power, at random, known by an opposing Pokemon.",
 		shortDesc: "On switch-in, this Pokemon is alerted to the foes' move with the highest power.",
 		onStart: function (pokemon) {
+			/**@type {(Move|Pokemon)[][]} */
 			let warnMoves = [];
 			let warnBp = 1;
 			for (const target of pokemon.side.foe.active) {
@@ -1145,7 +1154,9 @@ exports.BattleAbilities = {
 			if (source && target === source) return;
 			let showMsg = false;
 			for (let i in boost) {
+				// @ts-ignore
 				if (boost[i] < 0) {
+					// @ts-ignore
 					delete boost[i];
 					showMsg = true;
 				}
@@ -1380,8 +1391,8 @@ exports.BattleAbilities = {
 		shortDesc: "Prevents other Pokemon from lowering this Pokemon's Attack stat stage.",
 		onBoost: function (boost, target, source, effect) {
 			if (source && target === source) return;
-			if (boost['atk'] && boost['atk'] < 0) {
-				delete boost['atk'];
+			if (boost.atk && boost.atk < 0) {
+				delete boost.atk;
 				if (!effect.secondaries) this.add("-fail", target, "unboost", "Attack", "[from] ability: Hyper Cutter", "[of] " + target);
 			}
 		},
@@ -1605,8 +1616,8 @@ exports.BattleAbilities = {
 		shortDesc: "This Pokemon's accuracy can't be lowered by others; ignores their evasiveness stat.",
 		onBoost: function (boost, target, source, effect) {
 			if (source && target === source) return;
-			if (boost['accuracy'] && boost['accuracy'] < 0) {
-				delete boost['accuracy'];
+			if (boost.accuracy && boost.accuracy < 0) {
+				delete boost.accuracy;
 				if (!effect.secondaries) this.add("-fail", target, "unboost", "accuracy", "[from] ability: Keen Eye", "[of] " + target);
 			}
 		},
@@ -2258,9 +2269,11 @@ exports.BattleAbilities = {
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
+			// @ts-ignore
 			if (move.hasParentalBond && ++move.hit > 1) return this.chainModify(0.25);
 		},
 		onSourceModifySecondaries: function (secondaries, target, source, move) {
+			// @ts-ignore
 			if (move.hasParentalBond && move.id === 'secretpower' && move.hit < 2) {
 				// hack to prevent accidentally suppressing King's Rock/Razor Fang
 				return secondaries.filter(effect => effect.volatileStatus === 'flinch');
@@ -2703,6 +2716,7 @@ exports.BattleAbilities = {
 		desc: "This Pokemon does not take recoil damage besides Struggle, Life Orb, and crash damage.",
 		shortDesc: "This Pokemon does not take recoil damage besides Struggle/Life Orb/crash damage.",
 		onDamage: function (damage, target, source, effect) {
+			if (!this.activeMove) throw new Error("Battle.activeMove is null");
 			if (effect.id === 'recoil' && this.activeMove.id !== 'struggle') return null;
 		},
 		id: "rockhead",
@@ -2877,6 +2891,7 @@ exports.BattleAbilities = {
 			if (move.secondaries) {
 				this.debug('doubling secondary chance');
 				for (const secondary of move.secondaries) {
+					// @ts-ignore
 					secondary.chance *= 2;
 				}
 			}
@@ -3030,6 +3045,7 @@ exports.BattleAbilities = {
 		onBoost: function (boost, target, source, effect) {
 			if (effect && effect.id === 'zpower') return;
 			for (let i in boost) {
+				// @ts-ignore
 				boost[i] *= 2;
 			}
 		},
@@ -3041,7 +3057,7 @@ exports.BattleAbilities = {
 	"skilllink": {
 		shortDesc: "This Pokemon's multi-hit attacks always hit the maximum number of times.",
 		onModifyMove: function (move) {
-			if (move.multihit && move.multihit.length) {
+			if (move.multihit && Array.isArray(move.multihit) && move.multihit.length) {
 				move.multihit = move.multihit[1];
 			}
 			if (move.multiaccuracy) {
@@ -3342,6 +3358,7 @@ exports.BattleAbilities = {
 		shortDesc: "This Pokemon cannot lose its held item due to another Pokemon's attack.",
 		onTakeItem: function (item, pokemon, source) {
 			if (this.suppressingAttackEvents() && pokemon !== this.activePokemon || !pokemon.hp || pokemon.item === 'stickybarb') return;
+			if (!this.activeMove) throw new Error("Battle.activeMove is null");
 			if ((source && source !== pokemon) || this.activeMove.id === 'knockoff') {
 				this.add('-activate', pokemon, 'ability: Sticky Hold');
 				return false;
@@ -3507,6 +3524,7 @@ exports.BattleAbilities = {
 		onAllyAfterUseItem: function (item, pokemon) {
 			let sourceItem = this.effectData.target.getItem();
 			if (!sourceItem) return;
+			// @ts-ignore
 			if (!this.singleEvent('TakeItem', item, this.effectData.target.itemData, this.effectData.target, pokemon, this.effectData, item)) return;
 			sourceItem = this.effectData.target.takeItem();
 			if (!sourceItem) {
@@ -3529,6 +3547,7 @@ exports.BattleAbilities = {
 			if (effect && effect.id === 'toxicspikes') return;
 			if (status.id === 'slp' || status.id === 'frz') return;
 			this.add('-activate', target, 'ability: Synchronize');
+			// @ts-ignore
 			source.trySetStatus(status, target, {status: status.id, id: 'synchronize'});
 		},
 		id: "synchronize",
@@ -3555,7 +3574,7 @@ exports.BattleAbilities = {
 		onAfterDamage: function (damage, target, source, effect) {
 			if (effect && effect.flags['contact']) {
 				this.add('-ability', target, 'Tangling Hair');
-				this.boost({spe: -1}, source, target, null, null, true);
+				this.boost({spe: -1}, source, target, null, false, true);
 			}
 		},
 		id: "tanglinghair",
@@ -3968,7 +3987,9 @@ exports.BattleAbilities = {
 			if (source && target === source) return;
 			let showMsg = false;
 			for (let i in boost) {
+				// @ts-ignore
 				if (boost[i] < 0) {
+					// @ts-ignore
 					delete boost[i];
 					showMsg = true;
 				}
@@ -4139,3 +4160,5 @@ exports.BattleAbilities = {
 		num: -4,
 	},
 };
+
+exports.BattleAbilities = BattleAbilities;

--- a/data/aliases.js
+++ b/data/aliases.js
@@ -1,6 +1,7 @@
 'use strict';
 
-exports.BattleAliases = {
+/**@type {{[k: string]: string}} */
+let BattleAliases = {
 	// formats
 	"randbats": "[Gen 7] Random Battle",
 	"uber": "[Gen 7] Ubers",
@@ -841,3 +842,5 @@ exports.BattleAliases = {
 	// there's no need to type out the other Japanese names
 	// I'll autogenerate them at some point
 };
+
+exports.BattleAliases = BattleAliases;

--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1,6 +1,7 @@
 'use strict';
 
-exports.BattleFormatsData = {
+/**@type {{[k: string]: TemplateFormatsData}} */
+let BattleFormatsData = {
 	bulbasaur: {
 		randomBattleMoves: ["sleeppowder", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "sludgebomb", "powerwhip", "leechseed", "synthesis"],
 		randomDoubleBattleMoves: ["sleeppowder", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "sludgebomb", "powerwhip", "protect"],
@@ -7623,3 +7624,5 @@ exports.BattleFormatsData = {
 		tier: "Illegal",
 	},
 };
+
+exports.BattleFormatsData = BattleFormatsData;

--- a/data/items.js
+++ b/data/items.js
@@ -1,6 +1,7 @@
 'use strict';
 
-exports.BattleItems = {
+/**@type {{[k: string]: ItemData}} */
+let BattleItems = {
 	"abomasite": {
 		id: "abomasite",
 		name: "Abomasite",
@@ -2516,7 +2517,9 @@ exports.BattleItems = {
 			basePower: 130,
 		},
 		onEffectiveness: function (typeMod, target, type, move) {
+			// @ts-ignore
 			if (target.volatiles['ingrain'] || target.volatiles['smackdown'] || this.getPseudoWeather('gravity')) return;
+			// @ts-ignore
 			if (move.type === 'Ground' && target.hasType('Flying')) return 0;
 		},
 		// airborneness negation implemented in sim/pokemon.js:Pokemon#isGrounded
@@ -3170,6 +3173,7 @@ exports.BattleItems = {
 			if (this.activeMove.id !== 'knockoff' && this.activeMove.id !== 'thief' && this.activeMove.id !== 'covet') return false;
 		},
 		isUnreleased: true,
+		num: 0,
 		gen: 2,
 		desc: "Cannot be given to or taken from a Pokemon, except by Covet/Knock Off/Thief.",
 	},
@@ -4208,10 +4212,12 @@ exports.BattleItems = {
 		},
 		onAttractPriority: -1,
 		onAttract: function (target, source, effect) {
+			if (!this.activeMove) throw new Error("Battle.activeMove is null");
 			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) return false;
 		},
 		onBoostPriority: -1,
 		onBoost: function (boost, target, source, effect) {
+			if (!this.activeMove) throw new Error("Battle.activeMove is null");
 			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
 				if (effect && effect.effectType === 'Ability') {
 					// Ability activation always happens for boosts
@@ -4222,6 +4228,7 @@ exports.BattleItems = {
 		},
 		onDamagePriority: -1,
 		onDamage: function (damage, target, source, effect) {
+			if (!this.activeMove) throw new Error("Battle.activeMove is null");
 			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
 				if (effect && effect.effectType === 'Ability') {
 					this.add('-activate', source, effect.fullname);
@@ -4231,6 +4238,7 @@ exports.BattleItems = {
 			}
 		},
 		onSetAbility: function (ability, target, source, effect) {
+			if (!this.activeMove) throw new Error("Battle.activeMove is null");
 			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
 				if (effect && effect.effectType === 'Ability') {
 					this.add('-activate', source, effect.fullname);
@@ -4240,6 +4248,7 @@ exports.BattleItems = {
 			}
 		},
 		onSetStatus: function (status, target, source, effect) {
+			if (!this.activeMove) throw new Error("Battle.activeMove is null");
 			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) return false;
 		},
 		num: 880,
@@ -5357,6 +5366,7 @@ exports.BattleItems = {
 		onHit: function (target, source, move) {
 			if (source && source !== target && !source.item && move && move.flags['contact']) {
 				let barb = target.takeItem();
+				// @ts-ignore
 				source.setItem(barb);
 				// no message for Sticky Barb changing hands
 			}
@@ -5898,6 +5908,7 @@ exports.BattleItems = {
 			pokemon.addVolatile('confusion');
 			pokemon.setItem('');
 		},
+		num: 0,
 		gen: 2,
 		isNonstandard: 'gen2',
 		desc: "(Gen 2) On switch-in, raises holder's Attack by 2 and confuses it. Single use.",
@@ -6120,8 +6131,8 @@ exports.BattleItems = {
 			if (pokemon.item !== 'leppaberry') {
 				let foeActive = pokemon.side.foe.active;
 				let foeIsStale = false;
-				for (let i = 0; i < 1; i++) {
-					if (foeActive.isStale >= 2) {
+				for (let i = 0; i < foeActive.length; i++) {
+					if (foeActive[i].isStale >= 2) {
 						foeIsStale = true;
 						break;
 					}
@@ -6231,3 +6242,5 @@ exports.BattleItems = {
 		desc: "If held by a Crucibelle, this item allows it to Mega Evolve in battle.",
 	},
 };
+
+exports.BattleItems = BattleItems;

--- a/data/learnsets.js
+++ b/data/learnsets.js
@@ -1,6 +1,7 @@
 'use strict';
 
-exports.BattleLearnsets = {
+/**@type {{[k: string]: {learnset: {[k: string]: MoveSource[]}}}} */
+let BattleLearnsets = {
 	missingno: {learnset: {
 		blizzard: ["5L1"],
 		bubblebeam: ["5L1"],
@@ -64132,3 +64133,5 @@ exports.BattleLearnsets = {
 		workup: ["7M"],
 	}},
 };
+
+exports.BattleLearnsets = BattleLearnsets;

--- a/data/pokedex.js
+++ b/data/pokedex.js
@@ -1,6 +1,7 @@
 'use strict';
 
-exports.BattlePokedex = {
+/**@type {{[k: string]: TemplateData}} */
+let BattlePokedex = {
 	bulbasaur: {
 		num: 1,
 		species: "Bulbasaur",
@@ -13977,3 +13978,5 @@ exports.BattlePokedex = {
 		eggGroups: ["Undiscovered"],
 	},
 };
+
+exports.BattlePokedex = BattlePokedex;

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -3,7 +3,8 @@
 
 'use strict';
 
-exports.BattleFormats = {
+/**@type {{[k: string]: FormatsData}} */
+let BattleFormats = {
 
 	// Rulesets
 	///////////////////////////////////////////////////////////////////
@@ -11,28 +12,28 @@ exports.BattleFormats = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',
-		desc: ["The standard ruleset for all offical Smogon singles tiers (Ubers, OU, etc.)"],
+		desc: "The standard ruleset for all offical Smogon singles tiers (Ubers, OU, etc.)",
 		ruleset: ['Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Moody Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Unreleased', 'Illegal'],
 	},
 	standardnext: {
 		effectType: 'ValidatorRule',
 		name: 'Standard NEXT',
-		desc: ["The standard ruleset for the NEXT mod"],
+		desc: "The standard ruleset for the NEXT mod",
 		ruleset: ['Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Illegal', 'Soul Dew'],
 	},
 	standardubers: {
 		effectType: 'ValidatorRule',
 		name: 'Standard Ubers',
-		desc: ["The standard ruleset for [Gen 5] Ubers"],
+		desc: "The standard ruleset for [Gen 5] Ubers",
 		ruleset: ['Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'Moody Clause', 'OHKO Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Unreleased', 'Illegal'],
 	},
 	standardgbu: {
 		effectType: 'ValidatorRule',
 		name: 'Standard GBU',
-		desc: ["The standard ruleset for all official in-game Pok&eacute;mon tournaments and Battle Spot"],
+		desc: "The standard ruleset for all official in-game Pok&eacute;mon tournaments and Battle Spot",
 		ruleset: ['Species Clause', 'Nickname Clause', 'Item Clause', 'Team Preview', 'Cancel Mod'],
 		banlist: ['Unreleased', 'Illegal', 'Battle Bond',
 			'Mewtwo', 'Mew',
@@ -52,7 +53,7 @@ exports.BattleFormats = {
 	minimalgbu: {
 		effectType: 'ValidatorRule',
 		name: 'Minimal GBU',
-		desc: ["The standard ruleset for official tournaments, but without Restricted Legendary bans"],
+		desc: "The standard ruleset for official tournaments, but without Restricted Legendary bans",
 		ruleset: ['Species Clause', 'Nickname Clause', 'Item Clause', 'Cancel Mod'],
 		banlist: ['Unreleased', 'Illegal', 'Battle Bond',
 			'Mew',
@@ -72,14 +73,14 @@ exports.BattleFormats = {
 	standarddoubles: {
 		effectType: 'ValidatorRule',
 		name: 'Standard Doubles',
-		desc: ["The standard ruleset for all official Smogon doubles tiers"],
+		desc: "The standard ruleset for all official Smogon doubles tiers",
 		ruleset: ['Species Clause', 'Nickname Clause', 'OHKO Clause', 'Moody Clause', 'Evasion Abilities Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Unreleased', 'Illegal'],
 	},
 	pokemon: {
 		effectType: 'ValidatorRule',
 		name: 'Pokemon',
-		desc: ["Applies the basic limitations of pokemon games: level 100, 6 pokemon, 4 moves, no CAP, no future-gen pokemon/moves/etc - but does not include illegal move/ability validation"],
+		desc: "Applies the basic limitations of pokemon games: level 100, 6 pokemon, 4 moves, no CAP, no future-gen pokemon/moves/etc - but does not include illegal move/ability validation",
 		onValidateTeam: function (team, format) {
 			let problems = [];
 			if (team.length > 6) problems.push('Your team has more than six Pok\u00E9mon.');
@@ -173,12 +174,18 @@ exports.BattleFormats = {
 				}
 			}
 
-			for (let k in set.evs) {
-				if (typeof set.evs[k] !== 'number' || set.evs[k] < 0) {
-					set.evs[k] = 0;
+			if (set.evs) {
+				for (let k in set.evs) {
+					// @ts-ignore
+					if (typeof set.evs[k] !== 'number' || set.evs[k] < 0) {
+						// @ts-ignore
+						set.evs[k] = 0;
+					}
+					// @ts-ignore
+					totalEV += set.evs[k];
 				}
-				totalEV += set.evs[k];
 			}
+
 			if (this.gen <= 1) {
 				if (set.evs) set.evs['spd'] = set.evs['spa'];
 				if (set.ivs) set.ivs['spd'] = set.ivs['spa'];
@@ -214,6 +221,7 @@ exports.BattleFormats = {
 				template.species !== 'Unown' && template.baseSpecies !== 'Pikachu' && (template.baseSpecies !== 'Diancie' || !set.shiny)) {
 				let perfectIVs = 0;
 				for (let i in set.ivs) {
+					// @ts-ignore
 					if (set.ivs[i] >= 31) perfectIVs++;
 				}
 				let reason = (format.requirePentagon ? " and this format requires gen " + this.gen + " Pokémon" : " in gen 6");
@@ -286,6 +294,7 @@ exports.BattleFormats = {
 					// Ensure that the ability is (still) legal.
 					let legalAbility = false;
 					for (let i in template.abilities) {
+						// @ts-ignore
 						if (template.abilities[i] !== set.ability) continue;
 						legalAbility = true;
 						break;
@@ -302,7 +311,7 @@ exports.BattleFormats = {
 	hoennpokedex: {
 		effectType: 'ValidatorRule',
 		name: 'Hoenn Pokedex',
-		desc: ["Only allows Pok&eacute;mon native to the Hoenn region (OR/AS)"],
+		desc: "Only allows Pok&eacute;mon native to the Hoenn region (OR/AS)",
 		onValidateSet: function (set, format) {
 			let hoennDex = [
 				"Abra", "Absol", "Aggron", "Alakazam", "Altaria", "Anorith", "Armaldo", "Aron", "Azumarill", "Azurill", "Bagon", "Baltoy", "Banette", "Barboach", "Beautifly", "Beldum", "Bellossom", "Blaziken", "Breloom", "Budew", "Cacnea", "Cacturne", "Camerupt", "Carvanha", "Cascoon", "Castform", "Chimecho", "Chinchou", "Chingling", "Clamperl", "Claydol", "Combusken", "Corphish", "Corsola", "Cradily", "Crawdaunt", "Crobat", "Delcatty", "Dodrio", "Doduo", "Donphan", "Dusclops", "Dusknoir", "Duskull", "Dustox", "Electrike", "Electrode", "Exploud", "Feebas", "Flygon", "Froslass", "Gallade", "Gardevoir", "Geodude", "Girafarig", "Glalie", "Gloom", "Golbat", "Goldeen", "Golduck", "Golem", "Gorebyss", "Graveler", "Grimer", "Grovyle", "Grumpig", "Gulpin", "Gyarados", "Hariyama", "Heracross", "Horsea", "Huntail", "Igglybuff", "Illumise", "Jigglypuff", "Kadabra", "Kecleon", "Kingdra", "Kirlia", "Koffing", "Lairon", "Lanturn", "Latias", "Latios", "Lileep", "Linoone", "Lombre", "Lotad", "Loudred", "Ludicolo", "Lunatone", "Luvdisc", "Machamp", "Machoke", "Machop", "Magcargo", "Magikarp", "Magnemite", "Magneton", "Magnezone", "Makuhita", "Manectric", "Marill", "Marshtomp", "Masquerain", "Mawile", "Medicham", "Meditite", "Metagross", "Metang", "Mightyena", "Milotic", "Minun", "Mudkip", "Muk", "Natu", "Nincada", "Ninetales", "Ninjask", "Nosepass", "Numel", "Nuzleaf", "Oddish", "Pelipper", "Phanpy", "Pichu", "Pikachu", "Pinsir", "Plusle", "Poochyena", "Probopass", "Psyduck", "Raichu", "Ralts", "Regice", "Regirock", "Registeel", "Relicanth", "Rhydon", "Rhyhorn", "Rhyperior", "Roselia", "Roserade", "Sableye", "Salamence", "Sandshrew", "Sandslash", "Sceptile", "Seadra", "Seaking", "Sealeo", "Seedot", "Seviper", "Sharpedo", "Shedinja", "Shelgon", "Shiftry", "Shroomish", "Shuppet", "Silcoon", "Skarmory", "Skitty", "Slaking", "Slakoth", "Slugma", "Snorunt", "Solrock", "Spheal", "Spinda", "Spoink", "Starmie", "Staryu", "Surskit", "Swablu", "Swalot", "Swampert", "Swellow", "Taillow", "Tentacool", "Tentacruel", "Torchic", "Torkoal", "Trapinch", "Treecko", "Tropius", "Vibrava", "Vigoroth", "Vileplume", "Volbeat", "Voltorb", "Vulpix", "Wailmer", "Wailord", "Walrein", "Weezing", "Whiscash", "Whismur", "Wigglytuff", "Wingull", "Wobbuffet", "Wurmple", "Wynaut", "Xatu", "Zangoose", "Zigzagoon", "Zubat",
@@ -316,7 +325,7 @@ exports.BattleFormats = {
 	sinnohpokedex: {
 		effectType: 'ValidatorRule',
 		name: 'Sinnoh Pokedex',
-		desc: ["Only allows Pok&eacute;mon native to the Sinnoh region (Platinum)"],
+		desc: "Only allows Pok&eacute;mon native to the Sinnoh region (Platinum)",
 		onValidateSet: function (set, format) {
 			let sinnohDex = [
 				"Turtwig", "Grotle", "Torterra", "Chimchar", "Monferno", "Infernape", "Piplup", "Prinplup", "Empoleon", "Starly", "Staravia", "Staraptor", "Bidoof", "Bibarel", "Kricketot", "Kricketune", "Shinx", "Luxio", "Luxray", "Abra", "Kadabra", "Alakazam", "Magikarp", "Gyarados", "Budew", "Roselia", "Roserade", "Zubat", "Golbat", "Crobat", "Geodude", "Graveler", "Golem", "Onix", "Steelix", "Cranidos", "Rampardos", "Shieldon", "Bastiodon", "Machop", "Machoke", "Machamp", "Psyduck", "Golduck", "Burmy", "Wormadam", "Mothim", "Wurmple", "Silcoon", "Beautifly", "Cascoon", "Dustox", "Combee", "Vespiquen", "Pachirisu", "Buizel", "Floatzel", "Cherubi", "Cherrim", "Shellos", "Gastrodon", "Heracross", "Aipom", "Ambipom", "Drifloon", "Drifblim", "Buneary", "Lopunny", "Gastly", "Haunter", "Gengar", "Misdreavus", "Mismagius", "Murkrow", "Honchkrow", "Glameow", "Purugly", "Goldeen", "Seaking", "Barboach", "Whiscash", "Chingling", "Chimecho", "Stunky", "Skuntank", "Meditite", "Medicham", "Bronzor", "Bronzong", "Ponyta", "Rapidash", "Bonsly", "Sudowoodo", "Mime Jr.", "Mr. Mime", "Happiny", "Chansey", "Blissey", "Cleffa", "Clefairy", "Clefable", "Chatot", "Pichu", "Pikachu", "Raichu", "Hoothoot", "Noctowl", "Spiritomb", "Gible", "Gabite", "Garchomp", "Munchlax", "Snorlax", "Unown", "Riolu", "Lucario", "Wooper", "Quagsire", "Wingull", "Pelipper", "Girafarig", "Hippopotas", "Hippowdon", "Azurill", "Marill", "Azumarill", "Skorupi", "Drapion", "Croagunk", "Toxicroak", "Carnivine", "Remoraid", "Octillery", "Finneon", "Lumineon", "Tentacool", "Tentacruel", "Feebas", "Milotic", "Mantyke", "Mantine", "Snover", "Abomasnow", "Sneasel", "Weavile", "Uxie", "Mesprit", "Azelf", "Dialga", "Palkia", "Manaphy", "Rotom", "Gligar", "Gliscor", "Nosepass", "Probopass", "Ralts", "Kirlia", "Gardevoir", "Gallade", "Lickitung", "Lickilicky", "Eevee", "Vaporeon", "Jolteon", "Flareon", "Espeon", "Umbreon", "Leafeon", "Glaceon", "Swablu", "Altaria", "Togepi", "Togetic", "Togekiss", "Houndour", "Houndoom", "Magnemite", "Magneton", "Magnezone", "Tangela", "Tangrowth", "Yanma", "Yanmega", "Tropius", "Rhyhorn", "Rhydon", "Rhyperior", "Duskull", "Dusclops", "Dusknoir", "Porygon", "Porygon2", "Porygon-Z", "Scyther", "Scizor", "Elekid", "Electabuzz", "Electivire", "Magby", "Magmar", "Magmortar", "Swinub", "Piloswine", "Mamoswine", "Snorunt", "Glalie", "Froslass", "Absol", "Giratina",
@@ -330,7 +339,7 @@ exports.BattleFormats = {
 	alolapokedex: {
 		effectType: 'ValidatorRule',
 		name: 'Alola Pokedex',
-		desc: ["Only allows Pok&eacute;mon native to the Alola region (US/UM)"],
+		desc: "Only allows Pok&eacute;mon native to the Alola region (US/UM)",
 		onValidateSet: function (set, format) {
 			let alolaDex = [
 				"Rowlet", "Dartrix", "Decidueye", "Litten", "Torracat", "Incineroar", "Popplio", "Brionne", "Primarina", "Pikipek", "Trumbeak", "Toucannon", "Yungoos", "Gumshoos", "Rattata-Alola", "Raticate-Alola", "Caterpie", "Metapod", "Butterfree", "Ledyba", "Ledian", "Spinarak", "Ariados", "Buneary", "Lopunny", "Inkay", "Malamar", "Zorua", "Zoroark", "Furfrou", "Pichu", "Pikachu", "Raichu-Alola", "Grubbin", "Charjabug", "Vikavolt", "Bonsly", "Sudowoodo", "Happiny", "Chansey", "Blissey", "Munchlax", "Snorlax", "Slowpoke", "Slowbro", "Slowking", "Wingull", "Pelipper", "Abra", "Kadabra", "Alakazam", "Meowth-Alola", "Persian-Alola", "Magnemite", "Magneton", "Magnezone", "Grimer-Alola", "Muk-Alola", "Mime Jr.", "Mr. Mime", "Ekans", "Arbok", "Dunsparce", "Growlithe", "Arcanine", "Drowzee", "Hypno", "Makuhita", "Hariyama", "Smeargle", "Crabrawler", "Crabominable", "Gastly", "Haunter", "Gengar", "Drifloon", "Drifblim", "Murkrow", "Honchkrow", "Zubat", "Golbat", "Crobat", "Noibat", "Noivern", "Diglett-Alola", "Dugtrio-Alola", "Spearow", "Fearow", "Rufflet", "Braviary", "Vullaby", "Mandibuzz", "Mankey", "Primeape", "Delibird", "Hawlucha", "Oricorio", "Cutiefly", "Ribombee", "Flabe\u0301be\u0301", "Floette", "Florges", "Petilil", "Lilligant", "Cottonee", "Whimsicott", "Psyduck", "Golduck", "Smoochum", "Jynx", "Magikarp", "Gyarados", "Barboach", "Whiscash", "Seal", "Dewgong", "Machop", "Machoke", "Machamp", "Roggenrola", "Boldore", "Gigalith", "Carbink", "Sableye", "Mawile", "Rockruff", "Lycanroc", "Spinda", "Tentacool", "Tentacruel", "Finneon", "Lumineon", "Wishiwashi", "Luvdisc", "Corsola", "Mareanie", "Toxapex", "Shellder", "Cloyster", "Clamperl", "Huntail", "Gorebyss", "Remoraid", "Octillery", "Mantyke", "Mantine", "Bagon", "Shelgon", "Salamence", "Lillipup", "Herdier", "Stoutland", "Eevee", "Vaporeon", "Jolteon", "Flareon", "Espeon", "Umbreon", "Leafeon", "Glaceon", "Sylveon", "Mareep", "Flaaffy", "Ampharos", "Mudbray", "Mudsdale", "Igglybuff", "Jigglypuff", "Wigglytuff", "Tauros", "Miltank", "Surskit", "Masquerain", "Dewpider", "Araquanid", "Fomantis", "Lurantis", "Morelull", "Shiinotic", "Paras", "Parasect", "Poliwag", "Poliwhirl", "Poliwrath", "Politoed", "Goldeen", "Seaking", "Basculin", "Feebas", "Milotic", "Alomomola", "Fletchling", "Fletchinder", "Talonflame", "Salandit", "Salazzle", "Cubone", "Marowak-Alola", "Kangaskhan", "Magby", "Magmar", "Magmortar", "Larvesta", "Volcarona", "Stufful", "Bewear", "Bounsweet", "Steenee", "Tsareena", "Comfey", "Pinsir", "Hoothoot", "Noctowl", "Kecleon", "Oranguru", "Passimian", "Goomy", "Sliggoo", "Goodra", "Castform", "Wimpod", "Golisopod", "Staryu", "Starmie", "Sandygast", "Palossand", "Omanyte", "Omastar", "Kabuto", "Kabutops", "Lileep", "Cradily", "Anorith", "Armaldo", "Cranidos", "Rampardos", "Shieldon", "Bastiodon", "Tirtouga", "Carracosta", "Archen", "Archeops", "Tyrunt", "Tyrantrum", "Amaura", "Aurorus", "Pupitar", "Larvitar", "Tyranitar", "Phantump", "Trevenant", "Natu", "Xatu", "Nosepass", "Probopass", "Pyukumuku", "Chinchou", "Lanturn", "Type: Null", "Silvally", "Poipole", "Naganadel", "Zygarde", "Trubbish", "Garbodor", "Minccino", "Cinccino", "Pineco", "Forretress", "Skarmory", "Ditto", "Cleffa", "Clefairy", "Clefable", "Elgyem", "Beheeyem", "Minior", "Beldum", "Metang", "Metagross", "Porygon", "Porygon2", "Porygon-Z", "Pancham", "Pangoro", "Komala", "Torkoal", "Turtonator", "Houndour", "Houndoom", "Dedenne", "Togedemaru", "Electrike", "Manectric", "Elekid", "Electabuzz", "Electivire", "Geodude-Alola", "Graveler-Alola", "Golem-Alola", "Sandile", "Krokorok", "Krookodile", "Trapinch", "Vibrava", "Flygon", "Gible", "Gabite", "Garchomp", "Baltoy", "Claydol", "Golett", "Golurk", "Klefki", "Mimikyu", "Shuppet", "Banette", "Frillish", "Jellicent", "Bruxish", "Drampa", "Absol", "Snorunt", "Glalie", "Froslass", "Sneasel", "Weavile", "Sandshrew-Alola", "Sandslash-Alola", "Vulpix-Alola", "Ninetales-Alola", "Vanillite", "Vanillish", "Vanilluxe", "Scraggy", "Scrafty", "Pawniard", "Bisharp", "Snubbull", "Granbull", "Shellos", "Gastrodon", "Relicanth", "Dhelmise", "Carvanha", "Sharpedo", "Skrelp", "Dragalge", "Clauncher", "Clawitzer", "Wailmer", "Wailord", "Lapras", "Tropius", "Exeggcute", "Exeggutor-Alola", "Corphish", "Crawdaunt", "Mienfoo", "Mienshao", "Jangmo-o", "Hakamo-o", "Kommo-o", "Emolga", "Scyther", "Scizor", "Heracross", "Aipom", "Ampibom", "Litleo", "Pyroar", "Misdreavus", "Mismagius", "Druddigon", "Lickitung", "Lickilicky", "Riolu", "Lucario", "Dratini", "Dragonair", "Dragonite", "Aerodactyl", "Tapu Koko", "Tapu Lele", "Tapu Bulu", "Tapu Fini", "Cosmog", "Cosmoem", "Solgaleo", "Lunala", "Nihilego", "Stakataka", "Blacephalon", "Buzzwole", "Pheromosa", "Xurkitree", "Celesteela", "Kartana", "Guzzlord", "Necrozma", "Magearna", "Marshadow", "Zeraora",
@@ -353,7 +362,7 @@ exports.BattleFormats = {
 	teampreview: {
 		effectType: 'Rule',
 		name: 'Team Preview',
-		desc: ["Allows each player to see the Pok&eacute;mon on their opponent's team before they choose their lead Pok&eacute;mon"],
+		desc: "Allows each player to see the Pok&eacute;mon on their opponent's team before they choose their lead Pok&eacute;mon",
 		onStartPriority: -10,
 		onStart: function () {
 			this.add('clearpoke');
@@ -371,7 +380,7 @@ exports.BattleFormats = {
 	littlecup: {
 		effectType: 'ValidatorRule',
 		name: 'Little Cup',
-		desc: ["Only allows Pok&eacute;mon that can evolve and don't have any prior evolutions"],
+		desc: "Only allows Pok&eacute;mon that can evolve and don't have any prior evolutions",
 		onValidateSet: function (set) {
 			let template = this.getTemplate(set.species || set.name);
 			if (template.prevo) {
@@ -385,7 +394,7 @@ exports.BattleFormats = {
 	speciesclause: {
 		effectType: 'ValidatorRule',
 		name: 'Species Clause',
-		desc: ["Prevents teams from having more than one Pok&eacute;mon from the same species"],
+		desc: "Prevents teams from having more than one Pok&eacute;mon from the same species",
 		onStart: function () {
 			this.add('rule', 'Species Clause: Limit one of each Pokémon');
 		},
@@ -403,7 +412,7 @@ exports.BattleFormats = {
 	nicknameclause: {
 		effectType: 'ValidatorRule',
 		name: 'Nickname Clause',
-		desc: ["Prevents teams from having more than one Pok&eacute;mon with the same nickname"],
+		desc: "Prevents teams from having more than one Pok&eacute;mon with the same nickname",
 		onValidateTeam: function (team, format) {
 			let nameTable = {};
 			for (const set of team) {
@@ -423,7 +432,7 @@ exports.BattleFormats = {
 	itemclause: {
 		effectType: 'ValidatorRule',
 		name: 'Item Clause',
-		desc: ["Prevents teams from having more than one Pok&eacute;mon with the same item"],
+		desc: "Prevents teams from having more than one Pok&eacute;mon with the same item",
 		onStart: function () {
 			this.add('rule', 'Item Clause: Limit one of each item');
 		},
@@ -442,7 +451,7 @@ exports.BattleFormats = {
 	abilityclause: {
 		effectType: 'ValidatorRule',
 		name: 'Ability Clause',
-		desc: ["Prevents teams from having more than two Pok&eacute;mon with the same ability"],
+		desc: "Prevents teams from having more than two Pok&eacute;mon with the same ability",
 		onStart: function () {
 			this.add('rule', 'Ability Clause: Limit two of each ability');
 		},
@@ -481,7 +490,7 @@ exports.BattleFormats = {
 	ohkoclause: {
 		effectType: 'ValidatorRule',
 		name: 'OHKO Clause',
-		desc: ["Bans all OHKO moves, such as Fissure"],
+		desc: "Bans all OHKO moves, such as Fissure",
 		onStart: function () {
 			this.add('rule', 'OHKO Clause: OHKO moves are banned');
 		},
@@ -499,7 +508,7 @@ exports.BattleFormats = {
 	evasionabilitiesclause: {
 		effectType: 'ValidatorRule',
 		name: 'Evasion Abilities Clause',
-		desc: ["Bans abilities that boost Evasion under certain weather conditions"],
+		desc: "Bans abilities that boost Evasion under certain weather conditions",
 		banlist: ['Sand Veil', 'Snow Cloak'],
 		onStart: function () {
 			this.add('rule', 'Evasion Abilities Clause: Evasion abilities are banned');
@@ -508,7 +517,7 @@ exports.BattleFormats = {
 	evasionmovesclause: {
 		effectType: 'ValidatorRule',
 		name: 'Evasion Moves Clause',
-		desc: ["Bans moves that consistently raise the user's evasion when used"],
+		desc: "Bans moves that consistently raise the user's evasion when used",
 		banlist: ['Minimize', 'Double Team'],
 		onStart: function () {
 			this.add('rule', 'Evasion Moves Clause: Evasion moves are banned');
@@ -517,7 +526,7 @@ exports.BattleFormats = {
 	endlessbattleclause: {
 		effectType: 'Rule',
 		name: 'Endless Battle Clause',
-		desc: ["Prevents players from forcing a battle which their opponent cannot end except by forfeit"],
+		desc: "Prevents players from forcing a battle which their opponent cannot end except by forfeit",
 		// implemented in sim/battle.js
 
 		// A Pokémon has a confinement counter, which starts at 0:
@@ -549,7 +558,7 @@ exports.BattleFormats = {
 	moodyclause: {
 		effectType: 'ValidatorRule',
 		name: 'Moody Clause',
-		desc: ["Bans the ability Moody"],
+		desc: "Bans the ability Moody",
 		banlist: ['Moody'],
 		onStart: function () {
 			this.add('rule', 'Moody Clause: Moody is banned');
@@ -558,7 +567,7 @@ exports.BattleFormats = {
 	swaggerclause: {
 		effectType: 'ValidatorRule',
 		name: 'Swagger Clause',
-		desc: ["Bans the move Swagger"],
+		desc: "Bans the move Swagger",
 		banlist: ['Swagger'],
 		onStart: function () {
 			this.add('rule', 'Swagger Clause: Swagger is banned');
@@ -567,7 +576,7 @@ exports.BattleFormats = {
 	batonpassclause: {
 		effectType: 'ValidatorRule',
 		name: 'Baton Pass Clause',
-		desc: ["Stops teams from having more than one Pok&eacute;mon with Baton Pass, and no Pok&eacute;mon may be capable of passing boosts to both Speed and another stat"],
+		desc: "Stops teams from having more than one Pok&eacute;mon with Baton Pass, and no Pok&eacute;mon may be capable of passing boosts to both Speed and another stat",
 		banlist: ["Baton Pass > 1"],
 		onStart: function () {
 			this.add('rule', 'Baton Pass Clause: Limit one Baton Passer, can\'t pass Spe and other stats simultaneously');
@@ -577,22 +586,26 @@ exports.BattleFormats = {
 
 			let item = this.getItem(set.item);
 			let ability = toId(set.ability);
+			/**@type {boolean | string} */
 			let speedBoosted = false;
+			/**@type {boolean | string} */
 			let nonSpeedBoosted = false;
 
 			for (const moveId of set.moves) {
 				let move = this.getMove(moveId);
-				if (move.id === 'flamecharge' || move.boosts && move.boosts.spe > 0) {
+				if (move.id === 'flamecharge' || (move.boosts && move.boosts.spe && move.boosts.spe > 0)) {
 					speedBoosted = true;
 				}
-				if (['acupressure', 'bellydrum', 'chargebeam', 'curse', 'diamondstorm', 'fellstinger', 'fierydance', 'flowershield', 'poweruppunch', 'rage', 'rototiller', 'skullbash', 'stockpile'].includes(move.id) || move.boosts && (move.boosts.atk > 0 || move.boosts.def > 0 || move.boosts.spa > 0 || move.boosts.spd > 0)) {
+				if (['acupressure', 'bellydrum', 'chargebeam', 'curse', 'diamondstorm', 'fellstinger', 'fierydance', 'flowershield', 'poweruppunch', 'rage', 'rototiller', 'skullbash', 'stockpile'].includes(move.id) ||
+					move.boosts && ((move.boosts.atk && move.boosts.atk > 0) || (move.boosts.def && move.boosts.def > 0) || (move.boosts.spa && move.boosts.spa > 0) || (move.boosts.spd && move.boosts.spd > 0))) {
 					nonSpeedBoosted = true;
 				}
 				if (item.zMove && move.type === item.zMoveType) {
-					if (move.zMoveBoost && move.zMoveBoost.spe > 0) {
+					if (move.zMoveBoost && move.zMoveBoost.spe && move.zMoveBoost.spe > 0) {
 						if (!speedBoosted) speedBoosted = move.name;
 					}
-					if (move.zMoveBoost && (move.zMoveBoost.atk > 0 || move.zMoveBoost.def > 0 || move.zMoveBoost.spa > 0 || move.zMoveBoost.spd > 0)) {
+					if (move.zMoveBoost && ((move.zMoveBoost.atk && move.zMoveBoost.atk > 0) || (move.zMoveBoost.def && move.zMoveBoost.def > 0) ||
+						(move.zMoveBoost.spa && move.zMoveBoost.spa > 0) || (move.zMoveBoost.spd && move.zMoveBoost.spd > 0))) {
 						if (!nonSpeedBoosted || move.name === speedBoosted) nonSpeedBoosted = move.name;
 					}
 				}
@@ -617,7 +630,7 @@ exports.BattleFormats = {
 	cfzclause: {
 		effectType: 'ValidatorRule',
 		name: 'CFZ Clause',
-		desc: ["Bans the use of crystal-free Z-Moves"],
+		desc: "Bans the use of crystal-free Z-Moves",
 		banlist: ['10,000,000 Volt Thunderbolt', 'Acid Downpour', 'All-Out Pummeling', 'Black Hole Eclipse', 'Bloom Doom', 'Breakneck Blitz', 'Catastropika', 'Clangorous Soulblaze', 'Continental Crush', 'Corkscrew Crash', 'Devastating Drake', 'Extreme Evoboost', 'Genesis Supernova', 'Gigavolt Havoc', 'Guardian of Alola', 'Hydro Vortex', 'Inferno Overdrive', 'Let\'s Snuggle Forever', 'Light That Burns the Sky', 'Malicious Moonsault', 'Menacing Moonraze Maelstrom', 'Never-Ending Nightmare', 'Oceanic Operetta', 'Pulverizing Pancake', 'Savage Spin-Out', 'Searing Sunraze Smash', 'Shattered Psyche', 'Sinister Arrow Raid', 'Soul-Stealing 7-Star Strike', 'Splintered Stormshards', 'Stoked Sparksurfer', 'Subzero Slammer', 'Supersonic Skystrike', 'Tectonic Rage', 'Twinkle Tackle'],
 		onStart: function () {
 			this.add('rule', 'CFZ Clause: Crystal-free Z-Moves are banned');
@@ -626,7 +639,7 @@ exports.BattleFormats = {
 	hppercentagemod: {
 		effectType: 'Rule',
 		name: 'HP Percentage Mod',
-		desc: ["Shows the HP of Pok&eacute;mon in percentages"],
+		desc: "Shows the HP of Pok&eacute;mon in percentages",
 		onStart: function () {
 			this.add('rule', 'HP Percentage Mod: HP is shown in percentages');
 			this.reportPercentages = true;
@@ -635,7 +648,7 @@ exports.BattleFormats = {
 	exacthpmod: {
 		effectType: 'Rule',
 		name: 'Exact HP Mod',
-		desc: ["Shows the exact HP of all Pok&eacute;mon"],
+		desc: "Shows the exact HP of all Pok&eacute;mon",
 		onStart: function () {
 			this.add('rule', 'Exact HP Mod: Exact HP is shown');
 			this.reportExactHP = true;
@@ -644,7 +657,7 @@ exports.BattleFormats = {
 	cancelmod: {
 		effectType: 'Rule',
 		name: 'Cancel Mod',
-		desc: ["Allows players to change their own choices before their opponents make one"],
+		desc: "Allows players to change their own choices before their opponents make one",
 		onStart: function () {
 			this.supportCancel = true;
 		},
@@ -652,7 +665,7 @@ exports.BattleFormats = {
 	sleepclausemod: {
 		effectType: 'Rule',
 		name: 'Sleep Clause Mod',
-		desc: ["Prevents players from putting more than one of their opponent's Pok&eacute;mon to sleep at a time, and bans Mega Gengar from using Hypnosis"],
+		desc: "Prevents players from putting more than one of their opponent's Pok&eacute;mon to sleep at a time, and bans Mega Gengar from using Hypnosis",
 		banlist: ['Hypnosis + Gengarite'],
 		onStart: function () {
 			this.add('rule', 'Sleep Clause Mod: Limit one foe put to sleep');
@@ -676,7 +689,7 @@ exports.BattleFormats = {
 	switchpriorityclausemod: {
 		effectType: 'Rule',
 		name: 'Switch Priority Clause Mod',
-		desc: ["Makes a faster Pokémon switch first when double-switching, unlike in Emerald link battles, where player 1's Pokémon would switch first"],
+		desc: "Makes a faster Pokémon switch first when double-switching, unlike in Emerald link battles, where player 1's Pokémon would switch first",
 		onStart: function () {
 			this.add('rule', 'Switch Priority Clause Mod: Faster Pokémon switch first');
 		},
@@ -684,7 +697,7 @@ exports.BattleFormats = {
 	freezeclausemod: {
 		effectType: 'Rule',
 		name: 'Freeze Clause Mod',
-		desc: ["Prevents players from freezing more than one of their opponent's Pok&eacute;mon at a time"],
+		desc: "Prevents players from freezing more than one of their opponent's Pok&eacute;mon at a time",
 		onStart: function () {
 			this.add('rule', 'Freeze Clause Mod: Limit one foe frozen');
 		},
@@ -705,11 +718,12 @@ exports.BattleFormats = {
 	sametypeclause: {
 		effectType: 'ValidatorRule',
 		name: 'Same Type Clause',
-		desc: ["Forces all Pok&eacute;mon on a team to share a type with each other"],
+		desc: "Forces all Pok&eacute;mon on a team to share a type with each other",
 		onStart: function () {
 			this.add('rule', 'Same Type Clause: Pokémon in a team must share a type');
 		},
 		onValidateTeam: function (team) {
+			/**@type {string[]} */
 			let typeTable;
 			for (const [i, set] of team.entries()) {
 				let template = this.getTemplate(set.species);
@@ -717,6 +731,7 @@ exports.BattleFormats = {
 				if (i === 0) {
 					typeTable = template.types;
 				} else {
+					// @ts-ignore
 					typeTable = typeTable.filter(type => template.types.includes(type));
 				}
 				if (this.gen >= 7) {
@@ -737,12 +752,12 @@ exports.BattleFormats = {
 	megarayquazaclause: {
 		effectType: 'Rule',
 		name: 'Mega Rayquaza Clause',
-		desc: ["Prevents Rayquaza from mega evolving"],
+		desc: "Prevents Rayquaza from mega evolving",
 		onStart: function () {
 			this.add('rule', 'Mega Rayquaza Clause: You cannot mega evolve Rayquaza');
 			for (const side of this.sides) {
 				for (const pokemon of side.pokemon) {
-					if (pokemon.speciesid === 'rayquaza') pokemon.canMegaEvo = false;
+					if (pokemon.speciesid === 'rayquaza') pokemon.canMegaEvo = null;
 				}
 			}
 		},
@@ -750,7 +765,7 @@ exports.BattleFormats = {
 	inversemod: {
 		effectType: 'Rule',
 		name: 'Inverse Mod',
-		desc: ["The mod for Inverse Battle which inverts the type effectiveness chart, swapping resistances and weaknesses with each other"],
+		desc: "The mod for Inverse Battle which inverts the type effectiveness chart, swapping resistances and weaknesses with each other",
 		onNegateImmunity: false,
 		onEffectiveness: function (typeMod, target, type, move) {
 			// The effectiveness of Freeze Dry on Water isn't reverted
@@ -762,13 +777,13 @@ exports.BattleFormats = {
 	ignoreillegalabilities: {
 		effectType: 'ValidatorRule',
 		name: 'Ignore Illegal Abilities',
-		desc: ["Allows Pok&eacute;mon to use any ability"],
+		desc: "Allows Pok&eacute;mon to use any ability",
 		// Implemented in the 'pokemon' ruleset and in team-validator.js
 	},
 	stabmonsmovelegality: {
 		effectType: 'ValidatorRule',
 		name: 'STABmons Move Legality',
-		desc: ["Allows Pok&eacute;mon to use any move that they or a previous evolution/out-of-battle forme share a type with"],
+		desc: "Allows Pok&eacute;mon to use any move that they or a previous evolution/out-of-battle forme share a type with",
 		checkLearnset: function (move, template, lsetData, set) {
 			const restrictedMoves = this.format.restrictedMoves || [];
 			if (!move.isZ && !restrictedMoves.includes(move.name)) {
@@ -794,19 +809,21 @@ exports.BattleFormats = {
 	allowonesketch: {
 		effectType: 'ValidatorRule',
 		name: 'Allow One Sketch',
-		desc: ["Allows each Pok&eacute;mon to use one move they don't normally have access to via Sketch"],
+		desc: "Allows each Pok&eacute;mon to use one move they don't normally have access to via Sketch",
 		// Implemented in team-validator.js
 	},
 	allowcap: {
 		effectType: 'ValidatorRule',
 		name: 'Allow CAP',
-		desc: ["Allows the use of Pok&eacute;mon, abilities, moves, and items made by the Create-A-Pok&eacute;mon project"],
+		desc: "Allows the use of Pok&eacute;mon, abilities, moves, and items made by the Create-A-Pok&eacute;mon project",
 		// Implemented in the 'pokemon' ruleset
 	},
 	allowtradeback: {
 		effectType: 'ValidatorRule',
 		name: 'Allow Tradeback',
-		desc: ["Allows Gen 1 pokemon to have moves from their Gen 2 learnsets"],
+		desc: "Allows Gen 1 pokemon to have moves from their Gen 2 learnsets",
 		// Implemented in team-validator.js
 	},
 };
+
+exports.BattleFormats = BattleFormats;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -2,7 +2,8 @@
 
 const CHOOSABLE_TARGETS = new Set(['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'adjacentFoe']);
 
-exports.BattleScripts = {
+/**@type {BattleScriptsData} */
+let BattleScripts = {
 	gen: 7,
 	/**
 	 * runMove is the "outside" move caller. It handles deducting PP,
@@ -191,8 +192,10 @@ exports.BattleScripts = {
 		if (zMove && move.category !== 'Status') {
 			this.attrLastMove('[zeffect]');
 		} else if (zMove && move.zMoveBoost) {
+			// @ts-ignore
 			this.boost(move.zMoveBoost, pokemon, pokemon, {id: 'zpower'});
 		} else if (zMove && move.zMoveEffect === 'heal') {
+			// @ts-ignore
 			this.heal(pokemon.maxhp, pokemon, pokemon, {id: 'zpower'});
 		} else if (zMove && move.zMoveEffect === 'healreplacement') {
 			move.self = {sideCondition: 'healreplacement'};
@@ -206,13 +209,17 @@ exports.BattleScripts = {
 			pokemon.setBoost(boosts);
 			this.add('-clearnegativeboost', pokemon, '[zeffect]');
 		} else if (zMove && move.zMoveEffect === 'redirect') {
+			// @ts-ignore
 			pokemon.addVolatile('followme', pokemon, {id: 'zpower'});
 		} else if (zMove && move.zMoveEffect === 'crit2') {
+			// @ts-ignore
 			pokemon.addVolatile('focusenergy', pokemon, {id: 'zpower'});
 		} else if (zMove && move.zMoveEffect === 'curse') {
 			if (pokemon.hasType('Ghost')) {
+				// @ts-ignore
 				this.heal(pokemon.maxhp, pokemon, pokemon, {id: 'zpower'});
 			} else {
+				// @ts-ignore
 				this.boost({atk: 1}, pokemon, pokemon, {id: 'zpower'});
 			}
 		}
@@ -255,6 +262,7 @@ exports.BattleScripts = {
 			this.faint(pokemon, pokemon, move);
 		}
 
+		/**@type {number | false} */
 		let damage = false;
 		if (move.target === 'all' || move.target === 'foeSide' || move.target === 'allySide' || move.target === 'allyTeam') {
 			damage = this.tryMoveHit(target, pokemon, move);
@@ -297,6 +305,7 @@ exports.BattleScripts = {
 			damage = this.tryMoveHit(target, pokemon, move);
 			if (damage || damage === 0 || damage === undefined) moveResult = true;
 		}
+		// @ts-ignore
 		if (move.selfBoost && moveResult) this.moveHit(pokemon, pokemon, move, move.selfBoost, false, true);
 		if (!pokemon.hp) {
 			this.faint(pokemon, pokemon, move);
@@ -346,7 +355,7 @@ exports.BattleScripts = {
 			move.ignoreImmunity = (move.category === 'Status');
 		}
 
-		if (this.gen < 7 && move.ignoreImmunity !== true && !move.ignoreImmunity[move.type] && !target.runImmunity(move.type, true)) {
+		if (this.gen < 7 && (!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) && !target.runImmunity(move.type, true)) {
 			return false;
 		}
 
@@ -356,7 +365,7 @@ exports.BattleScripts = {
 			return false;
 		}
 
-		if (this.gen >= 7 && move.ignoreImmunity !== true && !move.ignoreImmunity[move.type] && !target.runImmunity(move.type, true)) {
+		if (this.gen >= 7 && (!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) && !target.runImmunity(move.type, true)) {
 			return false;
 		}
 		if (move.flags['powder'] && target !== pokemon && !this.getImmunity('powder', target)) {
@@ -417,6 +426,7 @@ exports.BattleScripts = {
 		} else {
 			accuracy = this.runEvent('Accuracy', target, pokemon, move, accuracy);
 		}
+		// @ts-ignore
 		if (accuracy !== true && !this.randomChance(accuracy, 100)) {
 			if (!move.spreadHit) this.attrLastMove('[miss]');
 			this.add('-miss', pokemon, target);
@@ -466,11 +476,12 @@ exports.BattleScripts = {
 		}
 
 		move.totalDamage = 0;
+		/**@type {number | false} */
 		let damage = 0;
 		pokemon.lastDamage = 0;
 		if (move.multihit) {
 			let hits = move.multihit;
-			if (hits.length) {
+			if (Array.isArray(hits)) {
 				// yes, it's hardcoded... meh
 				if (hits[0] === 2 && hits[1] === 5) {
 					if (this.gen >= 5) {
@@ -484,6 +495,7 @@ exports.BattleScripts = {
 			}
 			hits = Math.floor(hits);
 			let nullDamage = true;
+			/**@type {number | false} */
 			let moveDamage;
 			// There is no need to recursively check the ´sleepUsable´ flag as Sleep Talk can only be used while asleep.
 			let isSleepUsable = move.sleepUsable || this.getMove(move.sourceEffect).sleepUsable;
@@ -516,6 +528,7 @@ exports.BattleScripts = {
 					accuracy = this.runEvent('ModifyAccuracy', target, pokemon, move, accuracy);
 					if (!move.alwaysHit) {
 						accuracy = this.runEvent('Accuracy', target, pokemon, move, accuracy);
+						// @ts-ignore
 						if (accuracy !== true && !this.randomChance(accuracy, 100)) break;
 					}
 				}
@@ -546,6 +559,7 @@ exports.BattleScripts = {
 		}
 
 		if (move.struggleRecoil) {
+			// @ts-ignore
 			this.directDamage(this.clampIntRange(Math.round(pokemon.maxhp / 4), 1), pokemon, pokemon, {id: 'strugglerecoil'});
 		}
 
@@ -568,8 +582,10 @@ exports.BattleScripts = {
 		let damage;
 		move = this.getMoveCopy(move);
 
+		// @ts-ignore
 		if (!moveData) moveData = move;
 		if (!moveData.flags) moveData.flags = {};
+		/**@type {?boolean | number} */
 		let hitResult = true;
 
 		// TryHit events:
@@ -605,7 +621,7 @@ exports.BattleScripts = {
 		if (move.target === 'all' && !isSelf) {
 			hitResult = this.singleEvent('TryHitField', moveData, {}, target, pokemon, move);
 		} else if ((move.target === 'foeSide' || move.target === 'allySide') && !isSelf) {
-			hitResult = this.singleEvent('TryHitSide', moveData, {}, target.side, pokemon, move);
+			hitResult = this.singleEvent('TryHitSide', moveData, {}, (target ? target.side : null), pokemon, move);
 		} else if (target) {
 			hitResult = this.singleEvent('TryHit', moveData, {}, target, pokemon, move);
 		}
@@ -632,6 +648,7 @@ exports.BattleScripts = {
 		}
 
 		if (target) {
+			/**@type {?boolean | number} */
 			let didSomething = false;
 
 			damage = this.getDamage(pokemon, target, moveData);
@@ -751,12 +768,15 @@ exports.BattleScripts = {
 		}
 		if (moveData.self && !move.selfDropped) {
 			let selfRoll;
+			// @ts-ignore
 			if (!isSecondary && moveData.self.boosts) {
 				selfRoll = this.random(100);
 				if (!move.multihit) move.selfDropped = true;
 			}
 			// This is done solely to mimic in-game RNG behaviour. All self drops have a 100% chance of happening but still grab a random number.
+			// @ts-ignore
 			if (typeof moveData.self.chance === 'undefined' || selfRoll < moveData.self.chance) {
+				// @ts-ignore
 				this.moveHit(pokemon, pokemon, move, moveData.self, isSecondary, true);
 			}
 		}
@@ -786,6 +806,7 @@ exports.BattleScripts = {
 	},
 
 	calcRecoilDamage: function (damageDealt, move) {
+		// @ts-ignore
 		return this.clampIntRange(Math.round(damageDealt * move.recoil[0] / move.recoil[1]), 1);
 	},
 
@@ -838,6 +859,7 @@ exports.BattleScripts = {
 		if (pokemon) {
 			let item = pokemon.getItem();
 			if (move.name === item.zMoveFrom) {
+				// @ts-ignore
 				return this.getMoveCopy(item.zMove);
 			}
 		}
@@ -848,6 +870,7 @@ exports.BattleScripts = {
 			return zMove;
 		}
 		zMove = this.getMoveCopy(this.zMoveTable[move.type]);
+		// @ts-ignore
 		zMove.basePower = move.zMovePower;
 		zMove.category = move.category;
 		return zMove;
@@ -859,6 +882,7 @@ exports.BattleScripts = {
 		if (!item.zMove) return;
 		if (item.zMoveUser && !item.zMoveUser.includes(pokemon.template.species)) return;
 		let atLeastOne = false;
+		/**@type {AnyObject?[]} */
 		let zMoves = [];
 		for (const moveSlot of pokemon.moveSlots) {
 			if (moveSlot.pp <= 0) {
@@ -899,6 +923,7 @@ exports.BattleScripts = {
 
 	runMegaEvo: function (pokemon) {
 		const effectType = pokemon.canMegaEvo ? '-mega' : '-burst';
+		// @ts-ignore
 		const template = this.getTemplate(pokemon.canMegaEvo || pokemon.canUltraBurst);
 		const side = pokemon.side;
 
@@ -914,8 +939,10 @@ exports.BattleScripts = {
 		pokemon.details = template.species + (pokemon.level === 100 ? '' : ', L' + pokemon.level) + (pokemon.gender === '' ? '' : ', ' + pokemon.gender) + (pokemon.set.shiny ? ', shiny' : '');
 		if (pokemon.illusion) {
 			pokemon.ability = ''; // Don't allow Illusion to wear off
+			// @ts-ignore
 			this.add(effectType, pokemon, pokemon.illusion.template.baseSpecies, template.requiredItem);
 		} else {
+			// @ts-ignore
 			this.add(effectType, pokemon, template.baseSpecies, template.requiredItem);
 			this.add('detailschange', pokemon, pokemon.details);
 		}
@@ -945,3 +972,5 @@ exports.BattleScripts = {
 		return CHOOSABLE_TARGETS.has(targetType);
 	},
 };
+
+exports.BattleScripts = BattleScripts;

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -1,7 +1,11 @@
 'use strict';
 
-exports.BattleStatuses = {
+/**@type {{[k: string]: EffectData}} */
+let BattleStatuses = {
 	brn: {
+		name: 'brn',
+		id: 'brn',
+		num: 0,
 		effectType: 'Status',
 		onStart: function (target, source, sourceEffect) {
 			if (sourceEffect && sourceEffect.id === 'flameorb') {
@@ -19,6 +23,9 @@ exports.BattleStatuses = {
 		},
 	},
 	par: {
+		name: 'par',
+		id: 'par',
+		num: 0,
 		effectType: 'Status',
 		onStart: function (target, source, sourceEffect) {
 			if (sourceEffect && sourceEffect.effectType === 'Ability') {
@@ -41,6 +48,9 @@ exports.BattleStatuses = {
 		},
 	},
 	slp: {
+		name: 'slp',
+		id: 'slp',
+		num: 0,
 		effectType: 'Status',
 		onStart: function (target, source, sourceEffect) {
 			if (sourceEffect && sourceEffect.effectType === 'Ability') {
@@ -70,6 +80,9 @@ exports.BattleStatuses = {
 		},
 	},
 	frz: {
+		name: 'frz',
+		id: 'frz',
+		num: 0,
 		effectType: 'Status',
 		onStart: function (target, source, sourceEffect) {
 			if (sourceEffect && sourceEffect.effectType === 'Ability') {
@@ -111,6 +124,9 @@ exports.BattleStatuses = {
 		},
 	},
 	psn: {
+		name: 'psn',
+		id: 'psn',
+		num: 0,
 		effectType: 'Status',
 		onStart: function (target, source, sourceEffect) {
 			if (sourceEffect && sourceEffect.effectType === 'Ability') {
@@ -125,6 +141,9 @@ exports.BattleStatuses = {
 		},
 	},
 	tox: {
+		name: 'tox',
+		id: 'tox',
+		num: 0,
 		effectType: 'Status',
 		onStart: function (target, source, sourceEffect) {
 			this.effectData.stage = 0;
@@ -148,6 +167,9 @@ exports.BattleStatuses = {
 		},
 	},
 	confusion: {
+		name: 'confusion',
+		id: 'confusion',
+		num: 0,
 		// this is a volatile status
 		onStart: function (target, source, sourceEffect) {
 			if (sourceEffect && sourceEffect.id === 'lockedmove') {
@@ -175,12 +197,16 @@ exports.BattleStatuses = {
 			this.damage(this.getDamage(pokemon, pokemon, 40), pokemon, pokemon, {
 				id: 'confused',
 				effectType: 'Move',
+				// @ts-ignore
 				type: '???',
 			});
 			return false;
 		},
 	},
 	flinch: {
+		name: 'flinch',
+		id: 'flinch',
+		num: 0,
 		duration: 1,
 		onBeforeMovePriority: 8,
 		onBeforeMove: function (pokemon) {
@@ -192,6 +218,9 @@ exports.BattleStatuses = {
 		},
 	},
 	trapped: {
+		name: 'trapped',
+		id: 'trapped',
+		num: 0,
 		noCopy: true,
 		onTrapPokemon: function (pokemon) {
 			pokemon.tryTrap();
@@ -201,9 +230,15 @@ exports.BattleStatuses = {
 		},
 	},
 	trapper: {
+		name: 'trapper',
+		id: 'trapper',
+		num: 0,
 		noCopy: true,
 	},
 	partiallytrapped: {
+		name: 'partiallytrapped',
+		id: 'partiallytrapped',
+		num: 0,
 		duration: 5,
 		durationCallback: function (target, source) {
 			if (source.hasItem('gripclaw')) return 8;
@@ -233,6 +268,9 @@ exports.BattleStatuses = {
 	},
 	lockedmove: {
 		// Outrage, Thrash, Petal Dance...
+		name: 'lockedmove',
+		id: 'lockedmove',
+		num: 0,
 		duration: 2,
 		onResidual: function (target) {
 			if (target.status === 'slp') {
@@ -260,6 +298,9 @@ exports.BattleStatuses = {
 	},
 	twoturnmove: {
 		// Skull Bash, SolarBeam, Sky Drop...
+		name: 'twoturnmove',
+		id: 'twoturnmove',
+		num: 0,
 		duration: 2,
 		onStart: function (target, source, effect) {
 			this.effectData.move = effect.id;
@@ -282,7 +323,11 @@ exports.BattleStatuses = {
 		},
 	},
 	choicelock: {
+		name: 'choicelock',
+		id: 'choicelock',
+		num: 0,
 		onStart: function (pokemon) {
+			if (!this.activeMove) throw new Error("Battle.activeMove is null");
 			if (!this.activeMove.id || this.activeMove.hasBounced) return false;
 			this.effectData.move = this.activeMove.id;
 		},
@@ -315,6 +360,9 @@ exports.BattleStatuses = {
 		},
 	},
 	mustrecharge: {
+		name: 'mustrecharge',
+		id: 'mustrecharge',
+		num: 0,
 		duration: 2,
 		onBeforeMovePriority: 11,
 		onBeforeMove: function (pokemon) {
@@ -329,8 +377,12 @@ exports.BattleStatuses = {
 	},
 	futuremove: {
 		// this is a side condition
+		name: 'futuremove',
+		id: 'futuremove',
+		num: 0,
 		onStart: function (side) {
 			this.effectData.positions = [];
+			// @ts-ignore
 			for (let i = 0; i < side.active.length; i++) {
 				this.effectData.positions[i] = null;
 			}
@@ -338,6 +390,7 @@ exports.BattleStatuses = {
 		onResidualOrder: 3,
 		onResidual: function (side) {
 			let finished = true;
+			// @ts-ignore
 			for (const [i, target] of side.active.entries()) {
 				let posData = this.effectData.positions[i];
 				if (!posData) continue;
@@ -371,12 +424,16 @@ exports.BattleStatuses = {
 				this.effectData.positions[i] = null;
 			}
 			if (finished) {
+				// @ts-ignore
 				side.removeSideCondition('futuremove');
 			}
 		},
 	},
 	healreplacement: {
 		// this is a side condition
+		name: 'healreplacement',
+		id: 'healreplacement',
+		num: 0,
 		onStart: function (side, source, sourceEffect) {
 			this.effectData.position = source.position;
 			this.effectData.sourceEffect = sourceEffect;
@@ -393,6 +450,9 @@ exports.BattleStatuses = {
 	},
 	stall: {
 		// Protect, Detect, Endure counter
+		name: 'stall',
+		id: 'stall',
+		num: 0,
 		duration: 2,
 		counterMax: 729,
 		onStart: function () {
@@ -408,6 +468,7 @@ exports.BattleStatuses = {
 			return success;
 		},
 		onRestart: function () {
+			// @ts-ignore
 			if (this.effectData.counter < this.effect.counterMax) {
 				this.effectData.counter *= 3;
 			}
@@ -415,6 +476,9 @@ exports.BattleStatuses = {
 		},
 	},
 	gem: {
+		name: 'gem',
+		id: 'gem',
+		num: 0,
 		duration: 1,
 		affectsFainted: true,
 		onBasePower: function (basePower, user, target, move) {
@@ -426,6 +490,9 @@ exports.BattleStatuses = {
 	// weather is implemented here since it's so important to the game
 
 	raindance: {
+		name: 'RainDance',
+		id: 'raindance',
+		num: 0,
 		effectType: 'Weather',
 		duration: 5,
 		durationCallback: function (source, effect) {
@@ -462,6 +529,9 @@ exports.BattleStatuses = {
 		},
 	},
 	primordialsea: {
+		name: 'PrimordialSea',
+		id: 'primordialsea',
+		num: 0,
 		effectType: 'Weather',
 		duration: 0,
 		onTryMove: function (target, source, effect) {
@@ -490,6 +560,9 @@ exports.BattleStatuses = {
 		},
 	},
 	sunnyday: {
+		name: 'SunnyDay',
+		id: 'sunnyday',
+		num: 0,
 		effectType: 'Weather',
 		duration: 5,
 		durationCallback: function (source, effect) {
@@ -529,6 +602,9 @@ exports.BattleStatuses = {
 		},
 	},
 	desolateland: {
+		name: 'DesolateLand',
+		id: 'desolateland',
+		num: 0,
 		effectType: 'Weather',
 		duration: 0,
 		onTryMove: function (target, source, effect) {
@@ -560,6 +636,9 @@ exports.BattleStatuses = {
 		},
 	},
 	sandstorm: {
+		name: 'Sandstorm',
+		id: 'sandstorm',
+		num: 0,
 		effectType: 'Weather',
 		duration: 5,
 		durationCallback: function (source, effect) {
@@ -597,6 +676,9 @@ exports.BattleStatuses = {
 		},
 	},
 	hail: {
+		name: 'Hail',
+		id: 'hail',
+		num: 0,
 		effectType: 'Weather',
 		duration: 5,
 		durationCallback: function (source, effect) {
@@ -626,6 +708,9 @@ exports.BattleStatuses = {
 		},
 	},
 	deltastream: {
+		name: 'DeltaStream',
+		id: 'deltastream',
+		num: 0,
 		effectType: 'Weather',
 		duration: 0,
 		onEffectiveness: function (typeMod, target, type, move) {
@@ -654,11 +739,16 @@ exports.BattleStatuses = {
 	// in the Pokedex, so that needs to be overridden.
 	// This is mainly relevant for Hackmons and Balanced Hackmons.
 	arceus: {
+		name: 'Arceus',
+		id: 'arceus',
+		num: 493,
 		onSwitchInPriority: 101,
 		onSwitchIn: function (pokemon) {
 			let type = 'Normal';
 			if (pokemon.ability === 'multitype') {
+				// @ts-ignore
 				type = pokemon.getItem().onPlate;
+				// @ts-ignore
 				if (!type || type === true) {
 					type = 'Normal';
 				}
@@ -667,11 +757,16 @@ exports.BattleStatuses = {
 		},
 	},
 	silvally: {
+		name: 'Silvally',
+		id: 'silvally',
+		num: 773,
 		onSwitchInPriority: 101,
 		onSwitchIn: function (pokemon) {
 			let type = 'Normal';
 			if (pokemon.ability === 'rkssystem') {
+				// @ts-ignore
 				type = pokemon.getItem().onMemory;
+				// @ts-ignore
 				if (!type || type === true) {
 					type = 'Normal';
 				}
@@ -680,3 +775,5 @@ exports.BattleStatuses = {
 		},
 	},
 };
+
+exports.BattleStatuses = BattleStatuses;

--- a/data/typechart.js
+++ b/data/typechart.js
@@ -1,6 +1,7 @@
 'use strict';
 
-exports.BattleTypeChart = {
+/**@type {{[k: string]: TypeData}} */
+let BattleTypeChart = {
 	"Bug": {
 		damageTaken: {
 			"Bug": 0,
@@ -443,3 +444,5 @@ exports.BattleTypeChart = {
 		HPdvs: {"atk": 14, "def": 13},
 	},
 };
+
+exports.BattleTypeChart = BattleTypeChart;

--- a/dev-tools/global.d.ts
+++ b/dev-tools/global.d.ts
@@ -2,6 +2,7 @@ import * as BattleType from './../sim/battle'
 import * as BattleStreamType from './../sim/battle-stream'
 import * as DataType from './../sim/dex-data'
 import * as DexType from './../sim/dex'
+import * as SimType from './../sim/index'
 import * as PokemonType from './../sim/pokemon'
 import * as PRNGType from './../sim/prng'
 import * as SideType from './../sim/side'
@@ -41,6 +42,7 @@ declare global {
 	const Pokemon: typeof PokemonType
 	const PRNG: typeof PRNGType
 	const Side: typeof SideType
+	const Sim: typeof SimType
 	const TeamValidator: typeof TeamValidatorType
 	const Validator: typeof TeamValidatorType.Validator
 	const BattleStream: typeof BattleStreamType.BattleStream

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -1,3 +1,9 @@
+type Battle = typeof Sim.nullBattle
+type ModdedDex = typeof Dex
+type Pokemon = typeof Sim.nullPokemon
+type Side = typeof Sim.nullSide
+type Validator = typeof Sim.nullValidator
+
 interface AnyObject {[k: string]: any}
 
 let Config = require('../config/config');
@@ -18,6 +24,7 @@ type GenderName = 'M' | 'F' | 'N' | '';
 type StatName = 'hp' | 'atk' | 'def' | 'spa' | 'spd' | 'spe';
 type StatsTable = {hp: number, atk: number, def: number, spa: number, spd: number, spe: number};
 type SparseStatsTable = {hp?: number, atk?: number, def?: number, spa?: number, spd?: number, spe?: number};
+type SparseBoostsTable = {hp?: number, atk?: number, def?: number, spa?: number, spd?: number, spe?: number, accuracy?: number, evasion?: number};
 type PokemonSet = {
 	name: string,
 	species: string,
@@ -75,6 +82,30 @@ type MoveSource = string;
  */
 type PokemonSource = string;
 
+/**
+ * Keeps track of how a pokemon with a given set might be obtained.
+ *
+ * `sources` is a list of possible PokemonSources, and a nonzero
+ * sourcesBefore means the Pokemon is compatible with all possible
+ * PokemonSources from that gen or earlier.
+ *
+ * `limitedEgg` tracks moves that can only be obtained from an egg with
+ * another father in gen 2-5. If there are multiple such moves,
+ * potential fathers need to be checked to see if they can actually
+ * learn the move combination in question.
+ */
+type PokemonSources = {
+	sources: PokemonSource[]
+	sourcesBefore: number
+	babyOnly?: string
+	sketchMove?: string
+	hm?: string
+	restrictiveMoves?: string[]
+	limitedEgg?: (string | 'self')[]
+	isHidden?: boolean
+	fastCheck?: true
+}
+
 type EventInfo = {
 	generation: number,
 	level?: number,
@@ -87,5 +118,548 @@ type EventInfo = {
 	abilities?: string[],
 	moves?: string[],
 	pokeball?: string,
-	from: string,
+	from?: string,
 };
+
+type UnknownEffect = Ability | Item | Move | Template | Status | Weather
+
+interface SelfEffect {
+	boosts?: SparseBoostsTable
+	chance?: number
+	sideCondition?: string
+	volatileStatus?: string
+	onHit?: EffectData["onHit"]
+}
+
+interface SecondaryEffect {
+	ability?: Ability
+	boosts?: SparseBoostsTable
+	chance?: number
+	dustproof?: boolean
+	self?: SelfEffect
+	status?: string
+	volatileStatus?: string
+	onHit?: EffectData["onHit"]
+}
+
+interface EventMethods {
+	beforeMoveCallback?: (this: Battle, pokemon: Pokemon) => void
+	beforeTurnCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon) => void
+	damageCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon) => number
+	durationCallback?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => number
+	onAfterDamage?: (this: Battle, damage: number, target: Pokemon, soruce: Pokemon, move: Move) => void
+	onAfterMoveSecondary?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
+	onAfterSetStatus?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
+	onAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onAfterMoveSecondarySelf?: (this: Battle, source: Pokemon, target: Pokemon, move: Move) => void
+	onAfterMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onAfterHit?: (this: Battle, target: Pokemon, source: Pokemon) => void
+	onAllyTryAddVolatile?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onAllyBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onAllyModifyAtk?: (this: Battle, atk: number) => void
+	onAllyModifySpD?: (this: Battle, spd: number) => void
+	onAllyBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onAllySetStatus?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onAllyTryHitSide?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAllyFaint?: (this: Battle, target: Pokemon) => void
+	onAllyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
+	onAllyModifyMove?: (this: Battle, move: Move) => void
+	onAnyTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAnyTryMove?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAnyDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onAnyBasePower?: (this: Battle, basePower: number, source: Pokemon, target: Pokemon, move: Move) => void
+	onAnySetWeather?: (this: Battle, target: Pokemon, source: Pokemon, weather: Weather) => void
+	onAnyModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: Move) => void
+	onAnyRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: Pokemon, move: Move) => void
+	onAnyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: Move) => void
+	onAnyFaint?: (this: Battle) => void
+	onAnyModifyBoost?: (this: Battle, boosts: SparseBoostsTable, target: Pokemon) => void
+	onAnyDragOut?: (this: Battle, pokemon: Pokemon) => void
+	onAnySetStatus?: (this: Battle, status: Status, pokemon: Pokemon) => void
+	onAttract?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: Move) => number | boolean | void
+	onBasePower?: (this: Battle, basePower: number, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onBeforeSwitchIn?: (this: Battle, pokemon: Pokemon) => void
+	onBeforeMove?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onBeforeSwitchOut?: (this: Battle, pokemon: Pokemon) => void
+	onBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onChargeMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onCheckShow?: (this: Battle, pokemon: Pokemon) => void
+	onCopy?: (this: Battle, pokemon: Pokemon) => void
+	onDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onDeductPP?: (this: Battle, target: Pokemon, source: Pokemon) => number | void
+	onDisableMove?: (this: Battle, pokemon: Pokemon) => void
+	onDragOut?: (this: Battle, pokemon: Pokemon) => void
+	onEat?: ((this: Battle, pokemon: Pokemon) => void) | false
+	onEatItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
+	onEnd?: (this: Battle, pokemon: Pokemon) => void
+	onFaint?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onFlinch?: ((this: Battle, pokemon: Pokemon) => void) | boolean
+	onFoeAfterDamage?: (this: Battle, damage: number, target: Pokemon) => void
+	onFoeBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onFoeBeforeMove?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onFoeDisableMove?: (this: Battle, pokemon: Pokemon) => void
+	onFoeMaybeTrapPokemon?: (this: Battle, pokemon: Pokemon, source: Pokemon) => void
+	onFoeRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: UnknownEffect, move: Move) => void
+	onFoeSwitchOut?: (this: Battle, pokemon: Pokemon) => void
+	onFoeTrapPokemon?: (this: Battle, pokemon: Pokemon) => void
+	onFoeTryMove?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onHitField?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => boolean | void
+	onHitSide?: (this: Battle, side: Side, source: Pokemon) => void
+	onImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void
+	onLockMove?: string | ((this: Battle, pokemon: Pokemon) => void)
+	onLockMoveTarget?: (this: Battle) => number
+	onModifyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: Move) => number | void
+	onModifyAtk?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+	onModifyBoost?: (this: Battle, boosts: SparseBoostsTable) => void
+	onModifyCritRatio?: (this: Battle, critRatio: number, source: Pokemon, target: Pokemon) => number | void
+	onModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: Move) => number | void
+	onModifyDef?: (this: Battle, def: number, pokemon: Pokemon) => number | void
+	onModifyMove?: (this: Battle, move: Move, pokemon: Pokemon, target: Pokemon) => void
+	onModifyPriority?: (this: Battle, priority: number, pokemon: Pokemon, target: Pokemon, move: Move) => number | void
+	onModifySecondaries?: (this: Battle, secondaries: SecondaryEffect[]) => void
+	onModifySpA?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+	onModifySpD?: (this: Battle, spd: number, pokemon: Pokemon) => number | void
+	onModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void
+	onModifyWeight?: (this: Battle, weight: number, pokemon: Pokemon) => number | void
+	onMoveAborted?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onMoveFail?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => void) | boolean
+	onOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onPrepareHit?: (this: Battle, source: Pokemon, target: Pokemon, move: Move) => void
+	onPreStart?: (this: Battle, pokemon: Pokemon) => void
+	onPrimal?: (this: Battle, pokemon: Pokemon) => void
+	onRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: UnknownEffect) => void
+	onResidual?: (this: Battle, pokemon: Pokemon) => void
+	onRestart?: (this: Battle, pokemon: Pokemon, source: Pokemon) => void
+	onSetAbility?: (this: Battle, ability: string, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onSetStatus?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onSourceAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: Move) => void
+	onSourceBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onSourceFaint?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onSourceHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onSourceModifyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon) => number | void
+	onSourceModifyAtk?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+	onSourceModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: Move) => number | void
+	onSourceModifySecondaries?: (this: Battle, secondaries: SecondaryEffect[], target: Pokemon, source: Pokemon, move: Move) => void
+	onSourceModifySpA?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+	onSourceTryHeal?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onSourceTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onStallMove?: (this: Battle, pokemon: Pokemon) => void
+	onStart?: (this: Battle, pokemon: Pokemon, source: Pokemon, effect: UnknownEffect, move: Move) => void
+	onSwitchIn?: (this: Battle, pokemon: Pokemon) => void
+	onSwitchOut?: (this: Battle, pokemon: Pokemon) => void
+	onTakeItem?: ((this: Battle, item: Item, pokemon: Pokemon, source: Pokemon) => void) | false
+	onTerrain?: (this: Battle, pokemon: Pokemon) => void
+	onTrapPokemon?: (this: Battle, pokemon: Pokemon) => void
+	onTry?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onTryAddVolatile?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onTryEatItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
+	onTryHeal?: ((this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void) | boolean
+	onTryHit?: ((this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void) | boolean
+	onTryHitSide?: (this: Battle, side: Side, source: Pokemon) => void
+	onTryMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onUpdate?: (this: Battle, pokemon: Pokemon) => void
+	onUseMoveMessage?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onWeather?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
+	onWeatherModifyDamage?: (this: Battle, damage: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+
+	// multiple definitions due to relayVar (currently not supported)
+	onAfterSubDamage?: (this: Battle, damage: any, target: any, source: any, effect: any) => void
+	onEffectiveness?: (this: Battle, typeMod: any, target: any, type: any, move: any) => void
+}
+
+interface EffectData extends EventMethods {
+	id: string
+	name: string
+	num: number
+	affectsFainted?: boolean
+	counterMax?: number
+	desc?: string
+	drain?: number[]
+	duration?: number
+	effect?: Partial<EffectData>
+	effectType?: string
+	infiltrates?: boolean
+	isNonstandard?: boolean | string
+	isUnreleased?: boolean
+	isZ?: boolean | string
+	noCopy?: boolean
+	onAccuracyPriority?: number
+	onAfterDamageOrder?: number
+	onAfterMoveSecondaryPriority?: number
+	onAfterMoveSecondarySelfPriority?: number
+	onAttractPriority?: number
+	onBasePowerPriority?: number
+	onBeforeMovePriority?: number
+	onBeforeSwitchOutPriority?: number
+	onBoostPriority?: number
+	onCriticalHit?: boolean
+	onDamagePriority?: number
+	onDragOutPriority?: number
+	onFoeBeforeMovePriority?: number
+	onFoeRedirectTargetPriority?: number
+	onFoeTrapPokemonPriority?: number
+	onFoeTryEatItem?: boolean
+	onHitPriority?: number
+	onModifyAccuracyPriority?: number
+	onModifyAtkPriority?: number
+	onModifyDefPriority?: number
+	onModifyMovePriority?: number
+	onModifyPriorityPriority?: number
+	onModifySpAPriority?: number
+	onModifySpDPriority?: number
+	onModifyWeightPriority?: number
+	onRedirectTargetPriority?: number
+	onResidualOrder?: number
+	onResidualSubOrder?: number
+	onSwitchInPriority?: number
+	onTrapPokemonPriority?: number
+	onTryHealPriority?: number
+	onTryHitPriority?: number
+	onTryMovePriority?: number
+	onTryPrimaryHitPriority?: number
+	secondary?: boolean | SecondaryEffect
+	secondaries?: false | SecondaryEffect[]
+	self?: SelfEffect | boolean
+	shortDesc?: string
+	status?: string
+	weather?: string
+}
+
+type EffectTypes = 'Effect' | 'Pokemon' | 'Move' | 'Item' | 'Ability' | 'Format' | 'Ruleset' | 'Weather' | 'Status' | 'Rule' | 'ValidatorRule'
+
+interface Effect extends EffectData {
+	effectType: EffectTypes
+	exists: boolean
+	flags: AnyObject
+	fullname: string
+	gen: number
+	sourceEffect: string
+	toString: () => string
+}
+
+interface Status extends Effect {
+	effectType: 'Status'
+}
+
+interface Weather extends Effect {
+	effectType: 'Weather'
+}
+
+interface AbilityData extends EffectData {
+	rating: number
+	isUnbreakable?: boolean
+	suppressWeather?: boolean
+}
+
+interface Ability extends Effect, AbilityData {
+	effectType: 'Ability'
+	gen: number
+}
+
+interface FlingData {
+	basePower: number
+	status?: string
+	volatileStatus?: string
+	effect?: EventMethods["onHit"]
+}
+
+interface ItemData extends EffectData {
+	gen: number
+	fling?: FlingData
+	forcedForme?: string
+	ignoreKlutz?: boolean
+	isBerry?: boolean
+	isChoice?: boolean
+	isGem?: boolean
+	megaStone?: string
+	megaEvolves?: string
+	naturalGift?: {basePower: number, type: string}
+	onDrive?: string
+	onMemory?: string
+	onPlate?: string
+	spritenum?: number
+	zMove?: string | boolean
+	zMoveFrom?: string
+	zMoveType?: string
+	zMoveUser?: string[]
+}
+
+interface Item extends Effect, ItemData {
+	effectType: 'Item'
+	gen: number
+}
+
+interface MoveData extends EffectData {
+	accuracy: true | number
+	basePower: number
+	category: 'Physical' | 'Special' | 'Status'
+	flags: AnyObject
+	pp: number
+	priority: number
+	target: string
+	type: string
+	alwaysHit?: boolean
+	boosts?: SparseBoostsTable
+	breaksProtect?: boolean
+	contestType?: string
+	critModifier?: number
+	critRatio?: number
+	damage?: number | string | boolean
+	defensiveCategory?: 'Physical' | 'Special' | 'Status'
+	forceSwitch?: boolean
+	hasCustomRecoil?: boolean
+	heal?: number[],
+	ignoreAbility?: boolean
+	ignoreAccuracy?: boolean
+	ignoreDefensive?: boolean
+	ignoreEvasion?: boolean
+	ignoreImmunity?: boolean | {[k: string]: boolean}
+	ignoreNegativeOffensive?: boolean
+	ignoreOffensive?: boolean
+	ignorePositiveDefensive?: boolean
+	isFutureMove?: boolean
+	isViable?: boolean
+	mindBlownRecoil?: boolean
+	multiaccuracy?: boolean
+	multihit?: number | number[]
+	noFaint?: boolean
+	noMetronome?: string[]
+	nonGhostTarget?: string
+	noPPBoosts?: boolean
+	noSketch?: boolean
+	ohko?: boolean | string
+	pressureTarget?: string
+	pseudoWeather?: string
+	recoil?: number[]
+	selfBoost?: {boosts?: SparseBoostsTable}
+	selfdestruct?: string | boolean
+	selfSwitch?: string | boolean
+	sideCondition?: string
+	sleepUsable?: boolean
+	spreadModifier?: number
+	stallingMove?: boolean
+	stealsBoosts?: boolean
+	struggleRecoil?: boolean
+	terrain?: string
+	thawsTarget?: boolean
+	useTargetOffensive?: boolean
+	useSourceDefensive?: boolean
+	volatileStatus?: string
+	weather?: string
+	willCrit?: boolean
+	zMovePower?: number
+	zMoveEffect?: string
+	zMoveBoost?: SparseBoostsTable
+	basePowerCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => number | boolean
+}
+
+interface Move extends Effect, MoveData {
+	effectType: 'Move'
+	gen: number
+	typeMod: number
+	ability?: Ability
+	aerilateBoosted?: boolean
+	allies?: Pokemon[]
+	auraBoost?: number
+	crit?: boolean
+	forceStatus?: string
+	galvanizeBoosted?: boolean
+	hasAuraBreak?: boolean
+	hasBounced?: boolean
+	hasParentalBond?: boolean
+	hasSheerForce?: boolean
+	hasSTAB?: boolean
+	hit?: number
+	isExternal?: boolean
+	magnitude?: number
+	negateSecondary?: boolean
+	normalizeBoosted?: boolean
+	pixilateBoosted?: boolean
+	pranksterBoosted?: boolean
+	refrigerateBoosted?: boolean
+	selfDropped?: boolean
+	spreadHit?: boolean
+	stab?: number
+	totalDamage?: number | false
+	willChangeForme?: boolean
+	zBrokeProtect?: boolean
+}
+
+type TemplateAbility = {0: string, 1?: string, H?: string, S?: string}
+
+interface TemplateData {
+	abilities: TemplateAbility
+	baseStats: StatsTable
+	color: string
+	eggGroups: string[]
+	heightm: number
+	num: number
+	species: string
+	types: string[]
+	weightkg: number
+	baseForme?: string
+	baseSpecies?: string
+	evoLevel?: number
+	evoMove?: string
+	evos?: string[]
+	forme?: string
+	formeLetter?: string
+	gender?: GenderName
+	genderRatio?: {[k: string]: number}
+	maxHP?: number
+	otherForms?: string[]
+	otherFormes?: string[]
+	prevo?: string
+}
+
+interface TemplateFormatsData {
+	battleOnly?: boolean
+	doublesTier?: string
+	eventOnly?: boolean
+	eventPokemon?: EventInfo[]
+	gen?: number
+	isNonstandard?: boolean | string
+	isUnreleased?: boolean
+	randomBattleMoves?: string[]
+	randomDoubleBattleMoves?: string[]
+	requiredAbility?: string
+	requiredItem?: string
+	requiredItems?: string[]
+	requiredMove?: string
+	tier?: string
+	unreleasedHidden?: boolean
+}
+
+interface Template extends Effect, TemplateData, TemplateFormatsData {
+	effectType: 'Pokemon'
+	baseSpecies: string
+	doublesTier: string
+	eventOnly: boolean
+	evos: string[]
+	forme: string
+	formeLetter: string
+	gen: number
+	gender: GenderName
+	genderRatio: {M: number, F: number}
+	maleOnlyHidden: boolean
+	nfe: boolean
+	prevo: string
+	speciesid: string
+	spriteid: string
+	tier: string
+	addedType?: string
+	isMega?: boolean
+	isPrimal?: boolean
+	learnset?: {[k: string]: MoveSource[]}
+	originalMega?: string
+}
+
+type GameType = 'singles' | 'doubles' | 'triples' | 'rotation'
+
+interface FormatsData extends EventMethods {
+	name: string
+	banlist?: string[]
+	cannotMega?: string[]
+	canUseRandomTeam?: boolean
+	challengeShow?: boolean
+	debug?: boolean
+	defaultLevel?: number
+	desc?: string
+	effectType?: string
+	forcedLevel?: number
+	gameType?: GameType
+	maxForcedLevel?: number
+	maxLevel?: number
+	mod?: string
+	noChangeAbility?: boolean
+	noChangeForme?: boolean
+	onStartPriority?: number
+	onSwitchInPriority?: number
+	rated?: boolean
+	requirePentagon?: boolean
+	requirePlus?: boolean
+	restrictedAbilities?: string[]
+	restrictedMoves?: string[]
+	restrictedStones?: string[]
+	ruleset?: string[]
+	searchShow?: boolean
+	team?: string
+	teamLength?: {validate?: [number, number], battle?: number}
+	threads?: string[]
+	timer?: {starting?: number, perTurn?: number, maxPerTurn?: number, maxFirstTurn?: number, timeoutAutoChoose?: boolean, accelerate?: boolean}
+	tournamentShow?: boolean
+	unbanlist?: string[]
+	checkLearnset?: (this: Validator, move: Move, template: Template, lsetData: PokemonSources, set: PokemonSet) => {type: string, [any: string]: any} | null
+	onAfterMega?: (this: Battle, pokemon: Pokemon) => void
+	onBegin?: (this: Battle) => void
+	onChangeSet?: (this: ModdedDex, set: PokemonSet, format: Format, setHas: AnyObject, teamHas: AnyObject) => string[] | false | void
+	onModifyTemplate?: (this: Battle, template: Template, target: Pokemon, source: Pokemon) => Template | void
+	onTeamPreview?: (this: Battle) => void
+	onValidateSet?: (this: ModdedDex, set: PokemonSet, format: Format, setHas: AnyObject, teamHas: AnyObject) => string[] | false | void
+	onValidateTeam?: (this: ModdedDex, team: PokemonSet[], format: Format, teamHas: AnyObject) => string[] | false | void
+	validateSet?: (this: Validator, set: PokemonSet, teamHas: AnyObject) => string[] | false | void
+	validateTeam?: (this: Validator, team: PokemonSet[], removeNicknames: boolean) => string[] | false | void
+}
+
+interface RuleTable extends Map<string, string> {
+	checkLearnset: [Function, string] | null
+	complexBans: [string, string, number, string[]][]
+	complexTeamBans: [string, string, number, string[]][]
+	check: (thing: string, setHas: {[k: string]: true}) => string
+	getReason: (key: string) => string
+}
+
+interface Format extends Effect, FormatsData {
+	effectType: 'Format' | 'Ruleset' | 'Rule' | 'ValidatorRule'
+	baseRuleset: string[]
+	banlist: string[]
+	customRules: string[] | null
+	defaultLevel: number
+	maxLevel: number
+	noLog: boolean
+	ruleset: string[]
+	ruleTable: RuleTable | null
+	unbanlist: string[]
+}
+
+interface BattleScriptsData {
+	gen: number
+	zMoveTable?: {[k: string]: string}
+	calcRecoilDamage?: (this: Battle, damageDealt: number, move: Move) => number
+	canMegaEvo?: (this: Battle, pokemon: Pokemon) => string | undefined | null
+	canUltraBurst?: (this: Battle, pokemon: Pokemon) => string | null
+	canZMove?: (this: Battle, pokemon: Pokemon) => (AnyObject | null)[] | void
+	getZMove?: (this: Battle, move: Move, pokemon: Pokemon, skipChecks?: boolean) => string | undefined
+	getZMoveCopy?: (this: Battle, move: Move, pokemon: Pokemon) => Move
+	isAdjacent?: (this: Battle, pokemon1: Pokemon, pokemon2: Pokemon) => boolean
+	moveHit?: (this: Battle, target: Pokemon | null, pokemon: Pokemon, move: Move, moveData?: Move, isSecondary?: boolean, isSelf?: boolean) => number | false
+	runMegaEvo?: (this: Battle, pokemon: Pokemon) => boolean
+	runMove?: (this: Battle, move: Move, pokemon: Pokemon, targetLoc: number, sourceEffect?: Effect | null, zMove?: string, externalMove?: boolean) => void
+	targetTypeChoices?: (this: Battle, targetType: string) => boolean
+	tryMoveHit?: (this: Battle, target: Pokemon, pokemon: Pokemon, move: Move) => number | false
+	useMove?: (this: Battle, move: Move, pokemon: Pokemon, target: Pokemon | false, sourceEffect?: Effect | null, zMove?: string) => boolean
+	useMoveInner?: (this: Battle, move: Move, pokemon: Pokemon, target: Pokemon | false, sourceEffect?: Effect | null, zMove?: string) => boolean
+}
+
+interface TypeData {
+	damageTaken: {[attackingTypeNameOrEffectid: string]: number}
+	HPdvs?: SparseStatsTable
+	HPivs?: SparseStatsTable
+}
+
+interface TypeInfo extends TypeData {
+	effectType: 'Type' | 'EffectType'
+	exists: boolean
+	gen: number
+	HPdvs: SparseStatsTable
+	HPivs: SparseStatsTable
+	id: string
+	name: string
+	toString: () => string
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "@types/nodemailer": "^4.3.0",
     "eslint": "^4.16.0",
     "mocha": "^4.0.1",
-    "typescript": "^2.6.1"
+    "typescript": "^2.7.2"
   }
 }

--- a/room-battle.js
+++ b/room-battle.js
@@ -138,6 +138,8 @@ class BattleTimer {
 		const hasLongTurns = Dex.getFormat(battle.format, true).gameType !== 'singles';
 		const isChallenge = (!battle.rated && !battle.room.tour);
 		const timerSettings = Dex.getFormat(battle.format, true).timer;
+		/**@type {{perTurnTicks: number, startingTicks: number, maxPerTurnTicks: number, maxFirstTurnTicks: number, dcTimer: boolean, starting?: number, perTurn?: number, maxPerTurn?: number, maxFirstTurn?: number, timeoutAutoChoose?: boolean, accelerate?: boolean}} */
+		// @ts-ignore
 		this.settings = Object.assign({}, timerSettings);
 		if (this.settings.perTurn === undefined) {
 			this.settings.perTurn = hasLongTurns ? 25 : 10;

--- a/sim/dex-data.js
+++ b/sim/dex-data.js
@@ -84,7 +84,7 @@ class Effect {
 		this.fullname = '';
 		/**
 		 * Effect type.
-		 * @type {'Effect' | 'Pokemon' | 'Move' | 'Item' | 'Ability' | 'Format' | 'Ruleset' | 'Weather' | 'Status' | 'Rule' | 'ValidatorRule'}
+		 * @type {EffectTypes}
 		 */
 		this.effectType = 'Effect';
 		/**
@@ -135,7 +135,7 @@ class Effect {
 		this.isNonstandard = false;
 		/**
 		 * The duration of the effect.
-		 * @type {?number}
+		 * @type {number | undefined}
 		 */
 		this.duration = this.duration;
 		/**
@@ -161,21 +161,19 @@ class Effect {
 
 		/**
 		 * HP that the effect may drain.
-		 * @type {?number[]}
+		 * @type {number[] | undefined}
 		 */
 		this.drain = this.drain;
-		/**
-		 * @type {?Function}
-		 */
-		this.onRestart = this.onRestart;
-		/**
-		 * @type {?Function}
-		 */
-		this.durationCallback = this.durationCallback;
+
 		/**
 		 * @type {AnyObject}
 		 */
 		this.flags = this.flags || {};
+
+		/**
+		 * @type {string}
+		 */
+		this.sourceEffect = this.sourceEffect || '';
 
 		Object.assign(this, data);
 		if (moreData) Object.assign(this, moreData);
@@ -250,7 +248,7 @@ class Format extends Effect {
 		/**
 		 * Name of the team generator algorithm, if this format uses
 		 * random/fixed teams. null if players can bring teams.
-		 * @type {?string}
+		 * @type {string | undefined}
 		 */
 		this.team = this.team;
 		/** @type {'Format' | 'Ruleset' | 'Rule' | 'ValidatorRule'} */
@@ -260,15 +258,15 @@ class Format extends Effect {
 		 * Whether or not debug battle messages should be shown.
 		 * @type {boolean}
 		 */
-		this.debug = this.debug;
+		this.debug = !!this.debug;
 		/**
 		 * Whether or not a format is played for ladder points.
 		 * @type {boolean}
 		 */
-		this.rated = this.rated;
+		this.rated = !!this.rated;
 		/**
 		 * Game type.
-		 * @type {'singles' | 'doubles' | 'triples' | 'rotation'}
+		 * @type {GameType}
 		 */
 		this.gameType = this.gameType || 'singles';
 		/**
@@ -305,12 +303,12 @@ class Format extends Effect {
 		/**
 		 * The number of Pokemon players can bring to battle and
 		 * the number that can actually be used.
-		 * @type {?{battle: number, validate: number[]}}
+		 * @type {{battle?: number, validate?: [number, number]} | undefined}
 		 */
 		this.teamLength = this.teamLength;
 		/**
 		 * An optional function that runs at the start of a battle.
-		 * @type {?Function}
+		 * @type {(this: Battle) => void}
 		 */
 		this.onBegin = this.onBegin;
 
@@ -350,7 +348,7 @@ class Format extends Effect {
 		 * formats will change level 1 and level 100 pokemon to level 50,
 		 * which is what you want here. You usually want maxForcedLevel
 		 * instead.
-		 * @type {number?}
+		 * @type {number | undefined}
 		 */
 		this.forcedLevel = this.forcedLevel;
 		/**
@@ -358,46 +356,12 @@ class Format extends Effect {
 		 * will allow e.g. level 50 Hydreigon in Gen 5, which is not
 		 * normally legal because Hydreigon doesn't evolve until level
 		 * 64.
-		 * @type {number?}
+		 * @type {number | undefined}
 		 */
 		this.maxForcedLevel = this.maxForcedLevel;
 
-		/** @type {boolean | undefined} */
-		this.searchShow = this.searchShow;
-		/** @type {boolean | undefined} */
-		this.challengeShow = this.challengeShow;
-		/** @type {boolean | undefined} */
-		this.tournamentShow = this.tournamentShow;
-
-		/** @type {AnyObject?} */
-		this.timer = this.timer;
 		/** @type {boolean} */
 		this.noLog = !!this.noLog;
-
-		/**
-		 * @type {((this: Validator, set: PokemonSet, teamHas: AnyObject) => string[] | false)?}
-		 */
-		this.validateSet = this.validateSet;
-		/**
-		 * @type {((this: Validator, move: Move, template: Template, lsetData: PokemonSources, set: PokemonSet) => string | false)?}
-		 */
-		this.checkLearnset = this.checkLearnset;
-		/**
-		 * @type {((this: Validator, team: PokemonSet[], removeNicknames: boolean) => string[] | false)?}
-		 */
-		this.validateTeam = this.validateTeam;
-		/**
-		 * @type {((this: Validator, set: PokemonSet, format: Format, setHas: AnyObject, teamHas: AnyObject) => string[] | false)?}
-		 */
-		this.onChangeSet = this.onChangeSet;
-		/**
-		 * @type {((this: Validator, set: PokemonSet, format: Format, setHas: AnyObject, teamHas: AnyObject) => string[] | false)?}
-		 */
-		this.onValidateSet = this.onValidateSet;
-		/**
-		 * @type {((this: Validator, team: PokemonSet[], format: Format, teamHas: AnyObject) => string[] | false)?}
-		 */
-		this.onValidateTeam = this.onValidateTeam;
 	}
 }
 
@@ -426,33 +390,33 @@ class Item extends Effect {
 		/**
 		 * A Move-like object depicting what happens when Fling is used on
 		 * this item.
-		 * @type {?AnyObject}
+		 * @type {FlingData | undefined}
 		 */
 		this.fling = this.fling;
 		/**
 		 * If this is a Drive: The type it turns Techno Blast into.
 		 * undefined, if not a Drive.
-		 * @type {?string}
+		 * @type {string | undefined}
 		 */
 		this.onDrive = this.onDrive;
 		/**
 		 * If this is a Memory: The type it turns Multi-Attack into.
 		 * undefined, if not a Memory.
-		 * @type {?string}
+		 * @type {string | undefined}
 		 */
 		this.onMemory = this.onMemory;
 		/**
 		 * If this is a mega stone: The name (e.g. Charizard-Mega-X) of the
 		 * forme this allows transformation into.
 		 * undefined, if not a mega stone.
-		 * @type {?string}
+		 * @type {string | undefined}
 		 */
 		this.megaStone = this.megaStone;
 		/**
 		 * If this is a mega stone: The name (e.g. Charizard) of the
 		 * forme this allows transformation from.
 		 * undefined, if not a mega stone.
-		 * @type {?string}
+		 * @type {string | undefined}
 		 */
 		this.megaEvolves = this.megaEvolves;
 		/**
@@ -515,10 +479,16 @@ class Ability extends Effect {
 		this.effectType = 'Ability';
 
 		/**
+		 * Represents how useful or detrimental this ability is.
+		 * @type {number}
+		 */
+		this.rating = this.rating;
+
+		/**
 		 * Whether or not this ability suppresses weather.
 		 * @type {boolean}
 		 */
-		this.suppressWeather = this.suppressWeather;
+		this.suppressWeather = !!this.suppressWeather;
 
 		if (!this.gen) {
 			if (this.num >= 192) {
@@ -585,16 +555,16 @@ class Template extends Effect {
 		 * Other forms. List of names of cosmetic forms. These should have
 		 * `aliases.js` aliases to this entry, but not have their own
 		 * entry in `pokedex.js`.
-		 * @type {string[]?}
+		 * @type {string[] | undefined}
 		 */
-		this.otherForms = this.otherForms || null;
+		this.otherForms = this.otherForms;
 
 		/**
 		 * Other formes. List of names of formes, appears only on the base
 		 * forme. Unlike forms, these have their own entry in `pokedex.js`.
-		 * @type {string[]?}
+		 * @type {string[] | undefined}
 		 */
-		this.otherFormes = this.otherFormes || null;
+		this.otherFormes = this.otherFormes;
 
 		/**
 		 * Forme letter. One-letter version of the forme name. Usually the
@@ -613,7 +583,7 @@ class Template extends Effect {
 
 		/**
 		 * Abilities
-		 * @type {{0: string, 1?: string, H?: string, S?: string}}
+		 * @type {TemplateAbility}
 		 */
 		this.abilities = this.abilities || {0: ""};
 
@@ -625,7 +595,7 @@ class Template extends Effect {
 
 		/**
 		 * Added type (used in OMs)
-		 * @type {?string}
+		 * @type {string | undefined}
 		 */
 		this.addedType = this.addedType;
 
@@ -657,9 +627,9 @@ class Template extends Effect {
 
 		/**
 		 * Evolution level. falsy if doesn't evolve
-		 * @type {number?}
+		 * @type {number | undefined}
 		 */
-		this.evoLevel = this.evoLevel || null;
+		this.evoLevel = this.evoLevel;
 
 		/**
 		 * Is NFE? True if this Pokemon can evolve (Mega evolution doesn't
@@ -692,7 +662,7 @@ class Template extends Effect {
 
 		/**
 		 * Required item. Do not use this directly; see requiredItems.
-		 * @type {string}
+		 * @type {string | undefined}
 		 */
 		this.requiredItem = this.requiredItem;
 
@@ -700,13 +670,13 @@ class Template extends Effect {
 		 * Required items. Items required to be in this forme, e.g. a mega
 		 * stone, or Griseous Orb. Array because Arceus formes can hold
 		 * either a Plate or a Z-Crystal.
-		 * @type {?string[]}
+		 * @type {string[] | undefined}
 		 */
-		this.requiredItems = this.requiredItems || (this.requiredItem && [this.requiredItem]) || null;
+		this.requiredItems = this.requiredItems || (this.requiredItem ? [this.requiredItem] : undefined);
 
 		/**
 		 * Base stats
-		 * @type {AnyObject}
+		 * @type {StatsTable}
 		 */
 		this.baseStats = this.baseStats;
 
@@ -723,6 +693,12 @@ class Template extends Effect {
 		this.heightm = this.heightm;
 
 		/**
+		 * Color
+		 * @type {string}
+		 */
+		this.color = this.color || '';
+
+		/**
 		 * Does this Pokemon have an unreleased hidden ability?
 		 * @type {boolean}
 		 */
@@ -737,13 +713,13 @@ class Template extends Effect {
 
 		/**
 		 * Max HP. Used in the battle engine
-		 * @type {?number}
+		 * @type {number | undefined}
 		 */
 		this.maxHP = this.maxHP;
 
 		/**
 		 * Keeps track of exactly how a pokemon might learn a move, in the form moveid:sources[]
-		 * @type {?{[moveid: string]: MoveSource[]}}
+		 * @type {{[moveid: string]: MoveSource[]} | undefined}
 		 */
 		this.learnset = this.learnset;
 		/**
@@ -753,7 +729,7 @@ class Template extends Effect {
 		this.eventOnly = !!this.eventOnly;
 		/**
 		 * List of event data for each event.
-		 * @type {?EventInfo[]}
+		 * @type {EventInfo[] | undefined}
 		 */
 		this.eventPokemon = this.eventPokemon;
 
@@ -866,7 +842,7 @@ class Move extends Effect {
 
 		/**
 		 * Can this move OHKO foes?
-		 * @type {boolean}
+		 * @type {boolean | string}
 		 */
 		this.ohko = this.ohko;
 
@@ -880,7 +856,7 @@ class Move extends Effect {
 		/**
 		 * Secondary effect. You usually don't want to access this
 		 * directly; but through the secondaries array.
-		 * @type {?AnyObject}
+		 * @type {boolean  | SecondaryEffect | undefined}
 		 */
 		this.secondary = this.secondary;
 
@@ -888,9 +864,9 @@ class Move extends Effect {
 		 * Secondary effects. An array because there can be more than one
 		 * (for instance, Fire Fang has both a burn and a flinch
 		 * secondary).
-		 * @type {?AnyObject[]}
+		 * @type {false | SecondaryEffect[] | undefined}
 		 */
-		this.secondaries = this.secondaries || (this.secondary && [this.secondary]);
+		this.secondaries = this.secondaries || (this.secondary && typeof this.secondary !== 'boolean' && [this.secondary]);
 
 		/**
 		 * Move priority. Higher priorities go before lower priorities,
@@ -908,7 +884,7 @@ class Move extends Effect {
 		/**
 		 * Category that changes which defense to use when calculating
 		 * move damage.
-		 * @type {?'Physical' | 'Special' | 'Status'}
+		 * @type {'Physical' | 'Special' | 'Status' | undefined}
 		 */
 		this.defensiveCategory = this.defensiveCategory;
 
@@ -970,7 +946,7 @@ class Move extends Effect {
 
 		/**
 		 * Is this move a Z-Move?
-		 * @type {boolean}
+		 * @type {boolean | string | undefined}
 		 */
 		this.isZ = this.isZ;
 
@@ -997,13 +973,13 @@ class Move extends Effect {
 		 * Move target only used by Pressure
 		 * @type {string}
 		 */
-		this.pressureTarget = this.pressureTarget;
+		this.pressureTarget = this.pressureTarget || '';
 
 		/**
 		 * Move target used if the user is not a Ghost type
 		 * @type {string}
 		 */
-		this.nonGhostTarget = this.nonGhostTarget;
+		this.nonGhostTarget = this.nonGhostTarget || '';
 
 		/**
 		 * Whether or not the move ignores abilities
@@ -1026,14 +1002,14 @@ class Move extends Effect {
 		/**
 		 * Modifier that affects damage when multiple targets
 		 * are hit
-		 * @type {?number}
+		 * @type {number | undefined}
 		 */
 		this.spreadModifier = this.spreadModifier;
 
 		/**
 		 * Modifier that affects damage when this move is
 		 * a critical hit
-		 * @type {?number}
+		 * @type {number | undefined}
 		 */
 		this.critModifier = this.critModifier;
 
@@ -1041,7 +1017,7 @@ class Move extends Effect {
 		 * Damage modifier based on the user's types
 		 * @type {number}
 		 */
-		this.typeMod = this.typeMod;
+		this.typeMod = this.typeMod || 0;
 
 		/**
 		 * Whether or not this move gets STAB
@@ -1057,24 +1033,9 @@ class Move extends Effect {
 
 		/**
 		 * STAB (can be modified by other effects)
-		 * @type {?number}
+		 * @type {number | undefined}
 		 */
 		this.stab = this.stab;
-
-		/**
-		 * @type {?Function}
-		 */
-		this.damageCallback = this.damageCallback;
-
-		/**
-		 * @type {?Function}
-		 */
-		this.basePowerCallback = this.basePowerCallback;
-
-		/**
-		 * @type {?Function}
-		 */
-		this.beforeTurnCallback = this.beforeTurnCallback;
 
 		if (!this.gen) {
 			if (this.num >= 622) {

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -316,7 +316,7 @@ class ModdedDex {
 	}
 
 	/**
-	 * @param {string | Template} name
+	 * @param {string | Template | undefined} [name]
 	 * @return {Template}
 	 */
 	getTemplate(name) {
@@ -406,7 +406,7 @@ class ModdedDex {
 		return this.data.Learnsets[id].learnset;
 	}
 	/**
-	 * @param {string | Move} name
+	 * @param {string | Move | undefined} [name]
 	 * @return {Move}
 	 */
 	getMove(name) {
@@ -521,7 +521,7 @@ class ModdedDex {
 		return validatedFormatid;
 	}
 	/**
-	 * @param {string | Format} name
+	 * @param {string | Format | undefined} [name]
 	 * @return {Format}
 	 */
 	getFormat(name, isTrusted = false) {
@@ -565,7 +565,7 @@ class ModdedDex {
 		return effect;
 	}
 	/**
-	 * @param {string | Item} name
+	 * @param {string | Item | undefined} [name]
 	 * @return {Item}
 	 */
 	getItem(name) {
@@ -598,7 +598,7 @@ class ModdedDex {
 		return item;
 	}
 	/**
-	 * @param {string | Ability} name
+	 * @param {string | Ability | undefined} [name]
 	 * @return {Ability}
 	 */
 	getAbility(name = '') {

--- a/sim/index.js
+++ b/sim/index.js
@@ -17,6 +17,7 @@ const Side = require('./side');
 const Pokemon = require('./pokemon');
 const PRNG = require('./prng');
 const {BattleStream} = require('./battle-stream');
+const Validator = require('./team-validator').Validator; // eslint-disable-line no-unused-vars
 
 module.exports = {
 	Pokemon,
@@ -26,4 +27,19 @@ module.exports = {
 	Dex,
 
 	BattleStream,
+
+	// typescript hacks
+
+	/**@type {Battle} */
+	// @ts-ignore
+	nullBattle: null,
+	/**@type {Pokemon} */
+	// @ts-ignore
+	nullPokemon: null,
+	/**@type {Side} */
+	// @ts-ignore
+	nullSide: null,
+	/**@type {Validator} */
+	// @ts-ignore
+	nullValidator: null,
 };

--- a/sim/side.js
+++ b/sim/side.js
@@ -20,7 +20,7 @@ const Pokemon = require('./pokemon');
  * @property {number} [index] - the chosen index in Team Preview
  * @property {Side} [side] - the action's side
  * @property {?boolean} [mega] - true if megaing or ultra bursting
- * @property {?boolean} [zmove] - true if zmoving
+ * @property {string | undefined} [zmove] - if zmoving, the name of the zmove
  * @property {number} [priority] - priority of the action
  */
 
@@ -66,6 +66,7 @@ class Side {
 		this.pokemonLeft = 0;
 		this.faintedLastTurn = false;
 		this.faintedThisTurn = false;
+		this.zMoveUsed = false;
 		/** @type {Choice} */
 		this.choice = {
 			cantUndo: false,
@@ -347,7 +348,6 @@ class Side {
 
 		// Z-move
 
-		// @ts-ignore - battle script
 		const zMove = megaOrZ === 'zmove' ? this.battle.getZMove(move, pokemon) : undefined;
 		if (megaOrZ === 'zmove' && !zMove) {
 			return this.emitChoiceError(`Can't move: ${pokemon.name} can't use ${move.name} as a Z-move`);
@@ -364,7 +364,6 @@ class Side {
 
 		if (autoChoose) {
 			targetLoc = 0;
-			// @ts-ignore - battle script
 		} else if (this.battle.targetTypeChoices(targetType)) {
 			if (!targetLoc && this.active.length >= 2) {
 				return this.emitChoiceError(`Can't move: ${move.name} needs a target`);
@@ -399,10 +398,13 @@ class Side {
 			let disabledSource = '';
 			for (const moveId of moves) {
 				if (moveId.id !== moveid) continue;
+				// @ts-ignore
 				if (!moveId.disabled) {
 					isEnabled = true;
 					break;
+				// @ts-ignore
 				} else if (moveId.disabledSource) {
+					// @ts-ignore
 					disabledSource = moveId.disabledSource;
 				}
 			}

--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -11,30 +11,6 @@
 const Dex = require('./dex');
 const toId = Dex.getId;
 
-/**
- * Keeps track of how a pokemon with a given set might be obtained.
- *
- * `sources` is a list of possible PokemonSources, and a nonzero
- * sourcesBefore means the Pokemon is compatible with all possible
- * PokemonSources from that gen or earlier.
- *
- * `limitedEgg` tracks moves that can only be obtained from an egg with
- * another father in gen 2-5. If there are multiple such moves,
- * potential fathers need to be checked to see if they can actually
- * learn the move combination in question.
- *
- * @typedef {Object} PokemonSources
- * @property {PokemonSource[]} sources
- * @property {number} sourcesBefore
- * @property {string} [babyOnly]
- * @property {string} [sketchMove] limit 1 in fakemon Sketch-as-egg-move formats
- * @property {string} [hm] limit 1 HM transferred from gen 4 to 5
- * @property {string[]} [restrictiveMoves]
- * @property {(string | 'self')[]} [limitedEgg] list of egg moves
- * @property {boolean} [isHidden]
- * @property {true} [fastCheck]
- */
-
 class Validator {
 	/**
 	 * @param {string | Format} format
@@ -782,7 +758,7 @@ class Validator {
 			if (problem.type === 'incompatibleAbility') {
 				problemString += ` can only be learned in past gens without Hidden Abilities.`;
 			} else if (problem.type === 'incompatible') {
-				problemString = `${name}'s moves ${lsetData.restrictiveMoves.join(', ')} are incompatible.`;
+				problemString = `${name}'s moves ${(lsetData.restrictiveMoves || []).join(', ')} are incompatible.`;
 			} else if (problem.type === 'oversketched') {
 				let plural = (parseInt(problem.maxSketches) === 1 ? '' : 's');
 				problemString += ` can't be Sketched because it can only Sketch ${problem.maxSketches} move${plural}.`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     },
     "types": ["node"],
     "include": [
+        "./config/formats.js",
+        "./data/*",
         "./dev-tools/global.d.ts",
         "./dev-tools/globals.ts",
         "./dev-tools/node.d.ts",


### PR DESCRIPTION
Also removes Battle Factory methods accidentally re-added in d0a4a689a721ceb602a3d812a332d3080b5e881e.

Sorry for the large changelog but it was easiest to do everything together. I had to split <code>Format.desc</code> into <code>desc: string</code> and <code>threads: string[]</code> to be able to reuse other interfaces. Otherwise though, the additions are just simple type guards and <code>@ts-ignore</code> everywhere else (until it can be verified that nothing breaks).