### PR TITLE
Properly fix Benjamin Butterfree effects

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -458,16 +458,17 @@ let Formats = [
 			// @ts-ignore
 			if (!template.abilities[abilitySlot]) abilitySlot = '0';
 			pokemon.faintQueued = false;
+			pokemon.hp = pokemon.maxhp;
 			if (Object.values(pokemon.boosts).find(boost => boost !== 0)) {
 				pokemon.clearBoosts();
 				this.add('-clearboost', pokemon);
 			}
 			pokemon.formeChange(template, this.getFormat(), true, '', abilitySlot);
 			this.add('-message', `${pokemon.name} has devolved into ${template.species}!`);
+			pokemon.cureStatus(true);
 			let newHP = Math.floor(Math.floor(2 * pokemon.template.baseStats['hp'] + pokemon.set.ivs['hp'] + Math.floor(pokemon.set.evs['hp'] / 4) + 100) * pokemon.level / 100 + 10);
 			pokemon.maxhp = pokemon.hp = newHP;
 			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
-			pokemon.cureStatus(true);
 			let learnset = template.learnset || this.getTemplate(template.baseSpecies).learnset || {};
 			let prevoset = template.prevo && this.getTemplate(template.prevo).learnset || {};
 			for (const moveSlot of pokemon.baseMoveSlots) {


### PR DESCRIPTION
#4788 removed the HP setting from before the `formeChange` because I mistakenly thought it wasn't necessary now that the HP was being recalculated manually (as opposed to having `formeChange` do it for you) but of course you need to have HP for most effects to work and #4791 was the wrong fix, so this undoes #4791 and also restores the (now temporary) HP from #4788.