### PR TITLE
Fix Protective Pads throwing errors in valid situations

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -4212,44 +4212,54 @@ let BattleItems = {
 		},
 		onAttractPriority: -1,
 		onAttract: function (target, source, effect) {
-			if (!this.activeMove) throw new Error("Battle.activeMove is null");
-			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) return false;
+			if (this.activePokemon) {
+				if (!this.activeMove) throw new Error("Battle.activeMove is null");
+				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) return false;
+			}
 		},
 		onBoostPriority: -1,
 		onBoost: function (boost, target, source, effect) {
-			if (!this.activeMove) throw new Error("Battle.activeMove is null");
-			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
-				if (effect && effect.effectType === 'Ability') {
-					// Ability activation always happens for boosts
-					this.add('-activate', target, 'item: Protective Pads');
+			if (this.activePokemon) {
+				if (!this.activeMove) throw new Error("Battle.activeMove is null");
+				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
+					if (effect && effect.effectType === 'Ability') {
+						// Ability activation always happens for boosts
+						this.add('-activate', target, 'item: Protective Pads');
+					}
+					return false;
 				}
-				return false;
 			}
 		},
 		onDamagePriority: -1,
 		onDamage: function (damage, target, source, effect) {
-			if (!this.activeMove) throw new Error("Battle.activeMove is null");
-			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
-				if (effect && effect.effectType === 'Ability') {
-					this.add('-activate', source, effect.fullname);
-					this.add('-activate', target, 'item: Protective Pads');
+			if (this.activePokemon) {
+				if (!this.activeMove) throw new Error("Battle.activeMove is null");
+				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
+					if (effect && effect.effectType === 'Ability') {
+						this.add('-activate', source, effect.fullname);
+						this.add('-activate', target, 'item: Protective Pads');
+					}
+					return false;
 				}
-				return false;
 			}
 		},
 		onSetAbility: function (ability, target, source, effect) {
-			if (!this.activeMove) throw new Error("Battle.activeMove is null");
-			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
-				if (effect && effect.effectType === 'Ability') {
-					this.add('-activate', source, effect.fullname);
-					this.add('-activate', target, 'item: Protective Pads');
+			if (this.activePokemon) {
+				if (!this.activeMove) throw new Error("Battle.activeMove is null");
+				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
+					if (effect && effect.effectType === 'Ability') {
+						this.add('-activate', source, effect.fullname);
+						this.add('-activate', target, 'item: Protective Pads');
+					}
+					return false;
 				}
-				return false;
 			}
 		},
 		onSetStatus: function (status, target, source, effect) {
-			if (!this.activeMove) throw new Error("Battle.activeMove is null");
-			if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) return false;
+			if (this.activePokemon) {
+				if (!this.activeMove) throw new Error("Battle.activeMove is null");
+				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) return false;
+			}
 		},
 		num: 880,
 		gen: 7,

--- a/data/items.js
+++ b/data/items.js
@@ -4212,54 +4212,39 @@ let BattleItems = {
 		},
 		onAttractPriority: -1,
 		onAttract: function (target, source, effect) {
-			if (this.activePokemon) {
-				if (!this.activeMove) throw new Error("Battle.activeMove is null");
-				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) return false;
-			}
+			if (target !== source && target === this.activePokemon && this.activeMove && this.activeMove.flags['contact']) return false;
 		},
 		onBoostPriority: -1,
 		onBoost: function (boost, target, source, effect) {
-			if (this.activePokemon) {
-				if (!this.activeMove) throw new Error("Battle.activeMove is null");
-				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
-					if (effect && effect.effectType === 'Ability') {
-						// Ability activation always happens for boosts
-						this.add('-activate', target, 'item: Protective Pads');
-					}
-					return false;
+			if (target !== source && target === this.activePokemon && this.activeMove && this.activeMove.flags['contact']) {
+				if (effect && effect.effectType === 'Ability') {
+					// Ability activation always happens for boosts
+					this.add('-activate', target, 'item: Protective Pads');
 				}
+				return false;
 			}
 		},
 		onDamagePriority: -1,
 		onDamage: function (damage, target, source, effect) {
-			if (this.activePokemon) {
-				if (!this.activeMove) throw new Error("Battle.activeMove is null");
-				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
-					if (effect && effect.effectType === 'Ability') {
-						this.add('-activate', source, effect.fullname);
-						this.add('-activate', target, 'item: Protective Pads');
-					}
-					return false;
+			if (target !== source && target === this.activePokemon && this.activeMove && this.activeMove.flags['contact']) {
+				if (effect && effect.effectType === 'Ability') {
+					this.add('-activate', source, effect.fullname);
+					this.add('-activate', target, 'item: Protective Pads');
 				}
+				return false;
 			}
 		},
 		onSetAbility: function (ability, target, source, effect) {
-			if (this.activePokemon) {
-				if (!this.activeMove) throw new Error("Battle.activeMove is null");
-				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) {
-					if (effect && effect.effectType === 'Ability') {
-						this.add('-activate', source, effect.fullname);
-						this.add('-activate', target, 'item: Protective Pads');
-					}
-					return false;
+			if (target !== source && target === this.activePokemon && this.activeMove && this.activeMove.flags['contact']) {
+				if (effect && effect.effectType === 'Ability') {
+					this.add('-activate', source, effect.fullname);
+					this.add('-activate', target, 'item: Protective Pads');
 				}
+				return false;
 			}
 		},
 		onSetStatus: function (status, target, source, effect) {
-			if (this.activePokemon) {
-				if (!this.activeMove) throw new Error("Battle.activeMove is null");
-				if (target !== source && target === this.activePokemon && this.activeMove.flags['contact']) return false;
-			}
+			if (target !== source && target === this.activePokemon && this.activeMove && this.activeMove.flags['contact']) return false;
 		},
 		num: 880,
 		gen: 7,


### PR DESCRIPTION
Same thing as the Rock Head situation. Putting a condition for ``activePokemon´´ around it filters out all effects not caused by the active move, I think. Then again maybe this time we can just check for activeMove straight away? If activeMove is not set but should be, chances are activePokemon will also happen to not be set?