### PR TITLE
Fix /dt always displaying normal forme of Arceus/Silvally

### DIFF
--- a/sim/dex.js
+++ b/sim/dex.js
@@ -1042,7 +1042,7 @@ class ModdedDex {
 				searchResults.push({
 					isInexact: isInexact,
 					searchType: searchTypes[result],
-					name: res.name,
+					name: res.species ? res.species : res.name,
 				});
 			}
 		}


### PR DESCRIPTION
The template of, say, Arceus-Fire has the name "Arceus", so when that name is used to get the template again later on, the distinction is lost.