### PR TITLE
Ignore commas at the ends of commands

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -339,6 +339,8 @@ class CommandContext {
 			target = '';
 		}
 
+		if (cmd.endsWith(',')) cmd = cmd.slice(0, -1);
+
 		let curCommands = Chat.commands;
 		let commandHandler;
 		let fullCmd = cmd;


### PR DESCRIPTION
I type stuff like `/ds, normal type, recover, !uber` pretty often, and as far as I'm concerned there's no reason why it shouldn't just work.