### PR TITLE
Followup to #3211 to ignore Z-status moves

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -2598,7 +2598,7 @@ class Battle extends Dex.ModdedDex {
 				if (action.zmove) {
 					let zMoveName = this.getZMove(action.move, action.pokemon, true);
 					let zMove = this.getMove(zMoveName);
-					if (zMove.exists) {
+					if (zMove.exists && zMove.isZ) {
 						move = zMove;
 					}
 				}


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/7869706).

#3211 wants to pass in the Z-move to avoid Triage boosting a Z-powered draining move. However, it didn't check that the move it got was actually a Z-move. This means that Prankster ended up modifying the wrong move.