### PR TITLE
Refactor tests to use new `makeChoices` API

### DIFF
--- a/test/simulator/abilities/battlearmor.js
+++ b/test/simulator/abilities/battlearmor.js
@@ -22,7 +22,7 @@ describe('Battle Armor', function () {
 				assert.ok(!move.crit);
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move quickattack', 'move frostbreath');
 		assert.ok(successfulEvent);
 	});
 
@@ -31,7 +31,7 @@ describe('Battle Armor', function () {
 			[{species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack']}],
 			[{species: 'Cryogonal', ability: 'moldbreaker', item: 'zoomlens', moves: ['frostbreath']}],
 		]);
-		battle.commitDecisions(); // Team Preview
+		battle.makeChoices('move quickattack', 'move frostbreath');
 		let successfulEvent = false;
 		battle.onEvent('ModifyDamage', battle.getFormat(), function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
@@ -39,7 +39,7 @@ describe('Battle Armor', function () {
 				assert.ok(move.crit);
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move quickattack', 'move frostbreath');
 		assert.ok(successfulEvent);
 	});
 });

--- a/test/simulator/abilities/clearbody.js
+++ b/test/simulator/abilities/clearbody.js
@@ -17,7 +17,7 @@ describe('Clear Body', function () {
 
 		const stats = ['spd', 'def', 'spe', 'atk', 'spa'];
 		stats.forEach((stat, index) => {
-			battle.p2.chooseMove(index + 1).foe.chooseMove(1);
+			battle.makeChoices('move recover', 'move ' + (index + 1));
 			assert.statStage(battle.p1.active[0], stat, 0);
 		});
 		stats.forEach(stat => assert.statStage(battle.p1.active[0], stat, 0));

--- a/test/simulator/abilities/cloudnine.js
+++ b/test/simulator/abilities/cloudnine.js
@@ -14,7 +14,7 @@ describe('Cloud Nine', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['sunnyday']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Cherrim', ability: 'flowergift', item: 'laggingtail', moves: ['solarbeam']}]);
-		assert.false.hurts(p1.active[0], () => battle.commitDecisions()); // Solar Beam must charge
+		assert.false.hurts(p1.active[0], () => battle.makeChoices('move sunnyday', 'move solarbeam')); // Solar Beam must charge
 		assert.ok(battle.isWeather('', p2.active[0]));
 		assert.species(p2.active[0], 'Cherrim');
 	});
@@ -24,7 +24,7 @@ describe('Cloud Nine', function () {
 		let move, basePower;
 		battle.join('p1', 'Guest 1', 1, [{species: 'Groudon', ability: 'drought', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move rest', 'move calmmind');
 		move = Dex.getMove('firepledge');
 		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -38,7 +38,7 @@ describe('Cloud Nine', function () {
 		let move, basePower;
 		battle.join('p1', 'Guest 1', 1, [{species: 'Kyogre', ability: 'drizzle', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move rest', 'move calmmind');
 		move = Dex.getMove('firepledge');
 		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -51,46 +51,46 @@ describe('Cloud Nine', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tyranitar', ability: 'sandstream', moves: ['dragondance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
-		assert.false.hurts(battle.p2.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p2.active[0], () => battle.makeChoices('move dragondance', 'move calmmind'));
 	});
 
 	it('should negate the damage-dealing effects of Hail', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Abomasnow', ability: 'snowwarning', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
-		assert.false.hurts(battle.p2.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p2.active[0], () => battle.makeChoices('move rest', 'move calmmind'));
 	});
 
 	it('should not negate Desolate Land\'s ability to prevent other weathers from activating', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Groudon', ability: 'desolateland', moves: ['sunnyday']}]);
-		assert.constant(() => battle.weather, () => battle.commitDecisions());
+		assert.constant(() => battle.weather, () => battle.makeChoices('move raindance', 'move sunnyday'));
 	});
 
 	it('should not negate Primordial Sea\'s ability to prevent other weathers from activating', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Kyogre', ability: 'primordialsea', moves: ['sunnyday']}]);
-		assert.constant(() => battle.weather, () => battle.commitDecisions());
+		assert.constant(() => battle.weather, () => battle.makeChoices('move raindance', 'move sunnyday'));
 	});
 
 	it('should not negate Delta Stream\'s ability to prevent other weathers from activating', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['raindance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Rayquaza', ability: 'deltastream', moves: ['sunnyday']}]);
-		assert.constant(() => battle.weather, () => battle.commitDecisions());
+		assert.constant(() => battle.weather, () => battle.makeChoices('move raindance', 'move sunnyday'));
 	});
 
 	it('should still display status of the weather', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Golduck', ability: 'cloudnine', moves: ['calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Sunkern', ability: 'solarpower', moves: ['sunnyday']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move sunnyday');
 		assert.strictEqual(battle.log[battle.lastMoveLine + 1], '|-weather|SunnyDay');
 		for (let i = 0; i < 4; i++) {
 			assert.strictEqual(battle.log[battle.lastMoveLine + 3], '|-weather|SunnyDay|[upkeep]');
-			battle.commitDecisions();
+			battle.makeChoices('move calmmind', 'move sunnyday');
 		}
 		assert.strictEqual(battle.log[battle.lastMoveLine + 3], '|-weather|none');
 	});

--- a/test/simulator/abilities/comatose.js
+++ b/test/simulator/abilities/comatose.js
@@ -13,18 +13,18 @@ describe('Comatose', function () {
 	it('should make the user immune to status conditions', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['shadowclaw']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'noguard', moves: ['spore', 'glare', 'willowisp', 'toxic']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'noguard', moves: ['spore', 'glare', 'willowisp', 'toxic']}]);
 		for (let i = 1; i <= 4; i++) {
-			assert.constant(() => p1.active[0].status, () => p2.chooseMove(i).foe.chooseDefault());
+			assert.constant(() => p1.active[0].status, () => battle.makeChoices('move shadowclaw', 'move ' + i));
 		}
 	});
 
 	it('should not have its status immunity bypassed by Mold Breaker', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['shadowclaw']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'moldbreaker', moves: ['spore', 'glare', 'willowisp', 'toxic']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'moldbreaker', moves: ['spore', 'glare', 'willowisp', 'toxic']}]);
 		for (let i = 1; i <= 4; i++) {
-			assert.constant(() => p1.active[0].status, () => p2.chooseMove(i).foe.chooseDefault());
+			assert.constant(() => p1.active[0].status, () => battle.makeChoices('move shadowclaw', 'move ' + i));
 		}
 	});
 
@@ -32,16 +32,16 @@ describe('Comatose', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['aquajet']}]);
-		assert.hurts(p1.active[0], () => battle.commitDecisions());
-		assert.constant(() => p1.active[0].status, () => battle.commitDecisions());
+		assert.hurts(p1.active[0], () => battle.makeChoices('move rest', 'move aquajet'));
+		assert.constant(() => p1.active[0].status, () => battle.makeChoices('move rest', 'move aquajet'));
 	});
 
 	it('should allow the use of Snore and Sleep Talk as if the user were asleep', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['snore', 'sleeptalk', 'brickbreak']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['snore', 'sleeptalk', 'brickbreak']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['endure']}]);
 		for (let i = 1; i <= 2; i++) {
-			assert.hurts(p2.active[0], () => p1.chooseMove(i).foe.chooseDefault());
+			assert.hurts(p2.active[0], () => battle.makeChoices('move ' + i, 'move endure'));
 		}
 	});
 
@@ -49,23 +49,23 @@ describe('Comatose', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', moves: ['shadowclaw']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['dreameater']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move shadowclaw', 'move dreameater'));
 	});
 
 	it('should cause Wake-Up Slap and Hex to have doubled base power when used against the user', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Komala", ability: 'comatose', item: 'ringtarget', moves: ['endure']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['hex', 'wakeupslap']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'technician', moves: ['hex', 'wakeupslap']}]);
 
 		let bp = 0;
 		battle.onEvent('BasePower', battle.getFormat(), function (basePower, pokemon, target, move) {
 			bp = basePower;
 		});
 
-		p2.chooseMove(1).foe.chooseDefault();
+		battle.makeChoices('move endure', 'move hex');
 		assert.strictEqual(bp, battle.getMove('hex').basePower * 2);
 
-		p2.chooseMove(2).foe.chooseDefault();
+		battle.makeChoices('move endure', 'move wakeupslap');
 		assert.strictEqual(bp, battle.getMove('wakeupslap').basePower * 2);
 	});
 });

--- a/test/simulator/abilities/contrary.js
+++ b/test/simulator/abilities/contrary.js
@@ -15,7 +15,7 @@ describe('Contrary', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Spinda", ability: 'contrary', moves: ['superpower']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['dragondance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move superpower', 'move dragondance');
 		assert.statStage(p1.active[0], 'atk', 1);
 		assert.statStage(p1.active[0], 'def', 1);
 	});
@@ -24,7 +24,7 @@ describe('Contrary', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Serperior", ability: 'contrary', moves: ['leechseed']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Growlithe", ability: 'intimidate', moves: ['topsyturvy']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move leechseed', 'move topsyturvy');
 		assert.statStage(p1.active[0], 'atk', -1);
 	});
 
@@ -32,7 +32,7 @@ describe('Contrary', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Spinda", ability: 'contrary', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['dragondance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bellydrum', 'move dragondance');
 		assert.statStage(p1.active[0], 'atk', -6);
 	});
 
@@ -40,7 +40,7 @@ describe('Contrary', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Spinda", ability: 'contrary', moves: ['tackle']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", ability: 'moldbreaker', moves: ['growl']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move tackle', 'move growl');
 		assert.statStage(p1.active[0], 'atk', -1);
 	});
 });

--- a/test/simulator/abilities/damp.js
+++ b/test/simulator/abilities/damp.js
@@ -14,7 +14,7 @@ describe('Damp', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Politoed', ability: 'damp', moves: ['calmmind']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Electrode', ability: 'static', moves: ['explosion']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move explosion');
 		assert.fullHP(p1.active[0]);
 		assert.fullHP(p2.active[0]);
 	});
@@ -23,7 +23,7 @@ describe('Damp', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Poliwrath', ability: 'damp', moves: ['closecombat']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Aron', ability: 'aftermath', moves: ['leer']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move closecombat', 'move leer');
 		assert.fullHP(p1.active[0]);
 		assert.fainted(p2.active[0]);
 	});
@@ -32,7 +32,7 @@ describe('Damp', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Politoed', ability: 'damp', moves: ['calmmind']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Electrode', ability: 'moldbreaker', moves: ['explosion']}]);
-		assert.hurts(p1.active[0], () => battle.commitDecisions());
+		assert.hurts(p1.active[0], () => battle.makeChoices('move calmmind', 'move explosion'));
 		assert.fainted(p2.active[0]);
 	});
 });

--- a/test/simulator/abilities/dancer.js
+++ b/test/simulator/abilities/dancer.js
@@ -14,7 +14,7 @@ describe('Dancer', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Oricorio', ability: 'dancer', moves: ['swordsdance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Oricorio', ability: 'dancer', moves: ['howl']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move swordsdance', 'move howl');
 		assert.statStage(battle.p1.active[0], 'atk', 2);
 		assert.statStage(battle.p2.active[0], 'atk', 3);
 	});
@@ -30,7 +30,7 @@ describe('Dancer', function () {
 			{species: 'Shedinja', ability: 'dancer', moves: ['sleeptalk']},
 		]);
 		p1.active[1].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1);
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance 1, move sleeptalk');
 		assert.fainted(battle.p2.active[0]);
 		assert.fainted(battle.p2.active[1]);
 	});
@@ -46,9 +46,8 @@ describe('Dancer', function () {
 			{species: 'Shedinja', ability: 'dancer', moves: ['sleeptalk']},
 		]);
 		p1.active[1].boostBy({spe: 6});
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1);
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move trickroom, move sleeptalk');
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance 1, move sleeptalk');
 		assert.fainted(battle.p2.active[0]);
 		assert.fainted(battle.p2.active[1]);
 	});
@@ -68,26 +67,20 @@ describe('Dancer', function () {
 		p1.active[0].boostBy({atk: 6, spe: 6});
 		p2.active[0].boostBy({atk: -6});
 		p2.active[1].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1, 1);
-		p2.chooseMove(1, -2).chooseMove(1, 1);
+		battle.makeChoices('move dragondance, move featherdance 1', 'move fierydance -2, move finalgambit 1');
 		assert.fullHP(p2.active[0]);
 		assert.statStage(p1.active[0], 'atk', 6);
 		assert.statStage(p1.active[1], 'atk', 0);
 		assert.statStage(p2.active[0], 'atk', -6);
 		assert.statStage(p2.active[0], 'spe', 0);
 		// Next turn
-		battle.choose('p1', 'move 1');
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move dragondance, move featherdance', 'move protect');
 		assert.statStage(p1.active[0], 'atk', 6);
 		assert.statStage(p1.active[1], 'atk', 0);
 		// Next turn: Teeter Dance should be copied as long as it hits one thing
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 3');
-		battle.commitDecisions();
+		battle.makeChoices('move protect, move featherdance', 'move teeterdance');
 		// Next turn: Teeter Dance should NOT be copied if everything it hits is already confused
-		battle.choose('p1', 'move 3');
-		assert.constant(() => p1.active[0].volatiles['confusion'], () => battle.commitDecisions());
+		assert.constant(() => p1.active[0].volatiles['confusion'], () => battle.makeChoices('move teeterdance, move featherdance', 'move fierydance'));
 	});
 
 	it('should not copy a move that missed', function () {
@@ -96,9 +89,9 @@ describe('Dancer', function () {
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Oricorio', ability: 'dancer', item: 'brightpowder', moves: ['dig']}]);
 		p1.active[0].boostBy({accuracy: -6});
 		p2.active[0].boostBy({evasion: 6});
-		battle.commitDecisions();
+		battle.makeChoices('move revelationdance', 'move dig');
 		assert.fullHP(p1.active[0]);
-		battle.commitDecisions();
+		battle.makeChoices('move revelationdance', 'move dig');
 		assert.fullHP(p1.active[0]);
 	});
 
@@ -106,6 +99,6 @@ describe('Dancer', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Oricorio', ability: 'dancer', moves: ['fierydance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Shedinja', ability: 'dancer', item: 'focussash', moves: ['meanlook']}]);
-		assert.hurts(p1.active[0], () => battle.commitDecisions());
+		assert.hurts(p1.active[0], () => battle.makeChoices('move fierydance', 'move meanlook'));
 	});
 });

--- a/test/simulator/abilities/deltastream.js
+++ b/test/simulator/abilities/deltastream.js
@@ -23,7 +23,7 @@ describe('Delta Stream', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['thundershock', 'powdersnow', 'powergem']}]);
 		const pokemon = battle.p1.active[0];
 		for (let i = 1; i <= 3; i++) {
-			battle.p2.chooseMove(i).foe.chooseDefault();
+			battle.makeChoices('move recover', 'move ' + i);
 			assert.statStage(pokemon, 'atk', 0);
 			assert.statStage(pokemon, 'spa', 0);
 			assert.holdsItem(pokemon);
@@ -34,7 +34,7 @@ describe('Delta Stream', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Rayquaza", ability: 'deltastream', item: 'weaknesspolicy', moves: ['recover']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['dragonpulse']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move recover', 'move dragonpulse');
 		const pokemon = battle.p1.active[0];
 		assert.statStage(pokemon, 'atk', 2);
 		assert.statStage(pokemon, 'spa', 2);
@@ -52,53 +52,51 @@ describe('Delta Stream', function () {
 			{species: "Abomasnow", ability: 'snowwarning', moves: ['hail']},
 		]);
 		for (let i = 2; i <= 5; i++) {
-			battle.p2.chooseSwitch(i).foe.chooseDefault();
+			battle.makeChoices('move helpinghand', 'switch ' + i);
 			assert.ok(battle.isWeather('deltastream'));
-			battle.commitDecisions();
+			battle.makeChoices('move helpinghand', 'move 1');
 			assert.ok(battle.isWeather('deltastream'));
 		}
 	});
 
 	it('should cause the Delta Stream weather to fade if it switches out and no other Delta Stream Pokemon are active', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [
+		battle.join('p1', 'Guest 1', 1, [
 			{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']},
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['roost']}]);
-		p1.chooseSwitch(2);
-		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.makeChoices('switch 2', 'move roost'));
 	});
 
 	it('should not cause the Delta Stream weather to fade if it switches out and another Delta Stream Pokemon is active', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [
+		battle.join('p1', 'Guest 1', 1, [
 			{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']},
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['bulkup']}]);
-		p1.chooseSwitch(2);
-		assert.constant(() => battle.isWeather('deltastream'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('deltastream'), () => battle.makeChoices('switch 2', 'move bulkup'));
 	});
 
 	it('should cause the Delta Stream weather to fade if its ability is suppressed and no other Delta Stream Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['gastroacid']}]);
-		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should not cause the Delta Stream weather to fade if its ability is suppressed and another Delta Stream Pokemon is active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['gastroacid']}]);
-		assert.constant(() => battle.isWeather('deltastream'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('deltastream'), () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should cause the Delta Stream weather to fade if its ability is changed and no other Delta Stream Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Rayquaza", ability: 'deltastream', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['entrainment']}]);
-		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('deltastream'), false, () => battle.makeChoices('move helpinghand', 'move entrainment'));
 	});
 });

--- a/test/simulator/abilities/desolateland.js
+++ b/test/simulator/abilities/desolateland.js
@@ -24,7 +24,7 @@ describe('Desolate Land', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Cryogonal', ability: 'levitate', moves: ['splash']}]);
 		const attacker = battle.p1.active[0];
 		const defender = battle.p2.active[0];
-		assert.hurtsBy(defender, 152, () => battle.commitDecisions());
+		assert.hurtsBy(defender, 152, () => battle.makeChoices('move incinerate', 'move splash'));
 		const move = Dex.getMove('incinerate');
 		const basePower = battle.runEvent('BasePower', attacker, defender, move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -34,7 +34,7 @@ describe('Desolate Land', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blastoise", ability: 'torrent', moves: ['surf']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move helpinghand', 'move surf');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
@@ -43,7 +43,7 @@ describe('Desolate Land', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blastoise", ability: 'torrent', moves: ['soak']}]);
 		const soakTarget = battle.p1.active[0];
-		assert.sets(() => soakTarget.getTypes().join('/'), 'Water', () => battle.commitDecisions());
+		assert.sets(() => soakTarget.getTypes().join('/'), 'Water', () => battle.makeChoices('move helpinghand', 'move soak'));
 	});
 
 	it('should prevent moves and abilities from setting the weather to Sunny Day, Rain Dance, Sandstorm, or Hail', function () {
@@ -57,16 +57,16 @@ describe('Desolate Land', function () {
 			{species: "Abomasnow", ability: 'snowwarning', moves: ['hail']},
 		]);
 		for (let i = 2; i <= 5; i++) {
-			battle.p2.chooseSwitch(i).foe.chooseDefault();
+			battle.makeChoices('move helpinghand', 'switch ' + i);
 			assert.ok(battle.isWeather('desolateland'));
-			battle.commitDecisions();
+			battle.makeChoices('move helpinghand', 'move 1');
 			assert.ok(battle.isWeather('desolateland'));
 		}
 	});
 
 	it('should be treated as Sunny Day for any forme, move or ability that requires it', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand', 'solarbeam']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand', 'solarbeam']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [
 			{species: "Castform", ability: 'forecast', moves: ['weatherball']},
 			{species: "Cherrim", ability: 'flowergift', moves: ['growth']},
@@ -79,16 +79,16 @@ describe('Desolate Land', function () {
 				assert.strictEqual(move.type, 'Fire');
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move helpinghand', 'move weatherball');
 		assert.species(p2.active[0], 'Castform-Sunny');
-		p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move helpinghand', 'switch 2');
 		assert.species(p2.active[0], 'Cherrim-Sunshine');
-		p2.chooseSwitch(3).foe.chooseDefault();
+		battle.makeChoices('move helpinghand', 'switch 3');
 		assert.false.fullHP(p2.active[0], "Charizard should be hurt by Solar Power");
-		p1.chooseMove(2).foe.chooseSwitch(4);
+		battle.makeChoices('move solarbeam', 'switch 4');
 		assert.strictEqual(p2.active[0].getStat('spe'), 2 * p2.active[0].stats['spe'], "Venusaur's speed should be doubled by Chlorophyll");
 		assert.false.fullHP(p2.active[0], "Solar Beam should skip its charge turn");
-		p2.chooseSwitch(5).foe.chooseDefault();
+		battle.makeChoices('move helpinghand', 'switch 5');
 		assert.false.fullHP(p2.active[0], "Toxicroak should be hurt by Dry Skin");
 	});
 
@@ -99,8 +99,7 @@ describe('Desolate Land', function () {
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['roost']}]);
-		battle.p1.chooseSwitch(2);
-		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.makeChoices('switch 2', 'move roost'));
 	});
 
 	it('should not cause the Desolate Land weather to fade if it switches out and another Desolate Land Pokemon is active', function () {
@@ -110,28 +109,27 @@ describe('Desolate Land', function () {
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Groudon", ability: 'desolateland', moves: ['bulkup']}]);
-		battle.p2.chooseSwitch(2);
-		assert.constant(() => battle.isWeather('desolateland'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('desolateland'), () => battle.makeChoices('move helpinghand', 'switch 2'));
 	});
 
 	it('should cause the Desolate Land weather to fade if its ability is suppressed and no other Desolate Land Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['gastroacid']}]);
-		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should not cause the Desolate Land weather to fade if its ability is suppressed and another Desolate Land Pokemon is active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Groudon", ability: 'desolateland', moves: ['gastroacid']}]);
-		assert.constant(() => battle.isWeather('desolateland'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('desolateland'), () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should cause the Desolate Land weather to fade if its ability is changed and no other Desolate Land Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['entrainment']}]);
-		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('desolateland'), false, () => battle.makeChoices('move helpinghand', 'move entrainment'));
 	});
 });

--- a/test/simulator/abilities/dryskin.js
+++ b/test/simulator/abilities/dryskin.js
@@ -14,23 +14,22 @@ describe('Dry Skin', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Ninetales', ability: 'flashfire', moves: ['sunnyday']}]);
-		assert.hurtsBy(p1.active[0], Math.floor(p1.active[0].maxhp / 8), () => battle.commitDecisions());
+		assert.hurtsBy(p1.active[0], Math.floor(p1.active[0].maxhp / 8), () => battle.makeChoices('move bulkup', 'move sunnyday'));
 	});
 
 	it('should heal 1/8 max HP every turn that Rain Dance is active', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['substitute']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Politoed', ability: 'damp', moves: ['encore', 'raindance']}]);
-		battle.commitDecisions();
-		p2.chooseMove('raindance');
-		assert.hurtsBy(p1.active[0], -Math.floor(p1.active[0].maxhp / 8), () => battle.commitDecisions());
+		battle.join('p2', 'Guest 2', 1, [{species: 'Politoed', ability: 'damp', moves: ['encore', 'raindance']}]);
+		battle.makeChoices('move substitute', 'move encore');
+		assert.hurtsBy(p1.active[0], -Math.floor(p1.active[0].maxhp / 8), () => battle.makeChoices('move substitute', 'move raindance'));
 	});
 
 	it('should grant immunity to Water-type moves and heal 1/4 max HP', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['substitute']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Politoed', ability: 'damp', moves: ['watergun']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move watergun');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
@@ -38,7 +37,7 @@ describe('Dry Skin', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'unnerve', moves: ['incinerate']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bulkup', 'move incinerate');
 		let damage = battle.p1.active[0].maxhp - battle.p1.active[0].hp;
 		assert.bounded(damage, [51, 61]);
 	});
@@ -47,11 +46,10 @@ describe('Dry Skin', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Toxicroak', ability: 'dryskin', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['incinerate', 'surf']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bulkup', 'move incinerate');
 		const target = battle.p1.active[0];
 		const damage = target.maxhp - target.hp;
 		assert.bounded(damage, [41, 49]);
-		battle.p2.chooseMove('surf');
-		assert.hurts(target, () => battle.commitDecisions());
+		assert.hurts(target, () => battle.makeChoices('move bulkup', 'move surf'));
 	});
 });

--- a/test/simulator/abilities/emergencyexit.js
+++ b/test/simulator/abilities/emergencyexit.js
@@ -17,7 +17,7 @@ describe(`Emergency Exit`, function () {
 		]);
 		const eePokemon = battle.p1.active[0];
 		const foePokemon = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move superfang', 'move superfang');
 		assert.strictEqual(foePokemon.hp, foePokemon.maxhp);
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 		assert.strictEqual(battle.currentRequest, 'switch');
@@ -28,7 +28,7 @@ describe(`Emergency Exit`, function () {
 			[{species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'], item: 'sitrusberry', ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
 			[{species: "Raticate", ability: 'guts', moves: ['superfang']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move superfang');
 		assert.strictEqual(battle.currentRequest, 'move');
 	});
 
@@ -38,9 +38,9 @@ describe(`Emergency Exit`, function () {
 			[{species: "Deoxys-Attack", ability: 'pressure', item: 'laggingtail', moves: ['thunderbolt']}],
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move thunderbolt');
 		assert.false.atMost(eePokemon.hp, eePokemon.maxhp / 2);
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move thunderbolt');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 		assert.strictEqual(battle.currentRequest, 'move');
 	});
@@ -51,13 +51,13 @@ describe(`Emergency Exit`, function () {
 			[{species: "Zekrom", ability: 'pressure', moves: ['voltswitch']}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move voltswitch');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 
 		assert.false.holdsItem(eePokemon);
 		assert.strictEqual(battle.currentRequest, 'switch');
 
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move voltswitch');
 		assert.species(battle.p1.active[0], 'Clefable');
 		assert.species(battle.p2.active[0], 'Zekrom');
 	});
@@ -68,13 +68,13 @@ describe(`Emergency Exit`, function () {
 			[{species: "Raticate", ability: 'guts', moves: ['superfang']}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move superfang');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 
 		assert.false.holdsItem(eePokemon);
 		assert.strictEqual(battle.currentRequest, 'switch');
 
-		battle.commitDecisions();
+		battle.makeChoices('move metronome', 'move metronome');
 		assert.species(battle.p1.active[0], 'Clefable');
 		assert.species(battle.p2.active[0], 'Clefable');
 	});
@@ -85,13 +85,13 @@ describe(`Emergency Exit`, function () {
 			[{species: "Raticate", ability: 'guts', moves: ['superfang']}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move superfang');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 
 		assert.false.holdsItem(eePokemon);
 		assert.strictEqual(battle.currentRequest, 'switch');
 
-		battle.commitDecisions();
+		battle.makeChoices('move metronome', 'move superfang');
 		assert.species(battle.p1.active[0], 'Clefable');
 	});
 
@@ -101,7 +101,7 @@ describe(`Emergency Exit`, function () {
 			[{species: "Nidoking", ability: 'sheerforce', moves: ['thunder']}],
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move thunder');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 		assert.strictEqual(battle.currentRequest, 'move');
 	});

--- a/test/simulator/abilities/flashfire.js
+++ b/test/simulator/abilities/flashfire.js
@@ -14,7 +14,7 @@ describe('Flash Fire', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['incinerate']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['flareblitz']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move incinerate', 'move flareblitz');
 		assert.fullHP(p1.active[0]);
 		let damage = p2.active[0].maxhp - p2.active[0].hp;
 		assert.bounded(damage, [82, 97]);
@@ -25,23 +25,23 @@ describe('Flash Fire', function () {
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['flareblitz']}]);
 		p1.active[0].setStatus('frz');
-		assert.false.hurts(p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(p1.active[0], () => battle.makeChoices('move sleeptalk', 'move flareblitz'));
 	});
 
 	it('should have its Fire-type immunity suppressed by Mold Breaker', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['incinerate']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['firepunch']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move incinerate', 'move firepunch'));
 	});
 
 	it('should lose the Flash Fire boost if its ability is changed', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['sleeptalk', 'incinerate']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['incinerate', 'worryseed']}]);
-		battle.commitDecisions();
+		battle.join('p2', 'Guest 2', 1, [{species: 'Talonflame', ability: 'galewings', moves: ['incinerate', 'worryseed']}]);
+		battle.makeChoices('move sleeptalk', 'move incinerate');
 		battle.resetRNG();
-		p2.chooseMove('worryseed').foe.chooseMove('incinerate');
+		battle.makeChoices('move incinerate', 'move worryseed');
 		let damage = battle.p2.active[0].maxhp - battle.p2.active[0].hp;
 		assert.bounded(damage, [54, 65]);
 	});
@@ -58,6 +58,6 @@ describe('Flash Fire [Gen 4]', function () {
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Heatran', ability: 'flashfire', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Charizard', ability: 'blaze', moves: ['flamethrower']}]);
 		p1.active[0].setStatus('frz');
-		assert.false.hurts(p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(p1.active[0], () => battle.makeChoices('move sleeptalk', 'move flamethrower'));
 	});
 });

--- a/test/simulator/abilities/flowergift.js
+++ b/test/simulator/abilities/flowergift.js
@@ -35,8 +35,7 @@ describe('Flower Gift', function () {
 			[{species: "Blissey", ability: 'flowergift', moves: ['healbell']}, {species: "Blissey", ability: 'flowergift', moves: ['healbell']}],
 		]);
 
-		battle.choose('p1', 'move 1 1, move 1');
-		battle.choose('p2', 'move 1, move 1');
+		battle.makeChoices('move transform 1, move healbell 1', 'move healbell, move healbell');
 		let cherAtk = battle.p1.active[0].getStat('atk');
 		let cherSpd = battle.p1.active[0].getStat('spd');
 		let baseAtk = battle.p1.active[1].getStat('atk');

