### PR TITLE
Itemsearch: make 'show all' parameter independent from whitespace

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -1204,10 +1204,12 @@ function runItemsearch(target, cmd, canAll, message) {
 	let showAll = false;
 
 	target = target.trim();
-	if (target.substr(target.length - 5) === ', all') {
+	const lastCommaIndex = target.lastIndexOf(',');
+	const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
+	if (lastArgumentSubstr === 'all') {
 		if (!canAll) return {reply: "A search ending in ', all' cannot be broadcast."};
 		showAll = true;
-		target = target.substr(0, target.length - 5);
+		target = target.substr(0, lastCommaIndex);
 	}
 
 	target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');


### PR DESCRIPTION
It should not force exactly one space between the comma and "all" to actually display all items (spaces after commas matter just about nowhere else). Especially because, if it's formatted in any other way, it doesn't error out, it just considers "all" a search term, which is doubly wrong.
Now that I think about it, maybe it shouldn't even force the "all" to be at the end, in order to be even more consistent with /ds and /ms. On the other hand, I think that's way less likely than this scenario.