### PR TITLE
Prevent effects from changing stats after final Pokemon is KOed

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1830,6 +1830,7 @@ class Battle extends Dex.ModdedDex {
 			 (effect.id === this.data.Movedex.clangoroussoulblaze.id ||
 			  effect.id === this.data.Movedex.closecombat.id ||
 				effect.id === this.data.Movedex.poweruppunch.id)) return false;
+
 		if (this.gen > 5 && !target.side.foe.pokemonLeft) return false;
 		effect = this.getEffect(effect);
 		boost = this.runEvent('Boost', target, source, effect, Object.assign({}, boost));

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1825,10 +1825,7 @@ class Battle extends Dex.ModdedDex {
 		}
 		if (!target || !target.hp) return 0;
 		if (!target.isActive) return false;
-		if (target.side.foe.battle.faintQueue.length === target.side.foe.pokemonLeft &&
-			 (effect.id === this.data.Movedex.clangoroussoulblaze.id ||
-			  effect.id === this.data.Movedex.closecombat.id ||
-				effect.id === this.data.Movedex.poweruppunch.id)) return false;
+		if (target.side.foe.battle.faintQueue.length === target.side.foe.pokemonLeft) return false;
 		if (this.gen > 5 && !target.side.foe.pokemonLeft) return false;
 		effect = this.getEffect(effect);
 		boost = this.runEvent('Boost', target, source, effect, Object.assign({}, boost));

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1818,7 +1818,6 @@ class Battle extends Dex.ModdedDex {
 	 * @param {boolean} isSelf
 	 */
 	boost(boost, target = null, source = null, effect = null, isSecondary = false, isSelf = false) {
-
 		if (this.event) {
 			if (!target) target = this.event.target;
 			if (!source) source = this.event.source;
@@ -1830,7 +1829,6 @@ class Battle extends Dex.ModdedDex {
 			 (effect.id === this.data.Movedex.clangoroussoulblaze.id ||
 			  effect.id === this.data.Movedex.closecombat.id ||
 				effect.id === this.data.Movedex.poweruppunch.id)) return false;
-
 		if (this.gen > 5 && !target.side.foe.pokemonLeft) return false;
 		effect = this.getEffect(effect);
 		boost = this.runEvent('Boost', target, source, effect, Object.assign({}, boost));

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1825,8 +1825,7 @@ class Battle extends Dex.ModdedDex {
 		}
 		if (!target || !target.hp) return 0;
 		if (!target.isActive) return false;
-		if (target.side.foe.battle.faintQueue.length === target.side.foe.pokemonLeft) return false;
-		if (this.gen > 5 && !target.side.foe.pokemonLeft) return false;
+		if (this.gen > 5 && this.faintQueue.length === target.side.foe.pokemonLeft) return false;
 		effect = this.getEffect(effect);
 		boost = this.runEvent('Boost', target, source, effect, Object.assign({}, boost));
 		let success = null;

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1818,6 +1818,7 @@ class Battle extends Dex.ModdedDex {
 	 * @param {boolean} isSelf
 	 */
 	boost(boost, target = null, source = null, effect = null, isSecondary = false, isSelf = false) {
+
 		if (this.event) {
 			if (!target) target = this.event.target;
 			if (!source) source = this.event.source;
@@ -1825,6 +1826,10 @@ class Battle extends Dex.ModdedDex {
 		}
 		if (!target || !target.hp) return 0;
 		if (!target.isActive) return false;
+		if (target.side.foe.battle.faintQueue.length === target.side.foe.pokemonLeft &&
+			 (effect.id === this.data.Movedex.clangoroussoulblaze.id ||
+			  effect.id === this.data.Movedex.closecombat.id ||
+				effect.id === this.data.Movedex.poweruppunch.id)) return false;
 		if (this.gen > 5 && !target.side.foe.pokemonLeft) return false;
 		effect = this.getEffect(effect);
 		boost = this.runEvent('Boost', target, source, effect, Object.assign({}, boost));


### PR DESCRIPTION
A quick fix I put in for this bug. I would love some feedback, I am not 100% sure exactly what happens in the BeforeFaint state, what it means to be in the faintQueue or if this should return for all boosts in this state(I had event id checks but took them out thinking this should return at this state always?).


Thank you for any feedback provided :D

(refs #2367 Any effect that changes stats after the final Pokemon is KOed in battle should not activate)