### PR TITLE
Datasearch: Allow exclusion of multiple gens

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -292,7 +292,7 @@ function runDexsearch(target, cmd, canAll, message) {
 			if (group[cat][param] === undefined) {
 				if (uniqueTraits.includes(cat)) {
 					for (let currentParam in group[cat]) {
-						if (group[cat][currentParam] !== isNotSearch) return `A Pok&eacute;mon cannot have multiple ${cat}.`;
+						if (group[cat][currentParam] !== isNotSearch && !isNotSearch) return `A Pok&eacute;mon cannot have multiple ${cat}.`;
 					}
 				}
 				continue;
@@ -576,7 +576,7 @@ function runDexsearch(target, cmd, canAll, message) {
 			searches.push(orGroup);
 		}
 	}
-	if (showAll && searches.length === 0 && megaSearch === null) return {reply: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command."};
+	if (showAll && searches.length === 0 && megaSearch === null && !maxGen) return {reply: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command."};
 	if (!maxGen) maxGen = 7;
 	let mod = Dex.mod('gen' + maxGen);
 	let dex = {};


### PR DESCRIPTION
`/ds all, !gen6, !gen3` will return all Pokémon not in gen 3 or 6.
`/ds all, !gen6, gen3` will return all Pokémon in gen 3 (like in the old code).
`/ds all, gen3, gen5` will return the message `a pokémon can't have multiple gens`

Also makes `/ds maxgen[n]` work with the "all" parameter, because it didn't before and it probably should