### PR TITLE
Transform should ignore Roost's effects

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -13804,6 +13804,7 @@ let BattleMovedex = {
 			onResidualOrder: 20,
 			onTypePriority: -1,
 			onType: function (types, pokemon) {
+				this.effectData.typeWas = types;
 				return types.filter(type => type !== 'Flying');
 			},
 		},

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -808,7 +808,8 @@ class Pokemon {
 		}
 		this.transformed = true;
 
-		this.setType(pokemon.getTypes(true), true);
+		let types = pokemon.getTypes(true);
+		this.setType(pokemon.volatiles.roost ? pokemon.volatiles.roost.typeWas : types);
 		this.addedType = pokemon.addedType;
 		this.knownType = this.side === pokemon.side && pokemon.knownType;
 		this.apparentType = pokemon.apparentType;

--- a/test/simulator/moves/transform.js
+++ b/test/simulator/moves/transform.js
@@ -128,6 +128,16 @@ describe('Transform', function () {
 		battle.makeChoices('move transform', 'move rest');
 		assert.deepStrictEqual(battle.p1.active[0].getTypes(), ["Steel"]);
 	});
+
+	it(`should ignore the effects of Roost`, function () {
+		battle = common.createBattle([
+			[{species: "Mew", ability: 'synchronize', moves: ['seismictoss', 'transform']}],
+			[{species: "Talonflame", ability: 'flamebody', moves: ['roost']}],
+		]);
+		battle.makeChoices('move seismictoss', 'move roost');
+		battle.makeChoices('move transform', 'move roost');
+		assert.deepStrictEqual(battle.p1.active[0].getTypes(), ["Fire", "Flying"]);
+	});
 });
 
 describe('Transform [Gen 5]', function () {


### PR DESCRIPTION
Looks like we'll have to hard-code something Roost-related after all.