### PR TITLE
Modlog: avoid duplicate entries in `/modlog all`

### DIFF
--- a/chat-plugins/modlog.js
+++ b/chat-plugins/modlog.js
@@ -101,7 +101,7 @@ async function runModlog(roomidList, searchString, exactSearch, maxLines) {
 			checkAllRooms = true;
 			const fileList = await FS(LOG_PATH).readdir();
 			for (const file of fileList) {
-				if (file !== 'README.md') fileNameList.push(file);
+				if (file !== 'README.md' && file !== 'modlog_global.txt') fileNameList.push(file);
 			}
 		} else {
 			fileNameList.push(`modlog_${roomid}.txt`);
@@ -155,7 +155,7 @@ async function checkRoomModlog(path, regex, results) {
 function runRipgrepModlog(paths, regexString, results) {
 	let stdout;
 	try {
-		stdout = execFileSync('rg', ['-i', '-e', regexString, '--no-filename', '--no-line-number', ...paths], {cwd: path.normalize(`${__dirname}/../`)});
+		stdout = execFileSync('rg', ['-i', '-e', regexString, '--no-filename', '--no-line-number', ...paths, '-g', '!modlog_global.txt'], {cwd: path.normalize(`${__dirname}/../`)});
 	} catch (error) {
 		return results;
 	}


### PR DESCRIPTION
Since afaik everything that gets added to the global modlog also has an entry in the room modlog, the global modlog can be safely excluded from /modlog all so you don't get duplicate entries (one from each).