### PR TITLE
Fix Bestow, Covet, Symbiosis and Thief with a required item

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -3504,17 +3504,15 @@ let BattleAbilities = {
 		desc: "If an ally uses its item, this Pokemon gives its item to that ally immediately. Does not activate if the ally's item was stolen or knocked off.",
 		shortDesc: "If an ally uses its item, this Pokemon gives its item to that ally immediately.",
 		onAllyAfterUseItem: function (item, pokemon) {
-			let sourceItem = this.effectData.target.getItem();
-			if (!sourceItem) return;
+			let source = this.effectData.target;
+			let myItem = source.takeItem();
+			if (!myItem) return;
 			// @ts-ignore
-			if (!this.singleEvent('TakeItem', item, this.effectData.target.itemData, this.effectData.target, pokemon, this.effectData, item)) return;
-			sourceItem = this.effectData.target.takeItem();
-			if (!sourceItem) {
+			if (!this.singleEvent('TakeItem', myItem, source.itemData, pokemon, source, this.effectData, myItem) || !pokemon.setItem(myItem)) {
+				source.item = myItem.id;
 				return;
 			}
-			if (pokemon.setItem(sourceItem)) {
-				this.add('-activate', this.effectData.target, 'ability: Symbiosis', sourceItem, '[of] ' + pokemon);
-			}
+			this.add('-activate', source, 'ability: Symbiosis', myItem, '[of] ' + pokemon);
 		},
 		id: "symbiosis",
 		name: "Symbiosis",

--- a/data/moves.js
+++ b/data/moves.js
@@ -1231,14 +1231,13 @@ let BattleMovedex = {
 			if (target.item) {
 				return false;
 			}
-			let yourItem = source.takeItem();
-			if (!yourItem) return false;
-			if (!this.singleEvent('TakeItem', yourItem, source.itemData, source, target, move, yourItem)) return;
-			if (!target.setItem(yourItem)) {
-				source.item = yourItem.id;
+			let myItem = source.takeItem();
+			if (!myItem) return false;
+			if (!this.singleEvent('TakeItem', myItem, source.itemData, target, source, move, myItem) || !target.setItem(myItem)) {
+				source.item = myItem.id;
 				return false;
 			}
-			this.add('-item', target, yourItem.name, '[from] move: Bestow', '[of] ' + source);
+			this.add('-item', target, myItem.name, '[from] move: Bestow', '[of] ' + source);
 		},
 		secondary: false,
 		target: "normal",
@@ -2795,7 +2794,7 @@ let BattleMovedex = {
 		pp: 25,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onHit: function (target, source) {
+		onAfterHit: function (target, source, move) {
 			if (source.item || source.volatiles['gem']) {
 				return;
 			}
@@ -2803,7 +2802,7 @@ let BattleMovedex = {
 			if (!yourItem) {
 				return;
 			}
-			if (!source.setItem(yourItem)) {
+			if (!this.singleEvent('TakeItem', yourItem, target.itemData, source, target, move, yourItem) || !source.setItem(yourItem)) {
 				target.item = yourItem.id; // bypass setItem so we don't break choicelock or anything
 				return;
 			}
@@ -17343,7 +17342,7 @@ let BattleMovedex = {
 		pp: 25,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onAfterHit: function (target, source) {
+		onAfterHit: function (target, source, move) {
 			if (source.item || source.volatiles['gem']) {
 				return;
 			}
@@ -17351,7 +17350,7 @@ let BattleMovedex = {
 			if (!yourItem) {
 				return;
 			}
-			if (!source.setItem(yourItem)) {
+			if (!this.singleEvent('TakeItem', yourItem, target.itemData, source, target, move, yourItem) || !source.setItem(yourItem)) {
 				target.item = yourItem.id; // bypass setItem so we don't break choicelock or anything
 				return;
 			}

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -151,6 +151,7 @@ interface EventMethods {
 	onAfterDamage?: (this: Battle, damage: number, target: Pokemon, soruce: Pokemon, move: Move) => void
 	onAfterMoveSecondary?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
 	onAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
+	onAfterHit?: (this: Battle, source: Pokemon, target: Pokemon, move: Move) => void
 	onAfterSetStatus?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
 	onAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void
 	onAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
@@ -158,7 +159,6 @@ interface EventMethods {
 	onAfterMoveSecondarySelf?: (this: Battle, source: Pokemon, target: Pokemon, move: Move) => void
 	onAfterMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
 	onAfterMoveSelf?: (this: Battle, pokemon: Pokemon) => void
-	onAfterHit?: (this: Battle, target: Pokemon, source: Pokemon) => void
 	onAllyTryAddVolatile?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
 	onAllyBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: Move) => void
 	onAllyModifyAtk?: (this: Battle, atk: number) => void

--- a/test/simulator/abilities/symbiosis.js
+++ b/test/simulator/abilities/symbiosis.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Symbiosis', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should share its item with its ally', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [
+			[{species: 'Smeargle', ability: 'symbiosis', item: 'enigmaberry', moves: ['snarl']}, {species: 'Latias', ability: 'levitate', item: 'weaknesspolicy', moves: ['snarl']}],
+			[{species: 'Smeargle', moves: ['snarl']}, {species: 'Smeargle', moves: ['snarl']}],
+		]);
+		battle.makeChoices('move snarl, move snarl', 'move snarl, move snarl');
+		assert.strictEqual(battle.p1.active[0].item, '');
+		assert.strictEqual(battle.p1.active[1].item, '');
+	});
+
+	it('should not share an item required to change forme', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [
+			[{species: 'Smeargle', ability: 'symbiosis', item: 'latiasite', moves: ['snarl']}, {species: 'Latias', ability: 'levitate', item: 'weaknesspolicy', moves: ['snarl']}],
+			[{species: 'Smeargle', moves: ['snarl']}, {species: 'Smeargle', moves: ['snarl']}],
+		]);
+		battle.makeChoices('move snarl, move snarl', 'move snarl, move snarl');
+		assert.strictEqual(battle.p1.active[0].item, 'latiasite');
+		assert.strictEqual(battle.p1.active[1].item, '');
+	});
+});


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/threads/bug-reports-v3-0-read-op-before-posting.3634749/post-7809895) for Symbiosis passing Aerodactylite to an Aerodactyl but also seems to affect using Bestow to pass a Drive, Mega Stone, Memory, Plate etc. to its user or for that user to use Thief or Covet to steal it.

The code for Covet and Thief resembled that for Trick and Switcheroo (which don't have the bug) so they were easy to adapt but for Bestow and Symbiosis I thought it better to copy the Switcheroo code to make future maintenance easier.