### PR TITLE
Fix Illusion to display Users level instead of Illusions level

### DIFF
--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -319,7 +319,10 @@ class Pokemon {
 	 * @param {Side} side
 	 */
 	getDetailsInner(side) {
-		if (this.illusion) return this.illusion.details + '|' + this.getHealthInner(side);
+		if (this.illusion) {
+			let illusionDetails = this.illusion.species + (this.level === 100 ? '' : ', L' + this.level) + (this.illusion.gender === '' ? '' : ', ' + this.illusion.gender) + (this.illusion.set.shiny ? ', shiny' : '');
+			return illusionDetails + '|' + this.getHealthInner(side);
+		}
 		return this.details + '|' + this.getHealthInner(side);
 	}
 


### PR DESCRIPTION
Fix for "Illusion should display the Illusion Pokemon's actual level, not the level of the target it is disguised as." from Issue #2367. Illusion user's level is now displayed instead of the level of the Pokemon being displayed. 