### PR TITLE
Poll: Call Room#update in Poll#end to immediately display results

### DIFF
--- a/chat-plugins/poll.js
+++ b/chat-plugins/poll.js
@@ -171,7 +171,7 @@ class Poll {
 		let results = this.generateResults(true);
 
 		this.room.send('|uhtmlchange|poll' + this.room.pollNumber + '|<div class="infobox">(The poll has ended &ndash; scroll down to see the results)</div>');
-		this.room.add('|html|' + results);
+		this.room.add('|html|' + results).update();
 	}
 }
 


### PR DESCRIPTION
It was a little weird not seeing the results of an ended poll until someone spoke. I'm guessing it was unintentional?