### PR TITLE
Allow Pokestar props in Gen 5 formats lacking '-illegal'

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -126,7 +126,7 @@ let BattleFormats = {
 			if (template.gen > this.gen) {
 				problems.push(set.species + ' does not exist in gen ' + this.gen + '.');
 			}
-			if ((template.num === 25 || template.num === 172) && template.tier === 'Illegal') {
+			if (template.gen && template.gen !== this.gen && template.tier === 'Illegal') {
 				problems.push(set.species + ' does not exist outside of gen ' + template.gen + '.');
 			}
 			let ability = {};
@@ -157,7 +157,7 @@ let BattleFormats = {
 			}
 
 			if (!allowCAP || !template.tier.startsWith('CAP')) {
-				if (template.isNonstandard) {
+				if (template.isNonstandard && template.num > -5000) {
 					problems.push(set.species + ' does not exist.');
 				}
 			}
@@ -198,6 +198,11 @@ let BattleFormats = {
 			// ----------- legality line ------------------------------------------
 			if (!this.getRuleTable(format).has('-illegal')) return problems;
 			// everything after this line only happens if we're doing legality enforcement
+
+			// Pokestar studios
+			if (template.num <= -5000 && template.isNonstandard) {
+				problems.push(`${set.species} cannot be obtained by legal means.`);
+			}
 
 			// only in gen 1 and 2 it was legal to max out all EVs
 			if (this.gen >= 3 && totalEV > 510) {


### PR DESCRIPTION
For the purpose of making custom Gen 5 BH tours with Pokestar props allowed possible.

I know Zarel didn't like the idea of modding them all to be `tier: "Unreleased",` in gen 5, but how about this? In retrospect, they are significantly different from say Floette-Eternal in gen 6 as Floette-Eternal has a dex entry and doesn't crash the game when you catch it or move it around in your PC.