### PR TITLE
Psycho Shift should fail verbosely

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -12589,12 +12589,14 @@ let BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		onHit: function (target, pokemon) {
-			if (pokemon.status && !target.status && target.trySetStatus(pokemon.status)) {
+		onPrepareHit: function (move, pokemon) {
+			if (!pokemon.status) return false;
+			move.status = pokemon.status;
+		},
+		self: {
+			onHit: function (pokemon) {
 				pokemon.cureStatus();
-			} else {
-				return false;
-			}
+			},
 		},
 		secondary: false,
 		target: "normal",


### PR DESCRIPTION
As if it was Glare/Poison Gas/Spore/Toxic in the first place. Reported in Known Mechanics Bugs.