### PR TITLE
Fix Blizzard short description in gen 3 and earlier

### DIFF
--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -100,6 +100,7 @@ let BattleMovedex = {
 	blizzard: {
 		inherit: true,
 		desc: "Has a 10% chance to freeze the target.",
+		shortDesc: "10% chance to freeze foe(s).",
 		onModifyMove: function () { },
 	},
 	charge: {


### PR DESCRIPTION
The desc was updated to reflect that it can miss in Hail there, but the shortdesc wasn't. 