### PR TITLE
Fix Prankster interaction with bounced/encored moves against Dark types

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2463,12 +2463,8 @@ let BattleAbilities = {
 		shortDesc: "This Pokemon's Status moves have priority raised by 1, but Dark types are immune.",
 		onModifyPriority: function (priority, pokemon, target, move) {
 			if (move && move.category === 'Status') {
-				return priority + 1;
-			}
-		},
-		onModifyMove: function (move) {
-			if (move && move.category === 'Status') {
 				move.pranksterBoosted = true;
+				return priority + 1;
 			}
 		},
 		id: "prankster",

--- a/data/moves.js
+++ b/data/moves.js
@@ -9626,7 +9626,9 @@ let BattleMovedex = {
 		volatileStatus: 'magiccoat',
 		effect: {
 			duration: 1,
-			onStart: function (target) {
+			onStart: function (target, source, sourceEffect) {
+				// @ts-ignore
+				target.volatiles['magiccoat'].pranksterBoosted = sourceEffect.pranksterBoosted || false;
 				this.add('-singleturn', target, 'move: Magic Coat');
 			},
 			onTryHitPriority: 2,
@@ -9636,7 +9638,7 @@ let BattleMovedex = {
 				}
 				let newMove = this.getMoveCopy(move.id);
 				newMove.hasBounced = true;
-				newMove.pranksterBoosted = false;
+				newMove.pranksterBoosted = target.volatiles['magiccoat'].pranksterBoosted;
 				this.useMove(newMove, target, source);
 				return null;
 			},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -146,7 +146,7 @@ let BattleScripts = {
 		}
 		if (this.activeMove) {
 			move.priority = this.activeMove.priority;
-			move.pranksterBoosted = move.hasBounced ? false : this.activeMove.pranksterBoosted;
+			if (!move.hasBounced) move.pranksterBoosted = this.activeMove.pranksterBoosted;
 		}
 		let baseTarget = move.target;
 		if (!target && target !== false) target = this.resolveTarget(pokemon, move);
@@ -373,7 +373,7 @@ let BattleScripts = {
 			this.add('-immune', target, '[msg]');
 			return false;
 		}
-		if (this.gen >= 7 && move.pranksterBoosted && target.side !== pokemon.side && !this.getImmunity('prankster', target)) {
+		if (this.gen >= 7 && move.pranksterBoosted && pokemon.hasAbility('prankster') && target.side !== pokemon.side && !this.getImmunity('prankster', target)) {
 			this.debug('natural prankster immunity');
 			if (!target.illusion) this.add('-hint', "In gen 7, Dark is immune to Prankster moves.");
 			this.add('-immune', target, '[msg]');

--- a/test/simulator/abilities/prankster.js
+++ b/test/simulator/abilities/prankster.js
@@ -34,6 +34,30 @@ describe('Prankster', function () {
 		]);
 		assert.constant(() => battle.p2.active[0].status, () => battle.makeChoices('move magiccoat', 'move willowisp'));
 	});
+
+	it('should not cause bounced Status moves to fail against Dark Pokémon if it is removed', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Alakazam", ability: 'synchronize', moves: ['skillswap']},
+			{species: "Sableye", ability: 'prankster', moves: ['magiccoat']},
+		]);
+		const p2 = battle.join('p2', 'Guest 2', 1, [
+			{species: "Pyukumuku", ability: 'unaware', moves: ['curse']},
+			{species: "Houndoom", ability: 'flashfire', moves: ['confide']},
+		]);
+		battle.makeChoices('move skillswap -2, move magiccoat', 'move curse, move confide 2');
+		assert.statStage(p2.active[1], 'spa', -1);
+	});
+
+	it('should not cause Status moves forced by Encore to fail against Dark Pokémon', function () {
+		battle = common.createBattle([
+			[{species: "Liepard", ability: 'prankster', moves: ['encore']}],
+			[{species: "Riolu", ability: 'prankster', moves: ['confide', 'return']}],
+		]);
+		battle.makeChoices('move encore', 'move confide');
+		battle.makeChoices('move encore', 'move return');
+		assert.statStage(battle.p1.active[0], 'spa', -1);
+	});
 });
 
 describe('Prankster [Gen 6]', function () {


### PR DESCRIPTION
Fixes [this](https://www.smogon.com/forums/threads/bug-reports-v2-0-read-op-before-posting.3469932/page-395#post-7715202) bug, and fixes the case where a Pokemon without Prankster would use Magic Coat, then have Prankster Skill-Swapped to it before a dark type bounces a status move off of it and be unaffected, which is something I had @DaWoblefet test for me.