### PR TITLE
Allow global mods to force unrated ties in the event of a crash

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -3784,6 +3784,35 @@ exports.commands = {
 		`/forcewin [user] - Forces the current match to end in a win for a user. Requires: & ~`,
 	],
 
+	ecb: 'endcrashedbattle',
+	endcrashedbattle: function (target, room, user) {
+		if (!this.can('ban')) return false;
+		if (!room.battle) {
+			this.errorReply("/endcrashedbattle - This is not a battle room.");
+			return false;
+		}
+		if (!room.battle.crashed) {
+			this.errorReply("/endcrashedbattle - The battle has not crashed.");
+			return false;
+		}
+		if (room.battle.timer.waitingForChoice('p1')) {
+			if (room.battle.timer.waitingForChoice('p2')) {
+				this.errorReply(`/endcrashedbattle - The battle has not stalled; currently waiting for both players.`);
+			} else {
+				this.errorReply(`/endcrashedbattle - The battle has not stalled; currently waiting for ${room.battle.playerNames[0]}.`);
+			}
+		} else if (room.battle.timer.waitingForChoice('p2')) {
+			this.errorReply(`/endcrashedbattle - The battle has not stalled; currently waiting for ${room.battle.playerNames[1]}.`);
+		}
+
+		room.battle.endType = 'forced';
+		room.rated = false;
+		room.battle.tie();
+		this.modlog('FORCETIE CRASHED BATTLE');
+		return false;
+	},
+	endcrashedbattlehelp: [`/endcrashedbattle - Forces the current battle to end in an unrated tie, but only if it has crashed.`],
+
 	/*********************************************************
 	 * Challenging and searching commands
 	 *********************************************************/

--- a/room-battle.js
+++ b/room-battle.js
@@ -362,6 +362,7 @@ class Battle {
 		this.started = false;
 		this.ended = false;
 		this.active = false;
+		this.crashed = false;
 
 		/** @type {{[userid: string]: BattlePlayer}} */
 		this.players = Object.create(null);
@@ -541,6 +542,7 @@ class Battle {
 	receive(/** @type {string[]} */ lines) {
 		switch (lines[0]) {
 		case 'update':
+			if (lines[1].startsWith(`|html|<div class="broadcast-red"><b>The battle crashed`)) this.crashed = true;
 			for (const line of lines.slice(1)) {
 				this.room.add(line);
 			}


### PR DESCRIPTION
In light of all the recent crashed battles, I figured it might be useful if global moderators could forcetie battles in the event of a crash, and I know some people (maybe verbatim?) had expressed a wish that forcing a tie in a rated battle because it crashed didn't update rating.