### PR TITLE
Pursuit should not move before a switch when targeting an ally

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -12741,13 +12741,15 @@ let BattleMovedex = {
 		pp: 20,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		beforeTurnCallback: function (pokemon, target) {
-			if (target.side === pokemon.side) return;
-			target.side.addSideCondition('pursuit', pokemon);
-			if (!target.side.sideConditions['pursuit'].sources) {
-				target.side.sideConditions['pursuit'].sources = [];
+		beforeTurnCallback: function (pokemon) {
+			for (const side of this.sides) {
+				if (side === pokemon.side) continue;
+				side.addSideCondition('pursuit', pokemon);
+				if (!side.sideConditions['pursuit'].sources) {
+					side.sideConditions['pursuit'].sources = [];
+				}
+				side.sideConditions['pursuit'].sources.push(pokemon);
 			}
-			target.side.sideConditions['pursuit'].sources.push(pokemon);
 		},
 		onModifyMove: function (move, source, target) {
 			if (target && target.beingCalledBack) move.accuracy = true;

--- a/data/moves.js
+++ b/data/moves.js
@@ -12742,6 +12742,7 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		beforeTurnCallback: function (pokemon, target) {
+			if (target.side === pokemon.side) return;
 			target.side.addSideCondition('pursuit', pokemon);
 			if (!target.side.sideConditions['pursuit'].sources) {
 				target.side.sideConditions['pursuit'].sources = [];

--- a/test/simulator/moves/pursuit.js
+++ b/test/simulator/moves/pursuit.js
@@ -56,4 +56,16 @@ describe(`Pursuit`, function () {
 		battle.makeChoices('switch 2', 'switch 2');
 		assert.strictEqual(hpBeforeSwitch, clefable.hp);
 	});
+
+	it(`should not double in power or activate before a switch if targeting an ally`, function () {
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+			{species: "Beedrill", ability: 'swarm', item: 'beedrillite', moves: ['pursuit']},
+			{species: "Clefable", ability: 'unaware', moves: ['calmmind']},
+			{species: "Furret", ability: 'frisk', moves: ['uturn']},
+		], [
+			{species: "Clefable", ability: 'magicguard', moves: ['calmmind']},
+			{species: "Alakazam", ability: 'unaware', moves: ['calmmind']},
+		]]);
+		assert.hurtsBy(battle.p1.pokemon[2], 61, () => battle.makeChoices('move Pursuit mega -2, switch 3', 'auto'));
+	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v2-0-read-op-before-posting.3469932/post-7730273
To do: check whether this actually applies to generations older than 6.