### PR TITLE
 Stomping Tantrum should never get boosted the turn after hitting Protect.

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -16239,6 +16239,10 @@ let BattleMovedex = {
 		num: 707,
 		accuracy: 100,
 		basePower: 75,
+		basePowerCallback: function (pokemon, target, move) {
+			if (pokemon.moveLastTurnResult === false) return move.basePower * 2;
+			return move.basePower;
+		},
 		category: "Physical",
 		desc: "Power doubles if the user's last move on the previous turn, including moves called by other moves or those used out of turn through Instruct, Snatch, or Magic Coat or the Abilities Dancer or Magic Bounce, failed to do any of its normal effects, not counting damage from an unsuccessful Mind Blown, Jump Kick, or High Jump Kick, or if the user was prevented from moving by any effect other than recharging or Sky Drop. A move that was blocked by Baneful Bunker, Detect, King's Shield, Protect, Spiky Shield, Crafty Shield, Mat Block, Quick Guard, or Wide Guard will not double this move's power, nor will Bounce or Fly ending early due to the effect of Gravity, Smack Down, or Thousand Arrows.",
 		shortDesc: "Power doubles if the user's last move failed.",
@@ -16247,12 +16251,6 @@ let BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onBasePowerPriority: 4,
-		onBasePower: function (basePower, pokemon) {
-			if (pokemon.moveLastTurnResult === false) {
-				return this.chainModify(2);
-			}
-		},
 		secondary: false,
 		target: "normal",
 		type: "Ground",

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -131,6 +131,7 @@ let BattleScripts = {
 	 * Dancer.
 	 */
 	useMove: function (move, pokemon, target, sourceEffect, zMove) {
+		pokemon.moveThisTurnResult = undefined;
 		let oldMoveResult = pokemon.moveThisTurnResult;
 		let moveResult = this.useMoveInner(move, pokemon, target, sourceEffect, zMove);
 		if (oldMoveResult === pokemon.moveThisTurnResult) pokemon.moveThisTurnResult = moveResult;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -95,23 +95,23 @@ class Pokemon {
 		this.moveThisTurn = '';
 
 		/**
-		 * The result of the last move used on the previous turn by this 
+		 * The result of the last move used on the previous turn by this
 		 * Pokemon. Stomping Tantrum checks this property for a value of false
 		 * when determine whether to double its power, but it has four
 		 * possible values:
-		 * 
+		 *
 		 * undefined indicates this Pokemon was not active last turn. It should
 		 * not be used to indicate that a move was attempted and failed, either
 		 * in a way that boosts Stomping Tantrum or not.
-		 * 
+		 *
 		 * null indicates that the Pokemon's move was skipped in such a way
 		 * that does not boost Stomping Tantrum, either from having to recharge
 		 * or spending a turn trapped by another Pokemon's Sky Drop.
-		 * 
+		 *
 		 * false indicates that the move completely failed to execute for any
 		 * reason not mentioned above, including missing, the target being
 		 * immune, the user being immobilized by an effect such as paralysis, etc.
-		 * 
+		 *
 		 * true indicates that the move successfully executed one or more of
 		 * its effects on one or more targets, including hitting with an attack
 		 * but dealing 0 damage to the target in cases such as Disguise, or that
@@ -124,37 +124,33 @@ class Pokemon {
 		 * At the start of each turn, the value stored here is moved to its
 		 * counterpart, moveLastTurnResult, and this property is reinitialized
 		 * to undefined. This property can have one of four possible values:
-		 * 
+		 *
 		 * undefined indicates that this Pokemon has not yet finished an
 		 * attempt to use a move this turn. As this value is only overwritten
 		 * after a move finishes execution, it is not sufficient for an event
 		 * to examine only this property when checking if a Pokemon has not
 		 * moved yet this turn if the event could take place during that
 		 * Pokemon's move.
-		 * 
+		 *
 		 * null indicates that the Pokemon's move was skipped in such a way
 		 * that does not boost Stomping Tantrum, either from having to recharge
-		 * or spending a turn trapped by another Pokemon's Sky Drop, or that
-		 * the move was blocked by one or more moves such as Protect.
-		 * 
+		 * or spending a turn trapped by another Pokemon's Sky Drop.
+		 *
 		 * false indicates that the move completely failed to execute for any
 		 * reason not mentioned above, including missing, the target being
 		 * immune, the user being immobilized by an effect such as paralysis, etc.
-		 * 
+		 *
 		 * true indicates that the move successfully executed one or more of
 		 * its effects on one or more targets, including hitting with an attack
-		 * but dealing 0 damage to the target in cases such as Disguise.
-		 * Uniquely, this value can also be true if this Pokemon mega evolved
-		 * or ultra bursted this turn, but in that case the value should always
-		 * be overwritten by a move action before the end of that turn.
+		 * but dealing 0 damage to the target in cases such as Disguise. It can
+		 * also mean that the move was blocked by one or more moves such as
+		 * Protect. Uniquely, this value can also be true if this Pokemon mega
+		 * evolved or ultra bursted this turn, but in that case the value should
+		 * always be overwritten by a move action before the end of that turn.
 		 * @type {boolean | null | undefined}
 		 */
 		this.moveThisTurnResult = undefined;
 
-		/** 
-		 * The amount of direct damage this Pokemon last took in a single hit
-		 * from another Pokemon's attack.
-		 */
 		this.lastDamage = 0;
 		/**@type {?{pokemon: Pokemon, damage?: number, thisTurn: boolean, move?: string}} */
 		this.lastAttackedBy = null;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -94,12 +94,67 @@ class Pokemon {
 		/**@type {string | boolean} */
 		this.moveThisTurn = '';
 
-		// For Stomping Tantrum
-		/**@type {boolean | undefined} */
+		/**
+		 * The result of the last move used on the previous turn by this 
+		 * Pokemon. Stomping Tantrum checks this property for a value of false
+		 * when determine whether to double its power, but it has four
+		 * possible values:
+		 * 
+		 * undefined indicates this Pokemon was not active last turn. It should
+		 * not be used to indicate that a move was attempted and failed, either
+		 * in a way that boosts Stomping Tantrum or not.
+		 * 
+		 * null indicates that the Pokemon's move was skipped in such a way
+		 * that does not boost Stomping Tantrum, either from having to recharge
+		 * or spending a turn trapped by another Pokemon's Sky Drop.
+		 * 
+		 * false indicates that the move completely failed to execute for any
+		 * reason not mentioned above, including missing, the target being
+		 * immune, the user being immobilized by an effect such as paralysis, etc.
+		 * 
+		 * true indicates that the move successfully executed one or more of
+		 * its effects on one or more targets, including hitting with an attack
+		 * but dealing 0 damage to the target in cases such as Disguise, or that
+		 * the move was blocked by one or more moves such as Protect.
+		 * @type {boolean | null | undefined}
+		 */
 		this.moveLastTurnResult = undefined;
-		/**@type {boolean | undefined} */
+		/**
+		 * The result of the most recent move used this turn by this Pokemon.
+		 * At the start of each turn, the value stored here is moved to its
+		 * counterpart, moveLastTurnResult, and this property is reinitialized
+		 * to undefined. This property can have one of four possible values:
+		 * 
+		 * undefined indicates that this Pokemon has not yet finished an
+		 * attempt to use a move this turn. As this value is only overwritten
+		 * after a move finishes execution, it is not sufficient for an event
+		 * to examine only this property when checking if a Pokemon has not
+		 * moved yet this turn if the event could take place during that
+		 * Pokemon's move.
+		 * 
+		 * null indicates that the Pokemon's move was skipped in such a way
+		 * that does not boost Stomping Tantrum, either from having to recharge
+		 * or spending a turn trapped by another Pokemon's Sky Drop, or that
+		 * the move was blocked by one or more moves such as Protect.
+		 * 
+		 * false indicates that the move completely failed to execute for any
+		 * reason not mentioned above, including missing, the target being
+		 * immune, the user being immobilized by an effect such as paralysis, etc.
+		 * 
+		 * true indicates that the move successfully executed one or more of
+		 * its effects on one or more targets, including hitting with an attack
+		 * but dealing 0 damage to the target in cases such as Disguise.
+		 * Uniquely, this value can also be true if this Pokemon mega evolved
+		 * or ultra bursted this turn, but in that case the value should always
+		 * be overwritten by a move action before the end of that turn.
+		 * @type {boolean | null | undefined}
+		 */
 		this.moveThisTurnResult = undefined;
 
+		/** 
+		 * The amount of direct damage this Pokemon last took in a single hit
+		 * from another Pokemon's attack.
+		 */
 		this.lastDamage = 0;
 		/**@type {?{pokemon: Pokemon, damage?: number, thisTurn: boolean, move?: string}} */
 		this.lastAttackedBy = null;

--- a/test/simulator/moves/stompingtantrum.js
+++ b/test/simulator/moves/stompingtantrum.js
@@ -16,7 +16,7 @@ describe('Stomping Tantrum', function () {
 			[{species: 'Manaphy', ability: 'hydration', moves: ['rest']}],
 		]);
 
-		battle.onEvent('ModifyBasePower', battle.getFormat(), function (basePower) {
+		battle.onEvent('BasePower', battle.getFormat(), function (basePower) {
 			assert.strictEqual(basePower, 150);
 		});
 
@@ -32,7 +32,7 @@ describe('Stomping Tantrum', function () {
 			[{species: 'Manaphy', ability: 'hydration', moves: ['protect']}],
 		]);
 
-		battle.onEvent('ModifyBasePower', battle.getFormat(), function (basePower) {
+		battle.onEvent('BasePower', battle.getFormat(), function (basePower) {
 			assert.strictEqual(basePower, 75);
 		});
 
@@ -46,7 +46,7 @@ describe('Stomping Tantrum', function () {
 			[{species: 'Manaphy', ability: 'hydration', moves: ['rest']}],
 		]);
 
-		battle.onEvent('ModifyBasePower', battle.getFormat(), function (basePower) {
+		battle.onEvent('BasePower', battle.getFormat(), function (basePower) {
 			assert.strictEqual(basePower, 75);
 		});
 
@@ -60,8 +60,8 @@ describe('Stomping Tantrum', function () {
 			[{species: 'Lycanroc-Midnight', ability: 'noguard', moves: ['sleeptalk']}],
 		]);
 
-		battle.onEvent('ModifyBasePower', battle.getFormat(), function (basePower) {
-			assert.strictEqual(basePower, 75);
+		battle.onEvent('BasePower', battle.getFormat(), function (basePower, pokemon, target, move) {
+			if (move.id === 'stompingtantrum') assert.strictEqual(basePower, 75);
 		});
 
 		battle.makeChoices('move hyperbeam', 'move sleeptalk');


### PR DESCRIPTION
Since nobody apparently felt like doing the easy solution, I did the hard one.