### PR TITLE
Fix incorrect behavior of /pick when using different capitalization

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -2102,7 +2102,8 @@ const commands = {
 	pick: 'pickrandom',
 	pickrandom: function (target, room, user, connection, cmd) {
 		if (!this.canBroadcast()) return false;
-		target = this.message.slice(this.message.indexOf(cmd) + cmd.length + 1); // Not very elegant, but stops filter evasion using !pick.
+		// Not very elegant, but stops filter evasion using !pick.
+		target = this.message.slice(this.message.toLowerCase().indexOf(cmd) + cmd.length + 1);
 		let options = target.split(',');
 		if (options.length < 2) return this.parse('/help pick');
 		if (!this.runBroadcast(true)) return false;


### PR DESCRIPTION
The value of `cmd` is always lowercased, so searching for it in the original message might not find the command invocation, leading to the last last letter of the command and a space being added onto the target.
Is there a situation where we can't just assume that there's exactly one character between the start of the message and the start of a command?