### PR TITLE
Fix name of Arceus/Silvally templates

### DIFF
--- a/sim/dex.js
+++ b/sim/dex.js
@@ -374,7 +374,10 @@ class ModdedDex {
 			// Inherit any statuses from the base species (Arceus, Silvally).
 			const baseSpeciesStatuses = this.data.Statuses[toId(template.baseSpecies)];
 			if (baseSpeciesStatuses !== undefined) {
-				Object.assign(template, baseSpeciesStatuses);
+				for (const key in baseSpeciesStatuses) {
+					// @ts-ignore
+					if (!(key in template)) template[key] = baseSpeciesStatuses[key];
+				}
 			}
 			if (!template.tier && !template.doublesTier && template.baseSpecies !== template.species) {
 				if (template.baseSpecies === 'Mimikyu') {


### PR DESCRIPTION
The name (and presumably id?) of the typed formes is incorrectly overwritten when applying the type-changing effect. See #4600.