--- a/test/simulator/abilities/immunity.js
+++ b/test/simulator/abilities/immunity.js
@@ -14,7 +14,7 @@ describe('Immunity', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Snorlax', ability: 'immunity', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'infiltrator', moves: ['toxic']}]);
-		assert.constant(() => battle.p1.active[0].status, () => battle.commitDecisions());
+		assert.constant(() => battle.p1.active[0].status, () => battle.makeChoices('move curse', 'move toxic'));
 	});
 
 	it('should cure poison if a Pokemon receives the ability', function () {
@@ -22,16 +22,15 @@ describe('Immunity', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Snorlax', ability: 'thickfat', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'immunity', moves: ['toxic', 'skillswap']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.status, 'tox', () => battle.commitDecisions());
-		battle.p2.chooseMove('skillswap');
-		assert.sets(() => target.status, '', () => battle.commitDecisions());
+		assert.sets(() => target.status, 'tox', () => battle.makeChoices('move curse', 'move toxic'));
+		assert.sets(() => target.status, '', () => battle.makeChoices('move curse', 'move skillswap'));
 	});
 
 	it('should have its immunity to poison temporarily suppressed by Mold Breaker, but should cure the status immediately afterwards', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Snorlax', ability: 'immunity', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'moldbreaker', moves: ['toxic']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move toxic');
 		assert.strictEqual(battle.log.filter(line => line.match(/-status\|.*\|tox/)).length, 1);
 		assert.strictEqual(battle.p1.active[0].status, '');
 	});

--- a/test/simulator/abilities/intimidate.js
+++ b/test/simulator/abilities/intimidate.js
@@ -26,8 +26,8 @@ describe('Intimidate', function () {
 			{species: "Greninja", item: 'laggingtail', ability: 'protean', moves: ['uturn']},
 			{species: "Gyarados", item: 'leftovers', ability: 'intimidate', moves: ['splash']},
 		]);
-		battle.commitDecisions(); // Team Preview
-		battle.p2.chooseSwitch(2);
+		battle.makeChoices('move substitute', 'move uturn');
+		battle.makeChoices('move substitute', 'switch gyarados');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 	});
 
@@ -58,7 +58,7 @@ describe('Intimidate', function () {
 			assert.species(source, intimidateCount === 0 ? 'Arcanine' : 'Gyarados');
 			intimidateCount++;
 		});
-		battle.commitDecisions(); // Finish Team Preview, switch both Pokemon in
+		battle.makeChoices('teampreview', 'teampreview'); // Finish Team Preview, switch both Pokemon in
 		assert.strictEqual(intimidateCount, 2);
 		assert.statStage(p1.active[0], 'atk', -1);
 		assert.statStage(p2.active[0], 'atk', -1);
@@ -73,7 +73,7 @@ describe('Intimidate', function () {
 			assert.species(source, intimidateCount === 0 ? 'Arcanine' : 'Gyarados');
 			intimidateCount++;
 		});
-		battle.commitDecisions(); // Finish Team Preview, switch both Pokemon in
+		battle.makeChoices('teampreview', 'teampreview'); // Finish Team Preview, switch both Pokemon in
 		assert.strictEqual(intimidateCount, 2);
 		assert.statStage(p1.active[0], 'atk', -1);
 		assert.statStage(p2.active[0], 'atk', -1);
@@ -96,17 +96,18 @@ describe('Intimidate', function () {
 			assert.species(source, intimidateCount % 2 === 0 ? 'Arcanine' : 'Gyarados');
 			intimidateCount++;
 		});
-		battle.commitDecisions(); // Team Preview
+		battle.makeChoices('teampreview', 'teampreview'); // Team Preview
 
-		battle.commitDecisions();
-		p1.chooseSwitch(2).foe.chooseSwitch(2);
+		battle.makeChoices('move healingwish', 'move healingwish');
+
+		battle.makeChoices('switch arcanine', 'switch gyarados');
 		// Both Pokemon switched in at the same time
 		assert.strictEqual(intimidateCount, 2);
 		assert.statStage(p1.active[0], 'atk', -1);
 		assert.statStage(p2.active[0], 'atk', -1);
 		// Do it again with the Pokemon in reverse order
-		battle.commitDecisions();
-		p1.chooseSwitch(3).foe.chooseSwitch(3);
+		battle.makeChoices('move healingwish', 'move healingwish');
+		battle.makeChoices('switch gyarados', 'switch arcanine');
 		assert.strictEqual(intimidateCount, 4);
 		assert.statStage(p1.active[0], 'atk', -1);
 		assert.statStage(p2.active[0], 'atk', -1);

--- a/test/simulator/abilities/klutz.js
+++ b/test/simulator/abilities/klutz.js
@@ -15,7 +15,7 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'leftovers', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Giratina", ability: 'pressure', moves: ['shadowsneak']}]);
 		const klutzMon = battle.p1.active[0];
-		assert.hurtsBy(klutzMon, Math.floor(klutzMon.maxhp / 2), () => battle.commitDecisions(), "Leftovers healing should not apply");
+		assert.hurtsBy(klutzMon, Math.floor(klutzMon.maxhp / 2), () => battle.makeChoices('move bellydrum', 'move shadowsneak'), "Leftovers healing should not apply");
 	});
 
 	it('should prevent items from being consumed', function () {
@@ -23,7 +23,7 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", level: 1, ability: 'klutz', item: 'sitrusberry', moves: ['endure']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['psychic']}]);
 		const klutzMon = battle.p1.active[0];
-		assert.constant(() => klutzMon.item, () => battle.commitDecisions());
+		assert.constant(() => klutzMon.item, () => battle.makeChoices('move endure', 'move psychic'));
 		assert.strictEqual(klutzMon.hp, 1);
 	});
 
@@ -31,7 +31,7 @@ describe('Klutz', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'assaultvest', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['psychic']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move protect', 'move psychic');
 		assert.strictEqual(battle.p1.active[0].lastMove.id, 'protect');
 	});
 
@@ -40,7 +40,7 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Genesect", ability: 'klutz', item: 'dousedrive', moves: ['calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['trick']}]);
 		const klutzMon = battle.p1.active[0];
-		assert.constant(() => klutzMon.item, () => battle.commitDecisions());
+		assert.constant(() => klutzMon.item, () => battle.makeChoices('move calmmind', 'move trick'));
 	});
 
 	it('should cause Fling to fail', function () {
@@ -48,14 +48,14 @@ describe('Klutz', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'seaincense', moves: ['fling']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['calmmind']}]);
 		const klutzMon = battle.p1.active[0];
-		assert.constant(() => klutzMon.item, () => battle.commitDecisions());
+		assert.constant(() => klutzMon.item, () => battle.makeChoices('move fling', 'move calmmind'));
 	});
 
 	it('should not prevent Pokemon from Mega Evolving', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'klutz', item: 'lopunnite', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Deoxys", ability: 'noguard', moves: ['calmmind']}]);
-		battle.p1.chooseMove('protect', 0, true).foe.chooseDefault();
+		battle.makeChoices('move protect mega', 'move calmmind');
 		assert.species(battle.p1.active[0], 'Lopunny-Mega');
 	});
 });

--- a/test/simulator/abilities/levitate.js
+++ b/test/simulator/abilities/levitate.js
@@ -14,14 +14,14 @@ describe('Levitate', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rotom', ability: 'levitate', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Aggron', ability: 'sturdy', moves: ['earthquake']}]);
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move earthquake'));
 	});
 
 	it('should make the user airborne', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Unown', ability: 'levitate', moves: ['spore']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Espeon', ability: 'magicbounce', moves: ['electricterrain']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move spore', 'move electricterrain');
 		assert.strictEqual(battle.p1.active[0].status, 'slp', "Levitate Pokémon should not be awaken by Electric Terrain");
 	});
 
@@ -29,7 +29,7 @@ describe('Levitate', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['earthquake']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move earthquake'));
 	});
 
 	it('should have its airborne property suppressed by Mold Breaker if it is forced out by a move', function () {
@@ -39,8 +39,8 @@ describe('Levitate', function () {
 			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['roar', 'spikes']}]);
-		battle.p2.chooseMove('spikes').foe.chooseDefault();
-		assert.hurts(battle.p1.pokemon[1], () => battle.commitDecisions());
+		battle.makeChoices('move sleeptalk', 'move spikes');
+		assert.hurts(battle.p1.pokemon[1], () => battle.makeChoices('move sleeptalk', 'move roar'));
 	});
 
 	it('should not have its airborne property suppressed by Mold Breaker if it switches out via Eject Button', function () {
@@ -50,9 +50,9 @@ describe('Levitate', function () {
 			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['tackle', 'spikes']}]);
-		battle.p2.chooseMove('spikes').foe.chooseDefault();
-		battle.commitDecisions();
-		assert.false.hurts(battle.p1.pokemon[1], () => battle.p1.chooseSwitch(2));
+		battle.makeChoices('move sleeptalk', 'move spikes');
+		battle.makeChoices('move sleeptalk', 'move tackle');
+		assert.false.hurts(battle.p1.pokemon[1], () => battle.makeChoices('switch 2', 'move tackle'));
 	});
 
 	it('should not have its airborne property suppressed by Mold Breaker if that Pokemon is no longer active', function () {
@@ -62,7 +62,7 @@ describe('Levitate', function () {
 			{species: 'Haxorus', ability: 'moldbreaker', item: 'laggingtail', moves: ['tackle']},
 			{species: 'Rotom', ability: 'levitate', moves: ['rest']},
 		]);
-		assert.false.hurts(battle.p2.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p2.active[0], () => battle.makeChoices('move spikes', 'move tackle'));
 	});
 });
 
@@ -76,7 +76,7 @@ describe('Levitate [Gen 4]', function () {
 			[{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}, {species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']}],
 			[{species: 'Rampardos', ability: 'moldbreaker', moves: ['roar', 'spikes']}],
 		]);
-		battle.p2.chooseMove('spikes').foe.chooseDefault();
-		assert.false.hurts(battle.p1.pokemon[1], () => battle.commitDecisions());
+		battle.makeChoices('move sleeptalk', 'move spike');
+		assert.false.hurts(battle.p1.pokemon[1], () => battle.makeChoices('move sleeptalk', 'move roar'));
 	});
 });

--- a/test/simulator/abilities/lightningrod.js
+++ b/test/simulator/abilities/lightningrod.js
@@ -14,7 +14,7 @@ describe('Lightning Rod', function () {
 		battle = common.gen(6).createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Manectric', ability: 'lightningrod', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'static', moves: ['thunderbolt']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move thunderbolt');
 		assert.fullHP(battle.p1.active[0]);
 		assert.statStage(battle.p1.active[0], 'spa', 1);
 	});
@@ -23,7 +23,7 @@ describe('Lightning Rod', function () {
 		battle = common.gen(6).createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rhydon', ability: 'lightningrod', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'static', moves: ['thunderbolt']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move thunderbolt');
 		assert.statStage(battle.p1.active[0], 'spa', 0);
 	});
 
@@ -31,7 +31,7 @@ describe('Lightning Rod', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rhydon', ability: 'lightningrod', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'static', moves: ['thunderbolt']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move thunderbolt');
 		assert.fullHP(battle.p1.active[0]);
 		assert.statStage(battle.p1.active[0], 'spa', 1);
 	});
@@ -39,18 +39,17 @@ describe('Lightning Rod', function () {
 	it('should redirect single-target Electric-type attacks to the user if it is a valid target', function () {
 		this.timeout(3000);
 		battle = common.createBattle({gameType: 'triples'});
-		const p1 = battle.join('p1', 'Guest 1', 1, [
+		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Manectric', ability: 'lightningrod', moves: ['sleeptalk']},
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 		]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [
+		battle.join('p2', 'Guest 2', 1, [
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 		]);
-		p1.chooseMove(1).chooseMove(1, 1).chooseMove(1, 1);
-		p2.chooseMove(1, 3).chooseMove(1, 3).chooseMove(1, 2);
+		battle.makeChoices('move sleeptalk, move thunderbolt 1, move thunderbolt 1', 'move thunderbolt 3, move thunderbolt 3, move thunderbolt 2');
 		assert.statStage(battle.p1.active[0], 'spa', 3);
 		assert.false.fullHP(battle.p1.active[2]);
 		assert.false.fullHP(battle.p2.active[0]);
@@ -67,7 +66,7 @@ describe('Lightning Rod', function () {
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 		]);
 		p1.active[0].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1, 2);
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move thunderbolt 1, move thunderbolt 2');
 		assert.statStage(p1.active[0], 'spa', 2);
 		assert.statStage(p1.active[1], 'spa', 0);
 	});
@@ -82,7 +81,7 @@ describe('Lightning Rod', function () {
 			{species: 'Pichu', ability: 'static', moves: ['thunderbolt']},
 			{species: 'Pichu', ability: 'static', moves: ['thunderbolt']},
 		]);
-		p1.chooseMove(1, -2).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1, 2);
+		battle.makeChoices('move roleplay -2, move sleeptalk', 'move thunderbolt 1, move thunderbolt 2');
 		assert.statStage(p1.active[0], 'spa', 0);
 		assert.statStage(p1.active[1], 'spa', 2);
 	});
@@ -98,7 +97,7 @@ describe('Lightning Rod', function () {
 			{species: 'Electrode', ability: 'static', moves: ['thunderbolt']},
 		]);
 		p1.active[0].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 2).chooseMove(1, 1);
+		battle.makeChoices('move sleeptalk, move followme', 'move thunderbolt 2, move thunderbolt 1');
 		assert.statStage(p1.active[0], 'spa', 0);
 		assert.false.fullHP(p1.active[1]);
 	});
@@ -109,11 +108,11 @@ describe('Lightning Rod', function () {
 			{species: 'Manectric', ability: 'lightningrod', moves: ['endure']},
 			{species: 'Manaphy', ability: 'hydration', moves: ['tailglow']},
 		]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [
+		battle.join('p2', 'Guest 2', 1, [
 			{species: 'Haxorus', ability: 'moldbreaker', moves: ['thunderpunch']},
 			{species: 'Zekrom', ability: 'teravolt', moves: ['shockwave']},
 		]);
-		p2.chooseMove(1, 1).chooseMove(1, 2).foe.chooseDefault();
+		battle.makeChoices('move endure, move tailglow', 'move thunderpunch 1, move shockwave 2');
 		assert.false.fullHP(p1.active[0]);
 		assert.false.fullHP(p1.active[1]);
 	});

--- a/test/simulator/abilities/magicbounce.js
+++ b/test/simulator/abilities/magicbounce.js
@@ -16,7 +16,7 @@ describe('Magic Bounce', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Bulbasaur", ability: 'overgrow', moves: ['growl']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['futuresight']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move growl', 'move futuresight');
 		assert.statStage(battle.p1.active[0], 'atk', -1);
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 	});
@@ -25,7 +25,7 @@ describe('Magic Bounce', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Xatu", ability: 'magicbounce', moves: ['roost']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['growl']}]);
-		assert.doesNotThrow(() => battle.commitDecisions());
+		assert.doesNotThrow(() => battle.makeChoices('move roost', 'move growl'));
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'atk', -1);
 	});
@@ -37,8 +37,8 @@ describe('Magic Bounce', function () {
 			{species: "Xatu", item: 'choicescarf', ability: 'magicbounce', moves: ['roost', 'growl']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['growl', 'recover']}]);
-		battle.p1.chooseSwitch(2).foe.chooseDefault();
-		battle.p2.chooseMove(2).foe.chooseDefault();
+		battle.makeChoices('switch 2', 'move growl');
+		battle.makeChoices('move roost', 'move recover');
 		assert.notStrictEqual(battle.p1.active[0].lastMove.id, 'growl');
 	});
 
@@ -46,7 +46,7 @@ describe('Magic Bounce', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Bulbasaur", ability: 'moldbreaker', moves: ['growl']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Espeon", ability: 'magicbounce', moves: ['futuresight']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move growl', 'move futuresight');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'atk', -1);
 	});

--- a/test/simulator/abilities/magicguard.js
+++ b/test/simulator/abilities/magicguard.js
@@ -17,12 +17,12 @@ describe('Magic Guard', function () {
 			{species: 'Clefable', ability: 'magicguard', item: 'lifeorb', moves: ['doubleedge', 'mindblown']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'roughskin', moves: ['spikes', 'toxic']}]);
-		battle.commitDecisions();
-		battle.p1.chooseSwitch(2).foe.chooseMove('toxic');
+		battle.makeChoices('move splash', 'move spikes');
+		battle.makeChoices('switch 2', 'move toxic');
 		assert.strictEqual(battle.p1.active[0].status, 'tox');
 		assert.fullHP(battle.p1.active[0]);
-		battle.p1.chooseMove('mindblown').foe.chooseMove('toxic');
-		battle.commitDecisions();
+		battle.makeChoices('move mindblown', 'move toxic');
+		battle.makeChoices('move doubleedge', 'move spikes');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
@@ -33,8 +33,8 @@ describe('Magic Guard', function () {
 			{species: 'Clefable', ability: 'magicguard', moves: ['doubleedge']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['stealthrock', 'roar']}]);
-		battle.commitDecisions();
-		battle.p2.chooseMove('roar').foe.chooseDefault();
+		battle.makeChoices('move splash', 'move stealthrock');
+		battle.makeChoices('move splash', 'move roar');
 		assert.fullHP(battle.p1.active[0]);
 	});
 });

--- a/test/simulator/abilities/magnetpull.js
+++ b/test/simulator/abilities/magnetpull.js
@@ -12,19 +12,17 @@ describe('Magnet Pull', function () {
 
 	it('should prevent Steel-type Pokemon from switching out normally', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Magnezone", ability: 'magnetpull', moves: ['soak', 'charge']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [
+		battle.join('p1', 'Guest 1', 1, [{species: "Magnezone", ability: 'magnetpull', moves: ['soak', 'charge']}]);
+		battle.join('p2', 'Guest 2', 1, [
 			{species: "Heatran", ability: 'flashfire', moves: ['curse']},
 			{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 		]);
-		assert.false(p2.chooseSwitch(2));
-		battle.commitDecisions();
+		battle.makeChoices('move soak', 'switch 2');
 		assert.species(battle.p2.active[0], 'Heatran');
-		p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move soak', 'switch 2');
 		assert.species(battle.p2.active[0], 'Starmie');
-		p1.chooseMove(2).foe.chooseMove('reflecttype'); // Reflect Type makes Starmie part Steel
-		assert.false(p2.chooseSwitch(2));
-		battle.commitDecisions();
+		battle.makeChoices('move charge', 'move reflecttype'); // Reflect Type makes Starmie part Steel
+		battle.makeChoices('move soak', 'switch 2');
 		assert.species(battle.p2.active[0], 'Starmie');
 	});
 
@@ -35,8 +33,8 @@ describe('Magnet Pull', function () {
 			{species: "Heatran", ability: 'flashfire', moves: ['batonpass']},
 			{species: "Tentacruel", ability: 'clearbody', moves: ['rapidspin']},
 		]);
-		battle.p2.chooseMove('batonpass').foe.chooseDefault();
-		battle.p2.chooseSwitch(2);
+		battle.makeChoices('move toxic', 'move batonpass');
+		battle.makeChoices('move toxic', 'switch 2');
 		assert.species(battle.p2.active[0], 'Tentacruel');
 	});
 
@@ -47,7 +45,7 @@ describe('Magnet Pull', function () {
 			{species: "Aegislash", ability: 'stancechange', moves: ['swordsdance']},
 			{species: "Arcanine", ability: 'flashfire', moves: ['roar']},
 		]);
-		battle.p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move substitute', 'switch 2');
 		assert.species(battle.p2.active[0], 'Arcanine');
 	});
 });

--- a/test/simulator/abilities/multiscale.js
+++ b/test/simulator/abilities/multiscale.js
@@ -16,11 +16,11 @@ describe('Multiscale', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moxie', moves: ['incinerate']}]);
 		let damage, curhp;
 		let pokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move incinerate');
 		damage = pokemon.maxhp - pokemon.hp;
 		curhp = pokemon.hp;
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move incinerate');
 		assert.strictEqual(damage, battle.modify(curhp - pokemon.hp, 0.5));
 	});
 
@@ -30,11 +30,11 @@ describe('Multiscale', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moldbreaker', moves: ['incinerate']}]);
 		let damage, curhp;
 		let pokemon = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move incinerate');
 		damage = pokemon.maxhp - pokemon.hp;
 		curhp = pokemon.hp;
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move incinerate');
 		assert.strictEqual(curhp - pokemon.hp, damage);
 	});
 });

--- a/test/simulator/abilities/normalize.js
+++ b/test/simulator/abilities/normalize.js
@@ -14,7 +14,7 @@ describe('Normalize', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', moves: ['grassknot']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move grassknot', 'move endure');
 		assert.ok(battle.p2.active[0].hasType('Normal'));
 	});
 
@@ -22,7 +22,7 @@ describe('Normalize', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfighting']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move hiddenpowerfighting', 'move endure');
 		assert.ok(battle.p2.active[0].hasType('Fighting'));
 	});
 
@@ -30,7 +30,7 @@ describe('Normalize', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'dousedrive', moves: ['technoblast']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move technoblash', 'move endure');
 		assert.ok(battle.p2.active[0].hasType('Water'));
 	});
 
@@ -38,7 +38,7 @@ describe('Normalize', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'zapplate', moves: ['judgment']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move judgment', 'move endure');
 		assert.ok(battle.p2.active[0].hasType('Electric'));
 	});
 
@@ -46,7 +46,7 @@ describe('Normalize', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['sunnyday']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move weatherball', 'move sunnyday');
 		assert.ok(battle.p2.active[0].hasType('Fire'));
 	});
 
@@ -54,7 +54,7 @@ describe('Normalize', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Delcatty", ability: 'normalize', item: 'chopleberry', moves: ['naturalgift']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Latias", ability: 'colorchange', moves: ['endure']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move naturalgift', 'move endure');
 		assert.ok(battle.p2.active[0].hasType('Fighting'));
 	});
 });
@@ -69,7 +69,7 @@ describe('Normalize [Gen 4]', function () {
 			[{species: "Delcatty", ability: 'normalize', moves: ['grassknot']}],
 			[{species: "Latias", ability: 'colorchange', moves: ['endure']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move grassknot', 'move endure');
 		assert.ok(battle.p2.active[0].hasType('Normal'));
 	});
 
@@ -78,7 +78,7 @@ describe('Normalize [Gen 4]', function () {
 			[{species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfire']}],
 			[{species: "Latias", ability: 'colorchange', moves: ['endure']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move hiddenpowerfire', 'move endure');
 		assert.ok(battle.p2.active[0].hasType('Normal'));
 	});
 
@@ -87,7 +87,7 @@ describe('Normalize [Gen 4]', function () {
 			[{species: "Delcatty", ability: 'normalize', item: 'pixieplate', moves: ['judgment']}],
 			[{species: "Latias", ability: 'colorchange', moves: ['endure']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move judgment', 'move endure');
 		assert.ok(battle.p2.active[0].hasType('Normal'));
 	});
 
@@ -96,7 +96,7 @@ describe('Normalize [Gen 4]', function () {
 			[{species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball']}],
 			[{species: "Latias", ability: 'colorchange', moves: ['sunnyday']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move weatherball', 'move sunnyday');
 		assert.ok(battle.p2.active[0].hasType('Normal'));
 	});
 });

--- a/test/simulator/abilities/pickup.js
+++ b/test/simulator/abilities/pickup.js
@@ -14,7 +14,7 @@ describe('Pickup', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Gourgeist', ability: 'pickup', moves: ['flamethrower']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Paras', ability: 'dryskin', item: 'sitrusberry', moves: ['endure']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move flamethrower', 'move endure');
 		assert.holdsItem(battle.p1.active[0], "Pick Up should retrieve consumed Sitrus Berry");
 	});
 
@@ -22,7 +22,7 @@ describe('Pickup', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Gourgeist', ability: 'pickup', moves: ['endure']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Clefairy', ability: 'unaware', item: 'airballoon', moves: ['fling']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move endure', 'move fling');
 		assert.holdsItem(battle.p1.active[0], "Pick Up should retrieve flung Air Balloon");
 	});
 
@@ -30,7 +30,7 @@ describe('Pickup', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Ambipom', ability: 'pickup', moves: ['knockoff']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Machamp', ability: 'noguard', item: 'choicescarf', moves: ['bulkup']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move knockoff', 'move bulkup');
 		assert.false.holdsItem(battle.p1.active[0], "Pick Up should not retrieve knocked off Choice Scarf");
 	});
 
@@ -38,7 +38,7 @@ describe('Pickup', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Ambipom', ability: 'pickup', moves: ['fakeout']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Scizor', ability: 'swarm', item: 'airballoon', moves: ['roost']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move fakeout', 'move roost');
 		assert.false.holdsItem(battle.p1.active[0], "Pick Up should not retrieve popped Air Balloon");
 	});
 
@@ -53,9 +53,9 @@ describe('Pickup', function () {
 			{species: 'Clefable', ability: 'unaware', item: 'ejectbutton', moves: ['followme']},
 			{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 		]);
-		battle.commitDecisions();
-		battle.p2.chooseSwitch(3); // Eject Button activated
-		battle.p2.chooseSwitch(3);
+		battle.makeChoices('move shadowsneak, move rest', 'move uturn, move followme');
+		battle.makeChoices('move shadowsneak, move rest', 'switch 3'); // Eject Button activated
+		battle.makeChoices('move shadowsneak, move rest', 'switch 3');
 		assert.false.holdsItem(battle.p1.active[0], "Pick Up should not retrieve Eject Button of returned Clefable");
 	});
 
@@ -66,11 +66,11 @@ describe('Pickup', function () {
 			{species: 'Ambipom', ability: 'swarm', item: 'buggem', moves: ['uturn']},
 			{species: 'Dusknoir', ability: 'pressure', item: 'ejectbutton', moves: ['painsplit']},
 		]);
-		battle.p1.chooseMove('synthesis').foe.chooseMove('uturn');
-		battle.p2.chooseSwitch(2);
+		battle.makeChoices('move synthesis', 'move uturn');
+		battle.makeChoices('move shadowsneak', 'switch 2');
 		assert.false.holdsItem(battle.p1.active[0]);
-		battle.commitDecisions();
-		battle.choose('p2', 'switch 2');
+		battle.makeChoices('move shadowsneak', 'move painsplit');
+		battle.makeChoices('move shadowsneak', 'switch 2');
 		assert.false.holdsItem(battle.p1.active[0]);
 	});
 
@@ -78,7 +78,7 @@ describe('Pickup', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Ambipom', ability: 'pickup', moves: ['return']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Aron', level: 1, ability: 'sturdy', item: 'berryjuice', moves: ['recycle']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move return', 'move recycle');
 		assert.false.holdsItem(battle.p1.active[0]);
 	});
 
@@ -87,7 +87,7 @@ describe('Pickup', function () {
 			[{species: 'Ambipom', ability: 'pickup', moves: ['protect']}, {species: 'Aron', level: 1, ability: 'sturdy', item: 'berryjuice', moves: ['followme']}],
 			[{species: 'Ambipom', ability: 'technician', moves: ['return']}, {species: 'Arcanine', ability: 'flashfire', moves: ['protect']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move protect, move followme', 'move return, move protect');
 		assert.holdsItem(battle.p1.active[0]);
 	});
 
@@ -103,7 +103,7 @@ describe('Pickup', function () {
 			{species: 'Aggron', ability: 'sturdy', moves: ['rest']},
 			{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move protect, move curse, move extremespeed', 'move flamecharge, move rest, move splash');
 		assert.false.holdsItem(battle.p1.active[0]);
 	});
 });

--- a/test/simulator/abilities/prankster.js
+++ b/test/simulator/abilities/prankster.js
@@ -15,7 +15,7 @@ describe('Prankster', function () {
 			[{species: "Murkrow", ability: 'prankster', moves: ['taunt']}],
 			[{species: "Deoxys-Speed", ability: 'pressure', moves: ['calmmind']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move taunt', 'move calmmind');
 		assert.statStage(battle.p2.active[0], 'spa', 0);
 	});
 
@@ -24,7 +24,7 @@ describe('Prankster', function () {
 			[{species: "Sableye", ability: 'prankster', moves: ['willowisp']}],
 			[{species: "Sableye", ability: 'keeneye', moves: ['willowisp']}],
 		]);
-		assert.constant(() => battle.p2.active[0].status, () => battle.commitDecisions());
+		assert.constant(() => battle.p2.active[0].status, () => battle.makeChoices('move willowisp', 'move willowisp'));
 	});
 
 	it('should cause bounced Status moves to fail against Dark Pokémon', function () {
@@ -32,7 +32,7 @@ describe('Prankster', function () {
 			[{species: "Klefki", ability: 'prankster', moves: ['magiccoat']}],
 			[{species: "Spiritomb", ability: 'pressure', moves: ['willowisp']}],
 		]);
-		assert.constant(() => battle.p2.active[0].status, () => battle.commitDecisions());
+		assert.constant(() => battle.p2.active[0].status, () => battle.makeChoices('move magiccoat', 'move willowisp'));
 	});
 });
 
@@ -46,6 +46,6 @@ describe('Prankster [Gen 6]', function () {
 			[{species: "Sableye", ability: 'prankster', moves: ['willowisp']}],
 			[{species: "Sableye", ability: 'keeneye', moves: ['willowisp']}],
 		]);
-		assert.sets(() => battle.p2.active[0].status, 'brn', () => battle.commitDecisions());
+		assert.sets(() => battle.p2.active[0].status, 'brn', () => battle.makeChoices('move willowisp', 'move willowisp'));
 	});
 });

--- a/test/simulator/abilities/pressure.js
+++ b/test/simulator/abilities/pressure.js
@@ -15,8 +15,7 @@ describe('Pressure', function () {
 			[{species: "Giratina", ability: 'pressure', moves: ['rest']}, {species: "Talonflame", ability: 'galewings', moves: ['peck']}],
 			[{species: "Giratina", ability: 'defiant', moves: ['rest']}, {species: "Talonflame", ability: 'galewings', moves: ['peck']}],
 		]);
-		battle.choose('p1', 'move 1, move 1 -1');
-		battle.choose('p2', 'move 1, move 1 1');
+		battle.makeChoices('move rest, move peck -1', 'move rest, move peck 1');
 		let move = Dex.getMove('peck');
 		assert.strictEqual(battle.p1.active[1].getMoveData(move).pp, 55);
 		assert.strictEqual(battle.p2.active[1].getMoveData(move).pp, 54);
@@ -27,8 +26,7 @@ describe('Pressure', function () {
 			[{species: "Giratina", ability: 'pressure', moves: ['followme']}, {species: "Talonflame", ability: 'galewings', moves: ['peck']}],
 			[{species: "Clefable", ability: 'unaware', moves: ['followme']}, {species: "Ho-Oh", ability: 'pressure', moves: ['peck']}],
 		]);
