### PR TITLE
Properly check for battle before logging crash

### DIFF
--- a/sim/battle-stream.js
+++ b/sim/battle-stream.js
@@ -64,8 +64,8 @@ class BattleStream extends Streams.ObjectReadWriteStream {
 			const battle = this.battle;
 			require('./../lib/crashlogger')(err, 'A battle', {
 				message: message,
-				inputLog: '\n' + battle && battle.inputLog.join('\n'),
-				log: '\n' + battle && battle.getDebugLog(),
+				inputLog: battle ? '\n' + battle.inputLog.join('\n') : '',
+				log: battle ? '\n' + battle.getDebugLog() : '',
 			});
 
 			this.push(`update\n|html|<div class="broadcast-red"><b>The battle crashed</b><br />Don't worry, we're working on fixing it.</div>`);


### PR DESCRIPTION
I'm assuming you don't want `'\n' + null` either.