### PR TITLE
Fix type display in camomons after switching out

### DIFF
--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -904,6 +904,7 @@ class Pokemon {
 		this.beingCalledBack = false;
 
 		this.formeChange(this.baseTemplate);
+		this.apparentType = this.baseTemplate.types.join('/');
 	}
 
 	/**


### PR DESCRIPTION
In retrospect this was obvious.