-		battle.choose('p1', 'move 1, move 1 2');
-		battle.choose('p2', 'move 1, move 1 2');
+		battle.makeChoices('move followme, move peck 2', 'move followme, move peck 2');
 		let move = Dex.getMove('peck');
 		assert.strictEqual(battle.p1.active[1].getMoveData(move).pp, 55);
 		assert.strictEqual(battle.p2.active[1].getMoveData(move).pp, 54);
@@ -38,16 +36,13 @@ describe('Pressure', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Giratina", ability: 'pressure', item: 'laggingtail', moves: ['mistyterrain', 'shadowforce']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'desolateland', moves: ['doubleedge', 'spore', 'moonblast', 'surf']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move mistyterrain', 'move doubleedge');
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('doubleedge')).pp, 22);
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move shadowforce', 'move spore');
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('spore')).pp, 22);
-		battle.choose('p2', 'move 3');
-		battle.commitDecisions();
+		battle.makeChoices('move mistyterrain', 'move moonblast');
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('moonblast')).pp, 22);
-		battle.choose('p2', 'move 4');
-		battle.commitDecisions();
+		battle.makeChoices('move mistyterrain', 'move surf');
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('surf')).pp, 22);
 	});
 
@@ -64,7 +59,7 @@ describe('Pressure', function () {
 			{species: "Zekrom", ability: 'teravolt', moves: ['spikes']},
 			{species: "Reshiram", ability: 'turboblaze', moves: ['rockslide']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move rest, move rest, move rest', 'move hail, move spikes, move rockslide');
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('hail')).pp, 12);
 		assert.strictEqual(battle.p2.active[1].getMoveData(Dex.getMove('spikes')).pp, 28);
 		assert.strictEqual(battle.p2.active[2].getMoveData(Dex.getMove('rockslide')).pp, 13);
@@ -83,7 +78,7 @@ describe('Pressure', function () {
 			{species: "Zekrom", ability: 'teravolt', moves: ['imprison']},
 			{species: "Reshiram", ability: 'turboblaze', moves: ['rest']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move rest, move rest, move rest', 'move snatch, move imprison, move rest');
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('snatch')).pp, 12);
 		assert.strictEqual(battle.p2.active[1].getMoveData(Dex.getMove('imprison')).pp, 12);
 	});
@@ -99,8 +94,7 @@ describe('Pressure [Gen 4]', function () {
 			[{species: "Giratina", ability: 'pressure', moves: ['rest']}, {species: "Aerodactyl", ability: 'quickfeet', moves: ['peck']}],
 			[{species: "Giratina", ability: 'pressure', moves: ['rest']}, {species: "Aerodactyl", ability: 'quickfeet', moves: ['peck']}],
 		]);
-		battle.choose('p1', 'move 1, move 1 -1');
-		battle.choose('p2', 'move 1, move 1 1');
+		battle.makeChoices('move rest, move peck -1', 'move rest, move peck 1');
 		let move = Dex.getMove('peck');
 		assert.strictEqual(battle.p1.active[1].getMoveData(move).pp, 54);
 		assert.strictEqual(battle.p2.active[1].getMoveData(move).pp, 54);
@@ -111,8 +105,7 @@ describe('Pressure [Gen 4]', function () {
 			[{species: "Giratina", ability: 'pressure', moves: ['followme']}, {species: "Aerodactyl", ability: 'quickfeet', moves: ['peck']}],
 			[{species: "Clefable", ability: 'magicguard', moves: ['followme']}, {species: "Ho-Oh", ability: 'pressure', moves: ['peck']}],
 		]);
-		battle.choose('p1', 'move 1, move 1 2');
-		battle.choose('p2', 'move 1, move 1 2');
+		battle.makeChoices('move followme, move peck 2', 'move followme, move peck 2');
 		let move = Dex.getMove('peck');
 		assert.strictEqual(battle.p1.active[1].getMoveData(move).pp, 55);
 		assert.strictEqual(battle.p2.active[1].getMoveData(move).pp, 54);
@@ -124,10 +117,9 @@ describe('Pressure [Gen 4]', function () {
 			[{species: "Smeargle", ability: 'owntempo', moves: ['doubleedge', 'dragonpulse']}],
 		]);
 		const attacker = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move shadowforce', 'move doubleedge');
 		assert.strictEqual(attacker.getMoveData(Dex.getMove('doubleedge')).pp, 22);
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move shadowforce', 'move dragonpulse');
 		assert.strictEqual(attacker.getMoveData(Dex.getMove('dragonpulse')).pp, 14);
 	});
 
@@ -136,7 +128,7 @@ describe('Pressure [Gen 4]', function () {
 			[{species: "Palkia", ability: 'pressure', moves: ['rest']}, {species: "Dialga", ability: 'pressure', moves: ['rest']}],
 			[{species: "Lugia", ability: 'pressure', moves: ['hail']}, {species: "Ho-Oh", ability: 'pressure', moves: ['earthquake']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move rest', 'move earthquake');
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('hail')).pp, 12);
 		assert.strictEqual(battle.p2.active[1].getMoveData(Dex.getMove('earthquake')).pp, 12);
 	});
@@ -146,7 +138,7 @@ describe('Pressure [Gen 4]', function () {
 			[{species: "Palkia", ability: 'pressure', moves: ['calmmind']}],
 			[{species: "Dialga", ability: 'pressure', moves: ['calmmind']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move calmmind');
 		let move = Dex.getMove('calmmind');
 		assert.strictEqual(battle.p1.active[0].getMoveData(move).pp, 31);
 		assert.strictEqual(battle.p1.active[0].getMoveData(move).pp, 31);

--- a/test/simulator/abilities/primordialsea.js
+++ b/test/simulator/abilities/primordialsea.js
@@ -24,7 +24,7 @@ describe('Primordial Sea', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Blastoise', ability: 'torrent', moves: ['splash']}]);
 		const attacker = battle.p1.active[0];
 		const defender = battle.p2.active[0];
-		assert.hurtsBy(defender, 104, () => battle.commitDecisions());
+		assert.hurtsBy(defender, 104, () => battle.makeChoices('move waterpledge', 'move splash'));
 		const move = Dex.getMove('waterpledge');
 		const basePower = battle.runEvent('BasePower', attacker, defender, move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -34,7 +34,7 @@ describe('Primordial Sea', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Charizard", ability: 'blaze', moves: ['flamethrower']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move helpinghand', 'move flamethrower');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
@@ -42,7 +42,7 @@ describe('Primordial Sea', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Charizard", ability: 'noguard', moves: ['willowisp']}]);
-		assert.sets(() => battle.p1.active[0].status, 'brn', () => battle.commitDecisions());
+		assert.sets(() => battle.p1.active[0].status, 'brn', () => battle.makeChoices('move helpinghand', 'move willowisp'));
 	});
 
 	it('should prevent moves and abilities from setting the weather to Sunny Day, Rain Dance, Sandstorm, or Hail', function () {
@@ -56,9 +56,9 @@ describe('Primordial Sea', function () {
 			{species: "Abomasnow", ability: 'snowwarning', moves: ['hail']},
 		]);
 		for (let i = 2; i <= 5; i++) {
-			battle.p2.chooseSwitch(i).foe.chooseDefault();
+			battle.makeChoices('move helpinghand', 'move ' + i);
 			assert.ok(battle.isWeather('primordialsea'));
-			battle.commitDecisions();
+			battle.makeChoices('move helpinghand', 'move 1');
 			assert.ok(battle.isWeather('primordialsea'));
 		}
 	});
@@ -78,16 +78,16 @@ describe('Primordial Sea', function () {
 				assert.strictEqual(move.type, 'Water');
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move sonicboom', 'move weatherball');
 		assert.species(p2.active[0], 'Castform-Rainy');
-		p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move sonicboom', 'switch 2');
 		assert.strictEqual(battle.p2.active[0].getStat('spe'), 2 * battle.p2.active[0].stats['spe'], "Kingdra's Speed should be doubled by Swift Swim");
-		p2.chooseSwitch(3).foe.chooseMove(1);
+		battle.makeChoices('move sonicboom', 'switch 3');
 		assert.notStrictEqual(battle.p2.active[0].maxhp - battle.p2.active[0].hp, 20);
-		p2.chooseSwitch(4).foe.chooseMove(1);
+		battle.makeChoices('move sonicboom', 'switch 4');
 		assert.notStrictEqual(battle.p2.active[0].maxhp - battle.p2.active[0].hp, 20);
-		p2.chooseSwitch(5).foe.chooseDefault();
-		battle.commitDecisions();
+		battle.makeChoices('move sonicboom', 'switch 5');
+		battle.makeChoices('move sonicboom', 'move rest');
 		assert.strictEqual(battle.p2.active[0].status, '');
 	});
 
@@ -98,8 +98,7 @@ describe('Primordial Sea', function () {
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['roost']}]);
-		battle.p1.chooseSwitch(2);
-		assert.sets(() => battle.isWeather('primordialsea'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('primordialsea'), false, () => battle.makeChoices('switch 2', 'move roost'));
 	});
 
 	it('should not cause the Primordial Sea weather to fade if it switches out and another Primordial Sea Pokemon is active', function () {
@@ -109,28 +108,27 @@ describe('Primordial Sea', function () {
 			{species: "Ho-Oh", ability: 'pressure', moves: ['roost']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Kyogre", ability: 'primordialsea', moves: ['bulkup']}]);
-		battle.p1.chooseSwitch(2);
-		assert.constant(() => battle.isWeather('primordialsea'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('primordialsea'), () => battle.makeChoices('switch 2', 'move bulkup'));
 	});
 
 	it('should cause the Primordial Sea weather to fade if its ability is suppressed and no other Primordial Sea Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['gastroacid']}]);
-		assert.sets(() => battle.isWeather('primordialsea'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('primordialsea'), false, () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should not cause the Primordial Sea weather to fade if its ability is suppressed and another Primordial Sea Pokemon is active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Kyogre", ability: 'primordialsea', moves: ['gastroacid']}]);
-		assert.constant(() => battle.isWeather('primordialsea'), () => battle.commitDecisions());
+		assert.constant(() => battle.isWeather('primordialsea'), () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should cause the Primordial Sea weather to fade if its ability is changed and no other Primordial Sea Pokemon are active', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lugia", ability: 'pressure', moves: ['entrainment']}]);
-		assert.sets(() => battle.isWeather('primordialsea'), false, () => battle.commitDecisions());
+		assert.sets(() => battle.isWeather('primordialsea'), false, () => battle.makeChoices('move helpinghand', 'move entrainment'));
 	});
 });

--- a/test/simulator/abilities/rockhead.js
+++ b/test/simulator/abilities/rockhead.js
@@ -14,28 +14,28 @@ describe('Rock Head', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Aerodactyl', ability: 'rockhead', moves: ['doubleedge']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'clearbody', moves: ['rest']}]);
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move doubleedge', 'move rest'));
 	});
 
 	it('should not block recoil if the ability is disabled/removed mid-attack', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Aerodactyl', ability: 'rockhead', moves: ['doubleedge']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'mummy', moves: ['rest']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move doubleedge', 'move rest'));
 	});
 
 	it('should not block recoil from Struggle', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Aerodactyl', ability: 'rockhead', moves: ['roost']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Sableye', ability: 'prankster', moves: ['taunt']}]);
-		battle.commitDecisions();
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		battle.makeChoices('move roost', 'move taunt');
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move roost', 'move taunt'));
 	});
 
 	it('should not block crash damage', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rampardos', ability: 'rockhead', moves: ['jumpkick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Sableye', ability: 'prankster', moves: ['taunt']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move jumpkick', 'move taunt'));
 	});
 });

--- a/test/simulator/abilities/shadowtag.js
+++ b/test/simulator/abilities/shadowtag.js
@@ -17,8 +17,7 @@ describe('Shadow Tag', function () {
 			{species: "Tornadus", ability: 'defiant', moves: ['tailwind']},
 			{species: "Heatran", ability: 'flashfire', moves: ['roar']},
 		]);
-		assert.false(p2.chooseSwitch(2));
-		battle.commitDecisions();
+		assert.false(battle.makeChoices('move counter', 'switch 2'));
 		assert.species(p2.active[0], 'Tornadus');
 	});
 
@@ -29,8 +28,8 @@ describe('Shadow Tag', function () {
 			{species: "Tornadus", ability: 'defiant', moves: ['uturn']},
 			{species: "Heatran", ability: 'flashfire', moves: ['roar']},
 		]);
-		battle.commitDecisions();
-		p2.chooseSwitch(2);
+		battle.makeChoices('move counter', 'move uturn');
+		battle.makeChoices('move counter', 'switch 2');
 		assert.species(p2.active[0], 'Heatran');
 	});
 
@@ -41,8 +40,7 @@ describe('Shadow Tag', function () {
 			{species: "Gothitelle", ability: 'shadowtag', moves: ['psychic']},
 			{species: "Heatran", ability: 'flashfire', moves: ['roar']},
 		]);
-		p2.chooseSwitch(2);
-		battle.commitDecisions();
+		battle.makeChoices('move counter', 'switch 2');
 		assert.species(p2.active[0], 'Heatran');
 	});
 
@@ -53,8 +51,7 @@ describe('Shadow Tag', function () {
 			{species: "Gengar", ability: 'levitate', moves: ['curse']},
 			{species: "Heatran", ability: 'flashfire', moves: ['roar']},
 		]);
-		p2.chooseSwitch(2);
-		battle.commitDecisions();
+		battle.makeChoices('move counter', 'switch 2');
 		assert.species(p2.active[0], 'Heatran');
 	});
 });

--- a/test/simulator/abilities/sheerforce.js
+++ b/test/simulator/abilities/sheerforce.js
@@ -14,7 +14,7 @@ describe('Sheer Force', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Lapras', ability: 'shellarmor', item: 'laggingtail', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move rest');
 		assert.strictEqual(battle.p1.active[0].hp, 262);
 	});
 
@@ -22,7 +22,7 @@ describe('Sheer Force', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', moves: ['zapcannon']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Machamp', ability: 'noguard', moves: ['bulkup']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move zapcannon', 'move bulkup');
 		assert.strictEqual(battle.p2.active[0].status, '');
 	});
 
@@ -30,9 +30,8 @@ describe('Sheer Force', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['lockon', 'dynamicpunch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Scyther', ability: 'mummy', moves: ['irondefense']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move lockon', 'move irondefense');
+		battle.makeChoices('move dynamicpunch', 'move irondefense');
 		assert.false(battle.p2.active[0].volatiles['confusion']);
 		assert.strictEqual(battle.p1.active[0].hp, 262);
 	});
@@ -41,7 +40,7 @@ describe('Sheer Force', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['bodyslam']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Lapras', ability: 'shellarmor', item: 'laggingtail', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bodyslam', 'move rest');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 });

--- a/test/simulator/abilities/shellarmor.js
+++ b/test/simulator/abilities/shellarmor.js
@@ -22,7 +22,7 @@ describe('Shell Armor', function () {
 				assert.false(move.crit);
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move quickattack', 'move frostbreath');
 		assert.ok(successfulEvent);
 	});
 
@@ -38,7 +38,7 @@ describe('Shell Armor', function () {
 				assert.ok(move.crit);
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move quickattack', 'move frostbreath');
 		assert.ok(successfulEvent);
 	});
 });

--- a/test/simulator/abilities/shielddust.js
+++ b/test/simulator/abilities/shielddust.js
@@ -15,7 +15,7 @@ describe('Shield Dust', function () {
 			[{species: 'Latios', ability: 'noguard', moves: ['snarl']}, {species: 'Latias', ability: 'levitate', moves: ['roost']}],
 			[{species: 'Xerneas', ability: 'shielddust', moves: ['roost']}, {species: 'Yveltal', ability: 'pressure', moves: ['roost']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move snarl, move roost', 'move roost, move roost');
 		assert.statStage(battle.p2.active[0], 'spa', 0);
 		assert.statStage(battle.p2.active[1], 'spa', -1);
 	});
@@ -24,7 +24,7 @@ describe('Shield Dust', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Ledian', ability: 'ironfist', moves: ['poweruppunch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Dustox', ability: 'shielddust', moves: ['roost']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move poweruppunch', 'move roost');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
 	});
 
@@ -40,8 +40,8 @@ describe('Shield Dust', function () {
 				}
 			}
 		});
-		battle.commitDecisions(); // Team Preview
-		battle.commitDecisions();
+		battle.makeChoices('teampreview', 'teampreview'); // Team Preview
+		battle.makeChoices('move flamecharge', 'move cottonguard');
 		assert.statStage(battle.p1.active[0], 'spe', 1);
 		assert.statStage(battle.p2.active[0], 'def', 3); // Clefable did not flinch
 	});
@@ -50,7 +50,7 @@ describe('Shield Dust', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Ledian', ability: 'ironfist', item: 'petayaberry', moves: ['fling']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Dustox', ability: 'shielddust', moves: ['roost']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move fling', 'move roost');
 		assert.statStage(battle.p2.active[0], 'spa', 1);
 	});
 
@@ -58,10 +58,9 @@ describe('Shield Dust', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Ledian', ability: 'shielddust', moves: ['poweruppunch', 'strugglebug']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Clefable', ability: 'unaware', moves: ['softboiled']}]);
-		battle.choose('p1', 'move 1');
-		battle.commitDecisions();
+		battle.makeChoices('move powerpunch', 'move softboiled');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
-		battle.p1.chooseMove(2).foe.chooseDefault();
+		battle.makeChoices('move strugglebug', 'move softboiled');
 		assert.statStage(battle.p2.active[0], 'spa', -1);
 	});
 
@@ -69,7 +68,7 @@ describe('Shield Dust', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Pinsir', ability: 'moldbreaker', moves: ['strugglebug']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Dustox', ability: 'shielddust', moves: ['roost']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move strugglebug', 'move roost');
 		assert.statStage(battle.p2.active[0], 'spa', -1);
 	});
 });

--- a/test/simulator/abilities/simple.js
+++ b/test/simulator/abilities/simple.js
@@ -14,7 +14,7 @@ describe('Simple', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Bibarel", ability: 'simple', moves: ['curse']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Gyarados", ability: 'moxie', moves: ['splash']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move splash');
 		const target = battle.p1.active[0];
 		assert.statStage(target, 'atk', 2);
 		assert.statStage(target, 'def', 2);
@@ -33,7 +33,7 @@ describe('Simple [Gen 4]', function () {
 			[{species: "Gyarados", ability: 'moxie', moves: ['splash']}],
 		]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.getStat('def'), 2 * target.getStat('def'), () => battle.commitDecisions());
+		assert.sets(() => target.getStat('def'), 2 * target.getStat('def'), () => battle.makeChoices('move defensecurl', 'move splash'));
 		assert.statStage(target, 'def', 1);
 	});
 
@@ -42,8 +42,8 @@ describe('Simple [Gen 4]', function () {
 			[{species: "Sableye", ability: 'prankster', moves: ['batonpass']}, {species: "Bibarel", ability: 'simple', moves: ['protect']}],
 			[{species: "Gyarados", ability: 'intimidate', moves: ['splash']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'switch 2');
+		battle.makeChoices('move batonpass', 'move splash');
+		battle.makeChoices('switch 2', 'move splash');
 		assert.strictEqual(battle.p1.active[0].boosts['atk'], -1);
 		assert.strictEqual(battle.p1.active[0].getStat('atk'), Math.floor(0.5 * battle.p1.active[0].getStat('atk', true)));
 	});
@@ -54,7 +54,7 @@ describe('Simple [Gen 4]', function () {
 			[{species: "Haxorus", ability: 'moldbreaker', item: 'laggingtail', moves: ['earthquake']}],
 		]);
 		const target = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move defensecurl', 'move earthquake');
 		assert.bounded(target.maxhp - target.hp, [102, 120]);
 	});
 });

--- a/test/simulator/abilities/stickyhold.js
+++ b/test/simulator/abilities/stickyhold.js
@@ -20,12 +20,12 @@ describe('Sticky Hold', function () {
 			{species: 'Smeargle', ability: 'synchronize', moves: STEAL_MOVES},
 		]);
 		const itemHolder = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move recover', 'move grassknot');
 		assert.strictEqual(itemHolder.item, 'razzberry', "Shuckle should hold a Razz Berry");
-		battle.p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move recover', 'switch 2');
 
 		for (const moveid of STEAL_MOVES) {
-			battle.p2.chooseMove(moveid).foe.chooseDefault();
+			battle.makeChoices('move recover', 'move ' + moveid);
 			assert.holdsItem(itemHolder, "Shuckle should still hold its Razz Berry");
 		}
 	});
@@ -34,7 +34,7 @@ describe('Sticky Hold', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Pangoro', ability: 'moldbreaker', moves: ['knockoff']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Shuckle', ability: 'stickyhold', item: 'ironball', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move knockoff', 'move rest');
 		assert.false.holdsItem(battle.p2.active[0]);
 	});
 });

--- a/test/simulator/abilities/stormdrain.js
+++ b/test/simulator/abilities/stormdrain.js
@@ -14,25 +14,24 @@ describe('Storm Drain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move aquajet');
 		assert.fullHP(battle.p1.active[0]);
 		assert.statStage(battle.p1.active[0], 'spa', 1);
 	});
 
 	it('should redirect single-target Water-type attacks to the user if it is a valid target', function () {
 		battle = common.createBattle({gameType: 'triples'});
-		const p1 = battle.join('p1', 'Guest 1', 1, [
+		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk']},
 			{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']},
 			{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']},
 		]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [
+		battle.join('p2', 'Guest 2', 1, [
 			{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']},
 			{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']},
 			{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']},
 		]);
-		p1.chooseMove(1).chooseMove(1, 1).chooseMove(1, 1);
-		p2.chooseMove(1, 3).chooseMove(1, 3).chooseMove(1, 2);
+		battle.makeChoices('move sleeptalk, move aquajet 1, move aquajet 1', 'move aquajet 3, move aquajet 3, move aquajet 2');
 		assert.statStage(battle.p1.active[0], 'spa', 3);
 		assert.false.fullHP(battle.p1.active[2]);
 		assert.false.fullHP(battle.p2.active[0]);
@@ -49,7 +48,7 @@ describe('Storm Drain', function () {
 			{species: 'Azumarill', ability: 'thickfat', moves: ['waterfall']},
 		]);
 		p1.active[0].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 1).chooseMove(1, 2);
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move waterfall 1, move waterfall 2');
 		assert.statStage(p1.active[0], 'spa', 2);
 		assert.statStage(p1.active[1], 'spa', 0);
 	});
@@ -65,7 +64,7 @@ describe('Storm Drain', function () {
 			{species: 'Azumarill', ability: 'thickfat', moves: ['aquajet']},
 		]);
 		p1.active[0].boostBy({spe: 6});
-		p1.chooseMove(1).chooseMove(1).foe.chooseMove(1, 2).chooseMove(1, 1);
+		battle.makeChoices('move sleeptalk, move followme', 'move aquajet 2, move aquajet 1');
 		assert.statStage(p1.active[0], 'spa', 0);
 		assert.false.fullHP(p1.active[1]);
 	});
@@ -76,11 +75,11 @@ describe('Storm Drain', function () {
 			{species: 'Gastrodon', ability: 'stormdrain', moves: ['endure']},
 			{species: 'Manaphy', ability: 'hydration', moves: ['tailglow']},
 		]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [
+		battle.join('p2', 'Guest 2', 1, [
 			{species: 'Haxorus', ability: 'moldbreaker', moves: ['waterfall']},
 			{species: 'Reshiram', ability: 'turboblaze', moves: ['waterpulse']},
 		]);
-		p2.chooseMove(1, 1).chooseMove(1, 2).foe.chooseDefault();
+		battle.makeChoices('move endure, move tailglow', 'move waterfall 1, move waterpulse 2');
 		assert.false.fullHP(p1.active[0]);
 		assert.false.fullHP(p1.active[1]);
 	});

--- a/test/simulator/abilities/sturdy.js
+++ b/test/simulator/abilities/sturdy.js
@@ -14,14 +14,14 @@ describe('Sturdy', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Aron', level: 1, ability: 'sturdy', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Kyogre', ability: 'noguard', moves: ['sheercold']}]);
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move sheercold'));
 	});
 
 	it('should allow its user to survive an attack from full HP', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Paras', ability: 'sturdy', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Charizard', ability: 'drought', moves: ['fusionflare']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move fusionflare');
 		assert.strictEqual(battle.p1.active[0].hp, 1);
 	});
 
@@ -29,7 +29,7 @@ describe('Sturdy', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'sturdy', moves: ['absorb']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Klefki', ability: 'prankster', moves: ['confuseray']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move absorb', 'move confuseray');
 		assert.strictEqual(battle.p1.active[0].hp, 1);
 	});
 
@@ -37,7 +37,7 @@ describe('Sturdy', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'sturdy', moves: ['doubleedge']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Klefki', ability: 'prankster', moves: ['reflect']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move doubleedge', 'move reflect');
 		assert.fainted(battle.p1.active[0]);
 	});
 
@@ -45,7 +45,7 @@ describe('Sturdy', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'sturdy', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'infiltrator', moves: ['toxic']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move toxic');
 		assert.fainted(battle.p1.active[0]);
 	});
 
@@ -53,7 +53,7 @@ describe('Sturdy', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Paras', ability: 'sturdy', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Reshiram', ability: 'turboblaze', moves: ['fusionflare']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move fusionflare');
 		assert.fainted(battle.p1.active[0]);
 	});
 });

--- a/test/simulator/abilities/suctioncups.js
+++ b/test/simulator/abilities/suctioncups.js
@@ -17,11 +17,11 @@ describe('Suction Cups', function () {
 			{species: 'Forretress', ability: 'sturdy', moves: ['rapidspin']},
 		]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: 'Smeargle', ability: 'noguard', item: 'redcard', moves: ['healpulse', 'dragontail', 'circlethrow', 'roar']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move rapidspin', 'move healpulse');
 		assert.false.holdsItem(p2.active[0], "Red Card should activate");
 		assert.species(p1.active[0], 'Shuckle');
 		for (let i = 2; i <= 4; i++) {
-			p2.chooseMove(i).foe.chooseDefault();
+			battle.makeChoices('move rapidspin', 'move ' + i);
 			assert.species(p1.active[0], 'Shuckle');
 		}
 	});
@@ -33,7 +33,7 @@ describe('Suction Cups', function () {
 			{species: 'Shuckle', ability: 'suctioncups', item: 'ironball', moves: ['rest']},
 			{species: 'Forretress', ability: 'sturdy', moves: ['rapidspin']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move circlethrow', 'move rest');
 		assert.species(battle.p2.active[0], 'Forretress');
 	});
 });

--- a/test/simulator/abilities/thickfat.js
+++ b/test/simulator/abilities/thickfat.js
@@ -17,12 +17,12 @@ describe('Thick Fat', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Nidoking", ability: 'sheerforce', moves: ['incinerate', 'icebeam']}]);
 		const target = battle.p1.active[0];
 		// should not crit
-		battle.p2.chooseMove('incinerate').foe.chooseDefault();
+		battle.makeChoices('move splash', 'move incinerate');
 		assert.bounded(target.maxhp - target.hp, [29, 35]);
 		battle.heal(target.maxhp, target, target, battle.getFormat());
 		battle.resetRNG();
 		// should not crit
-		battle.p2.chooseMove('icebeam').foe.chooseDefault();
+		battle.makeChoices('move splash', 'move icebeam');
 		assert.bounded(target.maxhp - target.hp, [56, 66]);
 	});
 
@@ -33,12 +33,12 @@ describe('Thick Fat', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Nidoking", ability: 'moldbreaker', moves: ['incinerate', 'icebeam']}]);
 		const target = battle.p1.active[0];
 		// should not crit
-		battle.p2.chooseMove('incinerate').foe.chooseDefault();
+		battle.makeChoices('move splash', 'move incinerate');
 		assert.bounded(target.maxhp - target.hp, [57, 68]);
 		battle.heal(target.maxhp, target, target, battle.getFormat());
 		battle.resetRNG();
 		// should not crit
-		battle.p2.chooseMove('icebeam').foe.chooseDefault();
+		battle.makeChoices('move splash', 'move icebeam');
 		assert.bounded(target.maxhp - target.hp, [85, 101]);
 	});
 });

