### PR TITLE
Send enditem message on Pickpocket steal

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2324,6 +2324,7 @@ let BattleAbilities = {
 					source.item = yourItem.id;
 					return;
 				}
+				this.add('-enditem', source, yourItem, '[silent]', '[from] ability: Pickpocket', '[of] ' + source);
 				this.add('-item', target, yourItem, '[from] ability: Pickpocket', '[of] ' + source);
 			}
 		},


### PR DESCRIPTION
Fixes issues like the end of turn 2 here https://replay.pokemonshowdown.com/gen7metagamiate-775089230 where the balloon gets stolen but the statbar item stays