### PR TITLE
Fix Rock Head throwing errors in valid situations

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2716,8 +2716,10 @@ let BattleAbilities = {
 		desc: "This Pokemon does not take recoil damage besides Struggle, Life Orb, and crash damage.",
 		shortDesc: "This Pokemon does not take recoil damage besides Struggle/Life Orb/crash damage.",
 		onDamage: function (damage, target, source, effect) {
-			if (!this.activeMove) throw new Error("Battle.activeMove is null");
-			if (effect.id === 'recoil' && this.activeMove.id !== 'struggle') return null;
+			if (effect.id === 'recoil') {
+				if (!this.activeMove) throw new Error("Battle.activeMove is null");
+				if (this.activeMove.id !== 'struggle') return null;
+			}
 		},
 		id: "rockhead",
 		name: "Rock Head",

--- a/test/simulator/abilities/rockhead.js
+++ b/test/simulator/abilities/rockhead.js
@@ -38,4 +38,11 @@ describe('Rock Head', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Sableye', ability: 'prankster', moves: ['taunt']}]);
 		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
 	});
+
+	it('should not block indirect damage', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Rampardos', ability: 'rockhead', moves: ['splash']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Abomasnow', ability: 'snowwarning', moves: ['splash']}]);
+		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+	});
 });


### PR DESCRIPTION
onDamage is called in valid situations that don't have activeMove set, such as switching into hazards.
Admittedly, I don't know if `&& this.activeMove` is enough to stop a TS error (which I assume was the reason for adding this) from coming right back, but this is crashing a lot of battles right now.