--- a/test/simulator/abilities/unaware.js
+++ b/test/simulator/abilities/unaware.js
@@ -15,13 +15,12 @@ describe('Unaware', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['softboiled']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hariyama', ability: 'thickfat', moves: ['vitalthrow', 'bellydrum']}]);
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move softboiled', 'move vitalthrow');
 		let pokemon = battle.p1.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move softboiled', 'move bellydrum');
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move softboiled', 'move vitalthrow');
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
@@ -29,14 +28,13 @@ describe('Unaware', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['moonblast', 'nastyplot']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'prankster', moves: ['splash']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move moonblast', 'move splash');
 		let pokemon = battle.p2.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move nastyplot', 'move splash');
 		pokemon.hp = pokemon.maxhp;
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move moonblast', 'move splash');
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
@@ -45,12 +43,12 @@ describe('Unaware', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['moonblast']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hariyama', ability: 'thickfat', item: 'laggingtail', moves: ['amnesia']}]);
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move moonblast', 'move amnesia');
 		let pokemon = battle.p2.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
 		pokemon.hp = pokemon.maxhp;
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move moonblast', 'move amnesia');
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
@@ -58,12 +56,12 @@ describe('Unaware', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['irondefense']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Registeel', ability: 'clearbody', moves: ['shadowsneak']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move irondefense', 'move shadowsneak');
 		let pokemon = battle.p1.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
 		pokemon.hp = pokemon.maxhp;
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move irondefense', 'move shadowsneak');
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
@@ -71,13 +69,13 @@ describe('Unaware', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Clefable', ability: 'unaware', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Haxorus', ability: 'moldbreaker', moves: ['shadowsneak']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move shadowsneak');
 		let pokemon = battle.p1.active[0];
 		let damage = pokemon.maxhp - pokemon.hp;
 		battle.boost({atk: 2}, battle.p2.active[0]);
 		pokemon.hp = pokemon.maxhp;
 		battle.resetRNG();
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move shadowsneak');
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 });

--- a/test/simulator/abilities/unburden.js
+++ b/test/simulator/abilities/unburden.js
@@ -15,7 +15,7 @@ describe('Unburden', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Hitmonlee', ability: 'unburden', item: 'whiteherb', moves: ['closecombat']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.commitDecisions());
+		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move closecombat', 'move swordsdance'));
 	});
 
 	it('should trigger when an item is destroyed', function () {
@@ -23,7 +23,7 @@ describe('Unburden', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Drifblim', ability: 'unburden', item: 'airballoon', moves: ['endure']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Machamp', ability: 'noguard', moves: ['stoneedge']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.commitDecisions());
+		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move endure', 'move stoneedge'));
 	});
 
 	it('should trigger when Natural Gift consumes a berry', function () {
@@ -31,7 +31,7 @@ describe('Unburden', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sceptile', ability: 'unburden', item: 'oranberry', moves: ['naturalgift']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.commitDecisions());
+		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move naturalgift', 'move swordsdance'));
 	});
 
 	it('should trigger when an item is flung', function () {
@@ -39,7 +39,7 @@ describe('Unburden', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['fling']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.commitDecisions());
+		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move fling', 'move swordsdance'));
 	});
 
 	it('should trigger when an item is forcefully removed', function () {
@@ -47,7 +47,7 @@ describe('Unburden', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['leechseed']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Scizor', ability: 'swarm', moves: ['knockoff']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.commitDecisions());
+		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move leechseed', 'move knockoff'));
 	});
 
 	it('should not be suppressed by Mold Breaker', function () {
@@ -55,7 +55,7 @@ describe('Unburden', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['leechseed']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Scizor', ability: 'moldbreaker', moves: ['knockoff']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.commitDecisions());
+		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move leechseed', 'move knockoff'));
 	});
 
 	it('should lose the boost when it gains a new item', function () {
@@ -63,10 +63,9 @@ describe('Unburden', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Hitmonlee', ability: 'unburden', item: 'fightinggem', moves: ['machpunch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Togekiss', ability: 'serenegrace', item: 'laggingtail', moves: ['bestow', 'followme']}]);
 		const originalSpeed = battle.p1.active[0].getStat('spe');
-		battle.choose('p2', 'move followme');
-		battle.commitDecisions();
+		battle.makeChoices('move machpunch', 'move followme');
 		assert.strictEqual(battle.p1.active[0].getStat('spe'), 2 * originalSpeed);
-		battle.commitDecisions();
+		battle.makeChoices('move machpunch', 'move bestow');
 		assert.strictEqual(battle.p1.active[0].getStat('spe'), originalSpeed);
 	});
 });

--- a/test/simulator/abilities/wonderguard.js
+++ b/test/simulator/abilities/wonderguard.js
@@ -15,27 +15,24 @@ describe('Wonder Guard', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Aerodactyl", ability: 'wonderguard', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['knockoff', 'flamethrower', 'thousandarrows', 'moonblast']}]);
 		for (let i = 1; i <= 4; i++) {
-			battle.choose('p2', 'move ' + i);
-			battle.commitDecisions();
+			battle.makeChoices('move sleeptalk', 'move ' + i);
 			assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		}
 		// Thousand Arrows shouldn't add the Smack Down volatile if blocked by Wonder Guard
-		battle.p2.chooseMove('thousandarrows');
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move thousandarrows'));
 	});
 
 	it('should not make the user immune to status moves', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Abra", ability: 'wonderguard', moves: ['teleport']}]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'noguard', moves: ['poisongas', 'screech', 'healpulse', 'gastroacid']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", ability: 'noguard', moves: ['poisongas', 'screech', 'healpulse', 'gastroacid']}]);
 		const target = p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move teleport', 'move poisongas');
 		assert.strictEqual(target.status, 'psn');
-		p2.chooseMove(2).foe.chooseDefault();
+		battle.makeChoices('move teleport', 'move screech');
 		assert.statStage(target, 'def', -2);
-		p2.chooseMove('healpulse');
-		assert.hurtsBy(target, -Math.floor(target.maxhp / 8), () => battle.commitDecisions());
-		p2.chooseMove('gastroacid').foe.chooseDefault();
+		assert.hurtsBy(target, -Math.floor(target.maxhp / 8), () => battle.makeChoices('move teleport', 'move healpulse'));
+		battle.makeChoices('move teleport', 'move gastroacid');
 		assert.ok(battle.p1.active[0].volatiles['gastroacid']);
 		assert.false(battle.p1.active[0].hasAbility('wonderguard'));
 	});
@@ -44,6 +41,6 @@ describe('Wonder Guard', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zekrom", ability: 'wonderguard', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Reshiram", ability: 'turboblaze', moves: ['fusionflare']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move fusionflare'));
 	});
 });

--- a/test/simulator/items/assaultvest.js
+++ b/test/simulator/items/assaultvest.js
@@ -14,7 +14,7 @@ describe('Assault Vest', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Abra', ability: 'synchronize', moves: ['teleport']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', item: 'assaultvest', moves: ['teleport']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move teleport', 'move teleport');
 		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
@@ -22,7 +22,7 @@ describe('Assault Vest', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Lopunny', ability: 'klutz', item: 'assaultvest', moves: ['trick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', item: 'ironball', moves: ['calmmind']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move trick', 'move calmmind');
 		assert.statStage(battle.p2.active[0], 'spa', 1);
 		assert.statStage(battle.p2.active[0], 'spd', 1);
 	});

--- a/test/simulator/items/drives.js
+++ b/test/simulator/items/drives.js
@@ -24,12 +24,12 @@ describe('Drives', function () {
 					{species: 'Abra', ability: 'synchronize', moves: ['thief', 'trick', 'knockoff']},
 				]);
 				const holder = battle.p1.active[0];
-				battle.commitDecisions(); // Fennekin's Magician
+				battle.makeChoices('move recover', 'move thief'); // Fennekin's Magician
 				assert.holdsItem(holder);
-				battle.p2.chooseSwitch(2).foe.chooseDefault();
+				battle.makeChoices('move recover', 'switch 2');
 
 				for (let i = 1; i <= 3; i++) {
-					battle.p2.chooseMove(i).foe.chooseDefault();
+					battle.makeChoices('move recover', 'move ' + i);
 					assert.holdsItem(holder);
 				}
 			});
@@ -38,7 +38,7 @@ describe('Drives', function () {
 				battle = common.createBattle();
 				battle.join('p1', 'Guest 1', 1, [{species: 'Mawile', ability: 'intimidate', moves: ['swordsdance']}]);
 				battle.join('p2', 'Guest 2', 1, [{species: 'Genesect', ability: 'frisk', item: id, moves: ['fling']}]);
-				battle.commitDecisions();
+				battle.makeChoices('move swordsdance', 'move fling');
 				assert.holdsItem(battle.p2.active[0]);
 			});
 
@@ -46,7 +46,7 @@ describe('Drives', function () {
 				battle = common.createBattle();
 				battle.join('p1', 'Guest 1', 1, [{species: 'Genesect', ability: 'frisk', moves: ['thief']}]);
 				battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bestow']}]);
-				battle.commitDecisions();
+				battle.makeChoices('move thief', 'move bestow');
 				assert.false.holdsItem(battle.p1.active[0]);
 			});
 
@@ -54,7 +54,7 @@ describe('Drives', function () {
 				battle = common.createBattle();
 				battle.join('p1', 'Guest 1', 1, [{species: 'Genesect', ability: 'frisk', moves: ['knockoff']}]);
 				battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bulkup']}]);
-				battle.commitDecisions();
+				battle.makeChoices('move knockoff', 'move bulkup');
 				assert.false.holdsItem(battle.p2.active[0]);
 			});
 		});

--- a/test/simulator/items/flameorb.js
+++ b/test/simulator/items/flameorb.js
@@ -19,8 +19,8 @@ describe('Flame Orb', function () {
 		battle.join('p2', 'Guest 2', 1, [
 			{species: 'Breloom', ability: 'technician', moves: ['bulletseed']},
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'switch 2');
+		battle.makeChoices('move splash', 'move bulletseed');
+		battle.makeChoices('switch 2', 'move bulletseed');
 		assert.notStrictEqual(battle.p1.active[0].status, 'brn');
 	});
 
@@ -29,6 +29,6 @@ describe('Flame Orb', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Ursaring', ability: 'guts', item: 'flameorb', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']}]);
 		const target = battle.p1.active[0];
-		assert.sets(() => target.status, 'brn', () => battle.commitDecisions());
+		assert.sets(() => target.status, 'brn', () => battle.makeChoices('move protect', 'move splash'));
 	});
 });

--- a/test/simulator/items/focussash.js
+++ b/test/simulator/items/focussash.js
@@ -15,7 +15,7 @@ describe('Focus Sash', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Paras', ability: 'dryskin', item: 'focussash', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Delphox', ability: 'magician', moves: ['incinerate']}]);
 		const holder = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move incinerate');
 		assert.false.holdsItem(holder);
 		assert.false.fainted(holder);
 		assert.strictEqual(holder.hp, 1);
@@ -26,7 +26,7 @@ describe('Focus Sash', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['absorb']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Klefki', ability: 'prankster', moves: ['confuseray']}]);
 		const holder = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move absorb', 'move confuseray');
 		assert.false.holdsItem(holder);
 		assert.false.fainted(holder);
 		assert.strictEqual(holder.hp, 1);
@@ -37,7 +37,7 @@ describe('Focus Sash', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['doubleedge']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Klefki', ability: 'prankster', moves: ['reflect']}]);
 		const holder = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move doubleedge', 'move reflect');
 		assert.holdsItem(holder);
 		assert.fainted(holder);
 	});
@@ -47,7 +47,7 @@ describe('Focus Sash', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'infiltrator', moves: ['toxic']}]);
 		const holder = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move toxic');
 		assert.holdsItem(holder);
 		assert.fainted(holder);
 	});

--- a/test/simulator/items/ironball.js
+++ b/test/simulator/items/ironball.js
@@ -15,7 +15,7 @@ describe('Iron Ball', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', item: 'ironball', moves: ['bestow']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Aerodactyl", ability: 'pressure', moves: ['stealthrock']}]);
 		const target = battle.p2.active[0];
-		assert.sets(() => target.getStat('spe'), battle.modify(target.getStat('spe'), 0.5), () => battle.commitDecisions());
+		assert.sets(() => target.getStat('spe'), battle.modify(target.getStat('spe'), 0.5), () => battle.makeChoices('move bestow', 'move stealthrock'));
 	});
 
 	it('should negate Ground immunities and deal neutral type effectiveness to Flying-type Pokemon', function () {
@@ -25,12 +25,11 @@ describe('Iron Ball', function () {
 			{species: "Aerodactyl", ability: 'pressure', item: 'ironball', moves: ['stealthrock']},
 			{species: "Tropius", ability: 'harvest', item: 'ironball', moves: ['leechseed']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move stealthrock');
 		// Earthquake neutral on Aerodactyl
 		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.choose('p2', 'switch 2');
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'switch leechseed');
 		// Earthquake neutral on Tropius
 		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
@@ -44,14 +43,13 @@ describe('Iron Ball', function () {
 			{species: "Tropius", ability: 'shellarmor', item: 'ironball', moves: ['leechseed']},
 		]);
 		// Set up Gravity
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 1');
+		battle.makeChoices('move gravity', 'move stealthrock');
 
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move stealthrock');
 		// Earthquake supereffective on Aerodactyl
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move earthquake', 'switch 2');
 		// Earthquake not very effective on Tropius
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
@@ -64,10 +62,10 @@ describe('Iron Ball', function () {
 			{species: "Rotom", ability: 'levitate', item: 'ironball', moves: ['rest']},
 			{species: "Parasect", ability: 'levitate', item: 'ironball', moves: ['rest']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move rest');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move earthquake', 'switch 2');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
@@ -76,7 +74,7 @@ describe('Iron Ball', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['spore']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Thundurus", ability: 'prankster', item: 'ironball', moves: ['electricterrain']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move spore', 'move electricterrain');
 		assert.strictEqual(battle.p2.active[0].status, '');
 	});
 });

--- a/test/simulator/items/lansatberry.js
+++ b/test/simulator/items/lansatberry.js
@@ -15,7 +15,7 @@ describe('Lansat Berry', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Aggron', ability: 'sturdy', item: 'lansatberry', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Lucario', ability: 'adaptability', moves: ['aurasphere']}]);
 		const holder = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move aurasphere');
 		assert.false.holdsItem(holder);
 		assert.ok('focusenergy' in holder.volatiles);
 	});
@@ -33,8 +33,8 @@ describe('Lansat Berry', function () {
 			assert.strictEqual(critRatio, expectedRatio[i++]);
 		});
 
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move triplekick', 'move acidarmor');
+		battle.makeChoices('move triplekick', 'move acidarmor');
 
 		assert.false.holdsItem(holder);
 		assert.strictEqual(holder.hp, 3);

--- a/test/simulator/items/leftovers.js
+++ b/test/simulator/items/leftovers.js
@@ -19,11 +19,11 @@ describe('Leftovers [Gen 2]', function () {
 		battle.join('p2', 'Guest 2', 1, [
 			{species: "Miltank", moves: ['seismictoss']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move healbell', 'move seismictoss');
 		assert.strictEqual(p1.active[0].hp, 590);
 
-		p1.chooseSwitch(2).foe.chooseDefault();
-		p1.chooseSwitch(2);
+		battle.makeChoices('switch 2', 'move seismictoss');
+		battle.makeChoices('switch 2', 'move seismictoss');
 		assert.strictEqual(p1.active[0].hp, 630);
 	});
 });

--- a/test/simulator/items/mail.js
+++ b/test/simulator/items/mail.js
@@ -19,13 +19,11 @@ describe('Mail', function () {
 			{species: 'Lopunny', ability: 'klutz', moves: ['switcheroo']},
 		]);
 		const holder = battle.p1.active[0];
-		assert.constant(() => holder.item, () => battle.commitDecisions());
-		battle.p2.chooseSwitch(2).foe.chooseDefault();
-		battle.p2.chooseMove('trick');
-		assert.constant(() => holder.item, () => battle.commitDecisions());
-		battle.p2.chooseSwitch(2).foe.chooseDefault();
-		battle.p2.chooseMove('switcheroo');
-		assert.constant(() => holder.item, () => battle.commitDecisions());
+		assert.constant(() => holder.item, () => battle.makeChoices('move softboiled', 'move grassknot'));
+		battle.makeChoices('move softboiled', 'switch 2');
+		assert.constant(() => holder.item, () => battle.makeChoices('move softboiled', 'move trick'));
+		battle.makeChoices('move softboiled', 'switch 2');
+		assert.constant(() => holder.item, () => battle.makeChoices('move softboild', 'move switcheroo'));
 	});
 
 	it('should not be removed by Fling', function () {
@@ -33,7 +31,7 @@ describe('Mail', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Pangoro', ability: 'ironfist', moves: ['swordsdance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', item: 'mail', moves: ['fling']}]);
 		const holder = battle.p2.active[0];
-		assert.constant(() => holder.item, () => battle.commitDecisions());
+		assert.constant(() => holder.item, () => battle.makeChoices('move swordsdance', 'move fling'));
 	});
 
 	it('should be removed by Knock Off', function () {
@@ -41,7 +39,7 @@ describe('Mail', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Pangoro', ability: 'ironfist', item: 'mail', moves: ['swordsdance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['knockoff']}]);
 		const holder = battle.p1.active[0];
-		assert.false.constant(() => holder.item, () => battle.commitDecisions());
+		assert.false.constant(() => holder.item, () => battle.makeChoices('move swordsdance', 'move knockoff'));
 	});
 
 	it('should be stolen by Thief', function () {
@@ -49,6 +47,6 @@ describe('Mail', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Pangoro', ability: 'ironfist', item: 'mail', moves: ['swordsdance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['thief']}]);
 		const holder = battle.p1.active[0];
-		assert.false.constant(() => holder.item, () => battle.commitDecisions());
+		assert.false.constant(() => holder.item, () => battle.makeChoices('move swordsdance', 'move thief'));
 	});
 });

--- a/test/simulator/items/plates.js
+++ b/test/simulator/items/plates.js
@@ -27,12 +27,12 @@ describe('Plates', function () {
 					{species: 'Abra', ability: 'synchronize', moves: ['thief', 'trick', 'knockoff']},
 				]);
 				const holder = battle.p1.active[0];
-				battle.commitDecisions(); // Fennekin's Magician
+				battle.makeChoices('move recover', 'move mysticalfire'); // Fennekin's Magician
 				assert.holdsItem(holder);
-				battle.p2.chooseSwitch(2).foe.chooseDefault();
+				battle.makeChoices('move recover', 'switch 2');
 
 				for (let i = 1; i <= 3; i++) {
-					battle.p2.chooseMove(i).foe.chooseDefault();
+					battle.makeChoices('move recover', 'move ' + i);
 					assert.holdsItem(holder);
 				}
 			});
@@ -41,7 +41,7 @@ describe('Plates', function () {
 				battle = common.createBattle();
 				battle.join('p1', 'Guest 1', 1, [{species: 'Mawile', ability: 'intimidate', moves: ['swordsdance']}]);
 				battle.join('p2', 'Guest 2', 1, [{species: 'Arceus', ability: 'frisk', item: id, moves: ['fling']}]);
-				battle.commitDecisions();
+				battle.makeChoices('move swordsdance', 'move fling');
 				assert.holdsItem(battle.p2.active[0]);
 			});
 
@@ -49,7 +49,7 @@ describe('Plates', function () {
 				battle = common.createBattle();
 				battle.join('p1', 'Guest 1', 1, [{species: 'Arceus', ability: 'multitype', moves: ['thief']}]);
 				battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bestow']}]);
-				battle.commitDecisions();
+				battle.makeChoices('move thief', 'move bestow');
 				assert.false.holdsItem(battle.p1.active[0]);
 			});
 
@@ -57,7 +57,7 @@ describe('Plates', function () {
 				battle = common.createBattle();
 				battle.join('p1', 'Guest 1', 1, [{species: 'Arceus', ability: 'multitype', moves: ['knockoff']}]);
 				battle.join('p2', 'Guest 2', 1, [{species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bulkup']}]);
-				battle.commitDecisions();
+				battle.makeChoices('move knockoff', 'move bulkup');
 				assert.false.holdsItem(battle.p2.active[0]);
 			});
 		});

--- a/test/simulator/items/ringtarget.js
+++ b/test/simulator/items/ringtarget.js
@@ -19,19 +19,19 @@ describe('Ring Target', function () {
 			{species: "Girafarig", ability: 'innerfocus', item: 'ringtarget', moves: ['rest']},
 			{species: "Absol", ability: 'superluck', item: 'ringtarget', moves: ['rest']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move rest');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.false.fullHP(battle.p2.active[0]);
 
-		battle.p1.chooseMove('vitalthrow').foe.chooseSwitch(2); // Drifblim
+		battle.makeChoices('move vitalthrow', 'switch 2'); // Drifblim
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 		assert.false.fullHP(battle.p2.active[0]);
 
-		battle.p1.chooseMove('shadowball').foe.chooseSwitch(3); // Girafarig
+		battle.makeChoices('move shadowball', 'switch 3'); // Girafarig
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.false.fullHP(battle.p2.active[0]);
 
-		battle.p1.chooseMove('psychic').foe.chooseSwitch(4); // Absol
+		battle.makeChoices('move psychich', 'switch 4'); // Absol
 		assert.false.fullHP(battle.p2.active[0]);
 	});
 
@@ -42,11 +42,11 @@ describe('Ring Target', function () {
 			{species: "Mismagius", ability: 'levitate', item: 'ringtarget', moves: ['shadowsneak']},
 			{species: "Rotom-Fan", ability: 'levitate', item: 'ringtarget', moves: ['snore']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move shadowsneak');
 		assert.fullHP(battle.p2.active[0]);
 
 		// even if Rotom-Fan
-		battle.p2.chooseSwitch(2).foe.chooseDefault();
+		battle.makeChoices('move earthquake', 'switch 2');
 		assert.fullHP(battle.p2.active[0]);
 	});
 });

--- a/test/simulator/items/shedshell.js
+++ b/test/simulator/items/shedshell.js
@@ -17,8 +17,7 @@ describe('Shed Shell', function () {
 			{species: "Starmie", ability: 'naturalcure', item: 'shedshell', moves: ['recover']},
 			{species: "Heatran", ability: 'flashfire', moves: ['rest']},
 		]);
-		battle.p2.chooseSwitch(2);
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'switch 2');
 		assert.species(battle.p2.active[0], 'Heatran');
 	});
 
@@ -29,9 +28,8 @@ describe('Shed Shell', function () {
 			{species: "Venusaur", ability: 'overgrow', item: 'shedshell', moves: ['ingrain']},
 			{species: "Heatran", ability: 'flashfire', moves: ['rest']},
 		]);
-		battle.commitDecisions();
-		battle.p2.chooseSwitch(2);
-		battle.commitDecisions();
+		battle.makeChoices('move meanlook', 'move ingrain');
+		battle.makeChoices('move meanlook', 'switch 2');
 		assert.species(battle.p2.active[0], 'Heatran');
 	});
 
@@ -42,9 +40,8 @@ describe('Shed Shell', function () {
 			{species: "Magnezone", ability: 'sturdy', item: 'shedshell', moves: ['sleeptalk']},
 			{species: "Heatran", ability: 'flashfire', moves: ['rest']},
 		]);
-		battle.commitDecisions();
-		battle.p2.chooseSwitch(2);
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move sleeptalk');
+		battle.makeChoices('move skydrop', 'switch 2');
 		assert.species(battle.p2.active[0], 'Magnezone');
 	});
 });

--- a/test/simulator/items/sitrusberry.js
+++ b/test/simulator/items/sitrusberry.js
@@ -15,7 +15,7 @@ describe('Sitrus Berry', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Aggron', ability: 'sturdy', item: 'sitrusberry', moves: ['sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Lucario', ability: 'adaptability', moves: ['aurasphere']}]);
 		const holder = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move aurasphere');
 		assert.false.holdsItem(holder);
 		assert.strictEqual(holder.hp, Math.floor(holder.maxhp / 4) + 1);
 	});
@@ -27,7 +27,7 @@ describe('Sitrus Berry', function () {
 		]);
 		const holder = battle.p1.active[0];
 		const hpgain = Math.floor(holder.maxhp / 4);
-		battle.commitDecisions();
+		battle.makeChoices('move recycle', 'move earthquake');
 		assert.false.holdsItem(holder);
 		assert.strictEqual(holder.hp, hpgain + hpgain + 1);
 	});
@@ -37,7 +37,7 @@ describe('Sitrus Berry', function () {
 			[{species: 'Deoxys-Attack', ability: 'sturdy', item: 'sitrusberry', moves: ['sleeptalk']}],
 			[{species: 'Krookodile', ability: 'intimidate', moves: ['knockoff']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move knockoff');
 		assert.strictEqual(battle.p1.active[0].hp, 1);
 	});
 
@@ -47,7 +47,7 @@ describe('Sitrus Berry', function () {
 			[{species: 'Sableye', ability: 'prankster', moves: ['confuseray']}],
 		]);
 		const holder = battle.p1.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move confuseray');
 		assert.holdsItem(holder);
 		assert.false.strictEqual(holder.hp, holder.maxhp);
 	});

--- a/test/simulator/items/weaknesspolicy.js
+++ b/test/simulator/items/weaknesspolicy.js
@@ -15,7 +15,7 @@ describe('Weakness Policy', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lucario", ability: 'justified', moves: ['aurasphere']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blissey", ability: 'naturalcure', item: 'weaknesspolicy', moves: ['softboiled']}]);
 		const holder = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move aurasphere', 'move softboiled');
 		assert.false.holdsItem(holder);
 		assert.statStage(holder, 'atk', 2);
 		assert.statStage(holder, 'spa', 2);
@@ -26,7 +26,7 @@ describe('Weakness Policy', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lucario", ability: 'justified', moves: ['seismictoss']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blissey", ability: 'naturalcure', item: 'weaknesspolicy', moves: ['softboiled']}]);
 		const holder = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move seismictoss', 'move softboiled');
 		assert.holdsItem(holder);
 		assert.statStage(holder, 'atk', 0);
 		assert.statStage(holder, 'spa', 0);

--- a/test/simulator/misc/choice-parser.js
+++ b/test/simulator/misc/choice-parser.js
@@ -50,7 +50,7 @@ describe('Choice parser', function () {
 				]);
 				battle.join('p2', 'Guest 2', 1, [{species: "Rhydon", ability: 'prankster', moves: ['splash']}]);
 
-				battle.commitDecisions();
+				battle.makeChoices('move lunardance', 'move splash');
 
 				assert.false(battle.choose('p1', 'switch first'));
 				assert.false(battle.choose('p1', 'switch second'));
@@ -66,7 +66,7 @@ describe('Choice parser', function () {
 				]);
 				battle.join('p2', 'Guest 2', 1, [{species: "Rhydon", ability: 'prankster', moves: ['splash']}]);
 
-				battle.commitDecisions();
+				battle.makeChoices('move lunardance', 'move splash');
 
 				const badChoices = ['move 1', 'move 2 mega', 'team 1', 'pass', 'shift'];
 				for (const badChoice of badChoices) {
@@ -92,7 +92,7 @@ describe('Choice parser', function () {
 					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 					{species: "Ekans", ability: 'shedskin', moves: ['wrap']},
 				]);
-				battle.commitDecisions(); // Both p1 active Pokémon faint
+				battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense'); // Both p1 active Pokémon faint
 
 				const badChoices = ['move 1', 'move 2 mega', 'team 1', 'shift'];
 				for (const badChoice of badChoices) {
@@ -114,7 +114,7 @@ describe('Choice parser', function () {
 					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 					{species: "Ekans", ability: 'shedskin', moves: ['wrap']},
 				]);
-				battle.commitDecisions(); // Both p1 active Pokémon faint
+				battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense'); // Both p1 active Pokémon faint
 
 				const switchChoice = 'switch 3';
 				const passChoice = 'pass';
@@ -175,7 +175,7 @@ describe('Choice parser', function () {
 					{species: "Skarmory", ability: 'sturdy', moves: ['roost']},
 					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 				]);
-				battle.commitDecisions(); // Both p1 active Pokémon faint
+				battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense'); // Both p1 active Pokémon faint
 				battle.choose('p1', 'pass, switch 3'); // Koffing switches in at slot #2
 
 				assert.fainted(p1.active[0]);
@@ -290,7 +290,7 @@ describe('Choice parser', function () {
 					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 					{species: "Golem", ability: 'sturdy', moves: ['defensecurl']},
 				]);
-				battle.commitDecisions(); // All p1 active Pokémon faint
+				battle.makeChoices('move selfdestruct, move selfdestruct, move lunardance', 'move roost, move irondefense, move defensecurl'); // All p1 active Pokémon faint
 
 				p1.choosePass().chooseSwitch(4).chooseDefault(); // Forretress switches in to slot #2
 				assert.species(p1.active[1], 'Forretress');

--- a/test/simulator/misc/eventemitter.js
+++ b/test/simulator/misc/eventemitter.js
@@ -27,7 +27,7 @@ describe('Battle#on', function () {
 		battle.onEvent('ModifyDamage', battle.getFormat(), function () {
 			return 5;
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move bulkup', 'move peck');
 		assert.strictEqual(eventCount, 4);
 		assert.strictEqual(eventCount2, 2);
 		assert.strictEqual(battle.p1.active[0].maxhp - battle.p1.active[0].hp, 5);
@@ -48,7 +48,7 @@ describe('Battle#on', function () {
 		for (let i = 0; i < 9; i++) {
 			battle.onEvent('ModifyDamage', battle.getFormat(), -i, modHandler(i));
 		}
-		battle.commitDecisions();
+		battle.makeChoices('move bulkup', 'move peck');
 		assert.strictEqual(eventCount, 9);
 	});
 

--- a/test/simulator/misc/inversebattle.js
+++ b/test/simulator/misc/inversebattle.js
@@ -13,24 +13,24 @@ describe('Inverse Battle', function () {
 	it('should change natural resistances into weaknesses', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['vitalthrow']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Scyther", ability: 'swarm', moves: ['roost']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move vitalthrow', 'move roost');
+		battle.makeChoices('move vitalthrow', 'move roost');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 	});
 
 	it('should change natural weaknesses into resistances', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['vitalthrow']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Absol", ability: 'pressure', moves: ['leer']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move vitalthrow', 'move leer');
+		battle.makeChoices('move vitalthrow', 'move leer');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 	});
 
 	it('should negate natural immunities and make them weaknesses', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['vitalthrow']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dusknoir", ability: 'frisk', moves: ['rest']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move vitalthrow', 'move rest');
+		battle.makeChoices('move vitalthrow', 'move rest');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
@@ -38,8 +38,8 @@ describe('Inverse Battle', function () {
 	it('should not affect ability-based immunities', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Mismagius", ability: 'levitate', moves: ['shadowsneak']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move shadowsneak');
+		battle.makeChoices('move earthquake', 'move shadowsneak');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
@@ -47,16 +47,16 @@ describe('Inverse Battle', function () {
 	it('should not affect the type effectiveness of Freeze Dry on Water-type Pokemon', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Lapras", ability: 'waterabsorb', moves: ['freezedry']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Floatzel", ability: 'waterveil', moves: ['aquajet']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move freezedry', 'move aquajet');
+		battle.makeChoices('move freezedry', 'move aquajet');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 	});
 
 	it('should not affect the "ungrounded" state of Flying-type Pokemon', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Parasect", ability: 'dryskin', moves: ['spore']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Talonflame", ability: 'galewings', moves: ['mistyterrain']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move spore', 'move mistyterrain');
+		battle.makeChoices('move spore', 'move mistyterrain');
 		assert.strictEqual(battle.p2.active[0].status, 'slp');
 	});
 });

--- a/test/simulator/misc/statuses.js
+++ b/test/simulator/misc/statuses.js
@@ -16,7 +16,7 @@ describe('Burn', function () {
 			[{species: 'Sableye', ability: 'prankster', moves: ['willowisp']}],
 		]);
 		const target = battle.p1.active[0];
-		assert.hurtsBy(target, Math.floor(target.maxhp / 16), () => battle.commitDecisions());
+		assert.hurtsBy(target, Math.floor(target.maxhp / 16), () => battle.makeChoices('move bulkup', 'move willowisp'));
 	});
 
 	it('should halve damage from most Physical attacks', function () {
@@ -25,10 +25,9 @@ describe('Burn', function () {
 			[{species: 'Sableye', ability: 'prankster', moves: ['splash', 'willowisp']}],
 		]);
 		const target = battle.p2.active[0];
-		battle.commitDecisions();
-		battle.p2.chooseMove('willowisp');
+		battle.makeChoices('move boneclub', 'move splash');
 		// hardcoded to RNG
-		assert.hurtsBy(target, 64, () => battle.commitDecisions());
+		assert.hurtsBy(target, 64, () => battle.makeChoices('move boneclub', 'move willowisp'));
 	});
 
 	it('should not halve damage from moves with set damage', function () {
@@ -36,7 +35,7 @@ describe('Burn', function () {
 			[{species: 'Machamp', ability: 'noguard', moves: ['seismictoss']}],
 			[{species: 'Talonflame', ability: 'galewings', moves: ['willowisp']}],
 		]);
-		assert.hurtsBy(battle.p2.active[0], 100, () => battle.commitDecisions());
+		assert.hurtsBy(battle.p2.active[0], 100, () => battle.makeChoices('move seismictoss', 'move willowisp'));
 	});
 });
 
@@ -50,7 +49,7 @@ describe('Paralysis', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Vaporeon', ability: 'waterabsorb', moves: ['aquaring']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'voltabsorb', moves: ['thunderwave']}]);
 		let speed = battle.p1.active[0].getStat('spe');
-		battle.commitDecisions();
+		battle.makeChoices('move aquaring', 'move thunderwave');
 		assert.strictEqual(battle.p1.active[0].getStat('spe'), battle.modify(speed, 0.5));
 	});
 
@@ -59,7 +58,7 @@ describe('Paralysis', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Vaporeon', ability: 'waterabsorb', moves: ['aquaring']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'voltabsorb', moves: ['thunderwave']}]);
 		let speed = battle.p1.active[0].getStat('spe');
-		battle.commitDecisions();
+		battle.makeChoices('move aquaring', 'move thunderwave');
 		assert.strictEqual(battle.p1.active[0].getStat('spe'), battle.modify(speed, 0.25));
 	});
 
@@ -68,7 +67,7 @@ describe('Paralysis', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Vaporeon', ability: 'waterabsorb', moves: ['aquaring']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Jolteon', ability: 'voltabsorb', moves: ['thunderwave']}]);
 		let speed = battle.p1.active[0].getStat('spe');
