### PR TITLE
Random Battle: Replace Mega Aggron's Ice Punch with Stone Edge

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -3089,7 +3089,7 @@ let BattleFormatsData = {
 		doublesTier: "DUU",
 	},
 	aggronmega: {
-		randomBattleMoves: ["earthquake", "heavyslam", "icepunch", "stealthrock", "thunderwave", "roar", "toxic"],
+		randomBattleMoves: ["earthquake", "heavyslam", "thunderpunch", "stealthrock", "thunderwave", "roar", "toxic"],
 		randomDoubleBattleMoves: ["rockslide", "earthquake", "lowkick", "heavyslam", "aquatail", "protect"],
 		requiredItem: "Aggronite",
 		tier: "UU",

--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -3089,7 +3089,7 @@ let BattleFormatsData = {
 		doublesTier: "DUU",
 	},
 	aggronmega: {
-		randomBattleMoves: ["earthquake", "heavyslam", "thunderpunch", "stealthrock", "thunderwave", "roar", "toxic"],
+		randomBattleMoves: ["earthquake", "heavyslam", "stoneedge", "stealthrock", "thunderwave", "roar", "toxic"],
 		randomDoubleBattleMoves: ["rockslide", "earthquake", "lowkick", "heavyslam", "aquatail", "protect"],
 		requiredItem: "Aggronite",
 		tier: "UU",


### PR DESCRIPTION
Of the types that resist Aggron's STAB Heavy Slam, 3/4 of them also resist
Ice Punch, making it a very suboptimal move. Instead, use Stone Edge as
coverage against Flying-types that resist Steel.