### PR TITLE
Fix failure messages of nonstandard healing moves (again)

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -791,7 +791,7 @@ let BattleScripts = {
 
 			if (!didSomething && !moveData.self && !moveData.selfdestruct) {
 				if (!isSelf && !isSecondary) {
-					if (didSomething === false || didSomething === 0) this.add('-fail', pokemon);
+					if (didSomething === false) this.add('-fail', pokemon);
 				}
 				this.debug('move failed because it did nothing');
 				return false;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -791,7 +791,7 @@ let BattleScripts = {
 
 			if (!didSomething && !moveData.self && !moveData.selfdestruct) {
 				if (!isSelf && !isSecondary) {
-					if (didSomething === false) this.add('-fail', pokemon);
+					if (didSomething === false || didSomething === 0) this.add('-fail', pokemon);
 				}
 				this.debug('move failed because it did nothing');
 				return false;

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1986,10 +1986,10 @@ class Battle extends Dex.ModdedDex {
 		damage = Math.floor(damage);
 		// for things like Liquid Ooze, the Heal event still happens when nothing is healed.
 		damage = this.runEvent('TryHeal', target, source, effect, damage);
-		if (!damage) return 0;
-		if (!target || !target.hp) return 0;
+		if (!damage) return damage;
+		if (!target || !target.hp) return false;
 		if (!target.isActive) return false;
-		if (target.hp >= target.maxhp) return 0;
+		if (target.hp >= target.maxhp) return false;
 		let finalDamage = target.heal(damage, source, effect);
 		switch (effect.id) {
 		case 'leechseed':


### PR DESCRIPTION
These were apparently relying on default behavior that they really shouldn't have been anyway. Granted, I was the one who set up that default behavior _and_ the one who took it out from under them...