-		battle.commitDecisions();
+		battle.makeChoices('move aquaring', 'move thunderwave');
 		assert.strictEqual(battle.p1.active[0].getStat('spe'), battle.modify(speed, 0.25));
 	});
 });
@@ -85,7 +84,7 @@ describe('Toxic Poison', function () {
 		]);
 		const target = battle.p1.active[0];
 		for (let i = 1; i <= 8; i++) {
-			battle.commitDecisions();
+			battle.makeChoices('move softboiled', 'move toxic');
 			assert.strictEqual(target.maxhp - target.hp, Math.floor(target.maxhp / 16) * i);
 		}
 	});
@@ -96,11 +95,11 @@ describe('Toxic Poison', function () {
 			[{species: 'Crobat', ability: 'infiltrator', moves: ['toxic', 'whirlwind']}],
 		]);
 		for (let i = 0; i < 4; i++) {
-			battle.commitDecisions();
+			battle.makeChoices('move curse', 'move toxic');
 		}
 		let pokemon = battle.p1.active[0];
 		pokemon.hp = pokemon.maxhp;
-		battle.p1.chooseSwitch(2).foe.chooseMove('whirlwind');
+		battle.makeChoices('switch 2', 'move whirlwind');
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 16));
 	});
 });
@@ -116,7 +115,7 @@ describe('Burn [Gen 6]', function () {
 			[{species: 'Sableye', ability: 'prankster', moves: ['willowisp']}],
 		]);
 		const target = battle.p1.active[0];
-		assert.hurtsBy(target, Math.floor(target.maxhp / 8), () => battle.commitDecisions());
+		assert.hurtsBy(target, Math.floor(target.maxhp / 8), () => battle.makeChoices('move bulkup', 'move willowisp'));
 	});
 });
 
@@ -130,11 +129,10 @@ describe('Toxic Poison [Gen 1]', function () {
 			[{species: 'Venusaur', moves: ['toxic', 'leechseed']}],
 			[{species: 'Chansey', moves: ['splash']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move toxic', 'move splash');
 		let pokemon = battle.p2.active[0];
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 16));
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move leechseed', 'move splash');
 		// (1/16) + (2/16) + (3/16) = (6/16)
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 16) * 6);
 	});

--- a/test/simulator/misc/statusmoves.js
+++ b/test/simulator/misc/statusmoves.js
@@ -12,7 +12,7 @@ describe('Most status moves', function () {
 
 	it('should ignore natural type immunities', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'prankster', item: 'leftovers', moves: ['gastroacid', 'glare', 'confuseray', 'sandattack']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'prankster', item: 'leftovers', moves: ['gastroacid', 'glare', 'confuseray', 'sandattack']}]);
 		battle.join('p2', 'Guest 2', 1, [
 			{species: "Klefki", ability: 'magician', happiness: 0, moves: ['return']},
 			{species: "Dusknoir", ability: 'frisk', moves: ['shadowpunch']},
@@ -20,15 +20,15 @@ describe('Most status moves', function () {
 			{species: "Tornadus", ability: 'prankster', moves: ['tailwind']},
 			{species: "Unown", ability: 'levitate', moves: ['hiddenpower']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move gastroacid', 'move return');
 		assert.false.holdsItem(battle.p2.active[0]); // Klefki's Magician suppressed by Gastro Acid.
-		p1.chooseMove('glare').foe.chooseSwitch(2); // Dusknoir
+		battle.makeChoices('move glare', 'switch 2'); // Dusknoir
 		assert.strictEqual(battle.p2.active[0].status, 'par');
-		p1.chooseMove('confuseray').foe.chooseSwitch(3); // Slaking
+		battle.makeChoices('move confuseray', 'switch 3'); // Slaking
 		assert.ok(battle.p2.active[0].volatiles['confusion']);
-		p1.chooseMove('sandattack').foe.chooseSwitch(4); // Tornadus
+		battle.makeChoices('move sandattack', 'switch 4'); // Tornadus
 		assert.statStage(battle.p2.active[0], 'accuracy', -1);
-		p1.chooseMove('sandattack').foe.chooseSwitch(5); // Unown (Levitate)
+		battle.makeChoices('move sandattack', 'switch 5'); // Unown (Levitate)
 		assert.statStage(battle.p2.active[0], 'accuracy', -1);
 	});
 
@@ -36,7 +36,7 @@ describe('Most status moves', function () {
 		this.timeout(0);
 
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'noguard', item: 'laggingtail', moves: ['thunderwave', 'willowisp', 'poisongas', 'toxic']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'noguard', item: 'laggingtail', moves: ['thunderwave', 'willowisp', 'poisongas', 'toxic']}]);
 		battle.join('p2', 'Guest 2', 1, [
 			{species: "Zapdos", ability: 'pressure', moves: ['charge']},
 			{species: "Emboar", ability: 'blaze', moves: ['sleeptalk']},
@@ -44,27 +44,27 @@ describe('Most status moves', function () {
 			{species: "Aron", ability: 'sturdy', moves: ['magnetrise']},
 		]);
 
-		p1.chooseMove('thunderwave').foe.chooseDefault();
+		battle.makeChoices('move thunderwave', 'move charge');
 		assert.strictEqual(battle.p2.active[0].status, '');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
-		p1.chooseMove('willowisp').foe.chooseSwitch(2); // Emboar
+		battle.makeChoices('move willowisp', 'switch 2'); // Emboar
 		assert.strictEqual(battle.p2.active[0].status, '');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
-		p1.chooseMove('poisongas').foe.chooseSwitch(3); // Muk
+		battle.makeChoices('move poisongas', 'switch 3'); // Muk
 		assert.strictEqual(battle.p2.active[0].status, '');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
-		p1.chooseMove('toxic').foe.chooseDefault();
+		battle.makeChoices('move toxic', 'move shadowsneak');
 		assert.strictEqual(battle.p2.active[0].status, '');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
-		p1.chooseMove('poisongas').foe.chooseSwitch(4); // Aron
+		battle.makeChoices('move poisongas', 'switch 4'); // Aron
 		assert.strictEqual(battle.p2.active[0].status, '');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
-		p1.chooseMove('toxic').foe.chooseDefault();
+		battle.makeChoices('move toxic', 'move magnetrise');
 		assert.strictEqual(battle.p2.active[0].status, '');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 	});
@@ -87,8 +87,7 @@ describe('Poison-inflicting status moves [Gen 2]', function () {
 
 		const target = battle.p2.active[0];
 		POISON_STATUS_MOVES.forEach(move => {
-			battle.p1.chooseMove(move);
-			assert.constant(() => target.status, () => battle.commitDecisions());
+			assert.constant(() => target.status, () => battle.makeChoices('move ' + move, 'move sleeptalk'));
 		});
 	});
 });

--- a/test/simulator/misc/trapmoves.js
+++ b/test/simulator/misc/trapmoves.js
@@ -20,9 +20,8 @@ describe('Trapping Moves', function () {
 				{species: "Tangrowth", ability: 'leafguard', moves: ['swordsdance']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move), 'move swordsdance');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'tangrowth');
 		});
 
@@ -33,8 +32,8 @@ describe('Trapping Moves', function () {
 				{species: "Tangrowth", ability: 'leafguard', moves: ['batonpass']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
+			battle.makeChoices('move ' + toId(move), 'move batonpass');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
 		});
 
@@ -45,9 +44,8 @@ describe('Trapping Moves', function () {
 				{species: "Gourgeist", ability: 'insomnia', moves: ['synthesis']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move), 'move synthesis');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
 		});
 
@@ -61,15 +59,14 @@ describe('Trapping Moves', function () {
 				{species: "Tangrowth", ability: 'leafguard', moves: ['roar']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move), 'move roar');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
 		});
 
 		it('should free all trapped Pokemon if the user is no longer active', function () {
 			battle = common.createBattle({gameType: 'doubles'});
-			const p1 = battle.join('p1', 'Guest 1', 1, [
+			battle.join('p1', 'Guest 1', 1, [
 				{species: "Smeargle", ability: 'prankster', moves: [toId(move)]},
 				{species: "Cobalion", ability: 'justified', item: 'laggingtail', moves: ['swordsdance', 'closecombat']},
 			]);
@@ -80,13 +77,12 @@ describe('Trapping Moves', function () {
 				{species: "Hippowdon", ability: 'sandstream', moves: ['slackoff']},
 			]);
 			if (move !== 'Thousand Waves') {
-				p1.chooseMove(1, 1).chooseMove(1).foe.chooseMove(1).chooseMove(1);
-				p1.chooseMove(1, 2).chooseMove(2, -1).foe.chooseMove(1).chooseMove(1);
+				battle.makeChoices('move ' + toId(move) + ' 1, move swordsdance', 'move synthesis, move recover');
+				battle.makeChoices('move ' + toId(move) + ' 2, move closecombat -1', 'move synthesis, move recover');
 			} else {
-				p1.chooseMove(1).chooseMove(2, -1).foe.chooseMove(1).chooseMove(1);
+				battle.makeChoices('move ' + toId(move) + ', move closecombat -1', 'move synthesis, move recover');
 			}
-			battle.choose('p2', 'switch 3, switch 4');
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move) + ', move swordsdance', 'switch 3, switch 4');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'cradily');
 			assert.strictEqual(battle.p2.active[1].template.speciesid, 'hippowdon');
 		});
@@ -103,17 +99,12 @@ describe('Trapping Moves', function () {
 					{species: "Tangrowth", ability: 'leafguard', moves: ['synthesis', 'roar']},
 					{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 				]);
-				battle.commitDecisions();
-				battle.choose('p1', 'move 2');
-				battle.commitDecisions();
-				battle.choose('p1', 'switch 2');
-				battle.choose('p2', 'switch 2');
-				battle.commitDecisions();
+				battle.makeChoices('move ' + toId(move), 'move synthesis');
+				battle.makeChoices('move batonpass', 'move synthesis');
+				battle.makeChoices('switch 2', 'switch 2');
 				assert.strictEqual(battle.p2.active[0].template.speciesid, 'tangrowth');
-				battle.choose('p2', 'move 2');
-				battle.commitDecisions();
-				battle.choose('p2', 'switch 2');
-				battle.commitDecisions();
+				battle.makeChoices('move rest', 'move roar');
+				battle.makeChoices('move rest', 'switch 2');
 				assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
 			});
 		}
@@ -130,11 +121,10 @@ describe('Partial Trapping Moves', function () {
 			battle = common.createBattle();
 			battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'noguard', moves: [toId(move), 'rest']}]);
 			battle.join('p2', 'Guest 2', 1, [{species: "Blissey", ability: 'naturalcure', moves: ['healbell']}]);
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move), 'move healbell');
 			let pokemon = battle.p2.active[0];
 			pokemon.heal(pokemon.maxhp);
-			battle.choose('p1', 'move 2');
-			battle.commitDecisions();
+			battle.makeChoices('move rest', 'move healbell');
 			assert.strictEqual(pokemon.maxhp - pokemon.hp, battle.modify(pokemon.maxhp, 1 / 8));
 		});
 
@@ -145,9 +135,8 @@ describe('Partial Trapping Moves', function () {
 				{species: "Blissey", ability: 'naturalcure', moves: ['healbell']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move), 'move healbell');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'blissey');
 		});
 
@@ -158,8 +147,8 @@ describe('Partial Trapping Moves', function () {
 				{species: "Blissey", ability: 'naturalcure', moves: ['batonpass']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
+			battle.makeChoices('move ' + toId(move), 'move batonpass');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
 		});
 
@@ -170,9 +159,8 @@ describe('Partial Trapping Moves', function () {
 				{species: "Dusknoir", ability: 'frisk', moves: ['sleeptalk']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move), 'move sleeptalk');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
 		});
 
@@ -186,9 +174,8 @@ describe('Partial Trapping Moves', function () {
 				{species: "Blissey", ability: 'naturalcure', moves: ['roar']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move), 'move healbell');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
 		});
 
@@ -202,9 +189,8 @@ describe('Partial Trapping Moves', function () {
 				{species: "Blissey", ability: 'naturalcure', moves: ['rapidspin']},
 				{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 			]);
-			battle.commitDecisions();
-			battle.choose('p2', 'switch 2');
-			battle.commitDecisions();
+			battle.makeChoices('move ' + toId(move), 'move rapidspin');
+			battle.makeChoices('move ' + toId(move), 'switch 2');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'starmie');
 		});
 	}

--- a/test/simulator/misc/turn-order.js
+++ b/test/simulator/misc/turn-order.js
@@ -15,8 +15,7 @@ describe('Mega Evolution', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Banette', ability: 'frisk', item: 'banettite', moves: ['psychup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind']}]);
 		const pranksterMega = battle.p1.active[0];
-		battle.p1.chooseMove('psychup', null, true);
-		battle.commitDecisions();
+		battle.makeChoices('move psychup mega', 'move calmmind');
 		assert.statStage(pranksterMega, 'spa', 0);
 	});
 
@@ -25,8 +24,8 @@ describe('Mega Evolution', function () {
 			[{species: "Politoed", ability: 'drizzle', item: '', moves: ['scald']}, {species: "Kingdra", ability: 'swiftswim', item: '', moves: ['dragondance']}],
 			[{species: "Marowak", ability: 'rockhead', item: '', moves: ['earthquake']}, {species: "Alakazam", ability: 'magicguard', item: 'alakazite', moves: ['psychup']}],
 		]);
-		battle.p1.chooseSwitch(2).foe.chooseSwitch(2);
-		battle.p1.chooseMove('dragondance').foe.chooseMove('psychup', null, true);
+		battle.makeChoices('switch 2', 'switch 2');
+		battle.makeChoices('move dragondance', 'move psychup mega');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 		assert.species(battle.p2.active[0], 'Alakazam-Mega');
@@ -37,8 +36,7 @@ describe('Mega Evolution', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', item: 'sablenite', moves: ['psychup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind']}]);
 		const noPranksterMega = battle.p1.active[0];
-		battle.p1.chooseMove('psychup', null, true);
-		battle.commitDecisions();
+		battle.makeChoices('move psychup mega', 'move calmmind');
 		assert.statStage(noPranksterMega, 'spa', 1);
 	});
 
@@ -47,8 +45,7 @@ describe('Mega Evolution', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Beedrill', ability: 'swarm', item: 'beedrillite', moves: ['xscissor']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hoopa-Unbound', ability: 'magician', moves: ['psyshock']}]);
 		const fastBase = battle.p2.active[0];
-		battle.p1.chooseMove('xscissor', null, true);
-		battle.commitDecisions();
+		battle.makeChoices('move xscissor mega', 'move psyshock');
 		assert.fainted(fastBase);
 	});
 
@@ -57,8 +54,7 @@ describe('Mega Evolution', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Necrozma-Dusk-Mane', ability: 'swarm', item: 'ultranecroziumz', moves: ['xscissor']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hoopa-Unbound', ability: 'magician', moves: ['darkpulse']}]);
 		const fastBase = battle.p2.active[0];
-		battle.p1.chooseMove('xscissor', null, 'ultra');
-		battle.commitDecisions();
+		battle.makeChoices('move xscissor ultra', 'move darkpluse');
 		assert.strictEqual(fastBase.hp, 0);
 	});
 });
@@ -73,8 +69,7 @@ describe('Mega Evolution [Gen 6]', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Banette', ability: 'frisk', item: 'banettite', moves: ['psychup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind']}]);
 		const pranksterMega = battle.p1.active[0];
-		battle.p1.chooseMove('psychup', null, true);
-		battle.commitDecisions();
+		battle.makeChoices('move psychup mega', 'move calmmind');
 		assert.statStage(pranksterMega, 'spa', 1);
 	});
 
@@ -83,8 +78,8 @@ describe('Mega Evolution [Gen 6]', function () {
 			[{species: "Politoed", ability: 'drizzle', item: '', moves: ['scald']}, {species: "Kingdra", ability: 'swiftswim', item: '', moves: ['dragondance']}],
 			[{species: "Marowak", ability: 'rockhead', item: '', moves: ['earthquake']}, {species: "Alakazam", ability: 'magicguard', item: 'alakazite', moves: ['psychup']}],
 		]);
-		battle.p1.chooseSwitch(2).foe.chooseSwitch(2);
-		battle.p1.chooseMove('dragondance').foe.chooseMove('psychup', null, true);
+		battle.makeChoices('switch 2', 'switch 2');
+		battle.makeChoices('move dragondance', 'move psychup mega');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
 		assert.statStage(battle.p2.active[0], 'atk', 1);
 		assert.species(battle.p2.active[0], 'Alakazam-Mega');
@@ -95,8 +90,7 @@ describe('Mega Evolution [Gen 6]', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', item: 'sablenite', moves: ['psychup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind']}]);
 		const noPranksterMega = battle.p1.active[0];
-		battle.p1.chooseMove('psychup', null, true);
-		battle.commitDecisions();
+		battle.makeChoices('move psychup mega', 'move calmmind');
 		assert.statStage(noPranksterMega, 'spa', 0);
 	});
 
@@ -105,8 +99,7 @@ describe('Mega Evolution [Gen 6]', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Beedrill', ability: 'swarm', item: 'beedrillite', moves: ['xscissor']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Hoopa-Unbound', ability: 'magician', moves: ['psyshock']}]);
 		const fastMega = battle.p1.active[0];
-		battle.p1.chooseMove('xscissor', null, true);
-		battle.commitDecisions();
+		battle.makeChoices('move xscissor mega', 'move psyshock');
 		assert.fainted(fastMega);
 	});
 });

--- a/test/simulator/misc/typechange.js
+++ b/test/simulator/misc/typechange.js
@@ -22,7 +22,7 @@ describe('Type addition', function () {
 				battle.join('p1', 'Guest 1', 1, [{species: "Gourgeist", ability: 'frisk', moves: [moveData.name]}]);
 				battle.join('p2', 'Guest 2', 1, [{species: "Machamp", ability: 'guts', moves: ['crosschop']}]);
 				const target = battle.p2.active[0];
-				assert.sets(() => target.getTypes().join('/'), `Fighting/${moveData.type}`, () => battle.commitDecisions());
+				assert.sets(() => target.getTypes().join('/'), `Fighting/${moveData.type}`, () => battle.makeChoices('move ' + moveData.name, 'move crosschop'));
 			});
 
 			it('should not add ' + moveData.type + ' type to ' + moveData.type + ' targets', function () {
@@ -30,7 +30,7 @@ describe('Type addition', function () {
 				battle.join('p1', 'Guest 1', 1, [{species: "Gourgeist", ability: 'frisk', moves: [moveData.name]}]);
 				battle.join('p2', 'Guest 2', 1, [{species: "Trevenant", ability: 'harvest', moves: ['ingrain']}]);
 				const target = battle.p2.active[0];
-				assert.constant(() => target.getTypes().join('/'), () => battle.commitDecisions());
+				assert.constant(() => target.getTypes().join('/'), () => battle.makeChoices('move ' + moveData.name, 'move ingrain'));
 			});
 
 			it('should be able to add ' + moveData.type + ' type to Arceus', function () {
@@ -38,7 +38,7 @@ describe('Type addition', function () {
 				battle.join('p1', 'Guest 1', 1, [{species: "Gourgeist", ability: 'frisk', moves: [moveData.name]}]);
 				battle.join('p2', 'Guest 2', 1, [{species: "Arceus", ability: 'multitype', moves: ['extremespeed']}]);
 				const target = battle.p2.active[0];
-				assert.sets(() => target.getTypes().join('/'), `Normal/${moveData.type}`, () => battle.commitDecisions());
+				assert.sets(() => target.getTypes().join('/'), `Normal/${moveData.type}`, () => battle.makeChoices('move ' + moveData.name, 'move extremespeed'));
 			});
 
 			for (let moveData2 of adderMoves) {
@@ -48,8 +48,8 @@ describe('Type addition', function () {
 						battle.join('p1', 'Guest 1', 1, [{species: "Gourgeist", ability: 'frisk', moves: [moveData.name]}]);
 						battle.join('p2', 'Guest 2', 1, [{species: "Deoxys-Speed", ability: 'pressure', moves: ['spikes']}]);
 						const target = battle.p2.active[0];
-						battle.commitDecisions();
-						assert.constant(() => target.getTypes().join('/'), () => battle.commitDecisions());
+						battle.makeChoices('move ' + moveData.name, 'move spikes');
+						assert.constant(() => target.getTypes().join('/'), () => battle.makeChoices('move ' + moveData.name, 'move spikes'));
 						assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
 					});
 				} else {
@@ -58,8 +58,8 @@ describe('Type addition', function () {
 						battle.join('p1', 'Guest 1', 1, [{species: "Gourgeist", ability: 'frisk', moves: [moveData.name, moveData2.name]}]);
 						battle.join('p2', 'Guest 2', 1, [{species: "Deoxys-Speed", ability: 'pressure', moves: ['spikes']}]);
 						const target = battle.p2.active[0];
-						battle.p1.chooseMove(2).foe.chooseDefault();
-						assert.sets(() => target.getTypes().join('/'), `Psychic/${moveData.type}`, () => battle.commitDecisions());
+						battle.makeChoices('move ' + moveData2.name, 'move spikes');
+						assert.sets(() => target.getTypes().join('/'), `Psychic/${moveData.type}`, () => battle.makeChoices('move ' + moveData.name, 'move spikes'));
 					});
 				}
 			}

--- a/test/simulator/misc/weather.js
+++ b/test/simulator/misc/weather.js
@@ -17,7 +17,7 @@ describe('Weather damage calculation', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Cryogonal', ability: 'levitate', moves: ['splash']}]);
 		const attacker = battle.p1.active[0];
 		const defender = battle.p2.active[0];
-		assert.hurtsBy(defender, 152, () => battle.commitDecisions());
+		assert.hurtsBy(defender, 152, () => battle.makeChoices('move incinerate', 'move splash'));
 		const move = Dex.getMove('incinerate');
 		const basePower = battle.runEvent('BasePower', attacker, defender, move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -30,7 +30,7 @@ describe('Weather damage calculation', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Cryogonal', ability: 'levitate', moves: ['splash']}]);
 		const attacker = battle.p1.active[0];
 		const defender = battle.p2.active[0];
-		assert.hurtsBy(defender, 50, () => battle.commitDecisions());
+		assert.hurtsBy(defender, 50, () => battle.makeChoices('move incinerate', 'move splash'));
 		const move = Dex.getMove('incinerate');
 		const basePower = battle.runEvent('BasePower', attacker, defender, move, move.basePower, true);
 		assert.strictEqual(basePower, move.basePower);
@@ -41,7 +41,7 @@ describe('Weather damage calculation', function () {
 		battle.randomizer = dmg => dmg; // max damage
 		battle.join('p1', 'Guest 1', 1, [{species: 'Abomasnow', ability: 'snowwarning', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Sandslash', ability: 'sandveil', moves: ['protect']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move protect', 'move protect');
 		const p1active = battle.p1.active[0];
 		const p2active = battle.p2.active[0];
 		assert.strictEqual(p1active.hp, p1active.maxhp);

--- a/test/simulator/misc/weight.js
+++ b/test/simulator/misc/weight.js
@@ -21,7 +21,7 @@ describe('Heavy Metal', function () {
 				basePower = bp;
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move nastyplot', 'move grassknot');
 		assert.strictEqual(basePower, 80);
 	});
 
@@ -36,7 +36,7 @@ describe('Heavy Metal', function () {
 				basePower = bp;
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move nastyplot', 'move grassknot');
 		assert.strictEqual(basePower, 60);
 	});
 });
@@ -57,7 +57,7 @@ describe('Light Metal', function () {
 				basePower = bp;
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move grassknot');
 		assert.strictEqual(basePower, 100);
 	});
 
@@ -72,7 +72,7 @@ describe('Light Metal', function () {
 				basePower = bp;
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move grassknot');
 		assert.strictEqual(basePower, 120);
 	});
 });
@@ -93,7 +93,7 @@ describe('Float Stone', function () {
 				basePower = bp;
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move grassknot');
 		assert.strictEqual(basePower, 100);
 	});
 });
@@ -114,9 +114,9 @@ describe('Autotomize', function () {
 				basePower = bp;
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move autotomize', 'move grassknot');
 		assert.strictEqual(basePower, 100);
-		battle.commitDecisions();
+		battle.makeChoices('move autotomize', 'move grassknot');
 		assert.strictEqual(basePower, 20);
 	});
 
@@ -131,7 +131,7 @@ describe('Autotomize', function () {
 				basePower = bp;
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices('move autotomize', 'move grassknot');
 		assert.strictEqual(basePower, 60);
 	});
 });

--- a/test/simulator/moves/bellydrum.js
+++ b/test/simulator/moves/bellydrum.js
@@ -12,7 +12,7 @@ describe('Belly Drum', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Linoone", ability: 'limber', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Terrakion", ability: 'justified', moves: ['bulkup']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bellydrum', 'move bulkup');
 		assert.strictEqual(p1.active[0].hp, Math.ceil(p1.active[0].maxhp / 2));
 		assert.statStage(p1.active[0], 'atk', 6);
 	});
@@ -21,7 +21,7 @@ describe('Belly Drum', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Linoone", ability: 'sturdy', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Terrakion", ability: 'justified', moves: ['closecombat']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bellydrum', 'move closecombat');
 		assert.strictEqual(p1.active[0].hp, 1);
 		assert.statStage(p1.active[0], 'atk', 0);
 	});
@@ -34,7 +34,7 @@ describe('Z-Belly Drum', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Linoone", ability: 'limber', item: 'normaliumz', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Rattata", ability: 'guts', moves: ['quickattack']}]);
-		p1.chooseMove('bellydrum', 0, 'zmove').foe.chooseDefault();
+		battle.makeChoices('move bellydrum zmove', 'move quickattack');
 		assert.strictEqual(p1.active[0].hp, Math.ceil(p1.active[0].maxhp / 2));
 		assert.statStage(p1.active[0], 'atk', 6);
 	});
@@ -43,7 +43,7 @@ describe('Z-Belly Drum', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Linoone", ability: 'sturdy', item: 'normaliumz', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Terrakion", ability: 'justified', moves: ['closecombat']}]);
-		p1.chooseMove('bellydrum', 0, 'zmove').foe.chooseDefault();
+		battle.makeChoices('move bellydrum zmove', 'move closecombat');
 		assert.strictEqual(p1.active[0].hp, Math.ceil(p1.active[0].maxhp / 2));
 		assert.statStage(p1.active[0], 'atk', 6);
 	});

--- a/test/simulator/moves/boomburst.js
+++ b/test/simulator/moves/boomburst.js
@@ -14,9 +14,8 @@ describe('Boomburst', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'boomburst']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move boomburst', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 });

--- a/test/simulator/moves/bugbuzz.js
+++ b/test/simulator/moves/bugbuzz.js
@@ -14,9 +14,8 @@ describe('Bug Buzz', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'bugbuzz']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move bugbuzz', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 });
@@ -31,9 +30,8 @@ describe('Bug Buzz [Gen 5]', function () {
 			[{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'bugbuzz']}],
 			[{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move bugbuzz', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, 'focussash');
 	});
 });

--- a/test/simulator/moves/chatter.js
+++ b/test/simulator/moves/chatter.js
@@ -14,9 +14,8 @@ describe('Chatter', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'chatter']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move chatter', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 });
@@ -31,9 +30,8 @@ describe('Chatter [Gen 5]', function () {
 			[{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'chatter']}],
 			[{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move boomburst', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, 'focussash');
 	});
 });

--- a/test/simulator/moves/clearsmog.js
+++ b/test/simulator/moves/clearsmog.js
@@ -15,7 +15,7 @@ describe('Clear Smog', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['calmmind']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move clearsmog', 'move calmmind');
 
 		assert.strictEqual(battle.p2.pokemon[0].boosts['spa'], 0);
 		assert.strictEqual(battle.p2.pokemon[0].boosts['spd'], 0);
@@ -26,10 +26,8 @@ describe('Clear Smog', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog', 'toxic']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['substitute', 'calmmind']}]);
 
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move toxic', 'move substitute');
+		battle.makeChoices('move clearsmog', 'move calmmind');
 
 		assert.strictEqual(battle.p2.pokemon[0].boosts['spa'], 1);
 		assert.strictEqual(battle.p2.pokemon[0].boosts['spd'], 1);
@@ -40,7 +38,7 @@ describe('Clear Smog', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', item: 'laggingtail', moves: ['clearsmog']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Steelix", ability: 'prankster', moves: ['irondefense']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move clearsmog', 'move irondefense');
 
 		assert.strictEqual(battle.p2.pokemon[0].boosts['def'], 2);
 	});
