### PR TITLE
Random Battle: Improve STAB detection/rejection

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -536,13 +536,13 @@ class RandomTeams extends Dex.ModdedDex {
 			// Moves which have a base power, but aren't super-weak like Rapid Spin:
 			if (move.basePower > 30 || move.multihit || move.basePowerCallback || moveid === 'naturepower') {
 				counter[movetype]++;
-				if (hasType[movetype] || movetype === 'Normal' && (hasAbility['Aerilate'] || hasAbility['Pixilate'] || hasAbility['Refrigerate'] || hasAbility['Galvanize'])) {
+				if (hasType[movetype] || movetype === 'Normal' && (hasAbility['Aerilate'] || hasAbility['Galvanize'] || hasAbility['Pixilate'] || hasAbility['Refrigerate'])) {
 					counter['adaptability']++;
 					// STAB:
 					// Certain moves aren't acceptable as a Pokemon's only STAB attack
 					if (!NoStab.includes(moveid) && (moveid !== 'hiddenpower' || Object.keys(hasType).length === 1)) {
 						counter['stab']++;
-						// Ties between physical and special setup should broken in favor of STABs
+						// Ties between Physical and Special setup should broken in favor of STABs
 						counter[move.category] += 0.1;
 					}
 				} else if (move.priority === 0 && hasAbility['Protean'] && !NoStab.includes(moveid)) {
@@ -589,11 +589,7 @@ class RandomTeams extends Dex.ModdedDex {
 			let special = counter.Special + counter['specialpool'];
 			if (counter['physicalsetup'] && counter['specialsetup']) {
 				if (physical === special) {
-					if (counter.Physical === counter.Special) {
-						counter.setupType = 'Mixed';
-					} else {
-						counter.setupType = counter.Physical > counter.Special ? 'Physical' : 'Special';
-					}
+					counter.setupType = counter.Physical > counter.Special ? 'Physical' : 'Special';
 				} else {
 					counter.setupType = physical > special ? 'Physical' : 'Special';
 				}

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -528,20 +528,27 @@ class RandomTeams extends Dex.ModdedDex {
 			if (move.multihit && Array.isArray(move.multihit) && move.multihit[1] === 5) counter['skilllink']++;
 			if (move.recoil || move.hasCustomRecoil) counter['recoil']++;
 			if (move.drain) counter['drain']++;
+			// Conversion converts exactly one non-STAB into STAB
+			if (moveid === 'conversion') {
+				counter['stab']++;
+				counter['adaptability']++;
+			}
 			// Moves which have a base power, but aren't super-weak like Rapid Spin:
 			if (move.basePower > 30 || move.multihit || move.basePowerCallback || moveid === 'naturepower') {
 				counter[movetype]++;
-				if (hasType[movetype]) {
+				if (hasType[movetype] || movetype === 'Normal' && (hasAbility['Aerilate'] || hasAbility['Pixilate'] || hasAbility['Refrigerate'] || hasAbility['Galvanize'])) {
 					counter['adaptability']++;
 					// STAB:
 					// Certain moves aren't acceptable as a Pokemon's only STAB attack
-					if (!NoStab.includes(moveid) && (moveid !== 'hiddenpower' || Object.keys(hasType).length === 1)) counter['stab']++;
+					if (!NoStab.includes(moveid) && (moveid !== 'hiddenpower' || Object.keys(hasType).length === 1)) {
+						counter['stab']++;
+						// Ties between physical and special setup should broken in favor of STABs
+						counter[move.category] += 0.1;
+					}
+				} else if (move.priority === 0 && hasAbility['Protean'] && !NoStab.includes(moveid)) {
+					counter['stab']++;
 				}
-				if (move.priority === 0 && (hasAbility['Protean'] || moves.includes('conversion')) && !NoStab.includes(moveid)) counter['stab']++;
 				if (move.category === 'Physical') counter['hustle']++;
-				if (movetype === 'Normal' && !NoStab.includes(moveid)) {
-					if (hasAbility['Aerilate'] || hasAbility['Pixilate'] || hasAbility['Refrigerate']) counter['stab']++;
-				}
 				if (move.flags['bite']) counter['bite']++;
 				if (move.flags['punch']) counter['ironfist']++;
 				counter.damagingMoves.push(move);
@@ -582,7 +589,11 @@ class RandomTeams extends Dex.ModdedDex {
 			let special = counter.Special + counter['specialpool'];
 			if (counter['physicalsetup'] && counter['specialsetup']) {
 				if (physical === special) {
-					counter.setupType = counter.Physical > counter.Special ? 'Physical' : 'Special';
+					if (counter.Physical === counter.Special) {
+						counter.setupType = 'Mixed';
+					} else {
+						counter.setupType = counter.Physical > counter.Special ? 'Physical' : 'Special';
+					}
 				} else {
 					counter.setupType = physical > special ? 'Physical' : 'Special';
 				}
@@ -596,7 +607,8 @@ class RandomTeams extends Dex.ModdedDex {
 				}
 			}
 		}
-
+		counter['Physical'] = Math.floor(counter['Physical']);
+		counter['Special'] = Math.floor(counter['Special']);
 		return counter;
 	}
 

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -605,6 +605,7 @@ class RandomTeams extends Dex.ModdedDex {
 		}
 		counter['Physical'] = Math.floor(counter['Physical']);
 		counter['Special'] = Math.floor(counter['Special']);
+
 		return counter;
 	}
 


### PR DESCRIPTION
- Fixes Golem-Alola's Return not being counted as STAB, which would cause the set Return/Earthquake/Stealth Rock/Toxic to have a move rejected in favor of STAB.
- Having Conversion in Porygon-Z's moveset now counts for exactly once for STAB and Adaptability, instead of making every move count as STAB but not for Adaptability.
- Fixes Protean making moves that are STAB anyway count as two STABs each.
- Now STAB moves (except those granted by Conversion and Protean) count for 0.1 extra move in their category for the purposes of determining a moveset's `setupType`. This means that, in the case of a tie between physical and special setup, the tie will be broken by which side has more STABs, instead of such a tie always going to special setup by default. This fixes a case where Arceus-Dragon could end up with no STAB moves via the following events:

1. Roll Judgment, Earth Power, Swords Dance, and Outrage in that order
2. Reject Judgment due to the presence of another STAB and physical setup type
3. Roll Calm Mind; moves are now Earth Power, Swords Dance, Outrage, and Calm Mind
4. Reject Swords Dance due to the tie between physical and special setup having been settled in special setup's favor by default
5. Roll Fire Blast; moves are now Earth Power, Outrage, Calm Mind, and Fire Blast
6. Reject Outrage for not matching the special setup type, and being the only attack to do so
7. Roll Extreme Speed or Earthquake and reject it for the same reason as Outrage
8. Roll Recover and reject it for not being a STAB or a setup move, despite there being none such moves left in `movePool`

This change fixes this scenario by settling the tie in favor of the physical side because it has the only STAB move, resulting in Earth Power being rejected instead of Swords Dance. This leads to the subsequent rejection of Calm Mind, which happens regardless of what move is chosen to replace Earth Power, because with Judgment already gone, there is no way for the setup type to change to anything other than physical.