### PR TITLE
Limit /code characters to 8KiB

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -134,6 +134,7 @@ exports.commands = {
 		if (!target) return this.parse('/help code');
 		if (!this.canTalk()) return;
 		if (target.startsWith('\n')) target = target.slice(1);
+		if (target.length >= 8192) return this.errorReply("Your code must be under 8192 characters long!");
 		const separator = '\n';
 		if (target.includes(separator)) {
 			const params = target.split(separator);


### PR DESCRIPTION
Being able to send 100KiB messages whenever they want this easily
isn't a good idea. Limiting to 8KiB makes it harder for workers to
block.