@@ -50,7 +48,7 @@ describe('Clear Smog', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Arcanine", ability: 'intimidate', moves: ['morningsun']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move clearsmog', 'move morningsun');
 
 		assert.strictEqual(battle.p1.pokemon[0].boosts['atk'], -1);
 	});
@@ -60,12 +58,11 @@ describe('Clear Smog', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Amoonguss", ability: 'regenerator', item: 'scopelens', moves: ['focusenergy', 'clearsmog']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Primeape", ability: 'angerpoint', moves: ['bulkup']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move focusenergy', 'move bulkup');
 		assert.strictEqual(battle.p2.pokemon[0].boosts['atk'], 1);
 		assert.strictEqual(battle.p2.pokemon[0].boosts['def'], 1);
 
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move clearsmog', 'move bulkup');
 		assert.strictEqual(battle.p2.pokemon[0].boosts['atk'], 6);
 		assert.strictEqual(battle.p2.pokemon[0].boosts['def'], 0);
 	});

--- a/test/simulator/moves/curse.js
+++ b/test/simulator/moves/curse.js
@@ -23,7 +23,7 @@ describe('Curse', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Trevenant", ability: 'shedskin', item: 'laggingtail', moves: ['trickortreat']}]);
 
 		assert.strictEqual(battle.p1.active[0].getRequestData().moves[0].target, 'self');
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move trickortreat');
 		assert.strictEqual(battle.p1.active[0].getRequestData().moves[0].target, 'normal');
 	});
 
@@ -33,7 +33,7 @@ describe('Curse', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Jellicent", ability: 'waterabsorb', item: '', moves: ['soak']}]);
 
 		assert.strictEqual(battle.p1.active[0].getRequestData().moves[0].target, 'normal');
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move soak');
 		assert.strictEqual(battle.p1.active[0].getRequestData().moves[0].target, 'self');
 	});
 
@@ -51,8 +51,7 @@ describe('Curse', function () {
 			{species: "Zoroark", ability: 'illusion', item: '', moves: ['nastyplot']},
 			{species: "Gengar", ability: 'levitate', item: '', moves: ['spite']},
 		]);
-		battle.choose('p1', 'move 2'); // Reflect Type!
-		battle.commitDecisions();
+		battle.makeChoices('move reflecttype', 'move nastyplot');
 
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Dark"]); // Copied Zoroark's type instead of Gengar's
 		assert.strictEqual(battle.p1.active[0].getRequestData().moves[0].target, 'self');
@@ -63,13 +62,12 @@ describe('Curse', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Greninja", ability: 'protean', item: '', moves: ['curse', 'spite']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", ability: 'shedskin', item: '', moves: ['stringshot']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move stringshot');
 		let hps = [battle.p1.active[0].hp, battle.p2.active[0].hp];
 		assert.notStrictEqual(hps[0], battle.p1.active[0].maxhp); // Curse user cut its HP down + residual damage
 		assert.strictEqual(hps[1], battle.p2.active[0].maxhp); // Foe unaffected
 
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move spite', 'move stringshot');
 		assert.notStrictEqual(hps[0], battle.p1.active[0].hp); // Curse user is hurt by residual damage
 		assert.strictEqual(hps[1], battle.p2.active[0].hp); // Foe unaffected
 	});
@@ -79,13 +77,12 @@ describe('Curse', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Gengar", ability: 'protean', item: '', moves: ['curse', 'spite']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", ability: 'shedskin', item: '', moves: ['stringshot']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move curse', 'move stringshot');
 		let hps = [battle.p1.active[0].hp, battle.p2.active[0].hp];
 		assert.notStrictEqual(hps[0], battle.p1.active[0].maxhp); // Curse user cut its HP down
 		assert.notStrictEqual(hps[1], battle.p2.active[0].maxhp); // Curse residual damage
 
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions(); // Check residual damage
+		battle.makeChoices('move spite', 'move stringshot'); // Check residual damage
 		assert.strictEqual(hps[0], battle.p1.active[0].hp); // Curse user unaffected
 		assert.notStrictEqual(hps[1], battle.p2.active[0].hp); // Curse residual damage
 	});
@@ -113,15 +110,15 @@ describe('XY/ORAS Curse targetting when becoming Ghost the same turn', function 
 		let p2active = battle.p2.active;
 		let cursePartner = curseUser.side.active[1 - curseUser.position];
 
-		battle.choose('p1', 'move 1, move 1'); // Kecleon uses Curse last in the turn.
-		battle.choose('p2', 'move 1 ' + (curseUser.position + 1) + ', move 1 ' + (curseUser.position + 1)); // Fighting attack on Kecleon, then Ghost.
+		// p1: Kecleon uses Curse last in the turn.
+		// p2: Fighting attack on Kecleon, then Ghost.
+		battle.makeChoices('move curse, move lightscreen', 'move aurasphere ' + (curseUser.position + 1) + ', move lick ' + (curseUser.position + 1));
 
 		assert.ok(curseUser.hasType('Ghost')); // Curse user must be Ghost
 		assert.ok(curseUser.hp < curseUser.maxhp / 2); // Curse user cut its HP down
 
 		let foeHP = [p2active[0].hp, p2active[1].hp];
-		battle.choose('p1', 'move 2 1, move 2 1');
-		battle.choose('p2', 'move 2, move 2');
+		battle.makeChoices('move curse, move lightscreen', 'move calmmind, move calmmind');
 
 		assert.notStrictEqual(curseUser.hp, curseUser.maxhp); // Curse user cut its HP down
 		if (curseUser.position === 0) {
@@ -139,8 +136,9 @@ describe('XY/ORAS Curse targetting when becoming Ghost the same turn', function 
 		let p1active = battle.p1.active;
 		let p2active = battle.p2.active;
 
-		battle.choose('p1', 'move 1, move 1, move 1'); // Kecleon uses Curse last in the turn.
-		battle.choose('p2', 'move 1 ' + (curseUser.position + 1) + ', move 1 ' + (curseUser.position + 1) + ', move 1'); // Electric attack on Kecleon, then Ghost.
+		// p1: Kecleon uses Curse last in the turn.
+		// p2: Electric attack on Kecleon, then Ghost.
+		battle.makeChoices('move curse, move lightscree, move harden', 'move aurasphere ' + (curseUser.position + 1) + ', move lick ' + (curseUser.position + 1) + ', move harden');
 
 		assert.ok(curseUser.hasType('Ghost')); // Curse user must be Ghost
 		assert.ok(curseUser.hp < curseUser.maxhp / 2); // Curse user cut its HP down

--- a/test/simulator/moves/destinybond.js
+++ b/test/simulator/moves/destinybond.js
@@ -13,8 +13,8 @@ describe(`Destiny Bond`, function () {
 			[{species: "Gastly", ability: 'levitate', moves: ['destinybond']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
-		battle.p1.chooseMove('destinybond').foe.chooseMove('calmmind');
-		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
+		battle.makeChoices('move destinybond', 'move calmmind');
+		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.false.fainted(battle.p2.active[0]);
 
@@ -23,8 +23,8 @@ describe(`Destiny Bond`, function () {
 			[{species: "Gastly", ability: 'levitate', moves: ['destinybond']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
-		battle.p1.chooseMove('destinybond').foe.chooseMove('calmmind');
-		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
+		battle.makeChoices('move destinybond', 'move calmmind');
+		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.false.fainted(battle.p2.active[0]);
 	});
@@ -34,8 +34,8 @@ describe(`Destiny Bond`, function () {
 			[{species: "Gastly", ability: 'levitate', moves: ['destinybond', 'protect']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
-		battle.p1.chooseMove('protect').foe.chooseMove('calmmind');
-		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
+		battle.makeChoices('move protect', 'move calmmind');
+		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 	});
@@ -45,8 +45,8 @@ describe(`Destiny Bond`, function () {
 			[{species: "Gastly", ability: 'levitate', item: '', moves: ['destinybond', 'spite']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 			[{species: "Hypno", ability: 'insomnia', item: 'laggingtail', moves: ['psychic', 'hypnosis']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
-		battle.p1.chooseMove('destinybond').foe.chooseMove('hypnosis');
-		battle.commitDecisions();
+		battle.makeChoices('move destinybond', 'move hypnosis');
+		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.false.fainted(battle.p2.active[0]);
 	});
@@ -60,8 +60,8 @@ describe(`Destiny Bond [Gen 6]`, function () {
 			[{species: "Gastly", ability: 'levitate', moves: ['destinybond']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
-		battle.p1.chooseMove('destinybond').foe.chooseMove('calmmind');
-		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
+		battle.makeChoices('move destinybond', 'move calmmind');
+		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 
@@ -70,8 +70,8 @@ describe(`Destiny Bond [Gen 6]`, function () {
 			[{species: "Gastly", ability: 'levitate', moves: ['destinybond']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 			[{species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind']}, {species: "Clefable", ability: 'unaware', moves: ['calmmind']}],
 		]);
-		battle.p1.chooseMove('destinybond').foe.chooseMove('calmmind');
-		battle.p1.chooseMove('destinybond').foe.chooseMove('psychic');
+		battle.makeChoices('move destinybond', 'move calmmind');
+		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 	});

--- a/test/simulator/moves/disable.js
+++ b/test/simulator/moves/disable.js
@@ -14,8 +14,11 @@ describe('Disable', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Abra', ability: 'synchronize', item: 'laggingtail', moves: ['disable']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['teleport']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move disable', 'move teleport');
+
+		// Teleport is disable, p2 Abra will struggle instead
+		battle.makeChoices('move disable', 'move teleport');
+
 		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 });

--- a/test/simulator/moves/echoedvoice.js
+++ b/test/simulator/moves/echoedvoice.js
@@ -14,9 +14,8 @@ describe('Echoed Voice', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'echoedvoice']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move echoedvoice', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 });
@@ -31,9 +30,8 @@ describe('Echoed Voice [Gen 5]', function () {
 			[{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'echoedvoice']}],
 			[{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move echoedvoice', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, 'focussash');
 	});
 });

--- a/test/simulator/moves/electricterrain.js
+++ b/test/simulator/moves/electricterrain.js
@@ -14,16 +14,15 @@ describe('Electric Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'electricterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]);
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move electricterrain', 'move mist');
 		assert.ok(battle.isTerrain('electricterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move electricterrain', 'move mist');
 		assert.ok(battle.isTerrain('electricterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move electricterrain', 'move mist');
 		assert.ok(battle.isTerrain('electricterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move electricterrain', 'move mist');
 		assert.ok(battle.isTerrain('electricterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move electricterrain', 'move mist');
 		assert.ok(battle.isTerrain(''));
 	});
 
@@ -31,7 +30,7 @@ describe('Electric Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Thundurus", ability: 'defiant', moves: ['thunderwave']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move electricterrain', 'move thunderwave');
 		let basePower;
 		let move = Dex.getMove('thunderbolt');
 		basePower = battle.runEvent('BasePower', battle.p1.active[0], battle.p2.active[0], move, move.basePower, true);
@@ -44,9 +43,8 @@ describe('Electric Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'spore']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Abra", ability: 'magicguard', moves: ['telekinesis', 'spore']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move electricterrain', 'move thunderwave');
+		battle.makeChoices('move spore', 'move spore');
 		assert.strictEqual(battle.p1.active[0].status, 'slp');
 		assert.strictEqual(battle.p2.active[0].status, '');
 	});
@@ -55,7 +53,7 @@ describe('Electric Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['sleeptalk', 'electricterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Whimsicott", ability: 'prankster', moves: ['spore']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move sleeptalk', 'move spore');
 		assert.strictEqual(battle.p1.active[0].status, 'slp');
 	});
 
@@ -63,9 +61,8 @@ describe('Electric Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'yawn']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['yawn']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move electricterrain', 'move yawn');
+		battle.makeChoices('move yawn', 'move yawn');
 		assert.strictEqual(battle.p1.active[0].status, '');
 		assert.ok(!battle.p2.active[0].volatiles['yawn']);
 	});
@@ -74,9 +71,8 @@ describe('Electric Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'shellarmor', moves: ['electricterrain', 'rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move electricterrain', 'move doubleedge');
+		battle.makeChoices('move rest', 'move rest');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
@@ -85,9 +81,8 @@ describe('Electric Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['yawn', 'skydrop']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['yawn', 'electricterrain']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move yawn', 'move yawn');
+		battle.makeChoices('move skydrop', 'move electricterrain');
 		assert.strictEqual(battle.p1.active[0].status, 'slp');
 		assert.strictEqual(battle.p2.active[0].status, 'slp');
 	});
@@ -96,7 +91,7 @@ describe('Electric Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Shuckle", ability: 'sturdy', moves: ['naturepower']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move electricterrain', 'move naturepower');
 		let resultMove = toId(battle.log[battle.lastMoveLine].split('|')[3]);
 		assert.strictEqual(resultMove, 'thunderbolt');
 	});

--- a/test/simulator/moves/embargo.js
+++ b/test/simulator/moves/embargo.js
@@ -14,7 +14,7 @@ describe('Embargo', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'leftovers', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Giratina", ability: 'pressure', moves: ['embargo']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bellydrum', 'move embargo');
 		assert.strictEqual(battle.p1.active[0].hp, Math.ceil(battle.p1.active[0].maxhp / 2));
 	});
 
@@ -22,9 +22,8 @@ describe('Embargo', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'chopleberry', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['embargo', 'lowkick']}]);
-		battle.commitDecisions();
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move bulkup', 'move embargo');
+		battle.makeChoices('move bulkup', 'move lowkick');
 		assert.strictEqual(battle.p1.active[0].item, 'chopleberry');
 	});
 
@@ -32,8 +31,8 @@ describe('Embargo', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'assaultvest', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['embargo']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move protect', 'move embargo');
+		battle.makeChoices('move protect', 'move embargo');
 		assert.strictEqual(battle.p1.active[0].lastMove.id, 'protect');
 	});
 
@@ -41,7 +40,7 @@ describe('Embargo', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'seaincense', moves: ['fling']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['embargo']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move fling', 'move embargo');
 		assert.strictEqual(battle.p1.active[0].item, 'seaincense');
 	});
 
@@ -49,9 +48,8 @@ describe('Embargo', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'lopunnite', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['embargo', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 1 mega');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move bulkup', 'move embargo');
+		battle.makeChoices('move bulkup mega', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template.speciesid, 'lopunnymega');
 	});
 });

--- a/test/simulator/moves/focuspunch.js
+++ b/test/simulator/moves/focuspunch.js
@@ -14,7 +14,7 @@ describe('Focus Punch', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move focuspunch', 'move magicalleaf');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -22,7 +22,7 @@ describe('Focus Punch', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['toxic']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move focuspunch', 'move toxic');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -30,9 +30,8 @@ describe('Focus Punch', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['substitute', 'focuspunch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move magicalleaf');
+		battle.makeChoices('move focuspunch', 'move magicalleaf');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -40,7 +39,7 @@ describe('Focus Punch', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['naturepower']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move focuspunch', 'move naturepower');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -48,10 +47,9 @@ describe('Focus Punch', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move focuspunch', 'move magicalleaf');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move focuspunch', 'move toxic');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -60,8 +58,7 @@ describe('Focus Punch', function () {
 			[{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}, {species: 'Blissey', ability: 'naturalcure', moves: ['softboiled']}],
 			[{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}, {species: 'Ivysaur', ability: 'overgrow', moves: ['toxic']}],
 		]);
-		battle.choose('p1', 'move 1 1, move 1');
-		battle.choose('p2', 'move 1 1, move 1 1');
+		battle.makeChoices('move focuspunch 1, move softboiled', 'move magicalleaf 1, move toxic 1');
 		assert.strictEqual(battle.p1.active[0].status, 'tox');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});

--- a/test/simulator/moves/followme.js
+++ b/test/simulator/moves/followme.js
@@ -30,8 +30,7 @@ describe('Follow Me', function () {
 				hitCount++;
 			}
 		});
-		battle.choose('p2', 'move 1 2, move 1 2, move 1 2');
-		battle.commitDecisions();
+		battle.makeChoices('move followme, move calmmind, move calmmind', 'move lowkick 2, move lowkick 2, move lowkick 2');
 		assert.strictEqual(hitCount, 2);
 	});
 
@@ -45,7 +44,7 @@ describe('Follow Me', function () {
 			{species: 'Alakazam', ability: 'synchronize', moves: ['howl']},
 			{species: 'Kadabra', ability: 'synchronize', moves: ['howl']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move followme, move softboiled', 'move howl, move howl');
 		assert.strictEqual(battle.p1.active[0].boosts['atk'], 0);
 		assert.strictEqual(battle.p2.active[0].boosts['atk'], 1);
 		assert.strictEqual(battle.p2.active[1].boosts['atk'], 1);

--- a/test/simulator/moves/foresight.js
+++ b/test/simulator/moves/foresight.js
@@ -14,12 +14,10 @@ describe('Foresight', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['foresight', 'vitalthrow', 'tackle']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dusknoir", ability: 'prankster', moves: ['recover']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move foresight', 'move recover');
+		battle.makeChoices('move vitalthrow', 'move recover');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.choose('p1', 'move 3');
-		battle.commitDecisions();
+		battle.makeChoices('move tackle', 'move recover');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -27,11 +25,10 @@ describe('Foresight', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['avalanche', 'foresight']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Forretress", ability: 'sturdy', moves: ['synthesis']}]);
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move foresight', 'move synthesis');
 		battle.boost({evasion: 6}, battle.p2.active[0]);
 		for (let i = 0; i < 16; i++) {
-			battle.commitDecisions();
+			battle.makeChoices('move avalanche', 'move synthesis');
 			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		}
 	});
@@ -40,11 +37,10 @@ describe('Foresight', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['zapcannon', 'dynamicpunch', 'foresight']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Zapdos", ability: 'owntempo', moves: ['roost']}]);
-		battle.choose('p1', 'move 3');
-		battle.commitDecisions();
+		battle.makeChoices('move foresight', 'move roost');
 		battle.boost({spe: 6, evasion: -6}, battle.p2.active[0]);
 		for (let i = 0; i < 16; i++) {
-			battle.commitDecisions();
+			battle.makeChoices('move zapcannon', 'move roost');
 			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		}
 	});

--- a/test/simulator/moves/glare.js
+++ b/test/simulator/moves/glare.js
@@ -14,7 +14,7 @@ describe('Glare', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Arbok", ability: 'noguard', moves: ['glare']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ekans", ability: 'sturdy', moves: ['bulkup']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move glare', 'move bulkup');
 		assert.strictEqual(battle.p2.active[0].status, 'par');
 	});
 
@@ -22,7 +22,7 @@ describe('Glare', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Arbok", ability: 'noguard', moves: ['glare']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Gengar", ability: 'blaze', moves: ['bulkup']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move glare', 'move bulkup');
 		assert.strictEqual(battle.p2.active[0].status, 'par');
 	});
 });
@@ -37,7 +37,7 @@ describe('Glare [Gen 3]', function () {
 			[{species: "Arbok", ability: 'noguard', moves: ['glare']}],
 			[{species: "Gengar", ability: 'blaze', moves: ['bulkup']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move glare', 'move bulkup');
 		assert.strictEqual(battle.p2.active[0].status, '');
 	});
 });

--- a/test/simulator/moves/grassyterrain.js
+++ b/test/simulator/moves/grassyterrain.js
@@ -14,16 +14,15 @@ describe('Grassy Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'grassyterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]);
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move grassyterrain', 'move mist');
 		assert.ok(battle.isTerrain('grassyterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move mist', 'move mist');
 		assert.ok(battle.isTerrain('grassyterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move mist', 'move mist');
 		assert.ok(battle.isTerrain('grassyterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move mist', 'move mist');
 		assert.ok(battle.isTerrain('grassyterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move mist', 'move mist');
 		assert.ok(battle.isTerrain(''));
 	});
 
@@ -31,7 +30,7 @@ describe('Grassy Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Shaymin", ability: 'naturalcure', moves: ['grassyterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Shaymin-Sky", ability: 'serenegrace', moves: ['leechseed']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move grassyterrain', 'move leechseeed');
 		assert.strictEqual(battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], Dex.getMove('earthquake'), 100, true), 50);
 		assert.strictEqual(battle.runEvent('BasePower', battle.p1.active[0], battle.p2.active[0], Dex.getMove('earthquake'), 100, true), 50);
 		assert.strictEqual(battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], Dex.getMove('bulldoze'), 60, true), 30);
@@ -42,7 +41,7 @@ describe('Grassy Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Shaymin", ability: 'naturalcure', moves: ['grassyterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Shaymin-Sky", ability: 'serenegrace', moves: ['leechseed']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move grassyterrain', 'move leechseed');
 		let basePower;
 		let move = Dex.getMove('gigadrain');
 		basePower = battle.runEvent('BasePower', battle.p1.active[0], battle.p2.active[0], move, move.basePower, true);
@@ -55,9 +54,8 @@ describe('Grassy Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Shaymin", ability: 'naturalcure', moves: ['grassyterrain', 'dragonrage']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Magneton", ability: 'magnetpull', moves: ['magnetrise', 'dragonrage']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move grassyterrain', 'move magnetrise');
+		battle.makeChoices('move dragonrage', 'move dragonrage');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp - 40 + Math.floor(battle.p1.active[0].maxhp / 16));
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp - 40);
 	});
@@ -66,9 +64,8 @@ describe('Grassy Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['dragonrage', 'skydrop']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['dragonrage', 'grassyterrain']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move dragonrage', 'move dragonrage');
+		battle.makeChoices('move skydrop', 'move grassyterrain');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp - 40);
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp - 40);
 	});
@@ -77,7 +74,7 @@ describe('Grassy Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Whimsicott", ability: 'prankster', moves: ['grassyterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Shuckle", ability: 'sturdy', moves: ['naturepower']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move grassyterrain', 'move naturepower');
 		let resultMove = toId(battle.log[battle.lastMoveLine].split('|')[3]);
 		assert.strictEqual(resultMove, 'energyball');
 	});

--- a/test/simulator/moves/gravity.js
+++ b/test/simulator/moves/gravity.js
@@ -14,7 +14,7 @@ describe('Gravity', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Aerodactyl', ability: 'pressure', moves: ['gravity']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Aron', ability: 'sturdy', moves: ['earthpower']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move gravity', 'move earthpower');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
@@ -22,7 +22,7 @@ describe('Gravity', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rotom', ability: 'levitate', moves: ['gravity']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Aron', ability: 'sturdy', moves: ['earthpower']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move gravity', 'move earthpower');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
@@ -30,9 +30,9 @@ describe('Gravity', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['gravity']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Aerodactyl', ability: 'pressure', moves: ['fly']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move gravity', 'move fly');
 		assert.ok(!battle.p2.active[0].volatiles['twoturnmove']);
-		battle.commitDecisions();
+		battle.makeChoices('move gravity', 'move fly');
 		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 });

--- a/test/simulator/moves/haze.js
+++ b/test/simulator/moves/haze.js
@@ -16,12 +16,11 @@ describe('Haze - RBY', function () {
 			[{species: "Mewtwo", moves: ['swordsdance', 'splash']}],
 		]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move agility', 'move swordsdance');
 		assert.strictEqual(battle.p1.active[0].boosts.spe, 2);
 		assert.strictEqual(battle.p2.active[0].boosts.atk, 2);
 
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move haze', 'move splash');
 		assert.strictEqual(battle.p1.active[0].boosts.spe, 0);
 		assert.strictEqual(battle.p2.active[0].boosts.atk, 0);
 	});
@@ -32,11 +31,10 @@ describe('Haze - RBY', function () {
 			[{species: "Mewtwo", moves: ['splash']}],
 		]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move thunderwave', 'move splash');
 		assert.strictEqual(battle.p2.active[0].status, 'par');
 
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move haze', 'move splash');
 		assert.notStrictEqual(battle.p2.active[0].status, 'par');
 	});
 
@@ -46,10 +44,10 @@ describe('Haze - RBY', function () {
 			[{species: "Mewtwo", moves: ['haze']}],
 		]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move thunderwave', 'move haze');
 		assert.strictEqual(battle.p2.active[0].status, 'par');
 
-		battle.commitDecisions();
+		battle.makeChoices('move thunderwave', 'move haze');
 		assert.strictEqual(battle.p2.active[0].status, 'par');
 	});
 
@@ -59,11 +57,10 @@ describe('Haze - RBY', function () {
 			[{species: "Mewtwo", moves: ['focusenergy', 'haze']}],
 		]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move focusenergy');
 		assert.ok(battle.p2.active[0].volatiles['focusenergy']);
 
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move splash', 'move haze');
 		assert.strictEqual(typeof battle.p2.active[0].volatiles['focusenergy'], 'undefined');
 	});
 
@@ -73,15 +70,13 @@ describe('Haze - RBY', function () {
 			[{species: "Mewtwo", moves: ['splash']}],
 		]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move reflect', 'move splash');
 		assert.ok(battle.p1.active[0].volatiles['reflect']);
 
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move lightscreen', 'move splash');
 		assert.ok(battle.p1.active[0].volatiles['lightscreen']);
 
-		battle.choose('p1', 'move 3');
-		battle.commitDecisions();
+		battle.makeChoices('move haze', 'move splash');
 		assert.strictEqual(typeof battle.p1.active[0].volatiles['reflect'], 'undefined');
 		assert.strictEqual(typeof battle.p1.active[0].volatiles['lightscreen'], 'undefined');
 	});

--- a/test/simulator/moves/healblock.js
+++ b/test/simulator/moves/healblock.js
@@ -14,7 +14,7 @@ describe('Heal Block', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Hippowdon', ability: 'sandstream', moves: ['healblock']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move calmmind');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -22,7 +22,7 @@ describe('Heal Block', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Pansage', ability: 'gluttony', item: 'berryjuice', moves: ['bellydrum']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move bellydrum');
 		assert.strictEqual(battle.p2.active[0].item, 'berryjuice');
 		assert.strictEqual(battle.p2.active[0].hp, Math.ceil(battle.p2.active[0].maxhp / 2));
 	});
