### PR TITLE
Itemsearch: Fix some results not being the best match

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -1377,27 +1377,13 @@ function runItemsearch(target, cmd, canAll, message) {
 				if (descWords.includes(word)) matched++;
 			}
 
-			if (matched >= bestMatched && matched >= (searchedWords.length * 3 / 5)) foundItems.push(item.name);
-			if (matched > bestMatched) bestMatched = matched;
-		}
-
-		// iterate over found items again to make sure they all are the best match
-		for (let [i, id] of foundItems.entries()) {
-			let item = Dex.getItem(id);
-			let matched = 0;
-			let descWords = item.desc;
-			if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
-			if (item.isBerry) descWords += ' berry';
-			descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
-			descWords = descWords.toLowerCase().replace('-', ' ').replace(/[^a-z0-9\s/]/g, '').replace(/(\D)\./, (p0, p1) => p1).split(' ');
-
-			for (const word of searchedWords) {
-				if (descWords.includes(word)) matched++;
-			}
-
-			if (matched !== bestMatched) {
-				foundItems.splice(i, 1);
-				i--;
+			if (matched >= (searchedWords.length * 3 / 5)) {
+				if (matched === bestMatched) {
+					foundItems.push(item.name);
+				} else if (matched > bestMatched) {
+					foundItems = [item.name];
+					bestMatched = matched;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Since `entries()` will reflect changes to the array it's based on, it will skip the element immediately following one that was deleted from the array. Doing it in reverse avoids that, and I didn't find a way to do a reverse iterator, hence the `map()`.