### PR TITLE
Set gender when validating restricted sources

### DIFF
--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -459,7 +459,6 @@ class Validator {
 			for (const eventData of eventPokemon) {
 				if (this.validateEvent(set, eventData, eventTemplate)) continue;
 				legal = true;
-				if (eventData.gender) set.gender = eventData.gender;
 				break;
 			}
 			if (!legal && template.id === 'celebi' && dex.gen >= 7 && !this.validateSource(set, '7V', template)) {
@@ -641,7 +640,6 @@ class Validator {
 				if (fastReturn) return true;
 				problems.push(`${name}'s gender must be ${eventData.gender}${etc}.`);
 			}
-			if (!fastReturn) set.gender = eventData.gender;
 		}
 		if (eventData.nature && eventData.nature !== set.nature) {
 			if (fastReturn) return true;
@@ -743,8 +741,8 @@ class Validator {
 				}
 			}
 		}
-		if (!problems.length) return;
-		return problems;
+		if (problems.length) return problems;
+		if (eventData.gender) set.gender = eventData.gender;
 	}
 
 	/**


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/7858923).

When validating event-only Pokémon, the team validator performs a fast validation, then fixes up the gender afterwards. However, when validating Pokémon that are only limited by event-only moves, the team validator fails to fix up the gender. Worse, it doesn't know which event ended up validating, since it isn't calling `validateEvent` directly. To address this, validating an event now sets the gender if the validation is successful and the event specifies a gender, even for fast validation. This also means that the gender fixup code for validating event-only Pokémon can be removed.