@@ -31,8 +31,8 @@ describe('Heal Block', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Spiritomb', ability: 'pressure', moves: ['healblock']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Cresselia', ability: 'levitate', moves: ['recover']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move recover');
+		battle.makeChoices('move healblock', 'move recover');
 		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
@@ -40,7 +40,7 @@ describe('Heal Block', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['gigadrain']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move gigadrain');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
@@ -48,10 +48,9 @@ describe('Heal Block', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['healblock', 'surf']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move bellydrum');
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move surf', 'move calmmind');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 	});
 
@@ -59,10 +58,9 @@ describe('Heal Block', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Starmie', ability: 'noguard', moves: ['healblock']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move substitute');
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move leechseed');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
@@ -78,7 +76,7 @@ describe('Heal Block [Gen 5]', function () {
 			[{species: 'Hippowdon', ability: 'sandstream', moves: ['healblock']}],
 			[{species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move calmmind');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -87,7 +85,7 @@ describe('Heal Block [Gen 5]', function () {
 			[{species: 'Sableye', ability: 'prankster', moves: ['healblock']}],
 			[{species: 'Pansage', ability: 'gluttony', item: 'sitrusberry', moves: ['bellydrum']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move bellydrum');
 		assert.strictEqual(battle.p2.active[0].item, 'sitrusberry');
 		assert.strictEqual(battle.p2.active[0].hp, Math.ceil(battle.p2.active[0].maxhp / 2));
 	});
@@ -97,8 +95,8 @@ describe('Heal Block [Gen 5]', function () {
 			[{species: 'Spiritomb', ability: 'pressure', moves: ['healblock']}],
 			[{species: 'Cresselia', ability: 'levitate', moves: ['recover']}],
 		]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move recover');
+		battle.makeChoices('move healblock', 'move recover');
 		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
@@ -107,10 +105,9 @@ describe('Heal Block [Gen 5]', function () {
 			[{species: 'Sableye', ability: 'prankster', moves: ['healblock', 'surf']}],
 			[{species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move bellydrum');
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move surf', 'move calmmind');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 	});
 
@@ -119,10 +116,9 @@ describe('Heal Block [Gen 5]', function () {
 			[{species: 'Sableye', ability: 'prankster', moves: ['healblock']}],
 			[{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'gigadrain']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move substitute');
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move gigadrain');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
@@ -133,8 +129,7 @@ describe('Heal Block [Gen 5]', function () {
 			[{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed']}],
 		]);
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move leechseed');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
@@ -150,8 +145,8 @@ describe('Heal Block [Gen 4]', function () {
 			[{species: 'Spiritomb', ability: 'pressure', moves: ['healblock']}],
 			[{species: 'Cresselia', ability: 'levitate', moves: ['recover']}],
 		]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move recover');
+		battle.makeChoices('move healblock', 'move recover');
 		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
@@ -160,8 +155,8 @@ describe('Heal Block [Gen 4]', function () {
 			[{species: 'Spiritomb', ability: 'pressure', moves: ['healblock']}],
 			[{species: 'Deoxys', ability: 'pressure', moves: ['wish']}],
 		]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move wish');
+		battle.makeChoices('move healblock', 'move wish');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -170,10 +165,9 @@ describe('Heal Block [Gen 4]', function () {
 			[{species: 'Sableye', ability: 'prankster', moves: ['healblock']}],
 			[{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'gigadrain']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move substitute');
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move gigadrain');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
@@ -183,14 +177,11 @@ describe('Heal Block [Gen 4]', function () {
 			[{species: 'Spiritomb', ability: 'pressure', moves: ['healblock', 'shadowball']}],
 			[{species: 'Abra', level: 1, ability: 'synchronize', item: 'leftovers', moves: ['teleport', 'endure']}, {species: 'Abra', level: 1, ability: 'synchronize', item: 'sitrusberry', moves: ['teleport', 'endure']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move healblock', 'move teleport');
+		battle.makeChoices('move shadowball', 'move endure');
 		assert.notStrictEqual(battle.p2.active[0].hp, 1);
-		battle.choose('p2', 'switch 2');
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move healblock', 'switch 2');
+		battle.makeChoices('move shadowball', 'move endure');
 		assert.strictEqual(battle.p2.active[0].item, '');
 		assert.notStrictEqual(battle.p2.active[0].hp, 1);
 	});
@@ -200,10 +191,9 @@ describe('Heal Block [Gen 4]', function () {
 			[{species: 'Sableye', ability: 'keeneye', moves: ['healblock', 'surf']}],
 			[{species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move bellydrum');
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move surf', 'move calmmind');
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
 
@@ -212,10 +202,9 @@ describe('Heal Block [Gen 4]', function () {
 			[{species: 'Starmie', ability: 'noguard', moves: ['healblock']}],
 			[{species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move substitute');
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move healblock', 'move leechseed');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});

--- a/test/simulator/moves/hypervoice.js
+++ b/test/simulator/moves/hypervoice.js
@@ -14,9 +14,8 @@ describe('Hyper Voice', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'hypervoice']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move hypervoice', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 });
@@ -31,9 +30,8 @@ describe('Hyper Voice [Gen 5]', function () {
 			[{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'hypervoice']}],
 			[{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move hypervoice', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, 'focussash');
 	});
 });

--- a/test/simulator/moves/imprison.js
+++ b/test/simulator/moves/imprison.js
@@ -14,10 +14,10 @@ describe('Imprison', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Abra', ability: 'prankster', moves: ['imprison', 'calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abra', ability: 'synchronize', moves: ['calmmind', 'confusion']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move imprison', 'move calmmind');
 		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
 		assert.strictEqual(battle.p2.active[0].boosts['spd'], 0);
-		battle.commitDecisions();
+		battle.makeChoices('move imprison', 'move calmmind');
 		assert.strictEqual(battle.p2.active[0].lastMove.id, 'confusion');
 	});
 });

--- a/test/simulator/moves/ingrain.js
+++ b/test/simulator/moves/ingrain.js
@@ -14,7 +14,7 @@ describe('Ingrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Cradily', ability: 'stormdrain', moves: ['ingrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Miltank', ability: 'thickfat', moves: ['seismictoss']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move ingrain', 'move seismictoss');
 		assert.strictEqual(battle.p1.active[0].hp, Math.floor(battle.p1.active[0].maxhp * 17 / 16) - 100);
 	});
 
@@ -25,11 +25,9 @@ describe('Ingrain', function () {
 			{species: 'Pikachu', ability: 'static', moves: ['thunder']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Arcanine', ability: 'flashfire', moves: ['sleeptalk', 'roar']}]);
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move ingrain', 'move roar');
 		assert.strictEqual(battle.p1.active[0].speciesid, 'cradily');
-		battle.choose('p1', 'switch 2');
-		battle.commitDecisions();
+		battle.makeChoices('switch pikachu', 'move sleeptalk');
 		assert.strictEqual(battle.p1.active[0].speciesid, 'cradily');
 	});
 
@@ -37,9 +35,8 @@ describe('Ingrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Tropius', ability: 'harvest', moves: ['earthquake', 'ingrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Carnivine', ability: 'levitate', moves: ['earthquake', 'ingrain']}]);
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move ingrain', 'move ingrain');
+		battle.makeChoices('move earthquake', 'move earthquake');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});

--- a/test/simulator/moves/judgment.js
+++ b/test/simulator/moves/judgment.js
@@ -13,7 +13,7 @@ describe(`Judgment`, function () {
 			[{species: "Arceus", ability: 'Honey Gather', item: 'spookyplate', moves: ['judgment']}],
 			[{species: "Spiritomb", ability: 'stancechange', moves: ['calmmind']}],
 		]);
-		assert.hurts(battle.p2.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p2.active[0], () => battle.makeChoices('move judgment', 'move calmmind'));
 	});
 
 	it(`should not adapt its type to a held Z Crystal`, function () {
@@ -21,7 +21,7 @@ describe(`Judgment`, function () {
 			[{species: "Arceus", ability: 'Honey Gather', item: 'ghostiumz', moves: ['judgment']}],
 			[{species: "Spiritomb", ability: 'stancechange', moves: ['calmmind']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move judgment', 'move calmmind');
 		assert.fullHP(battle.p2.active[0]);
 	});
 });

--- a/test/simulator/moves/kingsshield.js
+++ b/test/simulator/moves/kingsshield.js
@@ -13,7 +13,7 @@ describe(`King's Shield`, function () {
 			[{species: "Gallade", ability: 'justified', moves: ['zenheadbutt']}],
 			[{species: "Aegislash", ability: 'stancechange', moves: ['kingsshield']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move zenheadbutt', 'move kingsshield');
 		assert.statStage(battle.p1.active[0], 'atk', -2);
 	});
 
@@ -22,7 +22,7 @@ describe(`King's Shield`, function () {
 			[{species: "Gallade", ability: 'justified', moves: ['drainpunch']}],
 			[{species: "Aegislash", ability: 'stancechange', moves: ['kingsshield']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move drainpunch', 'move kingsshield');
 		assert.statStage(battle.p1.active[0], 'atk', -2);
 	});
 });
@@ -35,7 +35,7 @@ describe(`King's Shield [Gen 6]`, function () {
 			[{species: "Gallade", ability: 'justified', moves: ['drainpunch']}],
 			[{species: "Aegislash", ability: 'stancechange', moves: ['kingsshield']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move drainpunch', 'move kingsshield');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 	});
 });

--- a/test/simulator/moves/knockoff.js
+++ b/test/simulator/moves/knockoff.js
@@ -14,7 +14,7 @@ describe('Knock Off', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['knockoff']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move knockoff', 'move softboiled');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 
@@ -22,7 +22,7 @@ describe('Knock Off', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['knockoff']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Arceus", ability: 'download', item: 'flameplate', moves: ['swordsdance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move knockoff', 'move swordsdance');
 		assert.strictEqual(battle.p2.active[0].item, 'flameplate');
 	});
 
@@ -30,7 +30,7 @@ describe('Knock Off', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['knockoff']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Genesect", ability: 'download', item: 'dousedrive', moves: ['shiftgear']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move knockoff', 'move shiftgear');
 		assert.strictEqual(battle.p2.active[0].item, 'dousedrive');
 	});
 
@@ -38,7 +38,7 @@ describe('Knock Off', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['knockoff']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Scizor", ability: 'technician', item: 'scizorite', moves: ['swordsdance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move knockoff', 'move swordsdance');
 		assert.strictEqual(battle.p2.active[0].item, 'scizorite');
 	});
 
@@ -46,7 +46,7 @@ describe('Knock Off', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['knockoff']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Scizor", ability: 'technician', item: 'audinite', moves: ['swordsdance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move knockoff', 'move swordsdance');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 
@@ -54,7 +54,7 @@ describe('Knock Off', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Shedinja", ability: 'wonderguard', moves: ['knockoff']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ferrothorn", ability: 'ironbarbs', item: 'rockyhelmet', moves: ['curse']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move knockoff', 'move curse');
 		assert.strictEqual(battle.p2.active[0].item, 'rockyhelmet');
 	});
 });

--- a/test/simulator/moves/magicroom.js
+++ b/test/simulator/moves/magicroom.js
@@ -14,7 +14,7 @@ describe('Magic Room', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'leftovers', moves: ['bellydrum']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Giratina", ability: 'pressure', moves: ['magicroom']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move bellydrum', 'move magicroom');
 		assert.strictEqual(battle.p1.active[0].hp, Math.ceil(battle.p1.active[0].maxhp / 2));
 	});
 
@@ -22,7 +22,7 @@ describe('Magic Room', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'chopleberry', moves: ['magicroom']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['lowkick']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move magicroom', 'move lowkick');
 		assert.strictEqual(battle.p1.active[0].item, 'chopleberry');
 	});
 
@@ -30,8 +30,8 @@ describe('Magic Room', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'assaultvest', moves: ['protect']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['magicroom']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move protect', 'move magicroom');
+		battle.makeChoices('move protect', 'move magicroom');
 		assert.strictEqual(battle.p1.active[0].lastMove.id, 'protect');
 	});
 
@@ -39,7 +39,7 @@ describe('Magic Room', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'seaincense', moves: ['fling']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['magicroom']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move fling', 'move magicroom');
 		assert.strictEqual(battle.p1.active[0].item, 'seaincense');
 	});
 
@@ -47,9 +47,8 @@ describe('Magic Room', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Lopunny", ability: 'limber', item: 'lopunnite', moves: ['bulkup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Golem", ability: 'noguard', moves: ['magicroom', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 1 mega');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move bulkup', 'move magicroom');
+		battle.makeChoices('move bulkup mega', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template.speciesid, 'lopunnymega');
 	});
 
@@ -60,8 +59,8 @@ describe('Magic Room', function () {
 			{species: "Groudon", ability: 'drought', item: 'redorb', moves: ['protect']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Meowstic", ability: 'prankster', moves: ['magicroom']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'switch 2');
+		battle.makeChoices('move voltswitch', 'move magicroom');
+		battle.makeChoices('switch groudon', 'move magicroom');
 		assert.strictEqual(battle.p1.active[0].template.speciesid, 'groudonprimal');
 	});
 });

--- a/test/simulator/moves/miracleeye.js
+++ b/test/simulator/moves/miracleeye.js
@@ -41,7 +41,6 @@ describe('Miracle Eye', function () {
 		], [
 			{species: "Zapdos", moves: ['roost']},
 		]]);
-		battle.choose('p1', 'move 3');
 		battle.makeChoices('move miracle eye', 'move roost');
 		battle.boost({spe: 6, evasion: -6}, battle.p2.active[0]);
 		for (let i = 0; i < 3; i++) {

--- a/test/simulator/moves/mistyterrain.js
+++ b/test/simulator/moves/mistyterrain.js
@@ -14,16 +14,15 @@ describe('Misty Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'mistyterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]);
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move mistyterrain', 'move mist');
 		assert.ok(battle.isTerrain('mistyterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move mist', 'move mist');
 		assert.ok(battle.isTerrain('mistyterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move mist', 'move mist');
 		assert.ok(battle.isTerrain('mistyterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move mist', 'move mist');
 		assert.ok(battle.isTerrain('mistyterrain'));
-		battle.commitDecisions();
+		battle.makeChoices('move mist', 'move mist');
 		assert.ok(battle.isTerrain(''));
 	});
 
@@ -31,7 +30,7 @@ describe('Misty Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Shaymin", ability: 'naturalcure', moves: ['mistyterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Shaymin-Sky", ability: 'serenegrace', moves: ['leechseed']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move mistyterrain', 'move leechseed');
 		let basePower;
 		let move = Dex.getMove('dragonpulse');
 		basePower = battle.runEvent('BasePower', battle.p2.active[0], battle.p1.active[0], move, move.basePower, true);
@@ -44,9 +43,8 @@ describe('Misty Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'toxic']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Machamp", ability: 'noguard', item: 'airballoon', moves: ['bulkup', 'toxic']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move mistyterrain', 'move bulkup');
+		battle.makeChoices('move toxic', 'move toxic');
 		assert.strictEqual(battle.p1.active[0].status, '');
 		assert.strictEqual(battle.p2.active[0].status, 'tox');
 	});
@@ -55,7 +53,7 @@ describe('Misty Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mistyterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Crobat", ability: 'infiltrator', moves: ['toxic']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move mistyterrain', 'move toxic');
 		assert.strictEqual(battle.p1.active[0].status, 'tox');
 	});
 
@@ -63,9 +61,8 @@ describe('Misty Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'yawn']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['yawn']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move mistyterrain', 'move yawn');
+		battle.makeChoices('move yawn', 'move yawn');
 		assert.strictEqual(battle.p1.active[0].status, '');
 		let dataLine = battle.log[battle.lastMoveLine + 1].split('|');
 		assert.strictEqual(dataLine[1], '-start');
@@ -76,9 +73,8 @@ describe('Misty Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move mistyterrain', 'move doubleedge');
+		battle.makeChoices('move rest', 'move rest');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
@@ -87,9 +83,8 @@ describe('Misty Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", ability: 'owntempo', moves: ['yawn', 'skydrop']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Sableye", ability: 'prankster', moves: ['yawn', 'mistyterrain']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move yawn', 'move yawn');
+		battle.makeChoices('move skydrop', 'move mistyterrain');
 		assert.strictEqual(battle.p1.active[0].status, 'slp');
 		assert.strictEqual(battle.p2.active[0].status, 'slp');
 	});
@@ -98,7 +93,7 @@ describe('Misty Terrain', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Whimsicott", ability: 'prankster', moves: ['mistyterrain']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Shuckle", ability: 'sturdy', moves: ['naturepower']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move mistyterrain', 'move naturepower');
 		let resultMove = toId(battle.log[battle.lastMoveLine].split('|')[3]);
 		assert.strictEqual(resultMove, 'moonblast');
 	});

--- a/test/simulator/moves/partingshot.js
+++ b/test/simulator/moves/partingshot.js
@@ -21,24 +21,24 @@ describe(`Parting Shot`, function () {
 		]);
 		const p1 = battle.p1;
 		const p2 = battle.p2;
-		battle.commitDecisions();
+		battle.makeChoices('move partingshot', 'move return');
 		assert.strictEqual(battle.currentRequest, 'move');
-		p1.chooseMove(1).foe.chooseSwitch(2); // Solgaleo
+		battle.makeChoices('move partingshot', 'switch 2'); // Solgaleo
 		assert.strictEqual(battle.currentRequest, 'move');
-		p1.chooseMove(1).foe.chooseSwitch(3); // Torkoal
+		battle.makeChoices('move partingshot', 'switch 3'); // Torkoal
 		assert.strictEqual(battle.currentRequest, 'move');
-		p1.chooseMove(1).foe.chooseSwitch(4); // Shaymin
+		battle.makeChoices('move partingshot', 'switch 4'); // Shaymin
 		assert.strictEqual(battle.currentRequest, 'move');
-		p1.chooseMove(2).foe.chooseSwitch(5); // Kingler
+		battle.makeChoices('move splash', 'switch 5'); // Kingler
 		p2.active[0].boostBy({spa: -6});
-		battle.commitDecisions();
+		battle.makeChoices('move partingshot', 'move splash');
 		assert.strictEqual(battle.currentRequest, 'move');
-		p1.chooseMove(2).foe.chooseSwitch(6); // Spinda
+		battle.makeChoices('move splash', 'switch 6'); // Spinda
 		p2.active[0].boostBy({atk: 6, spa: 6});
-		battle.commitDecisions();
+		battle.makeChoices('move partingshort', 'move splash');
 		assert.strictEqual(battle.currentRequest, 'move');
 		p1.active[0].boostBy({atk: -6, spa: -6});
-		p1.chooseMove(2).foe.chooseMove(2); // Parting Shot against Silvally this time
+		battle.makeChoices('move splash', 'move partingshot'); // Parting Shot against Silvally this time
 		assert.strictEqual(battle.currentRequest, 'move');
 	});
 });

--- a/test/simulator/moves/quash.js
+++ b/test/simulator/moves/quash.js
@@ -21,9 +21,8 @@ describe('Quash', function () {
 			{species: "Aerodactyl", ability: 'unnerve', moves: ['swift']},
 			{species: "Rotom", ability: 'levitate', moves: ['thunderbolt']},
 		]);
-		battle.choose('p1', 'move 1 2, move 1');
-		battle.choose('p2', 'move 1 2, move 1');
-		battle.choose('p2', 'switch 3, pass'); // Volt Switch
+		battle.makeChoices('move quash 2, move earthquake', 'move voltswitch 2, move swift');
+		battle.makeChoices('move quash, move earthquake', 'switch 3, pass'); // Volt Switch
 		assert.strictEqual(battle.log[battle.lastMoveLine].split('|')[3], 'Swift');
 	});
 
@@ -38,9 +37,8 @@ describe('Quash', function () {
 			{species: "Aerodactyl", ability: 'unnerve', moves: ['extremespeed']},
 			{species: "Rotom", ability: 'levitate', moves: ['thunderbolt']},
 		]);
-		battle.choose('p1', 'move 1 2, move 1');
-		battle.choose('p2', 'move 1 2, move 1 1');
-		battle.choose('p2', 'switch 3, pass'); // Volt Switch
+		battle.makeChoices('move quash 2, move earthquake', 'move voltswitch 2, move extremespeed 1');
+		battle.makeChoices('move quash, move earthquake', 'switch 3, pass'); // Volt Switch
 		assert.notStrictEqual(battle.log[battle.lastMoveLine].split('|')[3], 'Extremespeed');
 	});
 });

--- a/test/simulator/moves/ragepowder.js
+++ b/test/simulator/moves/ragepowder.js
@@ -38,8 +38,7 @@ describe('Rage Powder', function () {
 			hitCount[2]++;
 			return Sim.Pokemon.prototype.damage.apply(this, args);
 		};
-		battle.choose('p2', 'move 1 2, move 1 2, move 1 2');
-		battle.commitDecisions();
+		battle.makeChoices('move ragepowder, move growth, move growth', 'move absorb, move absorb, move absorb');
 		assert.strictEqual(hitCount[0], 2);
 		assert.strictEqual(hitCount[1], 1);
 		assert.strictEqual(hitCount[2], 0);
@@ -70,8 +69,7 @@ describe('Rage Powder', function () {
 			hitCount[2]++;
 			return Sim.Pokemon.prototype.damage.apply(this, args);
 		};
-		battle.choose('p2', 'move 1 3, move 1 1, move 1 1');
-		battle.commitDecisions();
+		battle.makeChoices('move growth, move ragepowder, move growth', 'move absorb 3, move absorb 1, move absorb 1');
 		assert.strictEqual(hitCount[0], 2);
 		assert.strictEqual(hitCount[1], 1);
 		assert.strictEqual(hitCount[2], 0);

--- a/test/simulator/moves/reflecttype.js
+++ b/test/simulator/moves/reflecttype.js
@@ -14,26 +14,26 @@ describe('Reflect Type', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Arcanine', ability: 'intimidate', moves: ['burnup']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype']}]);
-		assert.constant(() => battle.p2.active[0].getTypes(), () => battle.commitDecisions());
+		assert.constant(() => battle.p2.active[0].getTypes(), () => battle.makeChoices('move burnup', 'move reflecttype'));
 	});
 
 	it('should ignore the "???" type when used against a Pokemon whose type contains "???" and a non-added type', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Moltres', ability: 'pressure', moves: ['burnup']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move reflecttype', 'move burnup');
 		assert.strictEqual(battle.p1.active[0].getTypes().join('/'), 'Flying');
-		p1.chooseMove(2, 1).foe.chooseDefault();
-		battle.commitDecisions();
+		battle.makeChoices('move trickortreat', 'move burnup');
+		battle.makeChoices('move reflecttype', 'move burnup');
 		assert.strictEqual(battle.p1.active[0].getTypes().join('/'), 'Flying/Ghost');
 	});
 
 	it('should turn the "???" type into "Normal" when used against a Pokemon whose type is only "???" and an added type', function () {
 		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat']}]);
+		battle.join('p1', 'Guest 1', 1, [{species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Arcanine', ability: 'intimidate', moves: ['burnup']}]);
-		p1.chooseMove(2, 1).foe.chooseDefault();
-		battle.commitDecisions();
+		battle.makeChoices('move trickortreat', 'move burnup');
+		battle.makeChoices('move reflecttype', 'move burnup');
 		assert.strictEqual(battle.p1.active[0].getTypes().join('/'), 'Normal/Ghost');
 	});
 });

--- a/test/simulator/moves/relicsong.js
+++ b/test/simulator/moves/relicsong.js
@@ -14,7 +14,7 @@ describe('Relic Song', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Meloetta", ability: 'serenegrace', moves: ['relicsong']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Registeel", ability: 'clearbody', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move relicsong', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template.speciesid, 'meloettapirouette');
 	});
 
@@ -22,7 +22,7 @@ describe('Relic Song', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Meloetta-Pirouette", ability: 'serenegrace', moves: ['relicsong']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Registeel", ability: 'clearbody', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move relicsong', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template.speciesid, 'meloetta');
 	});
 
@@ -30,9 +30,8 @@ describe('Relic Song', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'relicsong']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move relicsong', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 });
@@ -47,9 +46,8 @@ describe('Relic Song [Gen 5]', function () {
 			[{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'relicsong']}],
 			[{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move relicsong', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, 'focussash');
 	});
 
@@ -58,7 +56,7 @@ describe('Relic Song [Gen 5]', function () {
 			[{species: "Meloetta", ability: 'serenegrace', moves: ['relicsong']}],
 			[{species: "Registeel", ability: 'prankster', moves: ['substitute']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move relicsong', 'move substitute');
 		assert.strictEqual(battle.p1.active[0].template.speciesid, 'meloettapirouette');
 	});
 });

--- a/test/simulator/moves/rollout.js
+++ b/test/simulator/moves/rollout.js
@@ -34,7 +34,7 @@ for (const move of moves) {
 			});
 
 			for (let i = 0; i < 8; i++) {
-				battle.commitDecisions();
+				battle.makeChoices('move ' + id, 'move recover');
 			}
 			assert.strictEqual(count, 8);
 		});
@@ -64,7 +64,7 @@ for (const move of moves) {
 			});
 
 			for (let i = 0; i < 5; i++) {
-				battle.commitDecisions();
+				battle.makeChoices('move ' + id, 'move recover');
 			}
 			assert.strictEqual(count, 5);
 		});
@@ -92,7 +92,7 @@ for (const move of moves) {
 			});
 
 			for (let i = 0; i < 5; i++) {
-				battle.commitDecisions();
+				battle.makeChoices('move ' + id, 'move recover');
 			}
 			assert.strictEqual(count, 5);
 		});
@@ -109,9 +109,8 @@ for (const move of moves) {
 				runCount++;
 			});
 
-			battle.choose('p1', 'move 2');
-			battle.commitDecisions();
-			battle.commitDecisions();
+			battle.makeChoices('move defensecurl', 'move recover');
+			battle.makeChoices('move ' + id, 'move recover');
 			assert.strictEqual(runCount, 1);
 		});
 
@@ -127,7 +126,7 @@ for (const move of moves) {
 				hitCount++;
 			});
 
-			battle.commitDecisions();
+			battle.makeChoices('move ' + id, 'move recover');
 			assert.strictEqual(hitCount, 1);
 		});
 	});

--- a/test/simulator/moves/roost.js
+++ b/test/simulator/moves/roost.js
@@ -15,7 +15,7 @@ describe('Roost', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Clefable", item: 'leftovers', ability: 'unaware', moves: ['calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", item: 'laggingtail', ability: 'multiscale', moves: ['roost']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move roost');
 		assert.strictEqual(battle.log[battle.lastMoveLine + 1], '|-fail|' + battle.p2.active[0]);
 	});
 
@@ -23,9 +23,8 @@ describe('Roost', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Clefable", ability: 'unaware', moves: ['calmmind', 'hiddenpowergrass']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['roost', 'dragondance']}]);
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move hiddenpowergrass', 'move dragondance');
+		battle.makeChoices('move calmmind', 'move roost');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -34,22 +33,19 @@ describe('Roost', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Aggron", item: 'leftovers', ability: 'sturdy', moves: ['mudslap', 'hiddenpowergrass']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Aerodactyl", item: 'focussash', ability: 'wonderguard', moves: ['roost', 'doubleedge']}]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move mudslap', 'move roost');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp); // Immune to Mud Slap
 
 		// Ensure that Aerodactyl has some damage
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move mudslap', 'move doubleedge');
 
-		battle.commitDecisions();
+		battle.makeChoices('move mudslap', 'move roost');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp); // Hit super-effectively by Mud Slap
 
 		// Ensure that Aerodactyl has some damage
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move mudslap', 'move doubleedge');
 
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move hiddenpowergrasss', 'move roost');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp); // Hit super-effectively by HP Grass
 	});
 
@@ -70,7 +66,7 @@ describe('Roost', function () {
 			return Sim.Pokemon.prototype.damage.apply(this, args);
 		};
 
-		battle.commitDecisions();
+		battle.makeChoices('move aircutter, move earthquake', 'move roost, move earthquake');
 		assert.strictEqual(hitCount, 3);
 	});
 
@@ -78,8 +74,8 @@ describe('Roost', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Tornadus", item: 'focussash', ability: 'prankster', moves: ['roost']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Gastly", item: 'laggingtail', ability: 'levitate', moves: ['astonish']}]);
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move roost', 'move astonish');
+		battle.makeChoices('move roost', 'move astonish');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp); // Immune to Astonish
 	});
 });
@@ -95,12 +91,11 @@ describe('Roost - DPP', function () {
 			[{species: "Gastly", item: 'laggingtail', ability: 'levitate', moves: ['astonish', 'earthpower']}],
 		]);
 
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move roost', 'move astonish');
+		battle.makeChoices('move roost', 'move astonish');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp); // Affected by Astonish
 
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move roost', 'move earthpower');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp); // Affected by Earth Power
 	});
 });

--- a/test/simulator/moves/round.js
+++ b/test/simulator/moves/round.js
@@ -14,9 +14,8 @@ describe('Round', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'round']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move round', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 });
@@ -32,9 +31,8 @@ describe('Round [Gen 5]', function () {
 			[{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}],
 		]);
 
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move round', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, 'focussash');
 	});
 });

--- a/test/simulator/moves/sheercold.js
+++ b/test/simulator/moves/sheercold.js
@@ -15,7 +15,7 @@ describe('Sheer Cold', function () {
 			[{species: "Deoxys-Speed", ability: 'noguard', moves: ['sheercold']}],
 			[{species: "Arceus-Ice", item: 'icicleplate', ability: 'multitype', moves: ['calmmind']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move sheercold', 'move calmmind');
 		assert.false.fainted(battle.p2.active[0]);
 	});
 });
@@ -30,7 +30,7 @@ describe('Sheer Cold [Gen 6]', function () {
 			[{species: "Deoxys-Speed", ability: 'noguard', moves: ['sheercold']}],
 			[{species: "Arceus-Ice", item: 'icicleplate', ability: 'multitype', moves: ['calmmind']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move sheercold', 'move calmmind');
 		assert.fainted(battle.p2.active[0]);
 	});
 });

--- a/test/simulator/moves/skydrop.js
+++ b/test/simulator/moves/skydrop.js
@@ -14,9 +14,9 @@ describe('Sky Drop', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lairon", ability: 'sturdy', moves: ['tackle']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
@@ -27,9 +27,8 @@ describe('Sky Drop', function () {
 			{species: "Lairon", ability: 'sturdy', moves: ['bulkup']},
 			{species: "Aggron", ability: 'sturdy', moves: ['bulkup']},
 		]);
-		battle.commitDecisions();
-		battle.choose('p2', 'switch 2');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move bulkup');
+		battle.makeChoices('move skydrop', 'switch aggron');
 		assert.strictEqual(battle.p2.active[0].template.speciesid, 'lairon');
 	});
 
@@ -45,8 +44,7 @@ describe('Sky Drop', function () {
 			{species: "Aggron", ability: 'noguard', moves: ['dragontail']},
 			{species: "Omastar", ability: 'swiftswim', moves: ['shellsmash']},
 		]);
-		battle.choose('p1', 'move 1 1, move 1 1');
-		battle.choose('p2', 'move 1 1, move 1 1');
+		battle.makeChoices('move skydrop 1, move circlethrow 1', 'move bulkup, move dragontail 1');
 		assert.strictEqual(battle.p1.active[0].template.speciesid, 'aerodactyl');
 		assert.strictEqual(battle.p2.active[0].template.speciesid, 'armaldo');
 	});
@@ -56,9 +54,8 @@ describe('Sky Drop', function () {
 			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}],
 			[{species: "Manectric", ability: 'intimidate', item: 'manectite', moves: ['charge']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p2', 'move 1 mega');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move charge');
+		battle.makeChoices('move skydrop', 'move charge mega');
 		assert.strictEqual(battle.p2.active[0].template.speciesid, 'manectric');
 	});
 
@@ -66,13 +63,12 @@ describe('Sky Drop', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Aegislash", ability: 'stancechange', moves: ['tackle', 'kingsshield']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.strictEqual(battle.p2.active[0].template.speciesid, 'aegislash');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.strictEqual(battle.p2.active[0].template.speciesid, 'aegislashblade');
-		battle.commitDecisions();
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
+		battle.makeChoices('move skydrop', 'move kingsshield');
 		assert.strictEqual(battle.p2.active[0].template.speciesid, 'aegislashblade');
 	});
 
@@ -81,8 +77,7 @@ describe('Sky Drop', function () {
 			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Kyogre", ability: 'noguard', moves: ['scald']}],
 			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup']}],
 		]);
-		battle.choose('p1', 'move 1 1, move 1 -1');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop 1, move scald -1', 'move bulkup, move bulkup');
 		assert.strictEqual(battle.p2.active[0].boosts['atk'], 1);
 		assert.strictEqual(battle.p2.active[0].boosts['def'], 1);
 	});
@@ -92,9 +87,9 @@ describe('Sky Drop', function () {
 			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}],
 			[{species: "Salamence", ability: 'intimidate', moves: ['tackle']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -117,10 +112,8 @@ describe('Sky Drop', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Aerodactyl", ability: 'unnerve', moves: ['honeclaws', 'skydrop']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Lairon", ability: 'sturdy', moves: ['substitute', 'tackle']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move honeclaws', 'move substitute');
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
@@ -128,7 +121,7 @@ describe('Sky Drop', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Aggron", ability: 'sturdy', moves: ['tackle']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
@@ -137,8 +130,7 @@ describe('Sky Drop', function () {
 			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Smeargle", ability: 'owntempo', moves: ['spore']}],
 			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup']}],
 		]);
-		battle.choose('p1', 'move 1 -2, move 1 1');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop -2, move spore 1', 'move bulkup, move bulkup');
 		assert.strictEqual(battle.p2.active[0].status, 'slp');
 	});
 
@@ -147,10 +139,8 @@ describe('Sky Drop', function () {
 			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Smeargle", ability: 'owntempo', moves: ['splash']}],
 			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup', 'allyswitch']}],
 		]);
-		battle.choose('p1', 'move 1 1, move 1');
-		battle.commitDecisions();
-		battle.choose('p2', 'move 1, move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move bulkup');
+		battle.makeChoices('move skydrop, move splash', 'move bulkup, move allyswitch');
 		assert.strictEqual(battle.p2.active[1].template.speciesid, 'lairon');
 		assert.notStrictEqual(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
 	});
@@ -160,10 +150,8 @@ describe('Sky Drop', function () {
 			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Smeargle", ability: 'owntempo', moves: ['splash']}],
 			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup', 'followme']}],
 		]);
-		battle.choose('p1', 'move 1 1, move 1');
-		battle.commitDecisions();
-		battle.choose('p2', 'move 1, move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop 1, move splash', 'move bulkup move bulkup');
+		battle.makeChoices('move skydrop, move splash', 'move bulkup, move followme');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		assert.strictEqual(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
 	});
