### PR TITLE
Recalculate max HP after devolving

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -458,7 +458,6 @@ let Formats = [
 			// @ts-ignore
 			if (!template.abilities[abilitySlot]) abilitySlot = '0';
 			pokemon.faintQueued = false;
-			pokemon.hp = pokemon.maxhp;
 			if (Object.values(pokemon.boosts).find(boost => boost !== 0)) {
 				pokemon.clearBoosts();
 				this.add('-clearboost', pokemon);
@@ -466,6 +465,8 @@ let Formats = [
 			pokemon.formeChange(template, this.getFormat(), true, '', abilitySlot);
 			this.add('-message', `${pokemon.name} has devolved into ${template.species}!`);
 			pokemon.cureStatus(true);
+			let newHP = Math.floor(Math.floor(2 * pokemon.template.baseStats['hp'] + pokemon.set.ivs['hp'] + Math.floor(pokemon.set.evs['hp'] / 4) + 100) * pokemon.level / 100 + 10);
+			pokemon.maxhp = pokemon.hp = newHP;
 			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 			let learnset = template.learnset || this.getTemplate(template.baseSpecies).learnset || {};
 			let prevoset = template.prevo && this.getTemplate(template.prevo).learnset || {};


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/threads/posts/7870569).

This is basically just cut'n'paste from Zygarde-Complete.

The reason I overlooked this is that ROM puts all of this code in `formeChange` because we've already calculated the new `maxhp` anyway:

     if (this.hp) {
        let maxhp = this.template.maxHP || stats.hp;
        this.hp += maxhp - this.maxhp;
        this.maxhp = maxhp;
    }

Much more readable IMHO.