@@ -177,11 +165,9 @@ describe('Sky Drop', function () {
 			// mod Sky Drop to deal no damage
 			if (effect.id === 'skydrop') return 0;
 		});
-		battle.choose('p1', 'move 1 1, move 1 2');
-		battle.choose('p2', 'move 1, move 1 2');
+		battle.makeChoices('move skydrop 1, move aquajet 2', 'move bulkup, move aquajet 2');
 		// Aerodactyl and Lairon are now airborne from Sky Drop
-		battle.choose('p1', 'move 1 1, move 1 1');
-		battle.choose('p2', 'move 1, move 1 1');
+		battle.makeChoices('move skydrop 1, move aquajet 1', 'move bulkup, move aquajet 1');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
@@ -191,8 +177,7 @@ describe('Sky Drop', function () {
 			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Jirachi", ability: 'serenegrace', moves: ['gravity']}],
 			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup']}],
 		]);
-		battle.choose('p1', 'move 1 1, move 1');
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop 1, move gravity', 'move bulkup, move bulkup');
 		assert.strictEqual(battle.p2.active[0].boosts['atk'], 1);
 		assert.strictEqual(battle.p2.active[0].boosts['def'], 1);
 	});
@@ -208,7 +193,7 @@ describe('Sky Drop [Gen 5]', function () {
 			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}],
 			[{species: "Aggron", ability: 'sturdy', moves: ['tackle']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move skydrop', 'move tackle');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
@@ -225,43 +210,36 @@ describe('Sky Drop [Gen 5]', function () {
 				{species: "Deoxys-Attack", ability: 'sturdy', moves: ['nastyplot', 'thunderbolt', 'roar']},
 				{species: "Azurill", ability: 'thickfat', moves: ['watersport']},
 			]);
-			battle.choose('p1', 'move 2 1, move 2');
-			battle.commitDecisions();
+			console.log('-------------------------------');
+			battle.makeChoices('move skydrop 1, move gravity', 'move sleeptalk, move nastyplot');
 			// Magikarp should now be stuck because of the Sky Drop glitch.
 		});
 
 		it('should prevent the target from moving or switching', function () {
-			battle.choose('p2', 'move 2 2, move 1');
-			battle.commitDecisions();
+			battle.makeChoices('move rockpolish, move recover', 'move tackle 2, move nastyplot');
 			assert.strictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
-			battle.choose('p2', 'switch 3, move 1');
-			battle.commitDecisions();
+			battle.makeChoices('move rockpolish, move recover', 'switch azurill, move nastyplot');
 			assert.strictEqual(battle.p2.active[0].template.speciesid, 'magikarp');
 		});
 
 		it('should prevent the user from being forced out', function () {
-			battle.choose('p2', 'move 1, move 3 1');
-			battle.commitDecisions();
+			battle.makeChoices('move rockpolish, move recover', 'move sleeptalk, move roar 1');
 			assert.strictEqual(battle.p1.active[0].template.speciesid, 'aerodactyl');
 		});
 
 		it('should end when the user switches out', function () {
-			battle.choose('p1', 'switch 3, move 1');
-			battle.choose('p2', 'move 2 2, move 1');
+			battle.makeChoices('switch 3, move rockpolish', 'move tackle 2, move nastyplot');
 			assert.notStrictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
 		});
 
 		it('should end when the user faints', function () {
-			battle.choose('p2', 'move 2 2, move 2 1');
-			battle.commitDecisions();
+			battle.makeChoices('move rockpolish, move recover', 'move tackle 2, move thunderbolt 1');
 			assert.notStrictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
 		});
 
 		it('should end when the user completes another two-turn move', function () {
-			battle.choose('p1', 'move 3 2, move 1');
-			battle.commitDecisions();
-			battle.choose('p2', 'move 2 2, move 1');
-			battle.commitDecisions();
+			battle.makeChoices('move dig 2, move recover', 'move sleeptalk, move nastyplot');
+			battle.makeChoices('move rockpolish, move recover', 'move tackle 2, move nastyplot');
 			assert.notStrictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
 		});
 	});

--- a/test/simulator/moves/smellingsalts.js
+++ b/test/simulator/moves/smellingsalts.js
@@ -14,9 +14,8 @@ describe('Smelling Salts', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Meloetta", ability: 'serenegrace', moves: ['smellingsalts', 'thunderwave']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", ability: 'multiscale', moves: ['roost']}]);
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move thunderwave', 'move roost');
+		battle.makeChoices('move smellingsalts', 'move roost');
 		assert.notStrictEqual(battle.p2.active[0].status, 'par');
 	});
 });

--- a/test/simulator/moves/spectralthief.js
+++ b/test/simulator/moves/spectralthief.js
@@ -15,18 +15,16 @@ describe(`Spectral Thief`, function () {
 		]);
 		const [thief, victim] = battle.sides.map(s => s.active[0]);
 
-		battle.p1.chooseMove('spectralthief');
-		battle.commitDecisions();
+		battle.makeChoices('move spectralthief', 'move swordsdance');
 		const minusOneDmg = victim.maxhp - victim.hp;
 
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move swordsdance');
+		battle.makeChoices('move calmmind', 'move swordsdance');
 
 		assert.statStage(thief, 'atk', -1);
 		assert.statStage(victim, 'atk', 6);
 
-		battle.p1.chooseMove('spectralthief');
-		battle.p2.chooseMove('roar');
+		battle.makeChoices('move spectralthief', 'move roar');
 		assert.statStage(thief, 'atk', 5);
 		assert.statStage(victim, 'atk', 0);
 
@@ -40,12 +38,11 @@ describe(`Spectral Thief`, function () {
 		]);
 		const [thief, victim] = battle.sides.map(s => s.active[0]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move swordsdance');
 		assert.statStage(thief, 'atk', 0);
 		assert.statStage(victim, 'atk', 2);
 
-		battle.p1.chooseMove('spectralthief');
-		battle.p2.chooseMove('roar');
+		battle.makeChoices('move spectralthief', 'move roar');
 		assert.statStage(thief, 'atk', 4);
 		assert.statStage(victim, 'atk', 0);
 	});
@@ -57,12 +54,11 @@ describe(`Spectral Thief`, function () {
 		]);
 		const [thief, victim] = battle.sides.map(s => s.active[0]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move calmmind', 'move swordsdance');
 		assert.statStage(thief, 'atk', 0);
 		assert.statStage(victim, 'atk', 2);
 
-		battle.p1.chooseMove('spectralthief');
-		battle.p2.chooseMove('roar');
+		battle.makeChoices('move spectralthief', 'move roar');
 		assert.false.holdsItem(victim); // Weakness Policy activated!
 		assert.statStage(thief, 'atk', 2);
 		assert.statStage(victim, 'atk', 2);
@@ -75,7 +71,7 @@ describe(`Spectral Thief`, function () {
 		]);
 		const [thief, victim] = battle.sides.map(s => s.active[0]);
 
-		battle.commitDecisions();
+		battle.makeChoices('move spectralthief', 'move swordsdance');
 		assert.statStage(thief, 'atk', 0);
 		assert.statStage(victim, 'atk', 2);
 	});
@@ -86,7 +82,7 @@ describe(`Spectral Thief`, function () {
 			[{species: "Serperior", ability: 'contrary', moves: ['leafstorm']}],
 		]);
 		const victim = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move spectralthief', 'move leafstorm');
 		assert.statStage(victim, 'spa', 0);
 		assert.false.fainted(victim);
 	});
@@ -97,7 +93,7 @@ describe(`Spectral Thief`, function () {
 			[{species: "Tentacruel", ability: 'clearbody', moves: ['swordsdance']}],
 		]);
 		const victim = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move spectralthief', 'move swordsdance');
 		assert.statStage(victim, 'atk', 0);
 		assert.false.fainted(victim);
 	});
@@ -108,7 +104,7 @@ describe(`Spectral Thief`, function () {
 			[{species: "Swoobat", ability: 'simple', moves: ['amnesia']}],
 		]);
 		const victim = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move spectralthief', 'move amnesia');
 		assert.statStage(victim, 'spd', 0);
 		assert.false.fainted(victim);
 	});

--- a/test/simulator/moves/stealthrock.js
+++ b/test/simulator/moves/stealthrock.js
@@ -14,7 +14,7 @@ describe('Stealth Rock', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", moves: ['stealthrock']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ninjask", moves: ['substitute']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move stealthrock', 'move substitute');
 		assert(battle.p2.sideConditions['stealthrock']);
 	});
 
@@ -29,12 +29,10 @@ describe('Stealth Rock', function () {
 			{species: "Hitmonchan", moves: ['rest']},
 			{species: "Steelix", moves: ['rest']},
 		]);
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move stealthrock', 'move protect');
 		let pokemon;
 		for (let i = 2; i <= 6; i++) {
-			battle.choose('p2', 'switch ' + i);
-			battle.commitDecisions();
+			battle.makeChoices('move splash', 'switch ' + i);
 			pokemon = battle.p2.active[0];
 			assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp * Math.pow(0.5, i - 1)));
 		}

--- a/test/simulator/moves/substitute.js
+++ b/test/simulator/moves/substitute.js
@@ -14,7 +14,7 @@ describe('Substitute', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['substitute']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['recover']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move recover');
 		let pokemon = battle.p1.active[0];
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 	});
@@ -23,9 +23,8 @@ describe('Substitute', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['substitute', 'calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['recover']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move recover');
+		battle.makeChoices('move calmmind', 'move recover');
 		assert.strictEqual(battle.p1.active[0].boosts['spa'], 1);
 		assert.strictEqual(battle.p1.active[0].boosts['spd'], 1);
 	});
@@ -34,7 +33,7 @@ describe('Substitute', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['substitute']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'pressure', item: 'laggingtail', moves: ['psystrike']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move psystrike');
 		let pokemon = battle.p1.active[0];
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 	});
@@ -43,9 +42,8 @@ describe('Substitute', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['substitute', 'doubleedge']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['nastyplot']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move nastyplot');
+		battle.makeChoices('move doubleedge', 'move nastyplot');
 		let pokemon = battle.p1.active[0];
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 	});
@@ -54,9 +52,8 @@ describe('Substitute', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['substitute']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'noguard', moves: ['nastyplot', 'lightofruin']}]);
-		battle.commitDecisions();
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move nastyplot');
+		battle.makeChoices('move substitute', 'move lightofruin');
 		let pokemon = battle.p2.active[0];
 		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.ceil(Math.floor(battle.p1.active[0].maxhp / 4) / 2));
 	});
@@ -65,10 +62,9 @@ describe('Substitute', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Zangoose', ability: 'pressure', moves: ['substitute']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Zangoose', ability: 'noguard', moves: ['bellydrum', 'drainpunch']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move bellydrum');
 		let hp = battle.p2.active[0].hp;
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move substitute', 'move drainpunch');
 		assert.strictEqual(battle.p2.active[0].hp - hp, Math.ceil(Math.floor(battle.p1.active[0].maxhp / 4) / 2));
 	});
 
@@ -77,8 +73,7 @@ describe('Substitute', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mewtwo', ability: 'noguard', moves: ['substitute']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'pressure', item: 'laggingtail', moves: ['hypnosis', 'toxic', 'poisongas', 'thunderwave', 'willowisp']}]);
 		for (let i = 1; i <= 5; i++) {
-			battle.choose('p2', 'move ' + i);
-			battle.commitDecisions();
+			battle.makeChoices('move substitute', 'move ' + i);
 			assert.strictEqual(battle.p1.active[0].status, '');
 		}
 	});
@@ -87,9 +82,8 @@ describe('Substitute', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Dragonite', ability: 'noguard', item: 'focussash', moves: ['substitute', 'roost']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Dragonite', ability: 'hugepower', item: 'laggingtail', moves: ['roost', 'dualchop']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move substitute', 'move roost');
+		battle.makeChoices('move roost', 'move dualchop');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 });

--- a/test/simulator/moves/taunt.js
+++ b/test/simulator/moves/taunt.js
@@ -14,10 +14,10 @@ describe('Taunt', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['taunt']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['calmmind']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move taunt', 'move calmmind');
 		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
 		assert.strictEqual(battle.p2.active[0].boosts['spd'], 0);
-		battle.commitDecisions();
+		battle.makeChoices('move taunt', 'move calmmind');
 		assert.strictEqual(battle.p2.active[0].lastMove.id, 'struggle');
 	});
 
@@ -25,7 +25,7 @@ describe('Taunt', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sableye', ability: 'prankster', moves: ['taunt']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Charmander', ability: 'blaze', item: 'firiumz', moves: ['sunnyday']}]);
-		battle.p2.chooseMove('sunnyday', 0, 'zmove').foe.chooseDefault();
+		battle.makeChoices('move taunt', 'move sunnyday zmove');
 		assert.statStage(battle.p2.active[0], 'spe', 1);
 		assert.ok(battle.isWeather('sunnyday'));
 	});

--- a/test/simulator/moves/thief.js
+++ b/test/simulator/moves/thief.js
@@ -14,7 +14,7 @@ describe('Thief', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['thief']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thief', 'move softboiled');
 		assert.strictEqual(battle.p1.active[0].item, 'shedshell');
 	});
 
@@ -22,7 +22,7 @@ describe('Thief', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', item: 'focussash', moves: ['thief']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thief', 'move softboiled');
 		assert.strictEqual(battle.p2.active[0].item, 'shedshell');
 	});
 
@@ -30,7 +30,7 @@ describe('Thief', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['thief']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Blissey", ability: 'naturalcure', item: 'lifeorb', moves: ['softboiled']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thief', 'move softboiled');
 		assert.strictEqual(battle.p1.active[0].hp, Math.ceil(9 / 10 * battle.p1.active[0].maxhp));
 	});
 });

--- a/test/simulator/moves/thousandarrows.js
+++ b/test/simulator/moves/thousandarrows.js
@@ -14,10 +14,9 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Tropius", ability: 'harvest', moves: ['synthesis']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move synthesis');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.choose('p1', 'move earthquake');
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move synthesis');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -25,10 +24,10 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'shellarmor', item: 'weaknesspolicy', moves: ['recover']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move recover');
 		assert.strictEqual(battle.p2.active[0].boosts.atk, 0);
 		assert.strictEqual(battle.p2.active[0].boosts.spa, 0);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move recover');
 		assert.strictEqual(battle.p2.active[0].boosts.atk, 2);
 		assert.strictEqual(battle.p2.active[0].boosts.spa, 2);
 	});
@@ -37,7 +36,7 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'wonderguard', item: 'ringtarget', moves: ['recover']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move recover');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -45,12 +44,11 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'mudslap']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'shellarmor', item: 'ironball', moves: ['recover', 'trick']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move recover');
 		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		let hp = battle.p2.active[0].hp;
 		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move mudslap', 'move trick');
 		assert.strictEqual(hp, battle.p2.active[0].hp);
 	});
 
@@ -58,16 +56,15 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'sleeptalk']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ho-Oh", ability: 'shellarmor', moves: ['recover', 'gravity']}]);
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move sleeptalk', 'move gravity');
 		// During Gravity, Thousand Arrows can be super effective but once it ends has to be neutral for one hit
 		while (battle.getPseudoWeather('gravity')) {
-			battle.commitDecisions();
+			battle.makeChoices('move thousandarrows', 'move recover');
 			assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		}
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move recover');
 		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move recover');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 	});
 
@@ -75,10 +72,9 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Cresselia", ability: 'levitate', moves: ['recover']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move recover');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.choose('p1', 'move earthquake');
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move recover');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -86,7 +82,7 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'aurabreak', moves: ['thousandarrows', 'earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Eelektross", ability: 'levitate', item: 'weaknesspolicy', moves: ['thunderwave']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move thunderwave');
 		assert.strictEqual(battle.p2.active[0].boosts.atk, 2);
 		assert.strictEqual(battle.p2.active[0].boosts.spa, 2);
 	});
@@ -95,10 +91,9 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Donphan", ability: 'sturdy', item: 'airballoon', moves: ['stealthrock']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move stealthrock');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.choose('p1', 'move earthquake');
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move stealthrock');
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -106,7 +101,7 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Stunfisk", ability: 'limber', moves: ['electrify']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousdandarrows', 'move electrify');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -114,7 +109,7 @@ describe('Thousand Arrows', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Zygarde", ability: 'normalize', item: 'laggingtail', moves: ['thousandarrows', 'earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dusknoir", ability: 'pressure', moves: ['haze']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thousandarrows', 'move earthquake');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 });

--- a/test/simulator/moves/thunderwave.js
+++ b/test/simulator/moves/thunderwave.js
@@ -14,7 +14,7 @@ describe('Thunder Wave', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'quickfeet', moves: ['thunderwave']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Vaporeon", ability: 'hydration', moves: ['aquaring']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thunderwave', 'move aquaring');
 		assert.strictEqual(battle.p2.active[0].status, 'par');
 	});
 
@@ -22,7 +22,7 @@ describe('Thunder Wave', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Jolteon", ability: 'quickfeet', moves: ['thunderwave']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Hippowdon", ability: 'sandforce', moves: ['slackoff']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move thunderwave', 'move slackoff');
 		assert.strictEqual(battle.p2.active[0].status, '');
 	});
 });

--- a/test/simulator/moves/transform.js
+++ b/test/simulator/moves/transform.js
@@ -14,7 +14,7 @@ describe('Transform', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Ditto", ability: 'limber', moves: ['transform']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Hoopa-Unbound", ability: 'magician', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template, battle.p2.active[0].template);
 	});
 
@@ -22,7 +22,7 @@ describe('Transform', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Ditto", ability: 'limber', moves: ['transform']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Mewtwo", ability: 'pressure', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		let p1poke = battle.p1.active[0];
 		let p2poke = battle.p2.active[0];
 		for (let stat in p1poke.stats) {
@@ -37,8 +37,7 @@ describe('Transform', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', item: 'laggingtail', moves: ['calmmind', 'agility', 'transform']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Scolipede", ability: 'swarm', moves: ['honeclaws', 'irondefense', 'doubleteam']}]);
 		for (let i = 1; i <= 3; i++) {
-			battle.choose('p1', 'move ' + i);
-			battle.choose('p2', 'move ' + i);
+			battle.makeChoices('move ' + i, 'move ' + i);
 		}
 		let p1poke = battle.p1.active[0];
 		let p2poke = battle.p2.active[0];
@@ -53,7 +52,7 @@ describe('Transform', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Mew", ability: 'synchronize', moves: ['rest', 'psychic', 'energyball', 'hyperbeam']}]);
 		let p1poke = battle.p1.active[0];
 		let p2poke = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		assert.strictEqual(p1poke.moves.length, p2poke.moves.length);
 		for (let i = 0; i < p1poke.moves.length; i++) {
 			let move = p1poke.moves[i];
@@ -68,7 +67,7 @@ describe('Transform', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Ditto", ability: 'limber', moves: ['transform']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Arcanine", ability: 'intimidate', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		assert.strictEqual(battle.p2.active[0].boosts['atk'], -1);
 	});
 
@@ -76,7 +75,7 @@ describe('Transform', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Ditto", ability: 'limber', moves: ['transform']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Hitmonlee", ability: 'unburden', item: 'normalgem', moves: ['feint']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move feint');
 		assert.notStrictEqual(battle.p1.active[0].getStat('spe'), battle.p2.active[0].getStat('spe'));
 	});
 
@@ -84,7 +83,7 @@ describe('Transform', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Ditto", ability: 'limber', moves: ['transform']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Mewtwo", ability: 'pressure', moves: ['substitute']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move substitute');
 		assert.notStrictEqual(battle.p1.active[0].template, battle.p2.active[0].template);
 	});
 
@@ -95,7 +94,7 @@ describe('Transform', function () {
 			{species: "Zoroark", ability: 'illusion', moves: ['rest']},
 			{species: "Mewtwo", ability: 'pressure', moves: ['rest']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		assert.notStrictEqual(battle.p1.active[0].template, battle.p2.active[0].template);
 	});
 
@@ -106,11 +105,10 @@ describe('Transform', function () {
 			{species: "Magikarp", ability: 'rattled', moves: ['splash']},
 			{species: "Mew", ability: 'synchronize', moves: ['transform']},
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move splash');
 		assert.strictEqual(battle.p1.active[0].template, battle.p2.active[0].template);
-		battle.choose('p2', 'switch 2');
-		battle.commitDecisions();
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'switch 2');
+		battle.makeChoices('move transform', 'move transform');
 		assert.notStrictEqual(battle.p1.active[0].template, battle.p2.active[0].template);
 	});
 });
@@ -125,7 +123,7 @@ describe('Transform [Gen 4]', function () {
 			[{species: "Ditto", ability: 'limber', moves: ['transform']}],
 			[{species: "Giratina-Origin", ability: 'levitate', item: 'griseousorb', moves: ['rest']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template.species, 'Giratina');
 	});
 
@@ -134,7 +132,7 @@ describe('Transform [Gen 4]', function () {
 			[{species: "Ditto", ability: 'limber', item: 'griseousorb', moves: ['transform']}],
 			[{species: "Giratina", ability: 'pressure', moves: ['rest']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template.species, 'Giratina-Origin');
 	});
 
@@ -143,7 +141,7 @@ describe('Transform [Gen 4]', function () {
 			[{species: "Ditto", ability: 'limber', item: 'flameplate', moves: ['transform']}],
 			[{species: "Arceus-Steel", ability: 'multitype', item: 'ironplate', moves: ['rest']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template.species, 'Arceus-Fire');
 	});
 
@@ -152,7 +150,7 @@ describe('Transform [Gen 4]', function () {
 			[{species: "Ditto", ability: 'limber', moves: ['transform']}],
 			[{species: "Mewtwo", ability: 'pressure', moves: ['substitute']}],
 		]);
-		battle.commitDecisions();
+		battle.makeChoices('move transform', 'move rest');
 		assert.strictEqual(battle.p1.active[0].template, battle.p2.active[0].template);
 	});
 });

--- a/test/simulator/moves/trick.js
+++ b/test/simulator/moves/trick.js
@@ -12,7 +12,7 @@ describe('Trick', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', item: 'leftovers', moves: ['trick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Purugly", ability: 'defiant', item: 'sitrusberry', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move trick', 'move rest');
 		assert.strictEqual(battle.p1.active[0].item, 'sitrusberry');
 		assert.strictEqual(battle.p2.active[0].item, 'leftovers');
 	});
@@ -21,7 +21,7 @@ describe('Trick', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['trick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Arceus", ability: 'download', item: 'flameplate', moves: ['swordsdance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move trick', 'move swordsdance');
 		assert.strictEqual(battle.p2.active[0].item, 'flameplate');
 	});
 
@@ -29,7 +29,7 @@ describe('Trick', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', item: 'fistplate', moves: ['trick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Arceus", ability: 'download', moves: ['swordsdance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move trick', 'move swordsdance');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 
@@ -37,7 +37,7 @@ describe('Trick', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['trick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Genesect", ability: 'download', item: 'dousedrive', moves: ['shiftgear']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move trick', 'move shiftgear');
 		assert.strictEqual(battle.p2.active[0].item, 'dousedrive');
 	});
 
@@ -45,7 +45,7 @@ describe('Trick', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', item: 'shockdrive', moves: ['trick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Genesect", ability: 'download', moves: ['shiftgear']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move trick', 'move shiftgear');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 
@@ -53,7 +53,7 @@ describe('Trick', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['trick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Scizor", ability: 'technician', item: 'scizorite', moves: ['swordsdance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move trick', 'move swordsdance');
 		assert.strictEqual(battle.p2.active[0].item, 'scizorite');
 	});
 
@@ -61,7 +61,7 @@ describe('Trick', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['trick']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Scizor", ability: 'technician', item: 'audinite', moves: ['swordsdance']}]);
-		battle.commitDecisions();
+		battle.makeChoices('move trick', 'move swordsdance');
 		assert.strictEqual(battle.p1.active[0].item, 'audinite');
 	});
 });
@@ -73,7 +73,7 @@ describe('Z-Trick', function () {
 		battle = common.createBattle();
 		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', item: 'psychiumz', moves: ['trick']}]);
 		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Rattata", ability: 'guts', item: 'leftovers', moves: ['quickattack']}]);
-		p1.chooseMove('trick', 0, 'zmove').foe.chooseDefault();
+		battle.makeChoices('move trick zmove', 'move quickattack');
 		assert.statStage(p1.active[0], 'spe', 2);
 		assert.strictEqual(p1.active[0].item, 'psychiumz');
 		assert.strictEqual(p2.active[0].item, 'leftovers');

--- a/test/simulator/moves/trickroom.js
+++ b/test/simulator/moves/trickroom.js
@@ -15,10 +15,8 @@ describe('Trick Room', function () {
 			[{species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom']}],
 			[{species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'spore']}],
 		]);
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move trickroom', 'move poisonjab');
+		battle.makeChoices('move spore', 'move spore');
 		assert.strictEqual(battle.p1.active[0].status, '');
 		assert.strictEqual(battle.p2.active[0].status, 'slp');
 	});
@@ -28,10 +26,8 @@ describe('Trick Room', function () {
 			[{species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom']}],
 			[{species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'protect']}],
 		]);
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move trickroom', 'move poisonjab');
+		battle.makeChoices('move spore', 'move protect');
 		assert.strictEqual(battle.p1.active[0].status, '');
 		assert.strictEqual(battle.p2.active[0].status, '');
 	});
@@ -46,12 +42,9 @@ describe('Trick Room', function () {
 			{species: 'Ninjask', ability: 'speedboost', moves: ['shellsmash']},
 			{species: 'Ninetales', ability: 'drought', moves: ['protect']},
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
-		battle.choose('p1', 'switch 2');
-		battle.choose('p2', 'switch 2');
-		battle.commitDecisions();
+		battle.makeChoices('move trickroom', 'move shellsmash');
+		battle.makeChoices('move explosion', 'move shellsmash');
+		battle.makeChoices('switch hippowdon', 'switch ninetales');
 		assert.strictEqual(battle.p1.active[0].speciesid, 'hippowdon');
 		assert.strictEqual(battle.p2.active[0].speciesid, 'ninetales');
 		assert.strictEqual(battle.effectiveWeather(), 'sunnyday');
@@ -64,8 +57,7 @@ describe('Trick Room', function () {
 			[{species: 'Ninjask', ability: 'swarm', evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 184}, moves: ['protect', 'spore']}],
 			[{species: 'Deoxys-Speed', ability: 'pressure', evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 224}, moves: ['spore', 'trickroom']}],
 		]);
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions(); // Trick Room is now up.
+		battle.makeChoices('move protect', 'move trickroom'); // Trick Room is now up.
 
 		// This sets Ninjask to exactly 1809 Speed
 		battle.p1.active[0].boostBy({spe: 4});
@@ -73,14 +65,12 @@ describe('Trick Room', function () {
 		// This sets Deoxys to exactly 1808 Speed
 		battle.p2.active[0].boostBy({spe: 6});
 
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move spore', 'move spore');
 		assert.strictEqual(battle.p1.active[0].status, '');
 		assert.strictEqual(battle.p2.active[0].status, 'slp');
 		battle.p2.active[0].setStatus('');
 		battle.p2.active[0].setItem('choicescarf'); // Deoxys is now much faster speed-wise than Ninjask, but should still be slower in Trick Room.
-		battle.choose('p1', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move spore', 'move spore');
 		assert.strictEqual(battle.p1.active[0].status, '');
 		assert.strictEqual(battle.p2.active[0].status, 'slp');
 	});
@@ -90,8 +80,7 @@ describe('Trick Room', function () {
 			[{species: 'Ninjask', ability: 'swarm', evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 184}, item: 'choicescarf', moves: ['earthquake']}],
 			[{species: 'Deoxys-Speed', ability: 'levitate', evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 224}, moves: ['gyroball', 'trickroom']}],
 		]);
-		battle.choose('p2', 'move 2');
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move trickroom');
 
 		battle.p1.active[0].boostBy({spe: 4}); // 1809 Speed
 		battle.p2.active[0].boostBy({spe: 6}); // 1808 Speed
@@ -101,7 +90,7 @@ describe('Trick Room', function () {
 			assert.strictEqual(bp, 25); // BP should theoretically be this based on speed values
 		});
 
-		battle.commitDecisions();
+		battle.makeChoices('move earthquake', 'move gyroball');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 });

--- a/test/simulator/moves/uproar.js
+++ b/test/simulator/moves/uproar.js
@@ -14,9 +14,8 @@ describe('Uproar', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'uproar']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move uproar', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, '');
 	});
 });
@@ -31,9 +30,8 @@ describe('Uproar [Gen 5]', function () {
 			[{species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'uproar']}],
 			[{species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest']}],
 		]);
-		battle.commitDecisions();
-		battle.choose('p1', 'move 2');
-		battle.choose('p2', 'move 2');
+		battle.makeChoices('move splash', 'move substitute');
+		battle.makeChoices('move uproar', 'move rest');
 		assert.strictEqual(battle.p2.active[0].item, 'focussash');
 	});
 });

--- a/test/simulator/moves/zmove.js
+++ b/test/simulator/moves/zmove.js
@@ -14,7 +14,7 @@ describe('Z-Moves', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Kecleon', ability: 'colorchange', item: 'normaliumz', moves: ['hiddenpower']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Gengar', ability: 'levitate', moves: ['calmmind']}]);
-		battle.p1.chooseMove('hiddenpower', 0, 'zmove').foe.chooseDefault();
+		battle.makeChoices('move hiddenpower zmove', 'move calmmind');
 		assert.fullHP(battle.p2.active[0]);
 	});
 
@@ -22,7 +22,7 @@ describe('Z-Moves', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Kecleon', ability: 'colorchange', item: 'ghostiumz', moves: ['shadowsneak']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Starmie', ability: 'naturalcure', moves: ['reflecttype']}]);
-		battle.p1.chooseMove('shadowsneak', 0, 'zmove').foe.chooseDefault();
+		battle.makeChoices('move shadowsneak zmove', 'move reflecttype');
 		assert.fullHP(battle.p2.active[0]);
 	});
 });


### PR DESCRIPTION
See https://github.com/Zarel/Pokemon-Showdown/commit/8473c3f4fa3c78785fb51535857d1139bd7687fd for the example followed in the refactor