### PR TITLE
Battle Factory: Update sets

### DIFF
--- a/data/factory-sets.json
+++ b/data/factory-sets.json
@@ -1850,16 +1850,9 @@
 				"species": "Alakazam",
 				"item": ["Alakazite"],
 				"ability": ["Magic Guard"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Psychic"], ["Focus Blast"], ["Shadow Ball"], ["Substitute", "Calm Mind"]]
-			}, {
-				"species": "Alakazam",
-				"item": ["Alakazite"],
-				"ability": ["Magic Guard"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Psychic"], ["Focus Blast"], ["Shadow Ball"], ["Hidden Power Fire"]]
+				"moves": [["Psychic"], ["Recover"], ["Focus Blast"], ["Shadow Ball", "Hidden Power Ice", "Hidden Power Fire", "Calm Mind", "Substitute"]]
 			}, {
 				"species": "Alakazam",
 				"item": ["Focus Sash"],
@@ -1868,6 +1861,13 @@
 				"ivs": {"def": 0},
 				"nature": "Hasty",
 				"moves": [["Counter"], ["Psychic"], ["Shadow Ball"], ["Hidden Power Fire"]]
+			}, {
+				"species": "Alakazam",
+				"item": ["Life Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Focus Blast"], ["Psychic", "Psyshock"], ["Shadow Ball", "Hidden Power Fire"], ["Recover"]]
 			}]
 		},
 		"bisharp": {
@@ -1907,6 +1907,25 @@
 				"ivs": {"atk": 0},
 				"nature": "Timid",
 				"moves": [["Shadow Ball"], ["Fire Blast", "Flamethrower"], ["Overheat"], ["Hidden Power Grass"]]
+			}, {
+				"species": "Blacephalon",
+				"item": ["Ghostium Z"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 236, "spa": 20, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Shadow Ball"], ["Flamethrower"], ["Substitute"], ["Calm Mind"]]
+			}]
+		},
+		"buzzwole": {
+			"flags": {},
+			"sets": [{
+				"species": "Buzzwole",
+				"item": ["Leftovers"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 248, "atk": 24, "def": 116, "spd": 8, "spe": 112},
+				"nature": "Impish",
+				"moves": [["Bulk Up"], ["Drain Punch"], ["Ice Punch"], ["Roost"]]
 			}]
 		},
 		"celesteela": {
@@ -1966,7 +1985,14 @@
 				"ability": ["Magic Guard"],
 				"evs": {"hp": 252, "def": 252, "spd": 4},
 				"nature": "Bold",
-				"moves": [["Moonblast"], ["Soft-Boiled"], ["Stealth Rock"], ["Knock Off", "Calm Mind"]]
+				"moves": [["Moonblast"], ["Soft-Boiled"], ["Calm Mind"], ["Stealth Rock", "Ice Beam", "Knock Off", "Thunder Wave", "Flamethrower"]]
+			}, {
+				"species": "Clefable",
+				"item": ["Leftovers"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Bold",
+				"moves": [["Moonblast"], ["Soft-Boiled"], ["Stealth Rock"], ["Knock Off", "Wish"]]
 			}, {
 				"species": "Clefable",
 				"item": ["Leftovers"],
@@ -1986,7 +2012,7 @@
 				"ability": ["Clear Body"],
 				"evs": {"atk": 4, "spa": 252, "spe": 252},
 				"nature": "Naive",
-				"moves": [["Moonblast"], ["Diamond Storm"], ["Hidden Power Fire"], ["Nature Power", "Earth Power"]]
+				"moves": [["Moonblast"], ["Diamond Storm"], ["Hidden Power Fire"], ["Earth Power"]]
 			}, {
 				"species": "Diancie",
 				"item": ["Diancite"],
@@ -2052,9 +2078,17 @@
 				"species": "Ferrothorn",
 				"item": ["Leftovers"],
 				"ability": ["Iron Barbs"],
-				"evs": {"hp": 252, "def": 48, "spd": 208},
+				"evs": {"hp": 252, "def": 92, "spd": 164},
+				"ivs": {"spe": 0},
+				"nature": "Sassy",
+				"moves": [["Spikes", "Stealth Rock"], ["Leech Seed"], ["Power Whip"], ["Gyro Ball"]]
+			}, {
+				"species": "Ferrothorn",
+				"item": ["Leftovers"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 252, "def": 92, "spd": 164},
 				"nature": "Careful",
-				"moves": [["Spikes", "Stealth Rock"], ["Leech Seed"], ["Power Whip"], ["Knock Off", "Protect", "Gyro Ball"]]
+				"moves": [["Spikes", "Stealth Rock"], ["Leech Seed"], ["Power Whip"], ["Knock Off", "Protect"]]
 			}]
 		},
 		"garchomp": {
@@ -2126,11 +2160,19 @@
 			"sets": [{
 				"species": "Greninja",
 				"gender": "M",
-				"item": ["Choice Scarf"],
+				"item": ["Waterium Z"],
 				"ability": ["Protean"],
-				"evs": {"atk": 176, "spa": 80, "spe": 252},
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Naive",
-				"moves": [["Rock Slide", "Gunk Shot"], ["U-turn"], ["Ice Beam"], ["Low Kick"]]
+				"moves": [["Spikes"], ["Hydro Pump"], ["Gunk Shot"], ["Hidden Power Fire"]]
+			}, {
+				"species": "Greninja",
+				"gender": "M",
+				"item": ["Fightinium Z"],
+				"ability": ["Protean"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Naive",
+				"moves": [["Spikes"], ["Ice Beam"], ["Gunk Shot"], ["Low Kick"]]
 			}, {
 				"species": "Greninja",
 				"gender": "M",
@@ -2138,7 +2180,7 @@
 				"ability": ["Protean"],
 				"evs": {"atk": 176, "spa": 80, "spe": 252},
 				"nature": "Naive",
-				"moves": [["Rock Slide", "Gunk Shot"], ["U-turn"], ["Ice Beam"], ["Spikes"]]
+				"moves": [["Rock Slide", "Gunk Shot"], ["U-turn"], ["Ice Beam"], ["Low Kick", "Spikes"]]
 			}, {
 				"species": "Greninja",
 				"gender": "M",
@@ -2170,15 +2212,7 @@
 				"ability": ["Protean"],
 				"evs": {"atk": 4, "spa": 252, "spe": 252},
 				"nature": "Naive",
-				"moves": [["Hydro Pump"], ["Extrasensory"], ["Gunk Shot"], ["Dark Pulse"]]
-			}, {
-				"species": "Greninja",
-				"gender": "M",
-				"item": ["Life Orb", "Expert Belt"],
-				"ability": ["Protean"],
-				"evs": {"atk": 4, "spa": 252, "spe": 252},
-				"nature": "Naive",
-				"moves": [["Hydro Pump"], ["Extrasensory"], ["Gunk Shot"], ["Hidden Power Fire"]]
+				"moves": [["Hydro Pump"], ["Extrasensory"], ["Gunk Shot"], ["Dark Pulse", "Hidden Power Fire"]]
 			}, {
 				"species": "Greninja",
 				"gender": "M",
@@ -2186,15 +2220,7 @@
 				"ability": ["Protean"],
 				"evs": {"atk": 4, "spa": 252, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Hydro Pump"], ["Extrasensory"], ["Ice Beam"], ["Dark Pulse"]]
-			}, {
-				"species": "Greninja",
-				"gender": "M",
-				"item": ["Life Orb", "Expert Belt"],
-				"ability": ["Protean"],
-				"evs": {"atk": 4, "spa": 252, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Hydro Pump"], ["Extrasensory"], ["Ice Beam"], ["Hidden Power Fire"]]
+				"moves": [["Hydro Pump"], ["Extrasensory"], ["Ice Beam"], ["Dark Pulse", "Hidden Power Fire"]]
 			}]
 		},
 		"greninjaash": {
@@ -2231,21 +2257,23 @@
 				"ability": ["Flash Fire"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Magma Storm"], ["Earth Power"], ["Toxic"], ["Taunt"]]
+				"moves": [["Magma Storm"], ["Earth Power"], ["Toxic", "Stealth Rock"], ["Taunt"]]
 			}, {
 				"species": "Heatran",
-				"item": ["Firium Z", "Groundium Z"],
+				"item": ["Steelium Z"],
 				"ability": ["Flash Fire"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Magma Storm"], ["Earth Power"], ["Stealth Rock"], ["Taunt"]]
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Flash Cannon"], ["Lava Plume", "Magma Storm"], ["Earth Power"], ["Stealth Rock", "Taunt"]]
 			}, {
 				"species": "Heatran",
 				"item": ["Leftovers"],
 				"ability": ["Flash Fire"],
-				"evs": {"hp": 248, "spd": 220, "spe": 40},
+				"evs": {"hp": 248, "spd": 132, "spe": 128},
+				"ivs": {"atk": 0},
 				"nature": "Calm",
-				"moves": [["Lava Plume"], ["Toxic"], ["Protect", "Taunt"], ["Stealth Rock"]]
+				"moves": [["Magma Storm", "Lava Plume"], ["Toxic", "Will-O-Wisp"], ["Protect"], ["Taunt", "Stealth Rock"]]
 			}, {
 				"species": "Heatran",
 				"item": ["Choice Scarf"],
@@ -2266,6 +2294,13 @@
 				"moves": [["Swords Dance"], ["Leaf Blade"], ["Sacred Sword"], ["Smart Strike", "Knock Off"]]
 			}, {
 				"species": "Kartana",
+				"item": ["Steelium Z"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Leaf Blade"], ["Sacred Sword"], ["Smart Strike"]]
+			}, {
+				"species": "Kartana",
 				"item": ["Fightinium Z", "Grassium Z"],
 				"ability": ["Beast Boost"],
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
@@ -2277,10 +2312,10 @@
 				"ability": ["Beast Boost"],
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Leaf Blade"], ["Sacred Sword"], ["Smart Strike"], ["Defog"]]
+				"moves": [["Leaf Blade"], ["Sacred Sword"], ["Smart Strike"], ["Defog", "Knock Off"]]
 			}, {
 				"species": "Kartana",
-				"item": ["Choice Scarf"],
+				"item": ["Choice Band"],
 				"ability": ["Beast Boost"],
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
 				"nature": "Jolly",
@@ -2297,6 +2332,13 @@
 		"keldeo": {
 			"flags": {},
 			"sets": [{
+				"species": "Keldeo",
+				"item": ["Choice Specs"],
+				"ability": ["Justified"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Hydro Pump"], ["Secret Sword"], ["Icy Wind"], ["Scald"]]
+			}, {
 				"species": "Keldeo",
 				"item": ["Choice Scarf"],
 				"ability": ["Justified"],
@@ -2320,7 +2362,7 @@
 				"ability": ["Teravolt"],
 				"evs": {"atk": 4, "spa": 252, "spe": 252},
 				"nature": "Naive",
-				"moves": [["Ice Beam"], ["Fusion Bolt"], ["Hidden Power Fire"], ["Roost"]]
+				"moves": [["Ice Beam"], ["Fusion Bolt"], ["Hidden Power Fire", "Earth Power"], ["Roost"]]
 			}, {
 				"species": "Kyurem-Black",
 				"item": ["Icium Z"],
@@ -2343,30 +2385,9 @@
 				"species": "Landorus-Therian",
 				"item": ["Choice Scarf"],
 				"ability": ["Intimidate"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Earthquake"], ["U-turn"], ["Stone Edge"], ["Explosion"]]
-			}, {
-				"species": "Landorus-Therian",
-				"item": ["Choice Scarf"],
-				"ability": ["Intimidate"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Earthquake"], ["U-turn"], ["Stone Edge"], ["Defog"]]
-			}, {
-				"species": "Landorus-Therian",
-				"item": ["Choice Scarf"],
-				"ability": ["Intimidate"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Earthquake"], ["U-turn"], ["Hidden Power Ice"], ["Explosion"]]
-			}, {
-				"species": "Landorus-Therian",
-				"item": ["Choice Scarf"],
-				"ability": ["Intimidate"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Earthquake"], ["U-turn"], ["Hidden Power Ice"], ["Defog"]]
+				"evs": {"hp": 80, "atk": 148, "def": 84, "spe": 196},
+				"nature": "Naive",
+				"moves": [["Earthquake"], ["U-turn"], ["Hidden Power Ice"], ["Defog", "Rock Slide", "Explosion", "Knock Off", "Superpower"]]
 			}, {
 				"species": "Landorus-Therian",
 				"item": ["Rockium Z"],
@@ -2380,14 +2401,7 @@
 				"ability": ["Intimidate"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Adamant",
-				"moves": [["Earthquake"], ["Fly"], ["Gravity", "Smack Down"], ["Swords Dance"]]
-			}, {
-				"species": "Landorus-Therian",
-				"item": ["Flyinium Z"],
-				"ability": ["Intimidate"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Earthquake"], ["Fly"], ["Gravity", "Smack Down"], ["Stealth Rock"]]
+				"moves": [["Earthquake"], ["Fly"], ["Gravity", "Smack Down"], ["Swords Dance", "Stealth Rock"]]
 			}, {
 				"species": "Landorus-Therian",
 				"item": ["Focus Sash"],
@@ -2426,21 +2440,7 @@
 				"ability": ["Levitate"],
 				"evs": {"atk": 4, "spa": 252, "spe": 252},
 				"nature": "Naive",
-				"moves": [["Draco Meteor"], ["Psychic"], ["Earthquake"], ["Roost"]]
-			}, {
-				"species": "Latios",
-				"item": ["Choice Specs"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Draco Meteor"], ["Psyshock", "Psychic"], ["Thunderbolt"], ["Trick"]]
-			}, {
-				"species": "Latios",
-				"item": ["Choice Specs"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Draco Meteor"], ["Psyshock", "Psychic"], ["Hidden Power Fire"], ["Trick"]]
+				"moves": [["Psychic"], ["Earthquake"], ["Ice Beam", "Draco Meteor", "Hidden Power Fire", "Defog"], ["Roost"]]
 			}]
 		},
 		"lopunny": {
@@ -2462,16 +2462,9 @@
 				"species": "Magearna",
 				"item": ["Assault Vest"],
 				"ability": ["Soul-Heart"],
-				"evs": {"hp": 248, "spa": 8, "spd": 252},
+				"evs": {"hp": 248, "spd": 224, "spe": 36},
 				"nature": "Sassy",
 				"moves": [["Fleur Cannon"], ["Iron Head"], ["Hidden Power Fire"], ["Volt Switch"]]
-			}, {
-				"species": "Magearna",
-				"item": ["Assault Vest"],
-				"ability": ["Soul-Heart"],
-				"evs": {"hp": 248, "spa": 8, "spd": 252},
-				"nature": "Calm",
-				"moves": [["Fleur Cannon"], ["Flash Cannon"], ["Hidden Power Fire"], ["Volt Switch"]]
 			}, {
 				"species": "Magearna",
 				"item": ["Electrium Z"],
@@ -2537,11 +2530,11 @@
 				"moves": [["Thunderbolt"], ["Hidden Power Fire"], ["Flash Cannon"], ["Volt Switch"]]
 			}, {
 				"species": "Magnezone",
-				"item": ["Assault Vest"],
+				"item": ["Choice Specs"],
 				"ability": ["Magnet Pull"],
-				"evs": {"hp": 136, "spa": 192, "spe": 180},
+				"evs": {"def": 4, "spa": 252, "spe": 252},
 				"nature": "Modest",
-				"moves": [["Volt Switch"], ["Hidden Power Fire"], ["Thunderbolt"], ["Flash Cannon"]]
+				"moves": [["Thunderbolt"], ["Hidden Power Fire"], ["Flash Cannon"], ["Volt Switch"]]
 			}]
 		},
 		"manaphy": {
@@ -2560,24 +2553,6 @@
 				"evs": {"hp": 4, "spa": 252, "spe": 252},
 				"nature": "Timid",
 				"moves": [["Tail Glow"], ["Scald"], ["Ice Beam"], ["Psychic"]]
-			}]
-		},
-		"marowakalola": {
-			"flags": {},
-			"sets": [{
-				"species": "Marowak-Alola",
-				"item": ["Thick Club"],
-				"ability": ["Rock Head"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Shadow Bone"], ["Flare Blitz"], ["Swords Dance"], ["Bonemerang"]]
-			}, {
-				"species": "Marowak-Alola",
-				"item": ["Thick Club"],
-				"ability": ["Lightning Rod"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Shadow Bone"], ["Fire Punch"], ["Swords Dance"], ["Bonemerang"]]
 			}]
 		},
 		"mawile": {
@@ -2611,6 +2586,13 @@
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["Fake Out"], ["High Jump Kick"], ["Ice Punch"], ["Zen Headbutt"]]
+			}, {
+				"species": "Medicham",
+				"item": ["Medichamite"],
+				"ability": ["Telepathy"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Fake Out"], ["High Jump Kick"], ["Ice Punch"], ["Zen Headbutt"]]
 			}]
 		},
 		"mew": {
@@ -2620,22 +2602,25 @@
 				"item": ["Leftovers"],
 				"ability": ["Synchronize"],
 				"evs": {"hp": 240, "def": 156, "spe": 112},
+				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Ice Beam"], ["Will-O-Wisp"], ["Soft-Boiled"], ["Defog"]]
-			}, {
-				"species": "Mew",
-				"item": ["Leftovers"],
-				"ability": ["Synchronize"],
-				"evs": {"hp": 240, "def": 156, "spe": 112},
-				"nature": "Timid",
-				"moves": [["Ice Beam"], ["Will-O-Wisp"], ["Soft-Boiled"], ["Stealth Rock"]]
+				"moves": [["Ice Beam", "Earthquake"], ["Will-O-Wisp"], ["Soft-Boiled"], ["Stealth Rock", "Defog"]]
 			}, {
 				"species": "Mew",
 				"item": ["Mewnium Z"],
 				"ability": ["Synchronize"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Nasty Plot"], ["Psychic"], ["Fire Blast", "Aura Sphere"], ["Rock Polish"]]
+			}, {
+				"species": "Mew",
+				"item": ["Mewnium Z"],
+				"ability": ["Synchronize"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Psychic"], ["Fire Blast", "Aura Sphere"], ["Nasty Plot"], ["Rock Polish"]]
+				"moves": [["Nasty Plot"], ["Psychic"], ["Fire Blast", "Aura Sphere"], ["Soft-Boiled"]]
 			}]
 		},
 		"mimikyu": {
@@ -2647,6 +2632,17 @@
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Adamant",
 				"moves": [["Swords Dance"], ["Shadow Sneak"], ["Play Rough"], ["Shadow Claw"]]
+			}]
+		},
+		"moltres": {
+			"flags": {},
+			"sets": [{
+				"species": "Moltres",
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 208, "def": 60, "spe": 240},
+				"nature": "Timid",
+				"moves": [["Roost"], ["Defog"], ["Flamethrower"], ["Substitute"]]
 			}]
 		},
 		"ninetalesalola": {
@@ -2698,6 +2694,44 @@
 				"moves": [["Swords Dance"], ["Return"], ["Earthquake", "Close Combat"], ["Quick Attack"]]
 			}]
 		},
+		"pyukumuku": {
+			"flags": {},
+			"sets": [{
+				"species": "Pyukumuku",
+				"item": ["Leftovers"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Bold",
+				"moves": [["Toxic"], ["Soak"], ["Recover"], ["Block"]]
+			}, {
+				"species": "Pyukumuku",
+				"item": ["Leftovers"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Bold",
+				"moves": [["Spite"], ["Rest", "Taunt"], ["Recover"], ["Block"]]
+			}, {
+				"species": "Pyukumuku",
+				"item": ["Aguav Berry"],
+				"ability": ["Innards Out"],
+				"level": 96,
+				"evs": {"hp": 252},
+				"ivs": {"atk": 0, "def": 0, "spd": 0},
+				"nature": "Hasty",
+				"moves": [["Toxic"], ["Soak"], ["Rest"], ["Block"]]
+			}]
+		},
+		"ribombee": {
+			"flags": {},
+			"sets": [{
+				"species": "Ribombee",
+				"item": ["Focus Sash"],
+				"ability": ["Shield Dust"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Sticky Web"], ["Moonblast"], ["Hidden Power Fire"], ["Stun Spore", "Quiver Dance"]]
+			}]
+		},
 		"sableye": {
 			"flags": {
 				"megaOnly": 1
@@ -2719,16 +2753,9 @@
 				"species": "Scizor",
 				"item": ["Scizorite"],
 				"ability": ["Light Metal"],
-				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"evs": {"hp": 248, "def": 244, "spd": 16},
 				"nature": "Impish",
-				"moves": [["Defog"], ["U-turn"], ["Bullet Punch"], ["Roost"]]
-			}, {
-				"species": "Scizor",
-				"item": ["Scizorite"],
-				"ability": ["Light Metal"],
-				"evs": {"hp": 248, "atk": 64, "def": 120, "spd": 16, "spe": 60},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Bullet Punch"], ["Knock Off", "U-turn"], ["Roost"]]
+				"moves": [["Curse", "Swords Dance"], ["Bullet Punch"], ["Knock Off", "U-turn"], ["Roost"]]
 			}]
 		},
 		"skarmory": {
@@ -2762,7 +2789,7 @@
 				"ability": ["Regenerator"],
 				"evs": {"hp": 252, "def": 28, "spd": 228},
 				"nature": "Sassy",
-				"moves": [["Giga Drain", "Leaf Storm"], ["Knock Off"], ["Hidden Power Ice", "Hidden Power Fire"], ["Earthquake"]]
+				"moves": [["Giga Drain", "Leaf Storm", "Grass Knot"], ["Knock Off"], ["Hidden Power Ice", "Hidden Power Fire"], ["Earthquake"]]
 			}, {
 				"species": "Tangrowth",
 				"item": ["Leftovers", "Rocky Helmet"],
@@ -2778,9 +2805,9 @@
 				"species": "Tapu Bulu",
 				"item": ["Assault Vest"],
 				"ability": ["Grassy Surge"],
-				"evs": {"hp": 248, "atk": 60, "spd": 56, "spe": 144},
-				"nature": "Adamant",
-				"moves": [["Horn Leech"], ["Wood Hammer"], ["Superpower"], ["Nature's Madness", "Stone Edge"]]
+				"evs": {"hp": 248, "atk": 28, "def": 36, "spd": 52, "spe": 144},
+				"nature": "Impish",
+				"moves": [["Horn Leech"], ["Wood Hammer"], ["Superpower"], ["Nature's Madness", "Megahorn", "Stone Edge"]]
 			}, {
 				"species": "Tapu Bulu",
 				"item": ["Rockium Z", "Fightinium Z"],
@@ -2792,9 +2819,16 @@
 				"species": "Tapu Bulu",
 				"item": ["Life Orb"],
 				"ability": ["Grassy Surge"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Substitute"], ["Horn Leech"], ["Superpower"]]
+				"evs": {"hp": 224, "spd": 216, "spe": 68},
+				"nature": "Careful",
+				"moves": [["Swords Dance"], ["Synthesis"], ["Horn Leech"], ["Superpower"]]
+			}, {
+				"species": "Tapu Bulu",
+				"item": ["Grassium Z"],
+				"ability": ["Grassy Surge"],
+				"evs": {"hp": 224, "spd": 216, "spe": 68},
+				"nature": "Careful",
+				"moves": [["Swords Dance"], ["Synthesis"], ["Horn Leech"], ["Superpower"]]
 			}, {
 				"species": "Tapu Bulu",
 				"item": ["Choice Band"],
@@ -2823,14 +2857,14 @@
 				"ability": ["Electric Surge"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Thunderbolt"], ["Dazzling Gleam"], ["Volt Switch"], ["Hidden Power Ice"]]
+				"moves": [["Thunderbolt"], ["Dazzling Gleam"], ["Volt Switch"], ["Hidden Power Ice", "Hidden Power Fire"]]
 			}, {
 				"species": "Tapu Koko",
-				"item": ["Choice Specs"],
+				"item": ["Light Clay"],
 				"ability": ["Electric Surge"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Thunderbolt"], ["Dazzling Gleam"], ["Volt Switch"], ["Hidden Power Fire"]]
+				"evs": {"hp": 248, "atk": 8, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Taunt"], ["Reflect"], ["Light Screen"], ["U-turn"]]
 			}, {
 				"species": "Tapu Koko",
 				"item": ["Electrium Z"],
@@ -2854,22 +2888,36 @@
 				"moves": [["Wild Charge"], ["Hidden Power Ice"], ["Taunt"], ["U-turn"]]
 			}, {
 				"species": "Tapu Koko",
-				"item": ["Zap Plate"],
+				"item": ["Electrium Z", "Leftovers"],
 				"ability": ["Electric Surge"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"evs": {"hp": 20, "spa": 252, "spd": 20, "spe": 216},
 				"nature": "Timid",
-				"moves": [["Thunderbolt"], ["U-turn"], ["Hidden Power Ice"], ["Taunt", "Volt Switch"]]
+				"moves": [["Thunderbolt"], ["Defog"], ["Roost"], ["U-turn", "Hidden Power Ice"]]
+			}, {
+				"species": "Tapu Koko",
+				"item": ["Shuca Berry"],
+				"ability": ["Electric Surge"],
+				"evs": {"hp": 104, "def": 12, "spa": 176, "spe": 216},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Defog", "Roost"], ["Volt Switch"], ["Hidden Power Ice"]]
 			}]
 		},
 		"tapulele": {
 			"flags": {},
 			"sets": [{
 				"species": "Tapu Lele",
+				"item": ["Psychium Z"],
+				"ability": ["Psychic Surge"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Psyshock"], ["Moonblast"], ["Calm Mind"], ["Hidden Power Fire", "Focus Blast"]]
+			}, {
+				"species": "Tapu Lele",
 				"item": ["Fightinium Z"],
 				"ability": ["Psychic Surge"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Psyshock"], ["Moonblast"], ["Hidden Power Fire"], ["Focus Blast"]]
+				"moves": [["Psychic", "Psyshock"], ["Moonblast"], ["Taunt"], ["Focus Blast"]]
 			}, {
 				"species": "Tapu Lele",
 				"item": ["Choice Specs"],
@@ -2894,19 +2942,19 @@
 				"ability": ["Regenerator"],
 				"evs": {"hp": 248, "def": 8, "spd": 252},
 				"nature": "Calm",
-				"moves": [["Scald"], ["Haze", "Toxic"], ["Recover"], ["Knock Off", "Baneful Bunker"]]
-			}, {
-				"species": "Toxapex",
-				"item": ["Black Sludge"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 248, "def": 8, "spd": 252},
-				"nature": "Calm",
-				"moves": [["Scald"], ["Haze", "Toxic"], ["Recover"], ["Toxic Spikes"]]
+				"moves": [["Scald"], ["Haze"], ["Recover"], ["Toxic", "Toxic Spikes"]]
 			}]
 		},
 		"tyranitar": {
 			"flags": {},
 			"sets": [{
+				"species": "Tyranitar",
+				"item": ["Choice Scarf"],
+				"ability": ["Sand Stream"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Crunch"], ["Pursuit"], ["Earthquake", "Superpower"]]
+			}, {
 				"species": "Tyranitar",
 				"item": ["Choice Band"],
 				"ability": ["Sand Stream"],
@@ -2944,21 +2992,28 @@
 				"species": "Venusaur",
 				"item": ["Venusaurite"],
 				"ability": ["Chlorophyll"],
-				"evs": {"hp": 248, "def": 88, "spd": 156, "spe": 16},
+				"evs": {"hp": 248, "def": 104, "spd": 156},
 				"nature": "Sassy",
 				"moves": [["Giga Drain", "Leech Seed"], ["Sludge Bomb"], ["Synthesis"], ["Earthquake"]]
-			}, {
-				"species": "Venusaur",
-				"item": ["Venusaurite"],
-				"ability": ["Chlorophyll"],
-				"evs": {"hp": 248, "def": 88, "spd": 156, "spe": 16},
-				"nature": "Sassy",
-				"moves": [["Giga Drain", "Leech Seed"], ["Sludge Bomb"], ["Synthesis"], ["Hidden Power Fire"]]
 			}]
 		},
 		"victini": {
 			"flags": {},
 			"sets": [{
+				"species": "Victini",
+				"item": ["Choice Scarf"],
+				"ability": ["Victory Star"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["V-create"], ["Bolt Strike"], ["U-turn"], ["Trick", "Final Gambit"]]
+			}, {
+				"species": "Victini",
+				"item": ["Choice Band"],
+				"ability": ["Victory Star"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["V-create"], ["Bolt Strike"], ["U-turn"], ["Zen Headbutt", "Brick Break"]]
+			}, {
 				"species": "Victini",
 				"item": ["Normalium Z"],
 				"ability": ["Victory Star"],
@@ -3010,53 +3065,84 @@
 				"moves": [["Discharge"], ["Roost"], ["Heat Wave"], ["Defog"]]
 			}]
 		},
+		"zeraora": {
+			"flags": {},
+			"sets": [{
+				"species": "Zeraora",
+				"item": ["Choice Band"],
+				"ability": ["Volt Absorb"],
+				"evs": {"atk": 252, "spa": 64, "spe": 192},
+				"nature": "Hasty",
+				"moves": [["Plasma Fists"], ["Knock Off"], ["Fire Punch", "Close Combat"], ["Hidden Power Ice"]]
+			}, {
+				"species": "Zeraora",
+				"item": ["Zap Plate"],
+				"ability": ["Volt Absorb"],
+				"evs": {"atk": 252, "spa": 64, "spe": 192},
+				"nature": "Hasty",
+				"moves": [["Plasma Fists"], ["Knock Off"], ["Volt Switch"], ["Hidden Power Ice"]]
+			}]
+		},
 		"zygarde": {
 			"flags": {},
 			"sets": [{
 				"species": "Zygarde",
-				"item": ["Dragonium Z"],
+				"item": ["Groundium Z"],
 				"ability": ["Aura Break"],
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
 				"nature": "Adamant",
-				"moves": [["Thousand Arrows"], ["Outrage"], ["Extreme Speed"], ["Dragon Dance"]]
+				"moves": [["Thousand Arrows"], ["Substitute", "Iron Tail"], ["Extreme Speed"], ["Dragon Dance"]]
+			}, {
+				"species": "Zygarde",
+				"item": ["Weakness Policy"],
+				"ability": ["Aura Break"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Thousand Arrows"], ["Substitute", "Iron Tail"], ["Extreme Speed"], ["Dragon Dance"]]
 			}, {
 				"species": "Zygarde",
 				"item": ["Leftovers"],
 				"ability": ["Aura Break"],
-				"evs": {"hp": 188, "atk": 140, "spe": 180},
-				"nature": "Adamant",
-				"moves": [["Substitute"], ["Dragon Dance"], ["Thousand Arrows"], ["Protect", "Extreme Speed"]]
+				"evs": {"hp": 236, "spd": 160, "spe": 112},
+				"nature": "Jolly",
+				"moves": [["Thousand Arrows"], ["Substitute"], ["Dragon Dance"], ["Protect"]]
+			}, {
+				"species": "Zygarde",
+				"item": ["Leftovers"],
+				"ability": ["Aura Break"],
+				"evs": {"hp": 236, "spd": 160, "spe": 112},
+				"nature": "Jolly",
+				"moves": [["Thousand Arrows"], ["Substitute"], ["Coil"], ["Glare"]]
+			}, {
+				"species": "Zygarde",
+				"item": ["Leftovers"],
+				"ability": ["Aura Break"],
+				"evs": {"hp": 236, "atk": 68, "def": 4, "spd": 168, "spe": 32},
+				"nature": "Careful",
+				"moves": [["Thousand Arrows"], ["Rest"], ["Sleep Talk"], ["Dragon Dance"]]
 			}, {
 				"species": "Zygarde",
 				"item": ["Choice Band"],
 				"ability": ["Aura Break"],
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
 				"nature": "Adamant",
-				"moves": [["Thousand Arrows"], ["Extreme Speed"], ["Outrage"], ["Toxic", "Iron Tail"]]
+				"moves": [["Thousand Arrows"], ["Extreme Speed"], ["Iron Tail", "Earthquake"], ["Outrage", "Superpower"]]
 			}, {
 				"species": "Zygarde",
-				"item": ["Iapapa Berry", "Sitrus Berry"],
+				"item": ["Iapapa Berry"],
 				"ability": ["Aura Break"],
-				"evs": {"hp": 160, "atk": 216, "spd": 28, "spe": 104},
+				"evs": {"atk": 228, "spd": 68, "spe": 212},
 				"nature": "Adamant",
-				"moves": [["Thousand Arrows"], ["Extreme Speed"], ["Dragon Dance"], ["Coil"]]
+				"moves": [["Thousand Arrows"], ["Substitute", "Extreme Speed"], ["Dragon Dance"], ["Coil"]]
 			}]
 		},
 		"rotomwash": {
 			"flags": {},
 			"sets": [{
 				"species": "Rotom-Wash",
-				"item": ["Waterium Z"],
+				"item": ["Iapapa Berry", "Leftovers"],
 				"ability": ["Levitate"],
-				"evs": {"hp": 196, "spa": 252, "spe": 60},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Defog"], ["Hydro Pump"], ["Volt Switch"], ["Hidden Power Fire"]]
-			}, {
-				"species": "Rotom-Wash",
-				"item": ["Iapapa Berry"],
-				"ability": ["Levitate"],
-				"evs": {"hp": 248, "def": 200, "spe": 60},
+				"evs": {"hp": 248, "def": 204, "spe": 56},
 				"ivs": {"atk": 0},
 				"nature": "Bold",
 				"moves": [["Hydro Pump"], ["Volt Switch"], ["Will-O-Wisp", "Pain Split"], ["Defog"]]
@@ -3071,6 +3157,27 @@
 				"evs": {"hp": 244, "spd": 152, "spe": 112},
 				"nature": "Jolly",
 				"moves": [["Defog"], ["Earthquake"], ["Roost"], ["Knock Off", "Taunt"]]
+			}, {
+				"species": "Gliscor",
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 44, "spd": 68, "spe": 152},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Earthquake"], ["Roost"], ["Facade", "Ice Fang"]]
+			}, {
+				"species": "Gliscor",
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 44, "spd": 108, "spe": 112},
+				"nature": "Jolly",
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Roost"], ["U-turn"]]
+			}, {
+				"species": "Gliscor",
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 44, "spd": 68, "spe": 152},
+				"nature": "Jolly",
+				"moves": [["Taunt"], ["Earthquake"], ["Roost"], ["Knock Off"]]
 			}]
 		},
 		"azumarill": {
@@ -3081,7 +3188,14 @@
 				"ability": ["Huge Power"],
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
 				"nature": "Adamant",
-				"moves": [["Belly Drum"], ["Aqua Jet"], ["Play Rough", "Waterfall"], ["Knock Off"]]
+				"moves": [["Belly Drum"], ["Aqua Jet"], ["Play Rough", "Waterfall", "Liquidation"], ["Knock Off"]]
+			}, {
+				"species": "Azumarill",
+				"item": ["Leftovers", "Iapapa Berry"],
+				"ability": ["Sap Sipper"],
+				"evs": {"hp": 252, "spd": 228, "spe": 28},
+				"nature": "Calm",
+				"moves": [["Perish Song"], ["Whirlpool"], ["Protect"], ["Toxic", "Hidden Power Fire"]]
 			}]
 		},
 		"camerupt": {
@@ -3115,7 +3229,7 @@
 				"species": "Hippowdon",
 				"item": ["Leftovers"],
 				"ability": ["Sand Stream"],
-				"evs": {"hp": 252, "def": 144, "spd": 112},
+				"evs": {"hp": 252, "def": 112, "spd": 144},
 				"nature": "Impish",
 				"moves": [["Stealth Rock"], ["Earthquake"], ["Slack Off"], ["Whirlwind"]]
 			}]
@@ -3142,17 +3256,6 @@
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
 				"moves": [["Volt Switch"], ["Thunderbolt"], ["Overheat", "Flamethrower"], ["Hidden Power Ice"]]
-			}]
-		},
-		"nihilego": {
-			"flags": {},
-			"sets": [{
-				"species": "Nihilego",
-				"item": ["Choice Scarf"],
-				"ability": ["Beast Boost"],
-				"evs": {"spa": 180, "spd": 80, "spe": 248},
-				"nature": "Timid",
-				"moves": [["Power Gem"], ["Sludge Wave"], ["Hidden Power Ice", "Hidden Power Fire"], ["Toxic Spikes"]]
 			}]
 		},
 		"shuckle": {
@@ -3204,9 +3307,9 @@
 				"species": "Altaria",
 				"item": ["Altarianite"],
 				"ability": ["Natural Cure"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Dragon Dance"], ["Return"], ["Earthquake"], ["Roost"]]
+				"evs": {"hp": 248, "def": 176, "spd":68, "spe": 16},
+				"nature": "Impish",
+				"moves": [["Body Slam"], ["Defog"], ["Earthquake"], ["Roost"]]
 			}]
 		},
 		"crawdaunt": {
@@ -3262,30 +3365,6 @@
 				"moves": [["Earth Power"], ["Sludge Wave"], ["Ice Beam"], ["Substitute", "Flamethrower"]]
 			}]
 		},
-		"salamence": {
-			"flags": {},
-			"sets": [{
-				"species": "Salamence",
-				"item": ["Flyinium Z"],
-				"ability": ["Moxie"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Dragon Dance"], ["Fly"], ["Dragon Claw", "Substitute"], ["Earthquake"]]
-			}]
-		},
-		"sharpedo": {
-			"flags": {
-				"megaOnly": 1
-			},
-			"sets": [{
-				"species": "Sharpedo",
-				"item": ["Sharpedonite"],
-				"ability": ["Speed Boost"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Protect"], ["Crunch"], ["Psychic Fangs"], ["Ice Fang", "Earthquake"]]
-			}]
-		},
 		"slowbro": {
 			"flags": {
 				"megaOnly": 1
@@ -3294,16 +3373,9 @@
 				"species": "Slowbro",
 				"item": ["Slowbronite"],
 				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "def": 216, "spd": 40},
+				"evs": {"hp": 252, "def": 212, "spe": 44},
 				"nature": "Bold",
-				"moves": [["Scald"], ["Ice Beam"], ["Psychic", "Fire Blast"], ["Slack Off"]]
-			}, {
-				"species": "Slowbro",
-				"item": ["Slowbronite"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "def": 216, "spd": 40},
-				"nature": "Bold",
-				"moves": [["Scald"], ["Calm Mind"], ["Slack Off"], ["Psyshock", "Ice Beam"]]
+				"moves": [["Scald"], ["Ice Beam"], ["Psyshock"], ["Slack Off"]]
 			}]
 		},
 		"thundurustherian": {
@@ -3348,17 +3420,6 @@
 				"moves": [["Stealth Rock"], ["Taunt"], ["Fire Blast"], ["Explosion"]]
 			}]
 		},
-		"porygonz": {
-			"flags": {},
-			"sets": [{
-				"species": "Porygon-Z",
-				"item": ["Normalium Z"],
-				"ability": ["Adaptability"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Modest",
-				"moves": [["Thunderbolt"], ["Ice Beam"], ["Conversion"], ["Nasty Plot"]]
-			}]
-		},
 		"scolipede": {
 			"flags": {},
 			"sets": [{
@@ -3368,17 +3429,6 @@
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["Swords Dance"], ["Megahorn"], ["Aqua Tail"], ["Earthquake"]]
-			}]
-		},
-		"talonflame": {
-			"flags": {},
-			"sets": [{
-				"species": "Talonflame",
-				"item": ["Flyinium Z"],
-				"ability": ["Gale Wings"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Brave Bird"], ["Flare Blitz"], ["Swords Dance"], ["Steel Wing", "Flame Charge"]]
 			}]
 		},
 		"hoopaunbound": {
@@ -3475,22 +3525,25 @@
 				"item": ["Latiasite"],
 				"ability": ["Levitate"],
 				"evs": {"hp": 252, "def": 4, "spe": 252},
+				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Calm Mind"], ["Recover"], ["Stored Power"], ["Thunderbolt", "Surf"]]
+				"moves": [["Calm Mind"], ["Recover"], ["Stored Power"], ["Substitute", "Reflect Type", "Thunderbolt", "Psyshock"]]
+			}, {
+				"species": "Latias",
+				"item": ["Latiasite"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Ice Beam"], ["Surf"], ["Hidden Power Fire"], ["Roost"]]
 			}, {
 				"species": "Latias",
 				"item": ["Choice Scarf"],
 				"ability": ["Levitate"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Draco Meteor"], ["Psyshock"], ["Healing Wish"], ["Trick"]]
-			}, {
-				"species": "Latias",
-				"item": ["Choice Scarf"],
-				"ability": ["Levitate"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Draco Meteor"], ["Psyshock"], ["Healing Wish"], ["Defog"]]
+				"moves": [["Draco Meteor"], ["Psyshock"], ["Healing Wish"], ["Trick", "Defog"]]
 			}]
 		},
 		"reuniclus": {
@@ -3502,6 +3555,13 @@
 				"evs": {"hp": 252, "def": 212, "spe": 44},
 				"nature": "Bold",
 				"moves": [["Calm Mind"], ["Psyshock"], ["Shadow Ball", "Focus Blast"], ["Recover"]]
+			}, {
+				"species": "Reuniclus",
+				"item": ["Leftovers"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 212, "spe": 44},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Psychic", "Psyshock"], ["Acid Armor"], ["Recover"]]
 			}]
 		},
 		"suicune": {
@@ -3523,9 +3583,16 @@
 				"species": "Heracross",
 				"item": ["Heracronite"],
 				"ability": ["Moxie"],
-				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Adamant",
-				"moves": [["Close Combat"], ["Pin Missile"], ["Rock Blast"], ["Swords Dance", "Earthquake"]]
+				"moves": [["Close Combat"], ["Pin Missile", "Substitute", "Bullet Seed"], ["Rock Blast"], ["Swords Dance"]]
+			}, {
+				"species": "Heracross",
+				"item": ["Heracronite"],
+				"ability": ["Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Close Combat"], ["Pin Missile", "Substitute", "Bullet Seed"], ["Rock Blast"], ["Swords Dance"]]
 			}]
 		},
 		"mamoswine": {
@@ -3553,6 +3620,13 @@
 		"jirachi": {
 			"flags": {},
 			"sets": [{
+				"species": "Jirachi",
+				"item": ["Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 248, "spd": 196, "spe": 64},
+				"nature": "Careful",
+				"moves": [["Wish"], ["Iron Head"], ["U-turn", "Body Slam"], ["Protect"]]
+			}, {
 				"species": "Jirachi",
 				"item": ["Leftovers"],
 				"ability": ["Serene Grace"],
@@ -3601,18 +3675,18 @@
 			"flags": {},
 			"sets": [{
 				"species": "Tornadus-Therian",
-				"item": ["Life Orb"],
+				"item": ["Flyinium Z"],
 				"ability": ["Regenerator"],
-				"evs": {"atk": 4, "spa": 252, "spe": 252},
-				"nature": "Naive",
-				"moves": [["Hurricane"], ["Heat Wave"], ["Taunt", "U-turn"], ["Superpower", "Knock Off"]]
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Defog"], ["Superpower", "U-turn"], ["Knock Off"]]
 			}, {
 				"species": "Tornadus-Therian",
-				"item": ["Assault Vest"],
+				"item": ["Rocky Helmet"],
 				"ability": ["Regenerator"],
-				"evs": {"hp": 248, "spd": 8, "spe": 252},
+				"evs": {"hp": 252, "def": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Hurricane"], ["Heat Wave"], ["Knock Off"], ["U-turn"]]
+				"moves": [["Hurricane"], ["Defog"], ["Knock Off"], ["U-turn"]]
 			}]
 		},
 		"araquanid": {
@@ -7078,1515 +7152,1459 @@
 	},
 	"NU": {
 		"accelgor": {
+            "flags": {},
+            "sets": [{
+                "species": "Accelgor",
+                "item": ["Choice Specs"],
+                "ability": ["Sticky Hold"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Bug Buzz"], ["Focus Blast"], ["Sludge Bomb"], ["U-turn"]]
+            }, {
+                "species": "Accelgor",
+                "item": ["Focus Sash"],
+                "ability": ["Sticky Hold"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Bug Buzz"], ["Spikes"], ["Final Gambit"], ["Encore"]]
+            }]
+        },
+		"aerodactyl": {
 			"flags": {},
 			"sets": [{
-				"species": "Accelgor",
-				"item": ["Choice Specs"],
-				"ability": ["Sticky Hold"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Bug Buzz"], ["Focus Blast"], ["Sludge Bomb"], ["U-turn"]]
-			}, {
-				"species": "Accelgor",
-				"item": ["Focus Sash"],
-				"ability": ["Sticky Hold"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Bug Buzz"], ["Spikes"], ["Final Gambit"], ["Encore"]]
+				"species": "Aerodactyl",
+				"item": ["Life Orb"],
+				"ability": ["Unnerve"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Earthquake"], ["Pursuit"], ["Wing Attack"]]
 			}]
 		},
 		"ambipom": {
+            "flags": {},
+            "sets": [{
+                "species": "Ambipom",
+                "item": ["Life Orb"],
+                "ability": ["Technician"],
+                "happiness": 0,
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Fake Out"], ["Frustration"], ["Low Kick"], ["U-turn"]]
+            }]
+        },
+        "aromatisse": {
+            "flags": {},
+            "sets": [{
+                "species": "Aromatisse",
+                "item": ["Leftovers"],
+                "ability": ["Aroma Veil"],
+                "evs": {"hp": 252, "def": 252, "spd": 4},
+                "nature": "Bold",
+                "moves": [["Moonblast"], ["Wish"], ["Protect"], ["Heal Bell"]]
+            }, {
+                "species": "Aromatisse",
+                "item": ["Leftovers"],
+                "ability": ["Aroma Veil"],
+                "evs": {"hp": 252, "def": 252, "spd": 4},
+                "nature": "Bold",
+                "moves": [["Moonblast"], ["Calm Mind"], ["Rest"], ["Sleep Talk"]]
+            }, {
+                "species": "Aromatisse",
+                "item": ["Fairium Z"],
+                "ability": ["Aroma Veil"],
+                "evs": {"hp": 252, "def": 4, "spa": 252},
+                "ivs": {"atk": 0},
+                "nature": "Quiet",
+                "moves": [["Nasty Plot"], ["Moonblast"], ["Psychic"], ["Trick Room"]]
+            }]
+        },
+        "audino": {
+            "flags": {
+                "megaOnly": 1
+            },
+            "sets": [{
+                "species": "Audino",
+                "item": ["Audinite"],
+                "ability": ["Regenerator"],
+                "evs": {"hp": 252, "def": 208, "spa": 48},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Calm Mind"], ["Dazzling Gleam"], ["Rest"], ["Sleep Talk"]]
+            }, {
+                "species": "Audino",
+                "item": ["Audinite"],
+                "ability": ["Regenerator"],
+                "evs": {"hp": 252, "spa": 48, "spd": 208},
+                "nature": "Calm",
+                "moves": [["Wish"], ["Protect"], ["Dazzling Gleam"], ["Knock Off"]]
+            }, {
+                "species": "Audino",
+                "item": ["Audinite"],
+                "ability": ["Regenerator"],
+                "evs": {"hp": 172, "spa": 252, "spe": 84},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Calm Mind"], ["Dazzling Gleam"], ["Fire Blast"], ["Surf"]]
+            }]
+        },
+        "blastoise": {
+            "flags": {},
+            "sets": [{
+                "species": "Blastoise",
+                "item": ["Leftovers"],
+                "ability": ["Torrent"],
+                "evs": {"hp": 252, "def": 252, "spd": 4},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Scald"], ["Rapid Spin"], ["Refresh"], ["Toxic"]]
+            }]
+        },
+        "braviary": {
+            "flags": {},
+            "sets": [{
+                "species": "Braviary",
+                "item": ["Choice Scarf"],
+                "ability": ["Defiant"],
+                "happiness": 0,
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Brave Bird"], ["U-turn"], ["Superpower"], ["Frustration"]]
+            }, {
+                "species": "Braviary",
+                "item": ["Leftovers"],
+                "ability": ["Defiant"],
+                "evs": {"hp": 248, "spd": 168, "spe": 92},
+                "nature": "Careful",
+                "moves": [["Substitute"], ["Bulk Up"], ["Brave Bird"], ["Roost"]]
+            }, {
+                "species": "Braviary",
+                "item": ["Sharp Beak"],
+                "ability": ["Defiant"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Superpower"], ["Bulk Up"], ["Brave Bird"], ["Roost"]]
+            }]
+        },
+        "cinccino": {
+            "flags": {},
+            "sets": [{
+                "species": "Cinccino",
+                "item": ["Choice Band"],
+                "ability": ["Skill Link"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Tail Slap"], ["Bullet Seed"], ["Knock Off"], ["U-turn"]]
+            }]
+        },
+        "clawitzer": {
+            "flags": {},
+            "sets": [{
+                "species": "Clawitzer",
+                "item": ["Choice Specs"],
+                "ability": ["Mega Launcher"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Modest",
+                "moves": [["Scald"], ["Dark Pulse"], ["Ice Beam"], ["U-turn"]]
+            }]
+        },
+        "comfey": {
+            "flags": {},
+            "sets": [{
+                "species": "Comfey",
+                "item": ["Pixie Plate"],
+                "ability": ["Triage"],
+                "evs": {"hp": 252, "def": 160, "spe": 96},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Calm Mind"], ["Draining Kiss"], ["Taunt"], ["Synthesis"]]
+            }]
+        },
+        "cryogonal": {
+            "flags": {},
+            "sets": [{
+                "species": "Cryogonal",
+                "item": ["Never-Melt Ice"],
+                "ability": ["Levitate"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Freeze-Dry"], ["Knock Off"], ["Rapid Spin"], ["Recover"]]
+            }, {
+                "species": "Cryogonal",
+                "item": ["Leftovers"],
+                "ability": ["Levitate"],
+                "evs": {"hp": 204, "spd": 148, "spe": 156},
+                "ivs": {"atk": 0},
+                "nature": "Calm",
+                "moves": [["Freeze-Dry"], ["Rapid Spin"], ["Toxic"], ["Recover"]]
+            }]
+        },
+		"decidueye": {
 			"flags": {},
 			"sets": [{
-				"species": "Ambipom",
-				"item": ["Life Orb"],
-				"ability": ["Technician"],
-				"happiness": 0,
+				"species": "Decidueye",
+				"item": ["Decidium Z"],
+				"ability": ["Overgrow"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Fake Out"], ["Frustration"], ["Low Kick"], ["Pursuit"]]
-			}]
-		},
-		"aromatisse": {
-			"flags": {},
-			"sets": [{
-				"species": "Aromatisse",
+				"moves": [["Swords Dance"], ["Spirit Shackle"], ["Leaf Blade"], ["Shadow Sneak"]]
+			}, {
+				"species": "Decidueye",
 				"item": ["Leftovers"],
-				"ability": ["Aroma Veil"],
+				"ability": ["Overgrow"],
 				"evs": {"hp": 252, "def": 252, "spd": 4},
 				"nature": "Bold",
-				"moves": [["Moonblast"], ["Wish"], ["Protect"], ["Heal Bell"]]
+				"moves": [["Giga Drain"], ["U-turn"], ["Roost"], ["Defog"]]
 			}, {
-				"species": "Aromatisse",
-				"item": ["Leftovers"],
-				"ability": ["Aroma Veil"],
-				"evs": {"hp": 252, "def": 252, "spd": 4},
-				"nature": "Bold",
-				"moves": [["Moonblast"], ["Calm Mind"], ["Rest"], ["Sleep Talk"]]
-			}, {
-				"species": "Aromatisse",
-				"item": ["Fairium Z"],
-				"ability": ["Aroma Veil"],
-				"evs": {"hp": 252, "def": 4, "spa": 252},
-				"ivs": {"atk": 0},
-				"nature": "Quiet",
-				"moves": [["Nasty Plot"], ["Moonblast"], ["Psychic"], ["Trick Room"]]
-			}]
-		},
-		"audino": {
-			"flags": {
-				"megaOnly": 1
-			},
-			"sets": [{
-				"species": "Audino",
-				"item": ["Audinite"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "def": 208, "spa": 48},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Calm Mind"], ["Dazzling Gleam"], ["Rest"], ["Sleep Talk"]]
-			}, {
-				"species": "Audino",
-				"item": ["Audinite"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "spa": 48, "spd": 208},
-				"nature": "Calm",
-				"moves": [["Wish"], ["Protect"], ["Dazzling Gleam"], ["Knock Off"]]
-			}, {
-				"species": "Audino",
-				"item": ["Audinite"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 172, "spa": 252, "spe": 84},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Calm Mind"], ["Dazzling Gleam"], ["Fire Blast"], ["Surf"]]
-			}]
-		},
-		"blastoise": {
-			"flags": {},
-			"sets": [{
-				"species": "Blastoise",
-				"item": ["Leftovers"],
-				"ability": ["Torrent"],
-				"evs": {"hp": 252, "def": 252, "spd": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Scald"], ["Rapid Spin"], ["Refresh"], ["Toxic"]]
-			}]
-		},
-		"braviary": {
-			"flags": {},
-			"sets": [{
-				"species": "Braviary",
+				"species": "Decidueye",
 				"item": ["Choice Scarf"],
-				"ability": ["Defiant"],
-				"happiness": 0,
+				"ability": ["Overgrow"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Brave Bird"], ["U-turn"], ["Superpower"], ["Frustration"]]
-			}, {
-				"species": "Braviary",
-				"item": ["Leftovers"],
-				"ability": ["Defiant"],
-				"evs": {"hp": 248, "spd": 168, "spe": 92},
-				"nature": "Careful",
-				"moves": [["Substitute"], ["Bulk Up"], ["Brave Bird"], ["Roost"]]
-			}, {
-				"species": "Braviary",
-				"item": ["Sharp Beak"],
-				"ability": ["Defiant"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Superpower"], ["Bulk Up"], ["Brave Bird"], ["Roost"]]
-			}]
-		},
-		"cinccino": {
-			"flags": {},
-			"sets": [{
-				"species": "Cinccino",
-				"item": ["Choice Band"],
-				"ability": ["Skill Link"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Tail Slap"], ["Bullet Seed"], ["Knock Off"], ["U-turn"]]
-			}]
-		},
-		"clawitzer": {
-			"flags": {},
-			"sets": [{
-				"species": "Clawitzer",
-				"item": ["Choice Specs"],
-				"ability": ["Mega Launcher"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Modest",
-				"moves": [["Scald"], ["Dark Pulse"], ["Ice Beam"], ["U-turn"]]
-			}]
-		},
-		"comfey": {
-			"flags": {},
-			"sets": [{
-				"species": "Comfey",
-				"item": ["Pixie Plate"],
-				"ability": ["Triage"],
-				"evs": {"hp": 252, "def": 160, "spe": 96},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Calm Mind"], ["Draining Kiss"], ["Taunt"], ["Synthesis"]]
-			}]
-		},
-		"cryogonal": {
-			"flags": {},
-			"sets": [{
-				"species": "Cryogonal",
-				"item": ["Never-Melt Ice"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Freeze-Dry"], ["Ice Beam"], ["Rapid Spin"], ["Recover"]]
-			}, {
-				"species": "Cryogonal",
-				"item": ["Leftovers"],
-				"ability": ["Levitate"],
-				"evs": {"hp": 204, "spd": 148, "spe": 156},
-				"ivs": {"atk": 0},
-				"nature": "Calm",
-				"moves": [["Recover"], ["Rapid Spin"], ["Freeze-Dry"], ["Toxic"]]
+				"moves": [["Spirit Shackle"], ["Leaf Blade"], ["Brave Bird"], ["U-turn"]]
 			}]
 		},
 		"delphox": {
+            "flags": {},
+            "sets": [{
+                "species": "Delphox",
+                "item": ["Choice Scarf"],
+                "ability": ["Blaze"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Fire Blast"], ["Psychic"], ["Grass Knot"], ["Trick"]]
+            }, {
+                "species": "Delphox",
+                "item": ["Firium Z"],
+                "ability": ["Blaze"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Fire Blast"], ["Psychic"], ["Grass Knot"], ["Calm Mind"]]
+            }, {
+                "species": "Delphox",
+                "item": ["Leftovers"],
+                "ability": ["Blaze"],
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Wish"], ["Protect"], ["Toxic"], ["Flamethrower"]]
+            }]
+        },
+		"dhelmise": {
 			"flags": {},
 			"sets": [{
-				"species": "Delphox",
-				"item": ["Choice Scarf"],
-				"ability": ["Blaze"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Fire Blast"], ["Psychic"], ["Grass Knot"], ["Trick"]]
+				"species": "Dhelmise",
+				"item": ["Choice Band"],
+				"ability": ["Steelworker"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Power Whip"], ["Anchor Shot"], ["Knock Off"], ["Earthquake"]]
 			}, {
-				"species": "Delphox",
-				"item": ["Firium Z"],
-				"ability": ["Blaze"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Fire Blast"], ["Psychic"], ["Grass Knot"], ["Calm Mind"]]
+				"species": "Dhelmise",
+				"item": ["Meadow Plate"],
+				"ability": ["Steelworker"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Power Whip"], ["Knock Off"], ["Rapid Spin"], ["Synthesis"]]
 			}, {
-				"species": "Delphox",
-				"item": ["Leftovers"],
-				"ability": ["Blaze"],
-        "evs": {"hp": 248, "spd": 108, "spe": 152},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Wish"], ["Protect"], ["Toxic"], ["Flamethrower"]]
+				"species": "Dhelmise",
+				"item": ["Grassium Z"],
+				"ability": ["Steelworker"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Power Whip"], ["Knock Off"], ["Rapid Spin"], ["Synthesis"]]
 			}]
 		},
 		"diancie": {
+            "flags": {},
+            "sets": [{
+                "species": "Diancie",
+                "item": ["Leftovers"],
+                "ability": ["Clear Body"],
+                "evs": {"hp": 252, "def": 132, "spd": 124},
+                "nature": "Sassy",
+                "moves": [["Stealth Rock"], ["Moonblast"], ["Diamond Storm"], ["Heal Bell"]]
+            }, {
+                "species": "Diancie",
+                "item": ["Leftovers"],
+                "ability": ["Clear Body"],
+                "evs": {"hp": 252, "def": 120, "spd": 136},
+                "nature": "Bold",
+                "moves": [["Calm Mind"], ["Moonblast"], ["Earth Power"], ["Substitute"]]
+            }, {
+                "species": "Diancie",
+                "item": ["Choice Specs"],
+                "ability": ["Clear Body"],
+                "evs": {"hp":0, "spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Moonblast"], ["Power Gem"], ["Earth Power"], ["Psychic"]]
+            }, {
+                "species": "Diancie",
+                "item": ["Life Orb"],
+                "ability": ["Clear Body"],
+                "evs": {"hp":0, "spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Quiet",
+                "moves": [["Trick Room"], ["Moonblast"], ["Earth Power"], ["Psychic"]]
+            }]
+        },
+        "dodrio": {
+            "flags": {},
+            "sets": [{
+                "species": "Dodrio",
+                "item": ["Fightinium Z"],
+                "ability": ["Early Bird"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Swords Dance"], ["Knock Off"], ["Brave Bird"], ["Jump Kick"]]
+            }, {
+                "species": "Dodrio",
+                "item": ["Choice Band"],
+                "ability": ["Early Bird"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Quick Attack"], ["Knock Off"], ["Brave Bird"], ["Jump Kick"]]
+            }, {
+                "species": "Dodrio",
+                "item": ["Choice Scarf"],
+                "ability": ["Early Bird"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Return"], ["Knock Off"], ["Brave Bird"], ["Jump Kick"]]
+            }]
+        },
+        "druddigon": {
+            "flags": {},
+            "sets": [{
+                "species": "Druddigon",
+                "item": ["Rocky Helmet"],
+                "ability": ["Mold Breaker"],
+                "evs": {"hp": 252, "def": 216, "spd": 12, "spe": 28},
+                "nature": "Impish",
+                "moves": [["Stealth Rock"], ["Dragon Tail"], ["Earthquake"], ["Glare"]]
+ 
+            }, {
+                "species": "Druddigon",
+                "item": ["Rocky Helmet"],
+                "ability": ["Rough Skin"],
+                "evs": {"hp": 252, "def": 216, "spd": 12, "spe": 28},
+                "nature": "Impish",
+                "moves": [["Stealth Rock"], ["Dragon Tail"], ["Earthquake"], ["Glare"]]
+            }]
+        },
+        "froslass": {
+            "flags": {},
+            "sets": [{
+                "species": "Froslass",
+                "item": ["Focus Sash"],
+                "ability": ["Cursed Body"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Spikes"], ["Taunt"], ["Ice Beam"], ["Destiny Bond"]]
+            }, {
+                "species": "Froslass",
+                "item": ["Life Orb"],
+                "ability": ["Cursed Body"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Shadow Ball"], ["Ice Beam"], ["Spikes"], ["Destiny Bond"]]
+            }]
+        },
+        "garbodor": {
+            "flags": {},
+            "sets": [{
+                "species": "Garbodor",
+                "item": ["Rocky Helmet"],
+                "ability": ["Aftermath"],
+                "evs": {"hp": 252, "def": 160, "spe": 96},
+                "nature": "Impish",
+                "moves": [["Spikes"], ["Drain Punch"], ["Gunk Shot"], ["Toxic Spikes"]]
+            }, {
+                "species": "Garbodor",
+                "item": ["Toxic Plate"],
+                "ability": ["Aftermath"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Spikes"], ["Gunk Shot"], ["Drain Punch"], ["Explosion"]]
+            }]
+        },
+        "golbat": {
+            "flags": {},
+            "sets": [{
+                "species": "Golbat",
+                "item": ["Eviolite"],
+                "ability": ["Infiltrator"],
+                "evs": {"hp": 248, "def": 84, "spe": 176},
+                "nature": "Jolly",
+                "moves": [["Brave Bird"], ["Toxic"], ["Defog"], ["Roost"]]
+            }, {
+                "species": "Golbat",
+                "item": ["Eviolite"],
+                "ability": ["Infiltrator"],
+                "evs": {"hp": 248, "def": 84, "spe": 176},
+                "nature": "Jolly",
+                "moves": [["Brave Bird"], ["Taunt"], ["Toxic"], ["Roost"]]
+            }]
+        },
+        "guzzlord": {
+            "flags": {},
+            "sets": [{
+                "species": "Guzzlord",
+                "item": ["Choice Specs"],
+                "ability": ["Beast Boost"],
+                "evs": {"spa": 252, "spd": 196, "spe": 60},
+                "nature": "Modest",
+                "moves": [["Draco Meteor"], ["Dark Pulse"], ["Fire Blast"], ["Hidden Power Steel"]]
+            }, {
+                "species": "Guzzlord",
+                "item": ["Dragonium Z"],
+                "ability": ["Beast Boost"],
+                "evs": {"spa": 252, "spd": 76, "spe": 180},
+                "nature": "Modest",
+                "moves": [["Draco Meteor"], ["Dark Pulse"], ["Fire Blast"], ["Heavy Slam"]]
+            }]
+        },
+        "hariyama": {
+            "flags": {},
+            "sets": [{
+                "species": "Hariyama",
+                "item": ["Assault Vest"],
+                "ability": ["Thick Fat"],
+                "evs": {"atk": 252, "def": 4, "spd": 252},
+                "nature": "Adamant",
+                "moves": [["Close Combat"], ["Fake Out"], ["Knock Off"], ["Bullet Punch"]]
+            }, {
+                "species": "Hariyama",
+                "item": ["Flame Orb"],
+                "ability": ["Guts"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Adamant",
+                "moves": [["Close Combat"], ["Knock Off"], ["Facade"], ["Bullet Punch"]]
+            }]
+        },
+        "heliolisk": {
+            "flags": {},
+            "sets": [{
+                "species": "Heliolisk",
+                "item": ["Life Orb"],
+                "ability": ["Dry Skin"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Volt Switch"], ["Hyper Voice"], ["Surf"], ["Dark Pulse"]]
+            }, {
+                "species": "Heliolisk",
+                "item": ["Choice Specs"],
+                "ability": ["Dry Skin"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Volt Switch"], ["Thunderbolt"], ["Hyper Voice"], ["Focus Blast"]]
+            }]
+        },
+        "hitmonlee": {
+            "flags": {},
+            "sets": [{
+                "species": "Hitmonlee",
+                "item": ["Choice Scarf"],
+                "ability": ["Reckless"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["High Jump Kick"], ["Knock Off"], ["Rapid Spin"], ["Earthquake"]]
+            }, {
+                "species": "Hitmonlee",
+                "item": ["Life Orb"],
+                "ability": ["Reckless"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["High Jump Kick"], ["Knock Off"], ["Rapid Spin"], ["Mach Punch"]]
+            }, {
+                "species": "Hitmonlee",
+                "item": ["Choice Band"],
+                "ability": ["Reckless"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["High Jump Kick"], ["Knock Off"], ["Mach Punch"], ["Earthquake"]]
+            }, {
+                "species": "Hitmonlee",
+                "item": ["White Herb"],
+                "ability": ["Unburden"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Curse"], ["Close Combat"], ["Stone Edge"], ["Earthquake"]]
+            }]
+        },
+        "houndoom": {
+            "flags": {},
+            "sets": [{
+                "species": "Houndoom",
+                "item": ["Darkinium Z"],
+                "ability": ["Unnerve"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Fire Blast"], ["Dark Pulse"], ["Nasty Plot"], ["Flame Charge"]]
+            }, {
+                "species": "Houndoom",
+                "item": ["Life Orb"],
+                "ability": ["Unnerve"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Hasty",
+                "moves": [["Fire Blast"], ["Pursuit"], ["Dark Pulse"], ["Sucker Punch"]]
+            }]
+        },
+        "incineroar": {
+            "flags": {},
+            "sets": [{
+                "species": "Incineroar",
+                "item": ["Iapapa Berry"],
+                "ability": ["Intimidate"],
+                "evs": {"hp": 244, "def": 128, "spd": 128, "spe":8},
+                "nature": "Sassy",
+                "moves": [["Fire Blast"], ["Knock Off"], ["U-turn"], ["Earthquake"]]
+            }, {
+                "species": "Incineroar",
+                "item": ["Incinium Z"],
+                "ability": ["Intimidate"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Flare Blitz"], ["Darkest Lariat"], ["Earthquake"], ["Swords Dance"]]
+            }]
+        },
+        "jellicent": {
+            "flags": {},
+            "sets": [{
+                "species": "Jellicent",
+                "item": ["Colbur Berry"],
+                "ability": ["Water Absorb"],
+                "evs": {"hp": 248, "def": 176, "spe": 84},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Hex"], ["Scald"], ["Recover"], ["Will-O-Wisp"]]
+            }, {
+                "species": "Jellicent",
+                "item": ["Colbur Berry"],
+                "ability": ["Water Absorb"],
+                "evs": {"hp": 248, "def": 176, "spe": 84},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Taunt"], ["Scald"], ["Recover"], ["Toxic"]]
+            }]
+        },
+        "klinklang": {
+            "flags": {},
+            "sets": [{
+                "species": "Klinklang",
+                "item": ["Steelium Z", "Leftovers"],
+                "ability": ["Clear Body"],
+                "happiness": 0,
+                "evs": {"hp": 104, "atk": 252, "spe": 152},
+                "nature": "Adamant",
+                "moves": [["Shift Gear"], ["Gear Grind"], ["Frustration"], ["Magnet Rise"]]
+            }, {
+                "species": "Klinklang",
+                "item": ["Electrium Z", "Lum Berry"],
+                "ability": ["Clear Body"],
+                "happiness": 0,
+                "evs": {"hp": 104, "atk": 252, "spe": 152},
+                "nature": "Adamant",
+                "moves": [["Shift Gear"], ["Gear Grind"], ["Frustration"], ["Wild Charge"]]
+            }]
+        },
+        "malamar": {
+            "flags": {},
+            "sets": [{
+                "species": "Malamar",
+                "item": ["Normalium Z"],
+                "ability": ["Contrary"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Happy Hour"], ["Superpower"], ["Knock Off"], ["Psycho Cut"]]
+            }, {
+                "species": "Malamar",
+                "item": ["Leftovers"],
+                "ability": ["Contrary"],
+                "evs": {"hp": 252, "spd": 252, "spe": 4},
+                "nature": "Careful",
+                "moves": [["Rest"], ["Superpower"], ["Knock Off"], ["Sleep Talk"]]
+            }]
+        },
+        "medicham": {
+            "flags": {},
+            "sets": [{
+                "species": "Medicham",
+                "item": ["Life Orb"],
+                "ability": ["Pure Power"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Adamant",
+                "moves": [["Bullet Punch"], ["Thunder Punch"], ["Zen Headbutt"], ["High Jump Kick"]]
+            }, {
+                "species": "Medicham",
+                "item": ["Choice Scarf"],
+                "ability": ["Pure Power"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Adamant",
+                "moves": [["Thunder Punch"], ["Trick"], ["Zen Headbutt"], ["High Jump Kick"]]
+            }]
+        },
+        "minior": {
+            "flags": {},
+            "sets": [{
+                "species": "Minior",
+                "item": ["White Herb"],
+                "ability": ["Shields Down"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "ivs": {"hp": 10},
+                "nature": "Adamant",
+                "moves": [["Shell Smash"], ["Acrobatics"], ["Earthquake"], ["Stone Edge"]]
+            }]
+        },
+        "mismagius": {
+            "flags": {},
+            "sets": [{
+                "species": "Mismagius",
+                "item": ["Ghostium Z"],
+                "ability": ["Levitate"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Shadow Ball"], ["Dazzling Gleam"], ["Nasty Plot"], ["Taunt"]]
+            }, {
+                "species": "Mismagius",
+                "item": ["Colbur Berry", "Ghostium Z"],
+                "ability": ["Levitate"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Hex"], ["Dazzling Gleam"], ["Nasty Plot"], ["Will-O-Wisp"]]
+            }]
+        },
+        "omastar": {
+            "flags": {},
+            "sets": [{
+                "species": "Omastar",
+                "item": ["Focus Sash"],
+                "ability": ["Weak Armor"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Stealth Rock"], ["Spikes"], ["Scald"], ["Shell Smash"]]
+            }, {
+                "species": "Omastar",
+                "item": ["Waterium Z"],
+                "ability": ["Swift Swim"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Ice Beam"], ["Hydro Pump"], ["Earth Power"], ["Shell Smash"]]
+            }, {
+                "species": "Omastar",
+                "item": ["Leftovers"],
+                "ability": ["Swift Swim"],
+                "evs": {"hp": 252, "def": 252, "spe": 4},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Stealth Rock"], ["Spikes"], ["Scald"], ["Toxic"]]
+            }]
+        },
+        "piloswine": {
+            "flags": {},
+            "sets": [{
+                "species": "Piloswine",
+                "item": ["Eviolite"],
+                "ability": ["Thick Fat"],
+                "evs": {"hp": 252, "atk": 252, "spd": 4},
+                "nature": "Adamant",
+                "moves": [["Stealth Rock"], ["Icicle Crash"], ["Earthquake"], ["Ice Shard"]]
+            }]
+        },
+		"quagsire": {
 			"flags": {},
 			"sets": [{
-				"species": "Diancie",
+				"species": "Quagsire",
 				"item": ["Leftovers"],
-				"ability": ["Clear Body"],
-				"evs": {"hp": 252, "def": 132, "spd": 124},
-				"nature": "Sassy",
-				"moves": [["Stealth Rock"], ["Moonblast"], ["Diamond Storm"], ["Heal Bell"]]
-			}, {
-				"species": "Diancie",
-				"item": ["Leftovers"],
-				"ability": ["Clear Body"],
-				"evs": {"hp": 252, "def": 120, "spd": 136},
-				"nature": "Bold",
-				"moves": [["Calm Mind"], ["Moonblast"], ["Earth Power"], ["Substitute"]]
-			}, {
-				"species": "Diancie",
-				"item": ["Choice Specs"],
-				"ability": ["Clear Body"],
-				"evs": {"hp":0, "spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Moonblast"], ["Power Gem"], ["Earth Power"], ["Hidden Power Fire"]]
-			}, {
-				"species": "Diancie",
-				"item": ["Life Orb"],
-				"ability": ["Clear Body"],
-				"evs": {"hp":0, "spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Quiet",
-				"moves": [["Trick Room"], ["Moonblast"], ["Earth Power"], ["Psychic"]]
-			}]
-		},
-		"dodrio": {
-			"flags": {},
-			"sets": [{
-				"species": "Dodrio",
-				"item": ["Fightinium Z"],
-				"ability": ["Early Bird"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Knock Off"], ["Brave Bird"], ["Jump Kick"]]
-			}, {
-				"species": "Dodrio",
-				"item": ["Choice Band"],
-				"ability": ["Early Bird"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Quick Attack"], ["Knock Off"], ["Brave Bird"], ["Jump Kick"]]
-			}, {
-				"species": "Dodrio",
-				"item": ["Choice Scarf"],
-				"ability": ["Early Bird"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Return"], ["Knock Off"], ["Brave Bird"], ["Jump Kick"]]
-			}]
-		},
-		"druddigon": {
-			"flags": {},
-			"sets": [{
-				"species": "Druddigon",
-				"item": ["Life Orb"],
-				"ability": ["Sheer Force"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Outrage"], ["Gunk Shot"], ["Earthquake"], ["Sucker Punch"]]
-			}, {
-				"species": "Druddigon",
-				"item": ["Rocky Helmet"],
-				"ability": ["Rough Skin"],
-				"evs": {"hp": 252, "def": 216, "spd": 12, "spe": 28},
-				"nature": "Impish",
-				"moves": [["Stealth Rock"], ["Dragon Tail"], ["Earthquake"], ["Glare"]]
-			}]
-		},
-		"dugtrio": {
-			"flags": {},
-			"sets": [{
-				"species": "Dugtrio",
-				"item": ["Life Orb"],
-				"ability": ["Sand Force"],
-				"evs": {"atk": 252, "spa": 4, "spe": 252},
-				"nature": "Naive",
-				"moves": [["Earthquake"], ["Stone Edge"], ["Sucker Punch"], ["Sludge Wave"]]
-			}]
-		},
-		"froslass": {
-			"flags": {},
-			"sets": [{
-				"species": "Froslass",
-				"item": ["Focus Sash"],
-				"ability": ["Cursed Body"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Spikes"], ["Taunt"], ["Ice Beam"], ["Destiny Bond"]]
-			}, {
-				"species": "Froslass",
-				"item": ["Life Orb"],
-				"ability": ["Cursed Body"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Shadow Ball"], ["Ice Beam"], ["Spikes"], ["Destiny Bond"]]
-			}]
-		},
-		"garbodor": {
-			"flags": {},
-			"sets": [{
-				"species": "Garbodor",
-				"item": ["Rocky Helmet"],
-				"ability": ["Aftermath"],
-				"evs": {"hp": 252, "def": 160, "spe": 96},
-				"nature": "Impish",
-				"moves": [["Spikes"], ["Drain Punch"], ["Gunk Shot"], ["Toxic Spikes"]]
-			}, {
-				"species": "Garbodor",
-				"item": ["Toxic Plate"],
-				"ability": ["Aftermath"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Spikes"], ["Gunk Shot"], ["Drain Punch"], ["Explosion"]]
-			}]
-		},
-		"gigalith": {
-			"flags": {},
-			"sets": [{
-				"species": "Gigalith",
-				"item": ["Leftovers"],
-				"ability": ["Sand Stream"],
-				"evs": {"hp": 252, "spd": 244, "spe": 12},
-				"nature": "Careful",
-				"moves": [["Stealth Rock"], ["Rock Blast"], ["Earthquake"], ["Toxic"]]
-			}]
-		},
-		"golbat": {
-			"flags": {},
-			"sets": [{
-				"species": "Golbat",
-				"item": ["Eviolite"],
-				"ability": ["Infiltrator"],
-				"evs": {"hp": 252, "def": 196, "spe": 60},
-				"nature": "Impish",
-				"moves": [["Super Fang"], ["Defog"], ["Brave Bird"], ["Roost"]]
-			}, {
-				"species": "Golbat",
-				"item": ["Eviolite"],
-				"ability": ["Infiltrator"],
-				"evs": {"hp": 252, "def": 172, "spe": 84},
-				"nature": "Jolly",
-				"moves": [["Roost"], ["Taunt"], ["Brave Bird"], ["Super Fang"]]
-			}]
-		},
-		"guzzlord": {
-			"flags": {},
-			"sets": [{
-				"species": "Guzzlord",
-				"item": ["Choice Specs"],
-				"ability": ["Beast Boost"],
-				"evs": {"spa": 252, "spd": 196, "spe": 60},
-				"nature": "Modest",
-				"moves": [["Draco Meteor"], ["Dark Pulse"], ["Fire Blast"], ["Sludge Bomb"]]
-			}, {
-				"species": "Guzzlord",
-				"item": ["Dragonium Z"],
-				"ability": ["Beast Boost"],
-				"evs": {"spa": 252, "spd": 76, "spe": 180},
-				"nature": "Modest",
-				"moves": [["Draco Meteor"], ["Dark Pulse"], ["Fire Blast"], ["Knock Off"]]
-			}]
-		},
-		"hariyama": {
-			"flags": {},
-			"sets": [{
-				"species": "Hariyama",
-				"item": ["Assault Vest"],
-				"ability": ["Thick Fat"],
-				"evs": {"atk": 252, "def": 4, "spd": 252},
-				"nature": "Adamant",
-				"moves": [["Close Combat"], ["Fake Out"], ["Knock Off"], ["Bullet Punch"]]
-			}, {
-				"species": "Hariyama",
-				"item": ["Flame Orb"],
-				"ability": ["Guts"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Close Combat"], ["Knock Off"], ["Facade"], ["Bullet Punch"]]
-			}]
-		},
-		"heliolisk": {
-			"flags": {},
-			"sets": [{
-				"species": "Heliolisk",
-				"item": ["Life Orb"],
-				"ability": ["Dry Skin"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Volt Switch"], ["Hyper Voice"], ["Surf"], ["Focus Blast"]]
-			}, {
-				"species": "Heliolisk",
-				"item": ["Choice Specs"],
-				"ability": ["Dry Skin"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Volt Switch"], ["Thunderbolt"], ["Hyper Voice"], ["Focus Blast"]]
-			}]
-		},
-		"hitmonlee": {
-			"flags": {},
-			"sets": [{
-				"species": "Hitmonlee",
-				"item": ["Choice Scarf"],
-				"ability": ["Reckless"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["High Jump Kick"], ["Knock Off"], ["Rapid Spin"], ["Earthquake"]]
-			}, {
-				"species": "Hitmonlee",
-				"item": ["Life Orb"],
-				"ability": ["Reckless"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["High Jump Kick"], ["Knock Off"], ["Rapid Spin"], ["Mach Punch"]]
-			}, {
-				"species": "Hitmonlee",
-				"item": ["Choice Band"],
-				"ability": ["Reckless"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["High Jump Kick"], ["Knock Off"], ["Mach Punch"], ["Earthquake"]]
-			}, {
-				"species": "Hitmonlee",
-				"item": ["Normal Gem"],
-				"ability": ["Unburden"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Fake Out"], ["Stone Edge"], ["Close Combat"], ["Poison Jab"]]
-			}]
-		},
-		"houndoom": {
-			"flags": {},
-			"sets": [{
-				"species": "Houndoom",
-				"item": ["Darkinium Z"],
-				"ability": ["Unnerve"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Fire Blast"], ["Dark Pulse"], ["Nasty Plot"], ["Flame Charge"]]
-			}, {
-				"species": "Houndoom",
-				"item": ["Life Orb"],
-				"ability": ["Unnerve"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Hasty",
-				"moves": [["Fire Blast"], ["Pursuit"], ["Dark Pulse"], ["Sucker Punch"]]
-			}]
-		},
-		"incineroar": {
-			"flags": {},
-			"sets": [{
-				"species": "Incineroar",
-				"item": ["Assault Vest"],
-				"ability": ["Intimidate"],
-				"evs": {"hp": 248, "atk": 252, "spa": 8},
-				"nature": "Brave",
-				"moves": [["Fire Blast"], ["Darkest Lariat"], ["U-turn"], ["Fake Out"]]
-			}, {
-				"species": "Incineroar",
-				"item": ["Incinium Z"],
-				"ability": ["Intimidate"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Flare Blitz"], ["Darkest Lariat"], ["Low Kick"], ["Swords Dance"]]
-			}]
-		},
-		"jellicent": {
-			"flags": {},
-			"sets": [{
-				"species": "Jellicent",
-				"item": ["Colbur Berry"],
-				"ability": ["Water Absorb"],
-				"evs": {"hp": 248, "def": 176, "spe": 84},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Hex"], ["Scald"], ["Recover"], ["Will-O-Wisp"]]
-			}, {
-				"species": "Jellicent",
-				"item": ["Colbur Berry"],
-				"ability": ["Water Absorb"],
-				"evs": {"hp": 248, "def": 176, "spe": 84},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Taunt"], ["Scald"], ["Recover"], ["Toxic"]]
-			}]
-		},
-		"klinklang": {
-			"flags": {},
-			"sets": [{
-				"species": "Klinklang",
-				"item": ["Steelium Z", "Leftovers"],
-				"ability": ["Clear Body"],
-				"happiness": 0,
-				"evs": {"hp": 104, "atk": 252, "spe": 152},
-				"nature": "Adamant",
-				"moves": [["Shift Gear"], ["Gear Grind"], ["Frustration"], ["Magnet Rise"]]
-			}, {
-				"species": "Klinklang",
-				"item": ["Electrium Z", "Lum Berry"],
-				"ability": ["Clear Body"],
-				"happiness": 0,
-				"evs": {"hp": 104, "atk": 252, "spe": 152},
-				"nature": "Adamant",
-				"moves": [["Shift Gear"], ["Gear Grind"], ["Frustration"], ["Wild Charge"]]
-			}]
-		},
-		"malamar": {
-			"flags": {},
-			"sets": [{
-				"species": "Malamar",
-				"item": ["Normalium Z"],
-				"ability": ["Contrary"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Happy Hour"], ["Superpower"], ["Knock Off"], ["Psycho Cut"]]
-			}, {
-				"species": "Malamar",
-				"item": ["Leftovers"],
-				"ability": ["Contrary"],
-				"evs": {"hp": 252, "spd": 252, "spe": 4},
-				"nature": "Careful",
-				"moves": [["Rest"], ["Superpower"], ["Knock Off"], ["Sleep Talk"]]
-			}]
-		},
-		"medicham": {
-			"flags": {},
-			"sets": [{
-				"species": "Medicham",
-				"item": ["Life Orb"],
-				"ability": ["Pure Power"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Bullet Punch"], ["Thunder Punch"], ["Zen Headbutt"], ["High Jump Kick"]]
-			}, {
-				"species": "Medicham",
-				"item": ["Choice Scarf"],
-				"ability": ["Pure Power"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Thunder Punch"], ["Trick"], ["Zen Headbutt"], ["High Jump Kick"]]
-			}]
-		},
-		"minior": {
-			"flags": {},
-			"sets": [{
-				"species": "Minior",
-				"item": ["White Herb"],
-				"ability": ["Shields Down"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"ivs": {"hp": 10},
-				"nature": "Adamant",
-				"moves": [["Shell Smash"], ["Acrobatics"], ["Earthquake"], ["Stone Edge"]]
-			}]
-		},
-		"mismagius": {
-			"flags": {},
-			"sets": [{
-				"species": "Mismagius",
-				"item": ["Ghostium Z"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Shadow Ball"], ["Dazzling Gleam"], ["Nasty Plot"], ["Taunt"]]
-			}, {
-				"species": "Mismagius",
-				"item": ["Colbur Berry", "Ghostium Z"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Hex"], ["Dazzling Gleam"], ["Nasty Plot"], ["Will-O-Wisp"]]
-			}]
-		},
-		"omastar": {
-			"flags": {},
-			"sets": [{
-				"species": "Omastar",
-				"item": ["Focus Sash"],
-				"ability": ["Weak Armor"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Stealth Rock"], ["Spikes"], ["Scald"], ["Shell Smash"]]
-			}, {
-				"species": "Omastar",
-				"item": ["Waterium Z"],
-				"ability": ["Swift Swim"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Ice Beam"], ["Hydro Pump"], ["Earth Power"], ["Shell Smash"]]
-			}, {
-				"species": "Omastar",
-				"item": ["Leftovers"],
-				"ability": ["Swift Swim"],
-				"evs": {"hp": 252, "def": 252, "spe": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Stealth Rock"], ["Spikes"], ["Scald"], ["Toxic"]]
-			}]
-		},
-		"piloswine": {
-			"flags": {},
-			"sets": [{
-				"species": "Piloswine",
-				"item": ["Eviolite"],
-				"ability": ["Thick Fat"],
-				"evs": {"hp": 252, "atk": 252, "spd": 4},
-				"nature": "Adamant",
-				"moves": [["Stealth Rock"], ["Icicle Crash"], ["Earthquake"], ["Ice Shard"]]
-			}]
-		},
-		"qwilfish": {
-			"flags": {},
-			"sets": [{
-				"species": "Qwilfish",
-				"item": ["Black Sludge"],
-				"ability": ["Intimidate"],
+				"ability": ["Unaware"],
 				"evs": {"hp": 252, "def": 252, "spd": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Scald"], ["Spikes"], ["Taunt"], ["Toxic Spikes"]]
+				"nature": "Relaxed",
+				"moves": [["Curse"], ["Earthquake"], ["Scald"], ["Recover"]]
 			}]
 		},
 		"rhydon": {
-			"flags": {},
-			"sets": [{
-				"species": "Rhydon",
-				"item": ["Eviolite"],
-				"ability": ["Reckless"],
-				"evs": {"hp": 252, "atk": 16, "spd": 240},
-				"nature": "Adamant",
-				"moves": [["Stealth Rock"], ["Earthquake"], ["Rock Blast"], ["Megahorn"]]
+            "flags": {},
+            "sets": [{
+                "species": "Rhydon",
+                "item": ["Eviolite"],
+                "ability": ["Reckless"],
+                "evs": {"hp": 252, "atk": 16, "spd": 240},
+                "nature": "Adamant",
+                "moves": [["Stealth Rock"], ["Earthquake"], ["Rock Blast"], ["Swords Dance"]]
+            }]
+        },
+        "rotom": {
+            "flags": {},
+            "sets": [{
+                "species": "Rotom",
+                "item": ["Choice Scarf"],
+                "ability": ["Levitate"],
+                "evs": {"def": 4, "spa": 252, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Thunderbolt"], ["Volt Switch"], ["Trick"], ["Shadow Ball"]]
+            }, {
+                "species": "Rotom",
+                "item": ["Iapapa Berry", "Ghostium Z"],
+                "ability": ["Levitate"],
+                "evs": {"hp": 252, "def": 88, "spe": 168},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Defog"], ["Hex"], ["Will-O-Wisp"], ["Volt Switch", "Pain Split"]]
+            }]
+        },
+        "samurott": {
+            "flags": {},
+            "sets": [{
+                "species": "Samurott",
+                "item": ["Buginium Z"],
+                "ability": ["Torrent"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Aqua Jet"], ["Waterfall"], ["Swords Dance"], ["Megahorn"]]
+            }]
+        },
+        "sceptile": {
+            "flags": {},
+            "sets": [{
+                "species": "Sceptile",
+                "item": ["Choice Specs"],
+                "ability": ["Overgrow"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Leaf Storm"], ["Giga Drain"], ["Focus Blast"], ["Hidden Power Ice"]]
+            }, {
+                "species": "Sceptile",
+                "item": ["Life Orb"],
+                "ability": ["Overgrow"],
+                "evs": {"atk": 4, "spa": 252, "spe": 252},
+                "ivs": {"atk": 30},
+                "nature": "Hasty",
+                "moves": [["Leaf Storm"], ["Giga Drain"], ["Hidden Power Ice"], ["Earthquake"]]
+            }]
+        },
+        "scrafty": {
+            "flags": {},
+            "sets": [{
+                "species": "Scrafty",
+                "item": ["Steelium Z"],
+                "ability": ["Moxie"],
+                "evs": {"atk": 252, "def": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["High Jump Kick"], ["Knock Off"], ["Dragon Dance"], ["Iron Tail"]]
+            }, {
+                "species": "Scrafty",
+                "item": ["Chople Berry"],
+                "ability": ["Moxie"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Dragon Dance"], ["Knock Off"], ["High Jump Kick"], ["Drain Punch"]]
+            }, {
+                "species": "Scrafty",
+                "item": ["Leftovers"],
+                "ability": ["Shed Skin"],
+                "evs": {"hp": 252, "spd": 244, "spe": 12},
+                "nature": "Careful",
+                "moves": [["Bulk Up"], ["Drain Punch"], ["Knock Off"], ["Rest"]]
+            }]
+        },
+        "scyther": {
+            "flags": {},
+            "sets": [{
+                "species": "Scyther",
+                "item": ["Choice Scarf"],
+                "ability": ["Technician"],
+                "evs": {"atk": 252, "def": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Aerial Ace"], ["Knock Off"], ["U-turn"], ["Bug Bite"]]
+            }]
+        },
+        "shuckle": {
+            "flags": {},
+            "sets": [{
+                "species": "Shuckle",
+                "item": ["Mental Herb"],
+                "ability": ["Sturdy"],
+                "evs": {"hp": 252, "def": 4, "spd": 252},
+                "ivs": {"atk": 0},
+                "nature": "Careful",
+                "moves": [["Stealth Rock"], ["Sticky Web"], ["Encore"], ["Toxic"]]
+            }]
+        },
+        "sigilyph": {
+            "flags": {},
+            "sets": [{
+                "species": "Sigilyph",
+                "item": ["Life Orb"],
+                "ability": ["Magic Guard"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Psychic"], ["Dazzling Gleam"], ["Dark Pulse"], ["Energy Ball"]]
+            }, {
+                "species": "Sigilyph",
+                "item": ["Focus Sash"],
+                "ability": ["Magic Guard"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Psychic"], ["Dazzling Gleam"], ["Energy Ball"], ["Defog"]]
+            }]
+        },
+        "silvallysteel": {
+            "flags": {},
+            "sets": [{
+                "species": "Silvally-Steel",
+                "item": ["Steel Memory"],
+                "ability": ["RKS System"],
+                "evs": {"hp": 252, "spd": 252, "spe": 4},
+                "ivs": {"atk": 0},
+                "nature": "Calm",
+                "moves": [["Defog"], ["Flamethrower"], ["Toxic"], ["Parting Shot"]]
+            }]
+        },
+        "slowking": {
+            "flags": {},
+            "sets": [{
+                "species": "Slowking",
+                "item": ["Assault Vest"],
+                "ability": ["Regenerator"],
+                "evs": {"hp": 248, "spa": 252, "spe": 8},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Scald"], ["Future Sight"], ["Fire Blast"], ["Dragon Tail"]]
+            }, {
+                "species": "Slowking",
+                "item": ["Life Orb", "Colbur Berry"],
+                "ability": ["Regenerator"],
+                "evs": {"hp": 248, "def": 8, "spa": 252},
+                "ivs": {"atk": 0, "spe": 0},
+                "nature": "Quiet",
+                "moves": [["Scald"], ["Psychic"], ["Trick Room"], ["Nasty Plot"]]
+            }]
+        },
+        "slowbro": {
+            "flags": {},
+            "sets": [{
+                "species": "Slowbro",
+                "item": ["Colbur Berry", "Psychium Z"],
+                "ability": ["Regenerator"],
+                "evs": {"hp": 252, "def": 252, "spe": 4},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Slack Off"], ["Scald"], ["Psyshock"], ["Toxic"]]
+            }, {
+                "species": "Slowbro",
+                "item": ["Colbur Berry"],
+                "ability": ["Regenerator"],
+                "evs": {"hp": 252, "def": 252, "spe": 4},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Slack Off"], ["Scald"], ["Psyshock"], ["Calm Mind"]]
+            }]
+        },
+        "smeargle": {
+            "flags": {},
+            "sets": [{
+                "species": "Smeargle",
+                "item": ["Focus Sash"],
+                "ability": ["Own Tempo"],
+                "evs": {"hp": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Jolly",
+                "moves": [["Sticky Web"], ["Stealth Rock"], ["Taunt"], ["Spore"]]
+            }]
+        },
+        "sneasel": {
+            "flags": {},
+            "sets": [{
+                "species": "Sneasel",
+                "item": ["Choice Band"],
+                "ability": ["Inner Focus"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Knock Off"], ["Pursuit"], ["Icicle Crash"], ["Ice Shard"]]
+            }]
+        },
+        "steelix": {
+            "flags": {},
+            "sets": [{
+                "species": "Steelix",
+                "item": ["Leftovers"],
+                "ability": ["Sturdy"],
+                "evs": {"hp": 244, "atk": 16, "spd": 248},
+                "nature": "Adamant",
+                "moves": [["Stealth Rock"], ["Earthquake"], ["Heavy Slam"], ["Toxic"]]
+            }]
+        },
+        "uxie": {
+            "flags": {},
+            "sets": [{
+                "species": "Uxie",
+                "item": ["Leftovers"],
+                "ability": ["Levitate"],
+                "evs": {"hp": 252, "def": 120, "spe": 136},
+                "nature": "Timid",
+                "moves": [["Stealth Rock"], ["U-turn"], ["Psychic"], ["Protect"]]
+            }]
+        },
+        "vanilluxe": {
+            "flags": {},
+            "sets": [{
+                "species": "Vanilluxe",
+                "item": ["Choice Specs"],
+                "ability": ["Snow Warning"],
+                "evs": {"def": 4, "spa": 252, "spe": 252},
+                "nature": "Modest",
+                "moves": [["Blizzard"], ["Freeze-Dry"], ["Flash Cannon"], ["Hidden Power Ground"]]
+            }, {
+                "species": "Vanilluxe",
+                "item": ["Choice Scarf"],
+                "ability": ["Snow Warning"],
+                "evs": {"def": 4, "spa": 252, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Blizzard"], ["Freeze-Dry"], ["Flash Cannon"], ["Hidden Power Ground"]]
+            }]
+        },
+        "vaporeon": {
+            "flags": {},
+            "sets": [{
+                "species": "Vaporeon",
+                "item": ["Leftovers"],
+                "ability": ["Water Absorb"],
+                "evs": {"hp": 192, "def": 252, "spd": 64},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Wish"], ["Protect"], ["Scald"], ["Toxic"]]
+            }, {
+                "species": "Vaporeon",
+                "item": ["Normalium Z"],
+                "ability": ["Water Absorb"],
+                "evs": {"def": 4, "spa": 252, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Hydro Pump"], ["Ice Beam"], ["Hidden Power Grass"], ["Celebrate"]]
+            }]
+        },
+        "vileplume": {
+            "flags": {},
+            "sets": [{
+                "species": "Vileplume",
+                "item": ["Black Sludge"],
+                "ability": ["Effect Spore"],
+                "evs": {"hp": 252, "def": 252, "spe": 4},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Strength Sap"], ["Giga Drain"], ["Sludge Bomb"], ["Aromatherapy"]]
+            }]
+        },
+        "vikavolt": {
+            "flags": {},
+            "sets": [{
+                "species": "Vikavolt",
+                "item": ["Leftovers"],
+                "ability": ["Levitate"],
+                "evs": {"hp": 252, "spa": 136, "spd": 44, "spe": 76},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Bug Buzz"], ["Volt Switch"], ["Energy Ball"], ["Roost"]]
+            }, {
+                "species": "Vikavolt",
+                "item": ["Choice Specs"],
+                "ability": ["Levitate"],
+                "evs": {"hp": 176, "def": 4, "spa": 252, "spe": 76},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Bug Buzz"], ["Volt Switch"], ["Energy Ball"], ["Thunderbolt"]]
+            }, {
+                "species": "Vikavolt",
+                "item": ["Buginium Z"],
+                "ability": ["Levitate"],
+                "evs": {"hp": 176, "def": 4, "spa": 252, "spe": 76},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Roost"], ["Bug Buzz"], ["Energy Ball"], ["Volt Switch"]]
+            }]
+        },
+        "vivillonfancy": {
+            "flags": {},
+            "sets": [{
+                "species": "Vivillon-Fancy",
+                "item": ["Flyinium Z"],
+                "ability": ["Compound Eyes"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Quiver Dance"], ["Sleep Powder"], ["Hurricane"], ["Substitute"]]
+            }]
+        },
+        "vivillon": {
+            "flags": {},
+            "sets": [{
+                "species": "Vivillon",
+                "item": ["Leftovers"],
+                "ability": ["Compound Eyes"],
+                "evs": {"hp": 16, "spa": 240, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Substitute"], ["Sleep Powder"], ["Quiver Dance"], ["Hurricane"]]
+            }, {
+                "species": "Vivillon",
+                "item": ["Focus Sash"],
+                "ability": ["Compound Eyes"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Quiver Dance"], ["Sleep Powder"], ["Hurricane"], ["Energy Ball"]]
+            }]
+        },
+        "whimsicott": {
+            "flags": {},
+            "sets": [{
+                "species": "Whimsicott",
+                "item": ["Choice Specs"],
+                "ability": ["Infiltrator"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Energy Ball"], ["Moonblast"], ["Psychic"], ["U-turn"]]
+            }, {
+                "species": "Whimsicott",
+                "item": ["Life Orb"],
+                "ability": ["Prankster"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Energy Ball"], ["Moonblast"], ["Psychic"], ["Defog"]]
+            }, {
+                "species": "Whimsicott",
+                "item": ["Pixie Plate"],
+                "ability": ["Prankster"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Giga Drain"], ["Moonblast"], ["Encore"], ["U-turn"]]
+            }, {
+                "species": "Whimsicott",
+                "item": ["Normalium Z"],
+                "ability": ["Infiltrator"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Growth"], ["Moonblast"], ["Energy Ball"], ["Psychic"]]
+            }]
+        },
+        "xatu": {
+            "flags": {},
+            "sets": [{
+                "species": "Xatu",
+                "item": ["Rocky Helmet"],
+                "ability": ["Magic Bounce"],
+                "evs": {"hp": 252, "def": 212, "spe": 44},
+                "nature": "Timid",
+                "moves": [["Psychic"], ["U-turn"], ["Grass Knot"], ["Roost"]]
+            }, {
+                "species": "Xatu",
+                "item": ["Colbur Berry"],
+                "ability": ["Magic Bounce"],
+                "evs": {"hp": 252, "def": 212, "spe": 44},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Calm Mind"], ["Psychic"], ["Signal Beam"], ["Roost"]]
+            }]
+        },
+        "charizard": {
+            "flags": {},
+            "sets": [{
+                "species": "Charizard",
+                "item": ["Normalium Z"],
+                "ability": ["Solar Power"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Celebrate"], ["Fire Blast"], ["Air Slash"], ["Focus Blast"]]
+            }, {
+                "species": "Charizard",
+                "item": ["Firium Z"],
+                "ability": ["Solar Power"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Sunny Day"], ["Fire Blast"], ["Solar Beam"], ["Air Slash"]]
+            }]
+        },
+        "gallade": {
+            "flags": {},
+            "sets": [{
+                "species": "Gallade",
+                "item": ["Lum Berry"],
+                "ability": ["Justified"],
+                "evs": {"atk": 252, "def": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Swords Dance"], ["Close Combat"], ["Zen Headbutt"], ["Leaf Blade"]]
+            }, {
+                "species": "Gallade",
+                "item": ["Choice Scarf"],
+                "ability": ["Justified"],
+                "evs": {"atk": 252, "def": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Memento"], ["Close Combat"], ["Zen Headbutt"], ["Knock Off"]]
+            }]
+        },
+        "kabutops": {
+            "flags": {},
+            "sets": [{
+                "species": "Kabutops",
+                "item": ["Rockium Z"],
+                "ability": ["Swift Swim"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Adamant",
+                "moves": [["Swords Dance"], ["Liquidation"], ["Stone Edge"], ["Aqua Jet"]]
+            }]
+        },
+        "haunter": {
+            "flags": {},
+            "sets": [{
+                "species": "Haunter",
+                "item": ["Life Orb"],
+                "ability": ["Levitate"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Shadow Ball"], ["Sludge Wave"], ["Dazzling Gleam"], ["Destiny Bond"]]
+            }, {
+                "species": "Haunter",
+                "item": ["Choice Scarf"],
+                "ability": ["Levitate"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Shadow Ball"], ["Sludge Wave"], ["Dazzling Gleam"], ["Trick"]]
+            }, {
+                "species": "Haunter",
+                "item": ["Life Orb"],
+                "ability": ["Levitate"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "ivs": {"atk": 0},
+                "nature": "Timid",
+                "moves": [["Substitute"], ["Pain Split"], ["Shadow Ball"], ["Sludge Bomb"]]
+            }]
+        },
+        "absol": {
+            "flags": {},
+            "sets": [{
+                "species": "Absol",
+                "item": ["Life Orb"],
+                "ability": ["Super Luck"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Adamant",
+                "moves": [["Swords Dance"], ["Sucker Punch"], ["Knock Off"], ["Superpower", "Iron Tail"]]
+            }]
+        },
+        "sawk": {
+            "flags": {},
+            "sets": [{
+                "species": "Sawk",
+                "item": ["Choice Scarf"],
+                "ability": ["Mold Breaker"],
+                "evs": {"atk": 252, "def": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Close Combat"], ["Knock Off"], ["Earthquake"], ["Ice Punch"]]
+            }, {
+                "species": "Sawk",
+                "item": ["Choice Band"],
+                "ability": ["Mold Breaker"],
+                "evs": {"atk": 252, "def": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Close Combat"], ["Knock Off"], ["Zen Headbutt"], ["Poison Jab"]]
+            }]
+        },
+        "drampa": {
+            "flags": {},
+            "sets": [{
+                "species": "Drampa",
+                "item": ["Choice Specs"],
+                "ability": ["Berserk"],
+                "evs": {"hp": 136, "spa": 252, "spe": 120},
+                "ivs": {"atk": 0},
+                "nature": "Modest",
+                "moves": [["Hyper Voice"], ["Energy Ball"], ["Fire Blast"], ["Draco Meteor"]]
+            }]
+        },
+        "hitmontop": {
+            "flags": {},
+            "sets": [{
+                "species": "Hitmontop",
+                "item": ["Leftovers"],
+                "ability": ["Intimidate"],
+                "evs": {"hp": 252, "atk": 4, "def": 252},
+                "nature": "Impish",
+                "moves": [["Close Combat"], ["Rapid Spin"], ["Foresight"], ["Toxic"]]
+            }]
+        },
+        "magmortar": {
+            "flags": {},
+            "sets": [{
+                "species": "Magmortar",
+                "item": ["Assault Vest"],
+                "ability": ["Vital Spirit"],
+                "evs": {"hp": 64, "spa": 252, "spe": 192},
+                "nature": "Mild",
+                "moves": [["Fire Blast"], ["Thunderbolt"], ["Hidden Power Grass"], ["Earthquake"]]
+            }, {
+                "species": "Magmortar",
+                "item": ["Fightinium Z"],
+                "ability": ["Vital Spirit"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Mild",
+                "moves": [["Fire Blast"], ["Thunderbolt"], ["Focus Blast"], ["Flame Charge"]]
+            }]
+        },
+        "mesprit": {
+            "flags": {},
+            "sets": [{
+                "species": "Mesprit",
+                "item": ["Choice Scarf"],
+                "ability": ["Levitate"],
+                "evs": {"def": 4, "spa": 252, "spe": 252},
+                "nature": "Timid",
+                "moves": [["U-turn"], ["Psyshock"], ["Ice Beam"], ["Healing Wish"]]
+            }]
+        },
+        "ferroseed": {
+            "flags": {},
+            "sets": [{
+                "species": "Ferroseed",
+                "item": ["Eviolite"],
+                "ability": ["Iron Barbs"],
+                "evs": {"hp": 252, "atk": 4, "def": 252},
+                "ivs": {"spe": 0},
+                "nature": "Relaxed",
+                "moves": [["Stealth Rock"], ["Leech Seed"], ["Protect"], ["Gyro Ball"]]
+            }]
+        },
+        "gourgeistsuper": {
+            "flags": {},
+            "sets": [{
+                "species": "Gourgeist-Super",
+                "item": ["Colbur Berry"],
+                "ability": ["Frisk"],
+                "evs": {"hp": 252, "def": 252, "spd": 4},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Leech Seed"], ["Will-O-Wisp"], ["Synthesis"], ["Foul Play"]]
+            }]
+        },
+        "spiritomb": {
+            "flags": {},
+            "sets": [{
+                "species": "Spiritomb",
+                "item": ["Leftovers"],
+                "ability": ["Pressure"],
+                "evs": {"hp": 252, "def": 252, "spd": 4},
+                "ivs": {"atk": 0},
+                "nature": "Impish",
+                "moves": [["Rest"], ["Sleep Talk"], ["Calm Mind"], ["Dark Pulse"]]
+            }]
+        },
+        "probopass": {
+            "flags": {},
+            "sets": [{
+                "species": "Probopass",
+                "item": ["Air Balloon"],
+                "ability": ["Magnet Pull"],
+                "evs": {"hp": 172, "spa": 252, "spe": 84},
+                "nature": "Modest",
+                "moves": [["Power Gem"], ["Magnet Rise"], ["Earth Power"], ["Stealth Rock"]]
+            }]
+        },
+        "togedemaru": {
+            "flags": {},
+            "sets": [{
+                "species": "Togedemaru",
+                "item": ["Leftovers"],
+                "ability": ["Lightning Rod"],
+                "evs": {"hp": 252, "atk": 4, "spd": 252},
+                "nature": "Careful",
+                "moves": [["Wish"], ["Spiky Shield"], ["Zing Zap", "U-turn"], ["Super Fang"]]
+            }]
+        },
+        "ludicolo": {
+            "flags": {},
+            "sets": [{
+                "species": "Ludicolo",
+                "item": ["Life Orb"],
+                "ability": ["Swift Swim"],
+                "evs": {"hp": 4, "spa": 252, "spe": 252},
+                "nature": "Modest",
+                "moves": [["Rain Dance"], ["Hydro Pump"], ["Giga Drain"], ["Ice Beam"]]
+            }]
+        },
+        "exeggutoralola": {
+            "flags": {},
+            "sets": [{
+                "species": "Exeggutor-Alola",
+                "item": ["Dragonium Z"],
+                "ability": ["Frisk"],
+                "evs": {"hp": 252, "spa": 252, "spd": 4},
+                "ivs": {"atk": 0, "spe": 0},
+                "nature": "Quiet",
+                "moves": [["Giga Drain"], ["Draco Meteor"], ["Flamethrower"], ["Trick Room"]]
+            }]
+        },
+        "typenull": {
+            "flags": {},
+            "sets": [{
+                "species": "Type: Null",
+                "item": ["Eviolite"],
+                "ability": ["Battle Armor"],
+                "happiness": 0,
+                "evs": {"hp": 252, "spd": 244, "spe": 12},
+                "nature": "Careful",
+                "moves": [["Swords Dance"], ["Iron Defense"], ["Frustration"], ["Rest"]]
+            }, {
+                "species": "Type: Null",
+                "item": ["Eviolite"],
+                "ability": ["Battle Armor"],
+                "happiness": 0,
+                "evs": {"hp": 252, "spd": 244, "spe": 12},
+                "nature": "Careful",
+                "moves": [["Sleep Talk"], ["U-turn"], ["Frustration"], ["Rest"]]
+            }]
+        },
+        "altaria": {
+            "flags": {},
+            "sets": [{
+                "species": "Altaria",
+                "item": ["Leftovers"],
+                "ability": ["Natural Cure"],
+                "evs": {"hp": 252, "def": 240, "spe": 16},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Defog"], ["Roost"], ["Flamethrower"], ["Toxic"]]
+            }]
+        },
+        "ditto": {
+            "flags": {},
+            "sets": [{
+                "species": "Ditto",
+                "item": ["Choice Scarf"],
+                "ability": ["Imposter"],
+                "evs": {"hp": 252, "atk": 4, "def": 252},
+                "ivs": {"atk": 30, "spa": 30, "spe": 0},
+                "nature": "Relaxed",
+                "moves": [["Transform"]]
+            }]
+        },
+        "passimian": {
+            "flags": {},
+            "sets": [{
+                "species": "Passimian",
+                "item": ["Choice Scarf"],
+                "ability": ["Receiver"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Close Combat"], ["U-turn"], ["Gunk Shot"], ["Knock Off"]]
+            }, {
+                "species": "Passimian",
+                "item": ["Choice Band"],
+                "ability": ["Receiver"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Adamant",
+                "moves": [["Close Combat"], ["U-turn"], ["Gunk Shot"], ["Knock Off"]]
+            }]
+        },
+        "palossand": {
+            "flags": {},
+            "sets": [{
+                "species": "Palossand",
+                "item": ["Colbur Berry"],
+                "ability": ["Water Compaction"],
+                "evs": {"hp": 252, "def": 252, "spe": 4},
+                "ivs": {"atk": 0},
+                "nature": "Bold",
+                "moves": [["Stealth Rock"], ["Earth Power"], ["Shadow Ball"], ["Shore Up"]]
+            }]
+        },
+        "zangoose": {
+            "flags": {},
+            "sets": [{
+                "species": "Zangoose",
+                "item": ["Sitrus Berry"],
+                "ability": ["Immunity"],
+                "evs": {"hp": 4, "atk": 252, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Belly Drum"], ["Quick Attack"], ["Knock Off"], ["Close Combat"]]
+            }]
+        },
+        "lycanroc": {
+            "flags": {},
+            "sets": [{
+                "species": "Lycanroc",
+                "item": ["Focus Sash"],
+                "ability": ["Keen Eye"],
+                "evs": {"atk": 252, "spd": 4, "spe": 252},
+                "nature": "Hasty",
+                "moves": [["Stealth Rock"], ["Taunt"], ["Endeavor"], ["Stone Edge"]]
 			}]
-		},
-		"rotom": {
-			"flags": {},
-			"sets": [{
-				"species": "Rotom",
-				"item": ["Choice Scarf"],
-				"ability": ["Levitate"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Thunderbolt"], ["Volt Switch"], ["Trick"], ["Shadow Ball"]]
-			}, {
-				"species": "Rotom",
-				"item": ["Iapapa Berry", "Ghostium Z"],
-				"ability": ["Levitate"],
-				"evs": {"hp": 252, "def": 88, "spe": 168},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Defog"], ["Hex"], ["Will-O-Wisp"], ["Volt Switch", "Pain Split"]]
-			}]
-		},
-		"samurott": {
-			"flags": {},
-			"sets": [{
-				"species": "Samurott",
-				"item": ["Life Orb"],
-				"ability": ["Torrent"],
-				"evs": {"atk": 4, "spa": 252, "spe": 252},
-				"nature": "Rash",
-				"moves": [["Hydro Pump"], ["Ice Beam"], ["Grass Knot"], ["Megahorn"]]
-			}, {
-				"species": "Samurott",
-				"item": ["Buginium Z"],
-				"ability": ["Torrent"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Aqua Jet"], ["Waterfall"], ["Swords Dance"], ["Megahorn"]]
-			}]
-		},
-		"sceptile": {
-			"flags": {},
-			"sets": [{
-				"species": "Sceptile",
-				"item": ["Choice Specs"],
-				"ability": ["Overgrow"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Leaf Storm"], ["Giga Drain"], ["Focus Blast"], ["Hidden Power Ice"]]
-			}, {
-				"species": "Sceptile",
-				"item": ["Life Orb"],
-				"ability": ["Overgrow"],
-				"evs": {"atk": 4, "spa": 252, "spe": 252},
-				"ivs": {"atk": 30},
-				"nature": "Hasty",
-				"moves": [["Leaf Storm"], ["Giga Drain"], ["Hidden Power Ice"], ["Earthquake"]]
-			}]
-		},
-		"scrafty": {
-			"flags": {},
-			"sets": [{
-				"species": "Scrafty",
-				"item": ["Steelium Z"],
-				"ability": ["Moxie"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["High Jump Kick"], ["Knock Off"], ["Dragon Dance"], ["Iron Tail"]]
-			}, {
-				"species": "Scrafty",
-				"item": ["Chople Berry"],
-				"ability": ["Moxie"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Dragon Dance"], ["Knock Off"], ["High Jump Kick"], ["Drain Punch"]]
-			}, {
-				"species": "Scrafty",
-				"item": ["Leftovers"],
-				"ability": ["Shed Skin"],
-				"evs": {"hp": 252, "spd": 244, "spe": 12},
-				"nature": "Careful",
-				"moves": [["Bulk Up"], ["Drain Punch"], ["Knock Off"], ["Rest"]]
-			}]
-		},
-		"scyther": {
-			"flags": {},
-			"sets": [{
-				"species": "Scyther",
-				"item": ["Choice Scarf"],
-				"ability": ["Technician"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Aerial Ace"], ["Knock Off"], ["U-turn"], ["Bug Bite"]]
-			}]
-		},
-		"shuckle": {
-			"flags": {},
-			"sets": [{
-				"species": "Shuckle",
-				"item": ["Mental Herb"],
-				"ability": ["Sturdy"],
-				"evs": {"hp": 252, "def": 4, "spd": 252},
-				"ivs": {"atk": 0},
-				"nature": "Careful",
-				"moves": [["Stealth Rock"], ["Sticky Web"], ["Encore"], ["Toxic"]]
-			}]
-		},
-		"sigilyph": {
-			"flags": {},
-			"sets": [{
-				"species": "Sigilyph",
-				"item": ["Life Orb"],
-				"ability": ["Magic Guard"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Psychic"], ["Dazzling Gleam"], ["Dark Pulse"], ["Energy Ball"]]
-			}, {
-				"species": "Sigilyph",
-				"item": ["Focus Sash"],
-				"ability": ["Magic Guard"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Psychic"], ["Dazzling Gleam"], ["Energy Ball"], ["Defog"]]
-			}]
-		},
-		"silvallysteel": {
-			"flags": {},
-			"sets": [{
-				"species": "Silvally-Steel",
-				"item": ["Steel Memory"],
-				"ability": ["RKS System"],
-				"evs": {"hp": 252, "spd": 252, "spe": 4},
-				"ivs": {"atk": 0},
-				"nature": "Calm",
-				"moves": [["Defog"], ["Flash Cannon"], ["Toxic"], ["Parting Shot"]]
-			}]
-		},
-		"slowking": {
-			"flags": {},
-			"sets": [{
-				"species": "Slowking",
-				"item": ["Assault Vest"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 248, "spa": 252, "spe": 8},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Scald"], ["Future Sight"], ["Ice Beam"], ["Dragon Tail"]]
-			}, {
-				"species": "Slowking",
-				"item": ["Life Orb", "Colbur Berry"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 248, "def": 8, "spa": 252},
-				"ivs": {"atk": 0, "spe": 0},
-				"nature": "Quiet",
-				"moves": [["Scald"], ["Signal Beam", "Psychic"], ["Trick Room"], ["Nasty Plot"]]
-			}]
-		},
-		"slowbro": {
-			"flags": {},
-			"sets": [{
-				"species": "Slowbro",
-				"item": ["Colbur Berry", "Psychium Z"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "def": 252, "spe": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Slack Off"], ["Scald"], ["Psyshock"], ["Toxic"]]
-			}, {
-				"species": "Slowbro",
-				"item": ["Colbur Berry"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "def": 252, "spe": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Slack Off"], ["Scald"], ["Psyshock"], ["Calm Mind"]]
-			}]
-		},
-		"smeargle": {
-			"flags": {},
-			"sets": [{
-				"species": "Smeargle",
-				"item": ["Focus Sash"],
-				"ability": ["Own Tempo"],
-				"evs": {"hp": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Jolly",
-				"moves": [["Sticky Web"], ["Stealth Rock"], ["Taunt"], ["Spore"]]
-			}]
-		},
-		"sneasel": {
-			"flags": {},
-			"sets": [{
-				"species": "Sneasel",
-				"item": ["Choice Band"],
-				"ability": ["Inner Focus"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Knock Off"], ["Pursuit"], ["Icicle Crash"], ["Ice Shard"]]
-			}, {
-				"species": "Sneasel",
-				"item": ["Focus Sash"],
-				"ability": ["Inner Focus"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Knock Off"], ["Icicle Crash"], ["Low Kick"]]
-			}]
-		},
-		"steelix": {
-			"flags": {},
-			"sets": [{
-				"species": "Steelix",
-				"item": ["Leftovers"],
-				"ability": ["Sturdy"],
-				"evs": {"hp": 244, "atk": 16, "spd": 248},
-				"nature": "Adamant",
-				"moves": [["Stealth Rock"], ["Earthquake"], ["Heavy Slam"], ["Toxic"]]
-			}]
-		},
-		"stoutland": {
-			"flags": {},
-			"sets": [{
-				"species": "Stoutland",
-				"item": ["Choice Band"],
-				"ability": ["Sand Rush"],
-				"happiness": 0,
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Frustration"], ["Facade"], ["Pursuit"], ["Superpower"]]
-			}]
-		},
-		"toxicroak": {
-			"flags": {},
-			"sets": [{
-				"species": "Toxicroak",
-				"item": ["Life Orb"],
-				"ability": ["Dry Skin"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Sucker Punch"], ["Swords Dance"], ["Drain Punch"], ["Gunk Shot"]]
-			}, {
-				"species": "Toxicroak",
-				"item": ["Life Orb"],
-				"ability": ["Dry Skin"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Nasty Plot"], ["Sludge Wave"], ["Dark Pulse"], ["Vacuum Wave"]]
-			}]
-		},
-		"typhlosion": {
-			"flags": {},
-			"sets": [{
-				"species": "Typhlosion",
-				"item": ["Choice Specs"],
-				"ability": ["Flash Fire"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Eruption"], ["Fire Blast"], ["Hidden Power Grass"], ["Focus Blast"]]
-			}]
-		},
-		"uxie": {
-			"flags": {},
-			"sets": [{
-				"species": "Uxie",
-				"item": ["Leftovers"],
-				"ability": ["Levitate"],
-				"evs": {"hp": 252, "def": 120, "spe": 136},
-				"nature": "Timid",
-				"moves": [["Stealth Rock"], ["U-turn"], ["Psychic"], ["Protect"]]
-			}]
-		},
-		"vanilluxe": {
-			"flags": {},
-			"sets": [{
-				"species": "Vanilluxe",
-				"item": ["Choice Specs"],
-				"ability": ["Snow Warning"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"nature": "Modest",
-				"moves": [["Blizzard"], ["Freeze-Dry"], ["Flash Cannon"], ["Hidden Power Ground"]]
-			}, {
-				"species": "Vanilluxe",
-				"item": ["Choice Scarf"],
-				"ability": ["Snow Warning"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Blizzard"], ["Freeze-Dry"], ["Flash Cannon"], ["Hidden Power Ground"]]
-			}]
-		},
-		"vaporeon": {
-			"flags": {},
-			"sets": [{
-				"species": "Vaporeon",
-				"item": ["Leftovers"],
-				"ability": ["Water Absorb"],
-				"evs": {"hp": 192, "def": 252, "spd": 64},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Wish"], ["Protect"], ["Scald"], ["Toxic"]]
-			}, {
-				"species": "Vaporeon",
-				"item": ["Normalium Z"],
-				"ability": ["Water Absorb"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Hydro Pump"], ["Ice Beam"], ["Hidden Power Grass"], ["Celebrate"]]
-			}]
-		},
-		"vileplume": {
-			"flags": {},
-			"sets": [{
-				"species": "Vileplume",
-				"item": ["Black Sludge"],
-				"ability": ["Effect Spore"],
-				"evs": {"hp": 252, "def": 252, "spe": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Strength Sap"], ["Giga Drain"], ["Sludge Bomb"], ["Aromatherapy"]]
-			}]
-		},
-		"vikavolt": {
-			"flags": {},
-			"sets": [{
-				"species": "Vikavolt",
-				"item": ["Leftovers"],
-				"ability": ["Levitate"],
-				"evs": {"hp": 252, "spa": 136, "spd": 44, "spe": 76},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Bug Buzz"], ["Volt Switch"], ["Energy Ball"], ["Roost"]]
-			}, {
-				"species": "Vikavolt",
-				"item": ["Choice Specs"],
-				"ability": ["Levitate"],
-				"evs": {"hp": 176, "def": 4, "spa": 252, "spe": 76},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Bug Buzz"], ["Volt Switch"], ["Energy Ball"], ["Thunderbolt"]]
-			}, {
-				"species": "Vikavolt",
-				"item": ["Buginium Z"],
-				"ability": ["Levitate"],
-				"evs": {"hp": 176, "def": 4, "spa": 252, "spe": 76},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Roost"], ["Bug Buzz"], ["Energy Ball"], ["Volt Switch"]]
-			}]
-		},
-		"vivillonfancy": {
-			"flags": {},
-			"sets": [{
-				"species": "Vivillon-Fancy",
-				"item": ["Flyinium Z"],
-				"ability": ["Compound Eyes"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Quiver Dance"], ["Sleep Powder"], ["Hurricane"], ["Substitute"]]
-			}]
-		},
-		"vivillon": {
-			"flags": {},
-			"sets": [{
-				"species": "Vivillon",
-				"item": ["Leftovers"],
-				"ability": ["Compound Eyes"],
-				"evs": {"hp": 16, "spa": 240, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Substitute"], ["Sleep Powder"], ["Quiver Dance"], ["Hurricane"]]
-			}, {
-				"species": "Vivillon",
-				"item": ["Focus Sash"],
-				"ability": ["Compound Eyes"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Quiver Dance"], ["Sleep Powder"], ["Hurricane"], ["Energy Ball"]]
-			}]
-		},
-		"whimsicott": {
-			"flags": {},
-			"sets": [{
-				"species": "Whimsicott",
-				"item": ["Choice Specs"],
-				"ability": ["Infiltrator"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Energy Ball"], ["Moonblast"], ["Psychic"], ["U-turn"]]
-			}, {
-				"species": "Whimsicott",
-				"item": ["Life Orb"],
-				"ability": ["Prankster"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Energy Ball"], ["Moonblast"], ["Psychic"], ["Defog"]]
-			}, {
-				"species": "Whimsicott",
-				"item": ["Pixie Plate"],
-				"ability": ["Prankster"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Giga Drain"], ["Moonblast"], ["Encore"], ["U-turn"]]
-			}, {
-				"species": "Whimsicott",
-				"item": ["Normalium Z"],
-				"ability": ["Infiltrator"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Growth"], ["Moonblast"], ["Energy Ball"], ["Psychic"]]
-			}]
-		},
-		"xatu": {
-			"flags": {},
-			"sets": [{
-				"species": "Xatu",
-				"item": ["Rocky Helmet"],
-				"ability": ["Magic Bounce"],
-				"evs": {"hp": 252, "def": 212, "spe": 44},
-				"nature": "Timid",
-				"moves": [["Psychic"], ["U-turn"], ["Grass Knot"], ["Roost"]]
-			}, {
-				"species": "Xatu",
-				"item": ["Colbur Berry"],
-				"ability": ["Magic Bounce"],
-				"evs": {"hp": 252, "def": 212, "spe": 44},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Calm Mind"], ["Psychic"], ["Signal Beam"], ["Roost"]]
-			}]
-		},
-		"charizard": {
-			"flags": {},
-			"sets": [{
-				"species": "Charizard",
-				"item": ["Normalium Z"],
-				"ability": ["Solar Power"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Celebrate"], ["Fire Blast"], ["Air Slash"], ["Focus Blast"]]
-			}, {
-				"species": "Charizard",
-				"item": ["Firium Z"],
-				"ability": ["Solar Power"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Sunny Day"], ["Fire Blast"], ["Solar Beam"], ["Air Slash"]]
-			}]
-		},
-		"gallade": {
-			"flags": {},
-			"sets": [{
-				"species": "Gallade",
-				"item": ["Lum Berry"],
-				"ability": ["Justified"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Close Combat"], ["Zen Headbutt"], ["Thunder Punch"]]
-			}, {
-				"species": "Gallade",
-				"item": ["Choice Scarf"],
-				"ability": ["Justified"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Memento"], ["Close Combat"], ["Zen Headbutt"], ["Knock Off"]]
-			}]
-		},
-		"abomasnow": {
-			"flags": {},
-			"sets": [{
-				"species": "Abomasnow",
-				"item": ["Life Orb"],
-				"ability": ["Snow Warning"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Hasty",
-				"moves": [["Blizzard"], ["Ice Shard"], ["Giga Drain"], ["Focus Blast"]]
-			}]
-		},
-		"kabutops": {
-			"flags": {},
-			"sets": [{
-				"species": "Kabutops",
-				"item": ["Rockium Z"],
-				"ability": ["Swift Swim"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Liquidation"], ["Stone Edge"], ["Aqua Jet"]]
-			}]
-		},
-		"haunter": {
-			"flags": {},
-			"sets": [{
-				"species": "Haunter",
-				"item": ["Life Orb"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Shadow Ball"], ["Sludge Wave"], ["Dazzling Gleam"], ["Destiny Bond"]]
-			}, {
-				"species": "Haunter",
-				"item": ["Choice Scarf"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Shadow Ball"], ["Sludge Wave"], ["Dazzling Gleam"], ["Trick"]]
-			}, {
-				"species": "Haunter",
-				"item": ["Life Orb"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Substitute"], ["Pain Split"], ["Shadow Ball"], ["Sludge Bomb"]]
-			}]
-		},
-		"absol": {
-			"flags": {},
-			"sets": [{
-				"species": "Absol",
-				"item": ["Life Orb"],
-				"ability": ["Super Luck"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Sucker Punch"], ["Knock Off"], ["Superpower", "Iron Tail"]]
-			}]
-		},
-		"raticatealola": {
-			"flags": {},
-			"sets": [{
-				"species": "Raticate-Alola",
-				"item": ["Darkinium Z"],
-				"ability": ["Hustle"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Crunch"], ["Double-Edge"], ["Sucker Punch"], ["Swords Dance"]]
-			}]
-		},
-		"sawk": {
-			"flags": {},
-			"sets": [{
-				"species": "Sawk",
-				"item": ["Choice Scarf"],
-				"ability": ["Mold Breaker"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Close Combat"], ["Knock Off"], ["Earthquake"], ["Ice Punch"]]
-			}, {
-				"species": "Sawk",
-				"item": ["Choice Band"],
-				"ability": ["Mold Breaker"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Close Combat"], ["Knock Off"], ["Zen Headbutt"], ["Poison Jab"]]
-			}]
-		},
-		"drampa": {
-			"flags": {},
-			"sets": [{
-				"species": "Drampa",
-				"item": ["Choice Specs"],
-				"ability": ["Berserk"],
-				"evs": {"hp": 136, "spa": 252, "spe": 120},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Hyper Voice"], ["Energy Ball"], ["Fire Blast"], ["Draco Meteor"]]
-			}]
-		},
-		"hitmontop": {
-			"flags": {},
-			"sets": [{
-				"species": "Hitmontop",
-				"item": ["Leftovers"],
-				"ability": ["Intimidate"],
-				"evs": {"hp": 252, "atk": 4, "def": 252},
-				"nature": "Impish",
-				"moves": [["Close Combat"], ["Rapid Spin"], ["Foresight"], ["Toxic"]]
-			}]
-		},
-		"magmortar": {
-			"flags": {},
-			"sets": [{
-				"species": "Magmortar",
-				"item": ["Assault Vest"],
-				"ability": ["Vital Spirit"],
-				"evs": {"hp": 64, "spa": 252, "spe": 192},
-				"nature": "Mild",
-				"moves": [["Fire Blast"], ["Thunderbolt"], ["Hidden Power Grass"], ["Earthquake"]]
-			}, {
-				"species": "Magmortar",
-				"item": ["Fightinium Z"],
-				"ability": ["Vital Spirit"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Mild",
-				"moves": [["Fire Blast"], ["Thunderbolt"], ["Focus Blast"], ["Flame Charge"]]
-			}]
-		},
-		"mesprit": {
-			"flags": {},
-			"sets": [{
-				"species": "Mesprit",
-				"item": ["Choice Scarf"],
-				"ability": ["Levitate"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"nature": "Timid",
-				"moves": [["U-turn"], ["Psyshock"], ["Ice Beam"], ["Healing Wish"]]
-			}]
-		},
-		"ferroseed": {
-			"flags": {},
-			"sets": [{
-				"species": "Ferroseed",
-				"item": ["Eviolite"],
-				"ability": ["Iron Barbs"],
-				"evs": {"hp": 252, "atk": 4, "def": 252},
-				"ivs": {"spe": 0},
-				"nature": "Relaxed",
-				"moves": [["Stealth Rock"], ["Leech Seed"], ["Protect"], ["Gyro Ball"]]
-			}]
-		},
-		"gastrodon": {
-			"flags": {},
-			"sets": [{
-				"species": "Gastrodon",
-				"item": ["Leftovers"],
-				"ability": ["Storm Drain"],
-				"evs": {"hp": 252, "def": 244, "spe": 12},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Scald"], ["Earth Power"], ["Recover"], ["Toxic"]]
-			}]
-		},
-		"gourgeistsuper": {
-			"flags": {},
-			"sets": [{
-				"species": "Gourgeist-Super",
-				"item": ["Colbur Berry"],
-				"ability": ["Frisk"],
-				"evs": {"hp": 252, "def": 252, "spd": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Leech Seed"], ["Will-O-Wisp"], ["Synthesis"], ["Foul Play"]]
-			}]
-		},
-		"spiritomb": {
-			"flags": {},
-			"sets": [{
-				"species": "Spiritomb",
-				"item": ["Leftovers"],
-				"ability": ["Pressure"],
-				"evs": {"hp": 252, "def": 252, "spd": 4},
-				"ivs": {"atk": 0},
-				"nature": "Impish",
-				"moves": [["Rest"], ["Sleep Talk"], ["Calm Mind"], ["Dark Pulse"]]
-			}]
-		},
-		"probopass": {
-			"flags": {},
-			"sets": [{
-				"species": "Probopass",
-				"item": ["Air Balloon"],
-				"ability": ["Magnet Pull"],
-				"evs": {"hp": 172, "spa": 252, "spe": 84},
-				"nature": "Modest",
-				"moves": [["Power Gem"], ["Magnet Rise"], ["Earth Power"], ["Stealth Rock"]]
-			}]
-		},
-		"togedemaru": {
-			"flags": {},
-			"sets": [{
-				"species": "Togedemaru",
-				"item": ["Leftovers"],
-				"ability": ["Lightning Rod"],
-				"evs": {"hp": 252, "atk": 4, "spd": 252},
-				"nature": "Careful",
-				"moves": [["Wish"], ["Spiky Shield"], ["Zing Zap", "U-turn"], ["Super Fang"]]
-			}]
-		},
-		"lilligant": {
-			"flags": {},
-			"sets": [{
-				"species": "Lilligant",
-				"item": ["Normalium Z"],
-				"ability": ["Chlorophyll"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Quiver Dance"], ["Hyper Beam"], ["Sleep Powder"], ["Giga Drain"]]
-			}]
-		},
-		"ludicolo": {
-			"flags": {},
-			"sets": [{
-				"species": "Ludicolo",
-				"item": ["Life Orb"],
-				"ability": ["Swift Swim"],
-				"evs": {"hp": 4, "spa": 252, "spe": 252},
-				"nature": "Modest",
-				"moves": [["Rain Dance"], ["Hydro Pump"], ["Giga Drain"], ["Ice Beam"]]
-			}]
-		},
-		"exeggutoralola": {
-			"flags": {},
-			"sets": [{
-				"species": "Exeggutor-Alola",
-				"item": ["Dragonium Z"],
-				"ability": ["Frisk"],
-				"evs": {"hp": 252, "spa": 252, "spd": 4},
-				"ivs": {"atk": 0, "spe": 0},
-				"nature": "Quiet",
-				"moves": [["Giga Drain"], ["Draco Meteor"], ["Flamethrower"], ["Trick Room"]]
-			}]
-		},
-		"granbull": {
-			"flags": {},
-			"sets": [{
-				"species": "Granbull",
-				"item": ["Normalium Z"],
-				"ability": ["Intimidate"],
-				"evs": {"hp": 248, "atk": 8, "def": 252},
-				"nature": "Impish",
-				"moves": [["Heal Bell"], ["Play Rough"], ["Earthquake"], ["Thunder Wave"]]
-			}, {
-				"species": "Granbull",
-				"item": ["Choice Band"],
-				"ability": ["Intimidate"],
-				"evs": {"hp": 132, "atk": 252, "spe": 124},
-				"nature": "Adamant",
-				"moves": [["Play Rough"], ["Close Combat"], ["Earthquake"], ["Ice Punch"]]
-			}]
-		},
-		"typenull": {
-			"flags": {},
-			"sets": [{
-				"species": "Type: Null",
-				"item": ["Eviolite"],
-				"ability": ["Battle Armor"],
-				"happiness": 0,
-				"evs": {"hp": 252, "spd": 244, "spe": 12},
-				"nature": "Careful",
-				"moves": [["Swords Dance"], ["Iron Defense"], ["Frustration"], ["Rest"]]
-			}, {
-				"species": "Type: Null",
-				"item": ["Eviolite"],
-				"ability": ["Battle Armor"],
-				"happiness": 0,
-				"evs": {"hp": 252, "spd": 244, "spe": 12},
-				"nature": "Careful",
-				"moves": [["Sleep Talk"], ["U-turn"], ["Frustration"], ["Rest"]]
-			}]
-		},
+		}
+	},
+	"PU": {
 		"altaria": {
 			"flags": {},
 			"sets": [{
 				"species": "Altaria",
 				"item": ["Leftovers"],
 				"ability": ["Natural Cure"],
-				"evs": {"hp": 252, "def": 240, "spe": 16},
+				"evs": {"hp": 252, "spd": 240, "spe": 16},
 				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Defog"], ["Roost"], ["Flamethrower"], ["Toxic"]]
+				"nature": "Calm",
+				"moves": [["Dragon Pulse"], ["Roost"], ["Flamethrower", "Toxic"], ["Defog"]]
 			}]
 		},
-		"ditto": {
+		"articuno": {
 			"flags": {},
 			"sets": [{
-				"species": "Ditto",
-				"item": ["Choice Scarf"],
-				"ability": ["Imposter"],
-				"evs": {"hp": 252, "atk": 4, "def": 252},
-				"ivs": {"atk": 30, "spa": 30, "spe": 0},
-				"nature": "Relaxed",
-				"moves": [["Transform"]]
-			}]
-		},
-		"passimian": {
-			"flags": {},
-			"sets": [{
-				"species": "Passimian",
-				"item": ["Choice Scarf"],
-				"ability": ["Receiver"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Close Combat"], ["U-turn"], ["Gunk Shot"], ["Knock Off"]]
+				"species": "Articuno",
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Substitute"], ["Roost"], ["Hurricane"], ["Freeze-Dry"]]
 			}, {
-				"species": "Passimian",
-				"item": ["Choice Band"],
-				"ability": ["Receiver"],
+				"species": "Articuno",
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 248, "spd": 220, "spe": 40},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Heal Bell"], ["Roost"], ["Defog", "Toxic"], ["Freeze-Dry"]]
+			}]
+		},
+		"kingler": {
+			"flags": {},
+			"sets": [{
+				"species": "Kingler",
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": "Naughty",
+				"moves": [["Liquidation"], ["Stomping Tantrum"], ["Agility"], ["Ice Beam"]]
+			}, {
+				"species": "Kingler",
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Adamant",
-				"moves": [["Close Combat"], ["U-turn"], ["Gunk Shot"], ["Knock Off"]]
+				"moves": [["Liquidation"], ["Stomping Tantrum", "Superpower"], ["Agility"], ["Swords Dance"]]
 			}]
 		},
-		"palossand": {
-			"flags": {},
-			"sets": [{
-				"species": "Palossand",
-				"item": ["Colbur Berry"],
-				"ability": ["Water Compaction"],
-				"evs": {"hp": 252, "def": 252, "spe": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Stealth Rock"], ["Earth Power"], ["Shadow Ball"], ["Shore Up"]]
-			}]
-		},
-		"silvallywater": {
-			"flags": {},
-			"sets": [{
-				"species": "Silvally-Water",
-				"item": ["Water Memory"],
-				"ability": ["RKS System"],
-				"evs": {"hp": 252, "def": 252, "spe": 4},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Defog"], ["Surf"], ["Parting Shot"], ["Toxic"]]
-			}]
-		},
-		"zangoose": {
-			"flags": {},
-			"sets": [{
-				"species": "Zangoose",
-				"item": ["Sitrus Berry"],
-				"ability": ["Immunity"],
-				"evs": {"hp": 4, "atk": 252, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Belly Drum"], ["Quick Attack"], ["Knock Off"], ["Close Combat"]]
-			}]
-		},
-		"lycanroc": {
-			"flags": {},
-			"sets": [{
-				"species": "Lycanroc",
-				"item": ["Focus Sash"],
-				"ability": ["Keen Eye"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Hasty",
-				"moves": [["Stealth Rock"], ["Taunt"], ["Endeavor"], ["Stone Edge"]]
-			}]
-		},
-		"crustle": {
-			"flags": {},
-			"sets": [{
-				"species": "Crustle",
-				"item": ["Mental Herb"],
-				"ability": ["Sturdy"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Stealth Rock"], ["Spikes"], ["Rock Blast"], ["Shell Smash"]]
-			}]
-		}
-	},
-	"PU": {
 		"mesprit": {
 			"flags": {},
 			"sets": [{
@@ -8601,15 +8619,15 @@
 				"item": ["Colbur Berry"],
 				"ability": ["Levitate"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Psychic"], ["Stealth Rock"], ["Ice Beam", "Dazzling Gleam"], ["U-turn", "Healing Wish"]]
+				"nature": ["Modest", "Timid"],
+				"moves": [["Psychic"], ["Stealth Rock"], ["Healing Wish", "U-turn"], ["Dazzling Gleam"]]
 			}, {
 				"species": "Mesprit",
 				"item": ["Choice Scarf"],
 				"ability": ["Levitate"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Psychic"], ["Ice Beam"], ["Dazzling Gleam", "Healing Wish"], ["U-turn"]]
+				"moves": [["Psychic"], ["Ice Beam"], ["Dazzling Gleam", "Trick"], ["U-turn"]]
 			}, {
 				"species": "Mesprit",
 				"item": ["Choice Specs"],
@@ -8617,23 +8635,15 @@
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Modest",
-				"moves": [["Psychic"], ["Ice Beam"], ["Signal Beam"], ["U-turn"]]
+				"moves": [["Psychic"], ["Dazzling Gleam"], ["Healing Wish"], ["Hidden Power Ground", "U-turn"]]
 			}, {
 				"species": "Mesprit",
-				"item": ["Choice Specs"],
-				"ability": ["Levitate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Psychic"], ["Ice Beam"], ["Signal Beam"], ["Hidden Power Ground"]]
-			}, {
-				"species": "Mesprit",
-				"item": ["Life Orb", "Colbur Berry"],
+				"item": ["Icium Z", "Leftovers"],
 				"ability": ["Levitate"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Psychic"], ["Ice Beam"], ["Hidden Power Ground"], ["Calm Mind"]]
+				"moves": [["Psychic"], ["Ice Beam"], ["Hidden Power Ground", "Substitute"], ["Calm Mind"]]
 			}]
 		},
 		"skuntank": {
@@ -8643,54 +8653,33 @@
 				"item": ["Black Sludge", "Darkinium Z"],
 				"ability": ["Aftermath"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Dark Pulse"], ["Acid Spray"], ["Fire Blast"], ["Defog"]]
+				"nature": "Modest",
+				"moves": [["Dark Pulse"], ["Acid Spray", "Sludge Bomb"], ["Taunt"], ["Defog"]]
 			}, {
 				"species": "Skuntank",
-				"item": ["Black Sludge", "Lum Berry"],
+				"item": ["Black Glasses", "Rocky Helmet", "Black Sludge"],
 				"ability": ["Aftermath"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Sucker Punch"], ["Pursuit"], ["Poison Jab", "Crunch"], ["Taunt"]]
+				"nature": "Adamant",
+				"moves": [["Sucker Punch"], ["Pursuit"], ["Poison Jab"], ["Defog"]]
 			}, {
 				"species": "Skuntank",
-				"item": ["Black Sludge", "Lum Berry"],
+				"item": ["Black Glasses", "Rocky Helmet", "Black Sludge", "Darkinium Z"],
 				"ability": ["Aftermath"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Sucker Punch"], ["Pursuit"], ["Poison Jab", "Crunch"], ["Defog"]]
-			}, {
-				"species": "Skuntank",
-				"item": ["Choice Band", "Black Glasses"],
-				"ability": ["Aftermath"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Sucker Punch"], ["Pursuit"], ["Poison Jab"], ["Crunch"]]
+				"nature": "Adamant",
+				"moves": [["Sucker Punch"], ["Pursuit"], ["Poison Jab", "Defog"], ["Crunch"]]
 			}]
 		},
 		"carracosta": {
 			"flags": {},
 			"sets": [{
 				"species": "Carracosta",
-				"item": ["Life Orb"],
+				"item": ["Rockium Z", "White Herb", "Life Orb"],
 				"ability": ["Solid Rock"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Naughty",
-				"moves": [["Shell Smash"], ["Hydro Pump", "Ice Beam"], ["Aqua Jet"], ["Stone Edge"]]
-			}, {
-				"species": "Carracosta",
-				"item": ["Life Orb"],
-				"ability": ["Solid Rock"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Naughty",
-				"moves": [["Shell Smash"], ["Hidden Power Grass"], ["Aqua Jet"], ["Stone Edge"]]
-			}, {
-				"species": "Carracosta",
-				"item": ["Life Orb", "White Herb"],
-				"ability": ["Solid Rock"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Shell Smash"], ["Aqua Jet"], ["Stone Edge"], ["Superpower", "Waterfall"]]
+				"nature": "Naive",
+				"moves": [["Shell Smash"], ["Hydro Pump"], ["Aqua Jet"], ["Stone Edge"]]
 			}, {
 				"species": "Carracosta",
 				"item": ["Leftovers"],
@@ -8717,7 +8706,7 @@
 				"evs": {"hp": 248, "def": 252, "spa": 8},
 				"ivs": {"atk": 0},
 				"nature": "Bold",
-				"moves": [["Dazzling Gleam"], ["Calm Mind"], ["Psyshock", "Psychic"], ["Moonlight"]]
+				"moves": [["Dazzling Gleam"], ["Calm Mind"], ["Psychic"], ["Moonlight"]]
 			}]
 		},
 		"weezing": {
@@ -8728,14 +8717,7 @@
 				"ability": ["Levitate"],
 				"evs": {"hp": 248, "def": 252, "spd": 8},
 				"nature": "Bold",
-				"moves": [["Pain Split", "Flamethrower"], ["Sludge Bomb"], ["Taunt"], ["Will-O-Wisp"]]
-			}, {
-				"species": "Weezing",
-				"item": ["Black Sludge", "Rocky Helmet"],
-				"ability": ["Levitate"],
-				"evs": {"hp": 248, "def": 252, "spd": 8},
-				"nature": "Bold",
-				"moves": [["Toxic Spikes"], ["Sludge Bomb"], ["Taunt"], ["Will-O-Wisp"]]
+				"moves": [["Pain Split", "Thunderbolt"], ["Sludge Bomb"], ["Taunt", "Will-O-Wisp"], ["Toxic Spikes"]]
 			}]
 		},
 		"gurdurr": {
@@ -8744,7 +8726,7 @@
 				"species": "Gurdurr",
 				"item": ["Eviolite"],
 				"ability": ["Guts"],
-				"evs": {"hp": 248, "atk": 56, "def": 200, "spe": 4},
+				"evs": {"hp": 248, "atk": 56, "def": 204},
 				"nature": "Adamant",
 				"moves": [["Bulk Up"], ["Drain Punch"], ["Knock Off"], ["Mach Punch"]]
 			}]
@@ -8758,15 +8740,15 @@
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Nasty Plot"], ["Ice Beam"], ["Psyshock"], ["Lovely Kiss"]]
+				"moves": [["Nasty Plot", "Focus Blast"], ["Ice Beam"], ["Psyshock"], ["Lovely Kiss"]]
 			}, {
 				"species": "Jynx",
-				"item": ["Choice Scarf"],
+				"item": ["Normalium Z", "Leftovers"],
 				"ability": ["Dry Skin"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Ice Beam"], ["Psyshock"], ["Focus Blast"], ["Lovely Kiss"]]
+				"moves": [["Ice Beam"], ["Substitute"], ["Nasty Plot"], ["Lovely Kiss"]]
 			}]
 		},
 		"lanturn": {
@@ -8777,21 +8759,14 @@
 				"ability": ["Volt Absorb"],
 				"evs": {"spa": 252, "spd": 132, "spe": 124},
 				"nature": "Modest",
-				"moves": [["Scald"], ["Volt Switch"], ["Ice Beam"], ["Hidden Power Grass"]]
-			}, {
-				"species": "Lanturn",
-				"item": ["Assault Vest"],
-				"ability": ["Volt Absorb"],
-				"evs": {"spa": 252, "spd": 132, "spe": 124},
-				"nature": "Modest",
-				"moves": [["Scald"], ["Volt Switch"], ["Ice Beam"], ["Hidden Power Fire"]]
+				"moves": [["Scald"], ["Volt Switch"], ["Ice Beam"], ["Discharge"]]
 			}, {
 				"species": "Lanturn",
 				"item": ["Leftovers"],
 				"ability": ["Volt Absorb"],
 				"evs": {"hp": 40, "def": 140, "spd": 204, "spe": 124},
 				"nature": "Calm",
-				"moves": [["Scald"], ["Volt Switch"], ["Heal Bell"], ["Toxic"]]
+				"moves": [["Scald"], ["Volt Switch"], ["Heal Bell", "Protect"], ["Toxic"]]
 			}]
 		},
 		"lilligant": {
@@ -8805,11 +8780,11 @@
 				"moves": [["Quiver Dance"], ["Sleep Powder"], ["Giga Drain"], ["Hyper Beam"]]
 			}, {
 				"species": "Lilligant",
-				"item": ["Life Orb"],
+				"item": ["Life Orb", "Grassium Z"],
 				"ability": ["Chlorophyll"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Quiver Dance"], ["Sleep Powder"], ["Giga Drain"], ["Hidden Power Fire"]]
+				"moves": [["Quiver Dance"], ["Sleep Powder"], ["Giga Drain"], ["Hidden Power Rock"]]
 			}, {
 				"species": "Lilligant",
 				"item": ["Choice Scarf"],
@@ -8817,6 +8792,24 @@
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
 				"moves": [["Leaf Storm"], ["Energy Ball"], ["Healing Wish"], ["Hidden Power Rock"]]
+			}, {
+				"species": "Lilligant",
+				"item": ["Choice Specs"],
+				"ability": ["Own tempo"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Petal Dance"], ["Giga Drain"], ["Healing Wish"], ["Hidden Power Rock"]]
+			}]
+		},
+		"bellossom": {
+			"flags": {},
+			"sets": [{
+				"species": "Bellossom",
+				"item": ["Grassium Z"],
+				"ability": ["Chlorophyll"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Quiver Dance"], ["Strength Sap"], ["Giga Drain"], ["Moonblast", "Safeguard"]]
 			}]
 		},
 		"sableye": {
@@ -8834,31 +8827,12 @@
 			"flags": {},
 			"sets": [{
 				"species": "Exeggutor-Alola",
-				"item": ["Dragonium Z", "Life Orb"],
-				"ability": ["Frisk"],
-				"evs": {"hp": 248, "spa": 252, "spd": 8},
-				"ivs": {"atk": 0},
-				"nature": "Quiet",
-				"moves": [["Trick Room"], ["Draco Meteor"], ["Energy Ball", "Giga Drain"], ["Flamethrower"]]
-			}, {
-				"species": "Exeggutor-Alola",
 				"item": ["Choice Specs"],
 				"ability": ["Frisk"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"evs": {"hp": 212, "spa": 252, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Modest",
-				"moves": [["Leaf Storm"], ["Draco Meteor"], ["Flamethrower"], ["Sludge Bomb", "Energy Ball"]]
-			}]
-		},
-		"ferroseed": {
-			"flags": {},
-			"sets": [{
-				"species": "Ferroseed",
-				"item": ["Eviolite"],
-				"ability": ["Iron Barbs"],
-				"evs": {"hp": 248, "def": 128, "spd": 132},
-				"nature": "Sassy",
-				"moves": [["Stealth Rock", "Spikes"], ["Leech Seed"], ["Gyro Ball"], ["Protect", "Knock Off"]]
+				"moves": [["Leaf Storm"], ["Draco Meteor"], ["Flamethrower"], ["Sludge Bomb", "Giga Drain"]]
 			}]
 		},
 		"golurk": {
@@ -8866,46 +8840,39 @@
 			"sets": [{
 				"species": "Golurk",
 				"item": ["Colbur Berry"],
-				"ability": ["Iron Fist"],
+				"ability": ["No Guard"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Stealth Rock"], ["Earthquake"], ["Shadow Punch"], ["Ice Punch"]]
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Dynamic Punch"], ["Ice Punch", "Stone Edge"]]
 			}]
 		},
 		"hitmonchan": {
 			"flags": {},
 			"sets": [{
 				"species": "Hitmonchan",
-				"item": ["Life Orb", "Fist Plate"],
-				"ability": ["Iron Fist"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Drain Punch", "Close Combat"], ["Ice Punch"], ["Mach Punch"], ["Rapid Spin"]]
-			}, {
-				"species": "Hitmonchan",
 				"item": ["Assault Vest"],
 				"ability": ["Iron Fist"],
-				"evs": {"hp": 252, "atk": 168, "spe": 88},
+				"evs": {"hp": 244, "atk": 152, "spe": 112},
 				"nature": "Adamant",
-				"moves": [["Drain Punch"], ["Mach Punch"], ["Ice Punch"], ["Rapid Spin"]]
-			}, {
-				"species": "Hitmonchan",
-				"item": ["Life Orb"],
-				"ability": ["Iron Fist"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Bulk Up"], ["Drain Punch"], ["Mach Punch"], ["Ice Punch"]]
+				"moves": [["Drain Punch"], ["Mach Punch"], ["Stone Edge", "Thunder Punch"], ["Rapid Spin"]]
 			}]
 		},
 		"kangaskhan": {
 			"flags": {},
 			"sets": [{
 				"species": "Kangaskhan",
-				"item": ["Silk Scarf"],
+				"item": ["Silk Scarf", "Normalium Z"],
 				"ability": ["Scrappy"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Adamant",
 				"moves": [["Fake Out"], ["Double-Edge"], ["Sucker Punch"], ["Earthquake"]]
+			}, {
+				"species": "Kangaskhan",
+				"item": ["Fightinium Z"],
+				"ability": ["Scrappy"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Fake Out", "Power-Up Punch"], ["Double-Edge"], ["Sucker Punch"], ["Focus Punch"]]
 			}]
 		},
 		"primeape": {
@@ -8916,21 +8883,21 @@
 				"ability": ["Defiant"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Close Combat"], ["U-turn"], ["Earthquake"], ["Stone Edge"]]
+				"moves": [["Close Combat"], ["U-turn"], ["Earthquake", "Gunk Shot"], ["Stone Edge"]]
 			}, {
 				"species": "Primeape",
 				"item": ["Choice Band"],
 				"ability": ["Defiant"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Close Combat"], ["U-turn"], ["Earthquake"], ["Stone Edge", "Gunk Shot"]]
+				"moves": [["Close Combat"], ["U-turn"], ["Earthquake", "Gunk Shot"], ["Stone Edge"]]
 			}]
 		},
 		"pyroar": {
 			"flags": {},
 			"sets": [{
 				"species": "Pyroar",
-				"item": ["Life Orb"],
+				"item": ["Life Orb", "Firium Z"],
 				"ability": ["Unnerve"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
 				"nature": "Timid",
@@ -8948,7 +8915,7 @@
 				"ability": ["Unnerve"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Fire Blast"], ["Hyper Voice"], ["Hidden Power Grass"], ["Flamethrower", "Overheat"]]
+				"moves": [["Fire Blast"], ["Hyper Voice"], ["Hidden Power Grass"], ["Flamethrower"]]
 			}]
 		},
 		"regirock": {
@@ -8957,9 +8924,9 @@
 				"species": "Regirock",
 				"item": ["Leftovers"],
 				"ability": ["Clear Body"],
-				"evs": {"hp": 252, "def": 56, "spd": 200},
+				"evs": {"hp": 248, "def": 56, "spd": 204},
 				"nature": "Impish",
-				"moves": [["Stealth Rock"], ["Rock Slide", "Stone Edge"], ["Earthquake", "Fire Punch"], ["Toxic"]]
+				"moves": [["Stealth Rock"], ["Rock Slide", "Stone Edge"], ["Earthquake"], ["Toxic", "Protect"]]
 			}]
 		},
 		"shiftry": {
@@ -8976,7 +8943,7 @@
 				"item": ["Grassium Z", "Life Orb"],
 				"ability": ["Chlorophyll"],
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
-				"nature": "Adamant",
+				"nature": ["Adamant", "Jolly"],
 				"moves": [["Swords Dance"], ["Knock Off"], ["Seed Bomb"], ["Sucker Punch"]]
 			}, {
 				"species": "Shiftry",
@@ -8984,7 +8951,7 @@
 				"ability": ["Pickpocket"],
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
 				"nature": "Adamant",
-				"moves": [["Knock Off"], ["Leaf Blade"], ["Rock Slide"], ["Explosion"]]
+				"moves": [["Knock Off"], ["Leaf Blade"], ["Rock Slide"], ["Explosion", "Defog"]]
 			}, {
 				"species": "Shiftry",
 				"item": ["Choice Scarf"],
@@ -9002,11 +8969,18 @@
 				"ability": ["Snow Warning"],
 				"evs": {"atk": 4, "spa": 252, "spe": 252},
 				"nature": "Rash",
-				"moves": [["Blizzard"], ["Giga Drain"], ["Earthquake"], ["Ice Shard"]]
+				"moves": [["Blizzard"], ["Giga Drain", "Wood Hammer"], ["Earthquake"], ["Ice Shard"]]
+			}, {
+				"species": "Abomasnow",
+				"item": ["Choice Scarf"],
+				"ability": ["Snow Warning"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": "Naive",
+				"moves": [["Blizzard"], ["Giga Drain"], ["Earthquake"], ["Focus Blast"]]
 			}, {
 				"species": "Abomasnow",
 				"item": ["Life Orb", "Grassium Z"],
-				"ability": ["Soundproof", "Snow Warning"],
+				"ability": ["Snow Warning"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["Swords Dance"], ["Seed Bomb", "Wood Hammer"], ["Earthquake"], ["Ice Shard"]]
@@ -9016,22 +8990,11 @@
 			"flags": {},
 			"sets": [{
 				"species": "Absol",
-				"item": ["Life Orb"],
+				"item": ["Fairium Z", "Darkinium Z", "Life Orb"],
 				"ability": ["Justified"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Knock Off"], ["Sucker Punch"], ["Play Rough", "Superpower"]]
-			}]
-		},
-		"gastrodon": {
-			"flags": {},
-			"sets": [{
-				"species": "Gastrodon",
-				"item": ["Leftovers"],
-				"ability": ["Storm Drain"],
-				"evs": {"hp": 248, "def": 252, "spd": 8},
-				"nature": "Relaxed",
-				"moves": [["Scald"], ["Earthquake"], ["Toxic"], ["Recover"]]
+				"moves": [["Swords Dance"], ["Knock Off"], ["Sucker Punch"], ["Play Rough"]]
 			}]
 		},
 		"gourgeistsuper": {
@@ -9042,7 +9005,7 @@
 				"ability": ["Frisk"],
 				"evs": {"hp": 248, "def": 252, "spd": 8},
 				"nature": "Impish",
-				"moves": [["Will-O-Wisp"], ["Synthesis"], ["Foul Play"], ["Leech Seed"]]
+				"moves": [["Will-O-Wisp"], ["Synthesis"], ["Foul Play"], ["Leech Seed", "Rock Slide"]]
 			}]
 		},
 		"granbull": {
@@ -9074,29 +9037,29 @@
 				"moves": [["Swords Dance"], ["Stone Edge"], ["Waterfall"], ["Aqua Jet"]]
 			}, {
 				"species": "Kabutops",
-				"item": ["Shuca Berry", "Life Orb"],
+				"item": ["Choice Scarf"],
 				"ability": ["Swift Swim"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Rapid Spin"], ["Stone Edge"], ["Waterfall"], ["Aqua Jet", "Superpower"]]
+				"moves": [["Rapid Spin"], ["Stone Edge"], ["Waterfall"], ["Knock Off"]]
 			}]
 		},
 		"lycanroc": {
 			"flags": {},
 			"sets": [{
 				"species": "Lycanroc",
-				"item": ["Rockium Z", "Life Orb"],
+				"item": ["Lycanium Z", "Life Orb"],
 				"ability": ["Sand Rush"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Stone Edge"], ["Drill Run", "Fire Fang"], ["Accelerock"]]
+				"moves": [["Swords Dance"], ["Stone Edge"], ["Drill Run"], ["Accelerock"]]
 			}]
 		},
 		"raichualola": {
 			"flags": {},
 			"sets": [{
 				"species": "Raichu-Alola",
-				"item": ["Life Orb", "Fightinium Z"],
+				"item": ["Life Orb", "Aloraichium Z"],
 				"ability": ["Surge Surfer"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
 				"nature": "Timid",
@@ -9107,29 +9070,11 @@
 			"flags": {},
 			"sets": [{
 				"species": "Raticate-Alola",
-				"item": ["Darkinium Z", "Normalium Z", "Life Orb"],
+				"item": ["Darkinium Z", "Normalium Z"],
 				"ability": ["Hustle"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Double-Edge"], ["Sucker Punch"], ["Knock Off"]]
-			}]
-		},
-		"torterra": {
-			"flags": {},
-			"sets": [{
-				"species": "Torterra",
-				"item": ["Soft Sand", "Lum Berry"],
-				"ability": ["Overgrow"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Rock Polish"], ["Wood Hammer"], ["Earthquake"], ["Stone Edge", "Swords Dance"]]
-			}, {
-				"species": "Torterra",
-				"item": ["Leftovers"],
-				"ability": ["Overgrow"],
-				"evs": {"hp": 252, "atk": 60, "def": 196},
-				"nature": "Adamant",
-				"moves": [["Wood Hammer"], ["Earthquake"], ["Stealth Rock"], ["Synthesis"]]
+				"moves": [["Swords Dance"], ["Double-Edge"], ["Sucker Punch"], ["Knock Off"]]
 			}]
 		},
 		"typenull": {
@@ -9138,9 +9083,9 @@
 				"species": "Type: Null",
 				"item": ["Eviolite"],
 				"ability": ["Battle Armor"],
-				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"evs": {"hp": 248, "def": 80, "spd": 180},
 				"nature": "Careful",
-				"moves": [["Swords Dance"], ["Rest"], ["Sleep Talk", "Iron Defense"], ["Return"]]
+				"moves": [["Swords Dance", "Toxic", "U-turn"], ["Rest"], ["Sleep Talk"], ["Return"]]
 			}]
 		},
 		"cradily": {
@@ -9151,18 +9096,36 @@
 				"ability": ["Storm Drain"],
 				"evs": {"hp": 248, "def": 8, "spd": 252},
 				"nature": "Sassy",
-				"moves": [["Stealth Rock"], ["Recover"], ["Giga Drain"], ["Rock Slide", "Toxic"]]
+				"moves": [["Stealth Rock"], ["Recover"], ["Giga Drain"], ["Rock Slide"]]
+			}]
+		},
+		"jumpluff": {
+			"flags": {},
+			"sets": [{
+				"species": "Jumpluff",
+				"item": [""],
+				"ability": ["Infiltrator"],
+				"evs": {"atk": 252, "def": 4, "spd": 252},
+				"nature": "Jolly",
+				"moves": [["U-turn", "Swords Dance"], ["Acrobatics"], ["Sleep Powder"], ["Strength Sap"]]
 			}]
 		},
 		"floatzel": {
 			"flags": {},
 			"sets": [{
 				"species": "Floatzel",
-				"item": ["Fightinium Z", "Life Orb"],
+				"item": ["Waterium Z"],
 				"ability": ["Water Veil"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Bulk Up"], ["Waterfall"], ["Low Kick"], ["Aqua Jet", "Ice Punch"]]
+				"moves": [["Bulk Up"], ["Waterfall"], ["Ice Punch"], ["Aqua Jet"]]
+			}, {
+				"species": "Floatzel",
+				"item": ["Normalium Z"],
+				"ability": ["Water Veil"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Bulk Up"], ["Waterfall"], ["Return"], ["Aqua Jet"]]
 			}, {
 				"species": "Floatzel",
 				"item": ["Life Orb"],
@@ -9170,15 +9133,7 @@
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Hydro Pump"], ["Ice Beam"], ["Hidden Power Electric"], ["Taunt", "Focus Blast"]]
-			}, {
-				"species": "Floatzel",
-				"item": ["Life Orb"],
-				"ability": ["Water Veil"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Hydro Pump"], ["Ice Beam"], ["Hidden Power Grass"], ["Taunt", "Focus Blast"]]
+				"moves": [["Hydro Pump"], ["Ice Beam"], ["Focus Blast"], ["Taunt"]]
 			}]
 		},
 		"haunter": {
@@ -9196,7 +9151,14 @@
 				"ability": ["Levitate"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Sludge Bomb"], ["Shadow Ball"], ["Substitute", "Taunt"], ["Pain Split"]]
+				"moves": [["Sludge Bomb"], ["Shadow Ball"], ["Substitute"], ["Destiny Bond", "Hidden Power Ground"]]
+			}, {
+				"species": "Haunter",
+				"item": ["Electrium Z"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Sludge Bomb"], ["Shadow Ball"], ["Substitute"], ["Thunder"]]
 			}]
 		},
 		"liepard": {
@@ -9207,14 +9169,7 @@
 				"ability": ["Limber"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Knock Off"], ["Pursuit"], ["Play Rough"], ["U-turn", "Sucker Punch"]]
-			}, {
-				"species": "Liepard",
-				"item": ["Black Glasses"],
-				"ability": ["Prankster"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Nasty Plot"], ["Dark Pulse"], ["Copycat"], ["Encore"]]
+				"moves": [["Knock Off"], ["Pursuit"], ["Play Rough"], ["U-turn", "Sucker Punch", "Copycat"]]
 			}]
 		},
 		"ludicolo": {
@@ -9236,14 +9191,21 @@
 				"ability": ["Dancer"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Revelation Dance"], ["Hurricane"], ["U-turn"], ["Toxic"]]
+				"moves": [["Revelation Dance"], ["Hurricane"], ["U-turn"], ["Toxic", "Defog"]]
 			}, {
 				"species": "Oricorio-Sensu",
-				"item": ["Flyinium Z", "Colbur Berry", "Leftovers"],
+				"item": ["Flyinium Z", "Leftovers"],
 				"ability": ["Dancer"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Timid",
 				"moves": [["Revelation Dance"], ["Hurricane"], ["Substitute"], ["Calm Mind"]]
+			}, {
+				"species": "Oricorio-Sensu",
+				"item": ["Flyinium Z", "Rocky Helmet"],
+				"ability": ["Dancer"],
+				"evs": {"hp": 252, "def": 168, "spe": 88},
+				"nature": "Timid",
+				"moves": [["Taunt"], ["Hurricane"], ["Roost"], ["Calm Mind"]]
 			}]
 		},
 		"persianalola": {
@@ -9265,14 +9227,7 @@
 				"ability": ["Mold Breaker"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["X-Scissor"], ["Earthquake"], ["Stone Edge"]]
-			}, {
-				"species": "Pinsir",
-				"item": ["Life Orb", "Lum Berry"],
-				"ability": ["Mold Breaker"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Stealth Rock"], ["Earthquake"], ["Stone Edge"]]
+				"moves": [["Swords Dance", "Stealth Rock"], ["X-Scissor"], ["Earthquake"], ["Stone Edge"]]
 			}, {
 				"species": "Pinsir",
 				"item": ["Normalium Z"],
@@ -9282,15 +9237,26 @@
 				"moves": [["Me First"], ["X-Scissor"], ["Earthquake"], ["Stone Edge"]]
 			}]
 		},
+		"silvallydragon": {
+			"flags": {},
+			"sets": [{
+				"species": "Silvally-Dragon",
+				"item": ["Dragon Memory"],
+				"ability": ["RKS System"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Draco Meteor"], ["Parting Shot"], ["Defog"], ["Flamethrower"]]
+			}]
+		},
 		"silvallyfairy": {
 			"flags": {},
 			"sets": [{
 				"species": "Silvally-Fairy",
 				"item": ["Fairy Memory"],
 				"ability": ["RKS System"],
-				"evs": {"hp": 184, "atk": 72, "spe": 252},
+				"evs": {"hp": 48, "atk": 208, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Multi-Attack"], ["Parting Shot"], ["Rock Slide", "Defog"], ["Toxic", "Thunder Wave"]]
+				"moves": [["Multi-Attack"], ["Parting Shot"], ["Defog"], ["Thunderbolt"]]
 			}]
 		},
 		"swanna": {
@@ -9298,7 +9264,7 @@
 			"sets": [{
 				"species": "Swanna",
 				"item": ["Life Orb", "Flyinium Z"],
-				"ability": ["Hydration"],
+				"ability": ["Big Pecks"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Timid",
@@ -9306,25 +9272,18 @@
 			}, {
 				"species": "Swanna",
 				"item": ["Choice Scarf"],
-				"ability": ["Big Pecks"],
+				"ability": ["Hydration"],
 				"evs": {"atk": 4, "spa": 252, "spe": 252},
 				"nature": "Naive",
-				"moves": [["Brave Bird"], ["Surf"], ["Hurricane"], ["Defog"]]
+				"moves": [["Brave Bird"], ["Scald"], ["Hurricane"], ["Defog"]]
 			}]
 		},
 		"togedemaru": {
 			"flags": {},
 			"sets": [{
 				"species": "Togedemaru",
-				"item": ["Leftovers"],
-				"ability": ["Lightning Rod"],
-				"evs": {"hp": 248, "def": 8, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Zing Zap", "Iron Head"], ["Encore"], ["Toxic"], ["U-turn"]]
-			}, {
-				"species": "Togedemaru",
 				"item": ["Choice Scarf"],
-				"ability": ["Iron Barbs"],
+				"ability": ["Lightning Rod"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["Iron Head"], ["Toxic"], ["U-turn"], ["Zing Zap"]]
@@ -9337,7 +9296,7 @@
 				"item": ["Toxic Orb"],
 				"ability": ["Toxic Boost"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
+				"nature": ["Jolly", "Adamant"],
 				"moves": [["Facade"], ["Knock Off"], ["Quick Attack"], ["Close Combat", "Swords Dance"]]
 			}]
 		},
@@ -9348,14 +9307,14 @@
 				"item": ["Choice Band"],
 				"ability": ["Rock Head"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Head Smash"], ["Heavy Slam"], ["Ice Punch"], ["Superpower"]]
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Head Smash"], ["Heavy Slam"], ["Ice Punch", "Earthquake"], ["Superpower"]]
 			}, {
 				"species": "Aggron",
-				"item": ["Lum Berry"],
+				"item": ["Rockium Z", "Shuca Berry", "Chople Berry"],
 				"ability": ["Rock Head"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Adamant",
+				"nature": ["Adamant", "Jolly"],
 				"moves": [["Head Smash"], ["Heavy Slam"], ["Stealth Rock"], ["Taunt"]]
 			}]
 		},
@@ -9368,7 +9327,7 @@
 				"evs": {"hp": 252, "def": 4, "spd": 252},
 				"ivs": {"atk": 0},
 				"nature": "Calm",
-				"moves": [["Stealth Rock"], ["Soft-Boiled"], ["Moonblast", "Seismic Toss"], ["Knock Off", "Toxic", "Thunder Wave"]]
+				"moves": [["Stealth Rock"], ["Soft-Boiled"], ["Moonblast"], ["Calm Mind", "Encore", "Thunder Wave"]]
 			}]
 		},
 		"drampa": {
@@ -9380,7 +9339,7 @@
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Modest",
-				"moves": [["Draco Meteor"], ["Hyper Voice"], ["Fire Blast"], ["Focus Blast"]]
+				"moves": [["Draco Meteor"], ["Hyper Voice"], ["Fire Blast"], ["Focus Blast", "Dragon Pulse"]]
 			}]
 		},
 		"dugtrioalola": {
@@ -9392,6 +9351,13 @@
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["Substitute"], ["Toxic"], ["Earthquake"], ["Iron Head"]]
+			}, {
+				"species": "Dugtrio-Alola",
+				"item": ["Life Orb"],
+				"ability": ["Tangling Hair"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Sucker Punch"], ["Earthquake"], ["Iron Head"]]
 			}]
 		},
 		"gorebyss": {
@@ -9400,43 +9366,65 @@
 				"species": "Gorebyss",
 				"item": ["White Herb"],
 				"ability": ["Swift Swim"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Modest",
-				"moves": [["Shell Smash"], ["Hydro Pump"], ["Ice Beam"], ["Substitute", "Hidden Power Grass", "Hidden Power Fire"]]
+				"moves": [["Shell Smash"], ["Hydro Pump"], ["Ice Beam"], ["Hidden Power Grass"]]
 			}]
 		},
-		"komala": {
+		"kecleon": {
 			"flags": {},
 			"sets": [{
 				"species": "Komala",
 				"item": ["Assault Vest"],
-				"ability": ["Comatose"],
-				"evs": {"hp": 252, "atk": 232, "spe": 24},
+				"ability": ["Protean"],
+				"evs": {"hp": 172, "atk": 252, "spe": 84},
 				"nature": "Adamant",
-				"moves": [["Rapid Spin"], ["Return"], ["U-turn"], ["Sucker Punch", "Earthquake"]]
+				"moves": [["Knock Off"], ["Drain Punch"], ["Shadow Sneak"], ["Sucker Punch", "Power-Up Punch"]]
 			}]
 		},
 		"leafeon": {
 			"flags": {},
 			"sets": [{
 				"species": "Leafeon",
-				"item": ["Leftovers", "Normalium Z"],
+				"item": ["Normalium Z"],
 				"ability": ["Chlorophyll"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Leaf Blade"], ["Knock Off"], ["Return"]]
+				"moves": [["Swords Dance"], ["Leaf Blade"], ["Knock Off"], ["Double-Edge"]]
 			}]
 		},
 		"manectric": {
 			"flags": {},
 			"sets": [{
 				"species": "Manectric",
-				"item": ["Choice Scarf"],
+				"item": ["Choice Scarf", "Choice Specs"],
 				"ability": ["Lightning Rod"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Thunderbolt"], ["Volt Switch"], ["Overheat", "Flamethrower"], ["Switcheroo", "Hidden Power Grass"]]
+				"moves": [["Thunderbolt"], ["Volt Switch"], ["Overheat", "Flamethrower"], ["Hidden Power Grass"]]
+			}]
+		},
+		"misdreavus": {
+			"flags": {},
+			"sets": [{
+				"species": "Misdreavus",
+				"item": ["Eviolite"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 248, "def": 8, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Hex"], ["Will-O-Wisp"], ["Thunder Wave", "Destiny Bond"], ["Taunt"]]
+			}]
+		},
+		"pyukumuku": {
+			"flags": {},
+			"sets": [{
+				"species": "Pyukumuku",
+				"item": ["Leftovers"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 252, "spe": 4},
+				"nature": "Bold",
+				"moves": [["Toxic"], ["Soak"], ["Recover"], ["Counter"]]
 			}]
 		},
 		"lurantis": {
@@ -9448,7 +9436,7 @@
 				"evs": {"hp": 252, "def": 252, "spa": 4},
 				"ivs": {"atk": 0},
 				"nature": "Bold",
-				"moves": [["Leaf Storm"], ["Hidden Power Fire"], ["Defog"], ["Synthesis"]]
+				"moves": [["Leaf Storm"], ["Superpower"], ["Defog"], ["Synthesis"]]
 			}]
 		},
 		"mrmime": {
@@ -9466,12 +9454,12 @@
 			"flags": {},
 			"sets": [{
 				"species": "Oricorio-Pom-Pom",
-				"item": ["Leftovers"],
+				"item": ["Flyinium Z", "Leftovers", "Rocky Helmet"],
 				"ability": ["Dancer"],
-				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"evs": {"hp": 252, "def": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Revelation Dance"], ["Toxic"], ["Taunt", "Defog"], ["Roost"]]
+				"moves": [["Taunt", "Revelation Dance"], ["Calm Mind"], ["Hurricane"], ["Roost"]]
 			}]
 		},
 		"throh": {
@@ -9483,13 +9471,6 @@
 				"evs": {"hp": 252, "def": 4, "spd": 252},
 				"nature": "Careful",
 				"moves": [["Circle Throw"], ["Bulk Up", "Knock Off"], ["Rest"], ["Sleep Talk"]]
-			}, {
-				"species": "Throh",
-				"item": ["Choice Band"],
-				"ability": ["Guts"],
-				"evs": {"hp": 252, "atk": 252, "def": 4},
-				"nature": "Adamant",
-				"moves": [["Superpower"], ["Knock Off"], ["Earthquake"], ["Ice Punch"]]
 			}]
 		},
 		"poliwrath": {
@@ -9498,27 +9479,30 @@
 				"species": "Poliwrath",
 				"item": ["Leftovers"],
 				"ability": ["Water Absorb"],
-				"evs": {"hp": 248, "spa": 164, "spe": 96},
+				"evs": {"hp": 248, "spa": 160, "spe": 100},
+				"ivs": {"atk": 0},
 				"nature": "Modest",
 				"moves": [["Scald"], ["Focus Blast"], ["Substitute"], ["Toxic"]]
 			}, {
 				"species": "Poliwrath",
-				"item": ["Leftovers", "Fightinium Z"],
+				"item": ["Leftovers"],
 				"ability": ["Water Absorb"],
-				"evs": {"hp": 72, "atk": 252, "spe": 184},
-				"nature": "Adamant",
-				"moves": [["Focus Punch"], ["Waterfall"], ["Substitute"], ["Toxic", "Encore"]]
+				"evs": {"hp": 248, "spa": 160, "spe": 100},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Scald"], ["Focus Blast"], ["Vacuum Wave"], ["Ice Beam"]]
 			}]
 		},
 		"probopass": {
 			"flags": {},
 			"sets": [{
 				"species": "Probopass",
-				"item": ["Leftovers"],
+				"item": ["Shuca Berry"],
 				"ability": ["Magnet Pull"],
 				"evs": {"hp": 172, "spa": 252, "spe": 84},
+				"ivs": {"atk": 0},
 				"nature": "Modest",
-				"moves": [["Stealth Rock"], ["Taunt"], ["Flash Cannon"], ["Hidden Power Fire"]]
+				"moves": [["Stealth Rock"], ["Volt Switch"], ["Flash Cannon"], ["Earth Power"]]
 			}]
 		},
 		"mudsdale": {
@@ -9529,14 +9513,14 @@
 				"ability": ["Stamina"],
 				"evs": {"hp": 132, "atk": 252, "spe": 124},
 				"nature": "Adamant",
-				"moves": [["Earthquake"], ["Heavy Slam"], ["Close Combat"], ["Rock Slide", "Toxic"]]
+				"moves": [["Earthquake"], ["Heavy Slam"], ["Close Combat"], ["Rock Slide"]]
 			}, {
 				"species": "Mudsdale",
-				"item": ["Leftovers", "Rocky Helmet"],
+				"item": ["Leftovers", "Figy Berry"],
 				"ability": ["Stamina"],
-				"evs": {"hp": 252, "def": 104, "spd": 152},
-				"nature": "Careful",
-				"moves": [["Earthquake", "Rock Slide"], ["Toxic"], ["Rest"], ["Sleep Talk"]]
+				"evs": {"hp": 252, "atk": 56, "def": 44, "spd": 156},
+				"nature": "Adamant",
+				"moves": [["Earthquake"], ["Toxic"], ["Stealth Rock"], ["Rock SLide", "Protect", "Roar"]]
 			}]
 		},
 		"golem": {
@@ -9574,7 +9558,7 @@
 				"species": "Mawile",
 				"item": ["Life Orb"],
 				"ability": ["Sheer Force"],
-				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Adamant",
 				"moves": [["Play Rough"], ["Iron Head"], ["Swords Dance"], ["Sucker Punch"]]
 			}]
@@ -9590,6 +9574,46 @@
 				"moves": [["Body Slam"], ["Curse"], ["Sleep Talk"], ["Rest"]]
 			}]
 		},
+		"murkrow": {
+			"flags": {},
+			"sets": [{
+				"species": "Murkrow",
+				"item": ["Flyinium Z"],
+				"ability": ["Prankster"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Mirror Move"], ["Brave Bird"], ["Sucker Punch"], ["Pursuit", "Protect"]]
+			}]
+		},
+        "smeargle": {
+            "flags": {},
+            "sets": [{
+                "species": "Smeargle",
+                "item": ["Focus Sash"],
+                "ability": ["Own Tempo"],
+                "evs": {"hp": 252, "spd": 4, "spe": 252},
+                "nature": "Jolly",
+                "moves": [["Sticky Web"], ["Stealth Rock"], ["Taunt", "Nuzzle", "Magic Coat"], ["Spore"]]
+            }]
+        },
+        "rotomfrost": {
+            "flags": {},
+            "sets": [{
+                "species": "Rotom-Frost",
+                "item": ["Icium Z", "Life Orb"],
+                "ability": ["Levitate"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Substitute"], ["Pain Split"], ["Blizzard"], ["Thunderbolt"]]
+            }, {
+                "species": "Rotom-Frost",
+                "item": ["Icium Z"],
+                "ability": ["Levitate"],
+                "evs": {"spa": 252, "spd": 4, "spe": 252},
+                "nature": "Timid",
+                "moves": [["Defog"], ["Volt Switch"], ["Blizzard"], ["Thunderbolt"]]
+            }]
+        },
 		"toucannon": {
 			"flags": {},
 			"sets": [{
@@ -9631,7 +9655,7 @@
 				"ability": ["Regenerator"],
 				"evs": {"hp": 248, "def": 8, "spd": 252},
 				"nature": "Calm",
-				"moves": [["Wish"], ["Protect"], ["Knock Off"], ["Heal Bell", "Encore"]]
+				"moves": [["Wish"], ["Protect"], ["Knock Off"], ["Toxic", "Encore"]]
 			}]
 		},
 		"combusken": {
@@ -9643,7 +9667,14 @@
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": "Timid",
-				"moves": [["Protect"], ["Focus Blast"], ["Fire Blast"], ["Hidden Power Electric"]]
+				"moves": [["Protect"], ["Focus Blast"], ["Fire Blast"], ["Hidden Power Ice"]]
+			}, {
+				"species": "Combusken",
+				"item": ["Firium Z", "Fightinium Z", "Eviolite"],
+				"ability": ["Speed Boost"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Protect"], ["Swords Dance"], ["Flare Blitz"], ["Sky Uppercut", "Low Kick"]]
 			}]
 		},
 		"eelektross": {
@@ -9654,7 +9685,7 @@
 				"ability": ["Levitate"],
 				"evs": {"hp": 248, "spa": 252, "spd": 8},
 				"nature": "Modest",
-				"moves": [["Volt Switch"], ["Giga Drain"], ["Flamethrower"], ["Knock Off"]]
+				"moves": [["Volt Switch"], ["Giga Drain"], ["Flamethrower"], ["Acid Spray", "Knock Off"]]
 			}]
 		},
 		"ninjask": {
@@ -9687,7 +9718,29 @@
 				"ability": ["RKS System"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
 				"nature": "Timid",
-				"moves": [["Shadow Ball"], ["Ice Beam", "Flamethrower"], ["Parting Shot"], ["Thunderbolt", "Defog"]]
+				"moves": [["Shadow Ball"], ["Ice Beam"], ["Parting Shot"], ["Defog"]]
+			}]
+		},
+		"silvallywater": {
+			"flags": {},
+			"sets": [{
+				"species": "Silvally-Water",
+				"item": ["Water Memory"],
+				"ability": ["RKS System"],
+				"evs": {"hp": 248, "def": 124, "spe": 136},
+				"nature": "Bold",
+				"moves": [["Surf"], ["Ice Beam", "Thunderbolt"], ["Parting Shot"], ["Defog"]]
+			}]
+		},
+		"tangela": {
+			"flags": {},
+			"sets": [{
+				"species": "Tangela",
+				"item": ["Eviolite"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spe": 4},
+				"nature": "Bold",
+				"moves": [["Giga Drain"], ["Hidden Power Ice"], ["Synthesis"], ["Leech Seed", "Sleep Powder", "Defog"]]
 			}]
 		},
 		"stoutland": {
@@ -9744,57 +9797,160 @@
 				"ability": ["Snow Warning"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"nature": "Modest",
-				"moves": [["Blizzard"], ["Freeze-Dry"], ["Earth Power"], ["Ancient Power"]]
-			}, {
-				"species": "Aurorus",
-				"item": ["Choice Specs"],
-				"ability": ["Refrigerate"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Modest",
-				"moves": [["Hyper Voice"], ["Freeze-Dry"], ["Earth Power"], ["Ancient Power"]]
+				"moves": [["Blizzard"], ["Freeze-Dry"], ["Earth Power"], ["Hidden Power Rock", "Flash Cannon"]]
 			}, {
 				"species": "Aurorus",
 				"item": ["Choice Scarf"],
 				"ability": ["Snow Warning"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Modest",
-				"moves": [["Blizzard"], ["Freeze-Dry"], ["Earth Power"], ["Ancient Power"]]
+				"nature": "Timid",
+				"moves": [["Blizzard"], ["Freeze-Dry"], ["Earth Power"], ["Hidden Power Rock"]]
 			}, {
 				"species": "Aurorus",
 				"item": ["Focus Sash"],
 				"ability": ["Snow Warning"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": "Timid",
-				"moves": [["Blizzard"], ["Freeze-Dry", "Thunder Wave"], ["Earth Power"], ["Stealth Rock"]]
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": "Hasty",
+				"moves": [["Blizzard"], ["Encore"], ["Rock Tomb", "Earth Power"], ["Stealth Rock"]]
 			}]
 		},
 		"sandslashalola": {
 			"flags": {},
 			"sets": [{
 				"species": "Sandslash-Alola",
+				"item": ["Icium Z", "Shuca Berry"],
+				"ability": ["Slush Rush"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Icicle Crash"], ["Earthquake"], ["Substitute", "Iron Head"]]
+			}, {
+				"species": "Sandslash-Alola",
 				"item": ["Shuca Berry"],
 				"ability": ["Slush Rush"],
-				"evs": {"hp": 4, "atk": 252, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Icicle Crash"], ["Earthquake"], ["Rapid Spin"]]
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Rapid Spin", "Stealth Rock"], ["Icicle Crash"], ["Earthquake"], ["Knock Off", "Iron Head"]]
 			}]
 		},
 		"spiritomb": {
 			"flags": {},
 			"sets": [{
 				"species": "Spiritomb",
-				"item": ["Black Glasses", "Mago Berry"],
+				"item": ["Black Glasses", "Aguav Berry", "Rocky Helmet"],
 				"ability": ["Infiltrator"],
 				"evs": {"hp": 248, "atk": 252, "def": 8},
-				"nature": "Adamant",
-				"moves": [["Pursuit"], ["Sucker Punch"], ["Foul Play"], ["Will-O-Wisp"]]
+				"nature": "Brave",
+				"moves": [["Pursuit"], ["Sucker Punch"], ["Psychic"], ["Will-O-Wisp"]]
 			}, {
 				"species": "Spiritomb",
-				"item": ["Leftovers"],
+				"item": ["Leftovers", "Darkinium Z"],
 				"ability": ["Pressure"],
 				"evs": {"hp": 248, "def": 252, "spd": 8},
 				"nature": "Bold",
 				"moves": [["Calm Mind"], ["Rest"], ["Sleep Talk"], ["Dark Pulse"]]
+			}]
+		},
+		"froslass": {
+			"flags": {},
+			"sets": [{
+				"species": "Froslass",
+				"item": ["Focus Sash"],
+				"ability": ["Cursed Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Spikes"], ["Icy Wind", "Ice Beam"], ["Taunt"], ["Destiny Bond"]]
+			}, {
+				"species": "Froslass",
+				"item": ["Choice Specs"],
+				"ability": ["Cursed Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Ice Beam"], ["Shadow Ball"], ["Trick"], ["Spikes", "Hidden Power Fighting"]]
+			}, {
+				"species": "Froslass",
+				"item": ["Icium Z", "Colbur Berry"],
+				"ability": ["Cursed Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Ice Beam"], ["Shadow Ball"], ["Spikes"], ["Will-O-Wisp", "Hidden Power Fighting"]]
+			}, {
+				"species": "Froslass",
+				"item": ["Colbur Berry", "Leftovers"],
+				"ability": ["Cursed Body"],
+				"evs": {"hp": 248, "def": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Spikes"], ["Will-O-Wisp"], ["Taunt", "Protect"], ["Hex"]]
+			}]
+		},
+		"omastar": {
+			"flags": {},
+			"sets": [{
+				"species": "Omastar",
+				"item": ["White Herb", "Waterium Z"],
+				"ability": ["Weak Armor"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Shell Smash"], ["Hydro Pump"], ["Ice Beam"], ["Earth Power"]]
+			}]
+		},
+		"qwilfish": {
+			"flags": {},
+			"sets": [{
+				"species": "Qwilfish",
+				"item": ["Rocky Helmet", "Black Sludge"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 248, "def": 8, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Spikes"], ["Waterfall"], ["Taunt"], ["Toxic Spikes", "Poison Jab", "Destiny Bond"]]
+			}, {
+				"species": "Qwilfish",
+				"item": ["Rocky Helmet", "Black Sludge"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 248, "def": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Spikes"], ["Scald"], ["Taunt"], ["Thunder Wave", "Sludge Bomb"]]
+			}]
+		},
+		"scyther": {
+			"flags": {},
+			"sets": [{
+				"species": "Scyther",
+				"item": ["Eviolite"],
+				"ability": ["Technician"],
+				"evs": {"hp": 248, "spd": 8, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Roost"], ["U-turn"], ["Aerial Ace"]]
+			}, {
+				"species": "Scyther",
+				"item": ["Choice Scarf"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Knock Off"], ["Brick Break"], ["U-turn"], ["Aerial Ace"]]
+			}, {
+				"species": "Scyther",
+				"item": ["Choice Scarf"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Knock Off", "Pursuit"], ["Brick Break"], ["U-turn"], ["Aerial Ace"]]
+			}]
+		},
+		"crabominable": {
+			"flags": {},
+			"sets": [{
+				"species": "Crabominable",
+				"item": ["Assault Vest"],
+				"ability": ["Iron Fist"],
+				"evs": {"hp": 248, "atk": 8, "spd": 252},
+				"nature": "Adamant",
+				"moves": [["Drain Punch"], ["Ice Hammer"], ["Close Combat"], ["Earthquake", "Pursuit"]]
 			}]
 		}
 	},
@@ -10979,38 +11135,6 @@
 				"moves": [["Counter"], ["Mirror Coat"], ["Encore"], ["Tickle"]]
 			}]
 		},
-		"cranidos": {
-			"flags": {},
-			"sets": [{
-				"species": "Cranidos",
-				"item": ["Choice Scarf"],
-				"ability": ["Sheer Force"],
-				"evs": {"atk": 236, "def": 36, "spe": 212},
-				"nature": "Adamant",
-				"moves": [["Rock Slide"], ["Zen Headbutt"], ["Superpower"], ["Pursuit", "Thunder Punch"]]
-			}, {
-				"species": "Cranidos",
-				"item": ["Choice Scarf"],
-				"ability": ["Mold Breaker"],
-				"evs": {"atk": 236, "def": 36, "spe": 212},
-				"nature": "Jolly",
-				"moves": [["Stone Edge"], ["Earthquake"], ["Zen Headbutt"], ["Superpower"]]
-			}, {
-				"species": "Cranidos",
-				"item": ["Life Orb"],
-				"ability": ["Sheer Force"],
-				"evs": {"atk": 236, "def": 36, "spe": 212},
-				"nature": "Jolly",
-				"moves": [["Rock Slide"], ["Fire Punch"], ["Zen Headbutt"], ["Crunch"]]
-			}, {
-				"species": "Cranidos",
-				"item": ["Life Orb"],
-				"ability": ["Sheer Force"],
-				"evs": {"atk": 236, "def": 36, "spe": 212},
-				"nature": "Jolly",
-				"moves": [["Rock Slide"], ["Fire Punch"], ["Zen Headbutt"], ["Rock Polish", "Substitute"]]
-			}]
-		},
 		"cottonee": {
 			"flags": {},
 			"sets": [{
@@ -11077,36 +11201,6 @@
 				"moves": [["Flare Blitz"], ["Leech Life"], ["Wild Charge"], ["U-turn"]]
 			}]
 		},
-		"magby": {
-			"flags": {},
-			"sets": [{
-				"species": "Magby",
-				"item": ["Berry Juice"],
-				"ability": ["Vital Spirit"],
-				"evs": {"atk": 236, "spe": 252},
-				"ivs": {"hp": 29},
-				"nature": "Jolly",
-				"moves": [["Belly Drum"], ["Fire Punch"], ["Thunder Punch", "Thief"], ["Mach Punch"]]
-			}]
-		},
-		"skrelp": {
-			"flags": {},
-			"sets": [{
-				"species": "Skrelp",
-				"item": ["Eviolite"],
-				"ability": ["Adaptability"],
-				"evs": {"hp": 116, "def": 116, "spa": 200, "spd": 36, "spe": 40},
-				"nature": "Calm",
-				"moves": [["Hydro Pump"], ["Sludge Bomb"], ["Thunderbolt"], ["Scald"]]
-			}, {
-				"species": "Skrelp",
-				"item": ["Eviolite"],
-				"ability": ["Adaptability"],
-				"evs": {"hp": 116, "def": 116, "spa": 200, "spd": 36, "spe": 40},
-				"nature": "Calm",
-				"moves": [["Hydro Pump"], ["Sludge Wave"], ["Thunderbolt"], ["Toxic Spikes"]]
-			}]
-		},
 		"snover": {
 			"flags": {},
 			"sets": [{
@@ -11116,40 +11210,6 @@
 				"evs": {"atk": 104, "spa": 184, "spe": 200},
 				"nature": "Naive",
 				"moves": [["Blizzard"], ["Giga Drain"], ["Hidden Power Fire", "Hidden Power Ground"], ["Ice Shard"]]
-			}]
-		},
-		"spinarak": {
-			"flags": {},
-			"sets": [{
-				"species": "Spinarak",
-				"item": ["Eviolite"],
-				"ability": ["Insomnia"],
-				"evs": {"hp": 116, "def": 196, "spd": 196},
-				"nature": "Impish",
-				"moves": [["Sticky Web"], ["Toxic Spikes"], ["Leech Life"], ["Poison Jab"]]
-			}, {
-				"species": "Spinarak",
-				"item": ["Eviolite"],
-				"ability": ["Insomnia"],
-				"evs": {"hp": 116, "def": 196, "spa": 36, "spd": 36, "spe": 116},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Sticky Web"], ["Psychic"], ["Giga Drain"], ["Sludge Bomb"]]
-			}, {
-				"species": "Spinarak",
-				"item": ["Eviolite"],
-				"ability": ["Insomnia"],
-				"evs": {"hp": 116, "def": 196, "spa": 36, "spd": 36, "spe": 116},
-				"ivs": {"atk": 0},
-				"nature": "Bold",
-				"moves": [["Sticky Web"], ["Psychic"], ["Baton Pass"], ["Sludge Bomb"]]
-			}, {
-				"species": "Spinarak",
-				"item": ["Focus Sash"],
-				"ability": ["Insomnia"],
-				"evs": {"hp": 116, "atk": 196, "spe": 196},
-				"nature": "Adamant",
-				"moves": [["Sticky Web"], ["Megahorn"], ["Poison Jab"], ["Thief", "Sucker Punch"]]
 			}]
 		},
 		"taillow": {
@@ -11349,31 +11409,6 @@
 				"moves": [["Swords Dance"], ["High Jump Kick"], ["Protect", "Meteor Mash", "Crunch"], ["Copycat"]]
 			}]
 		},
-		"rowlet": {
-			"flags": {},
-			"sets": [{
-				"species": "Rowlet",
-				"item": ["Life Orb"],
-				"ability": ["Overgrow"],
-				"evs": {"atk": 236, "spd": 36, "spe": 180},
-				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Brave Bird"], ["Leaf Blade", "Sucker Punch"], ["Baton Pass"]]
-			}, {
-				"species": "Rowlet",
-				"item": ["Eviolite"],
-				"ability": ["Overgrow"],
-				"evs": {"hp": 132, "def": 156, "spd": 196},
-				"nature": "Sassy",
-				"moves": [["Nasty Plot"], ["Energy Ball"], ["Roost"], ["Baton Pass"]]
-			}, {
-				"species": "Rowlet",
-				"item": ["Eviolite"],
-				"ability": ["Overgrow"],
-				"evs": {"hp": 132, "def": 156, "spd": 196, "spe": 20},
-				"nature": "Careful",
-				"moves": [["Defog"], ["Brave Bird"], ["Leaf Blade"], ["Roost"]]
-			}]
-		},
 		"salandit": {
 			"flags": {},
 			"sets": [{
@@ -11404,266 +11439,6 @@
 				"moves": [["Icicle Spear"], ["Iron Head"], ["Earthquake"], ["Rapid Spin"]]
 			}]
 		},
-		"tyrunt": {
-			"flags": {},
-			"sets": [{
-				"species": "Tyrunt",
-				"item": ["Berry Juice"],
-				"ability": ["Sturdy"],
-				"evs": {"atk": 204, "spd": 76, "spe": 212},
-				"ivs": {"hp": 23},
-				"nature": "Jolly",
-				"moves": [["Dragon Dance"], ["Outrage"], ["Stone Edge"], ["Earthquake"]]
-			}, {
-				"species": "Tyrunt",
-				"item": ["Choice Scarf"],
-				"ability": ["Strong Jaw"],
-				"evs": {"atk": 204, "spd": 76, "spe": 212},
-				"nature": "Jolly",
-				"moves": [["Outrage"], ["Stone Edge", "Rock Slide"], ["Earthquake", "Superpower"], ["Crunch"]]
-			}]
-		},
-		"venipede": {
-			"flags": {},
-			"sets": [{
-				"species": "Venipede",
-				"item": ["Eviolite"],
-				"ability": ["Speed Boost"],
-				"evs": {"atk": 76, "def": 124, "spd": 124, "spe": 148},
-				"nature": "Impish",
-				"moves": [["Spikes"], ["Toxic Spikes"], ["Pin Missile"], ["Protect"]]
-			}, {
-				"species": "Venipede",
-				"item": ["Focus Sash"],
-				"ability": ["Speed Boost"],
-				"evs": {"hp": 36, "atk": 76, "def": 204, "spd": 44, "spe": 148},
-				"nature": "Impish",
-				"moves": [["Protect"], ["Spikes"], ["Pin Missile"], ["Endeavor"]]
-			}]
-		},
-		"anorith": {
-			"flags": {},
-			"sets": [{
-				"species": "Anorith",
-				"item": ["Berry Juice"],
-				"ability": ["Battle Armor"],
-				"evs": {"atk": 236, "def": 36, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Stealth Rock"], ["Rock Blast"], ["Knock Off"], ["Aerial Ace", "Rapid Spin"]]
-			}]
-		},
-		"axew": {
-			"flags": {},
-			"sets": [{
-				"species": "Axew",
-				"item": ["Eviolite"],
-				"ability": ["Mold Breaker"],
-				"evs": {"hp": 68, "atk": 220, "spe": 220},
-				"nature": "Jolly",
-				"moves": [["Dragon Dance"], ["Outrage", "Dual Chop"], ["Superpower"], ["Poison Jab", "Iron Tail"]]
-			}, {
-				"species": "Axew",
-				"item": ["Eviolite"],
-				"ability": ["Mold Breaker"],
-				"evs": {"hp": 68, "atk": 220, "spe": 220},
-				"nature": "Adamant",
-				"moves": [["Dragon Dance"], ["Outrage"], ["Superpower"], ["Iron Tail"]]
-			}, {
-				"species": "Axew",
-				"item": ["Choice Scarf"],
-				"ability": ["Mold Breaker"],
-				"evs": {"hp": 68, "atk": 220, "spe": 220},
-				"nature": "Jolly",
-				"moves": [["Outrage"], ["Superpower"], ["Poison Jab"], ["Dual Chop"]]
-			}]
-		},
-		"darumaka": {
-			"flags": {},
-			"sets": [{
-				"species": "Darumaka",
-				"item": ["Choice Scarf"],
-				"ability": ["Hustle"],
-				"evs": {"hp": 116, "atk": 196, "spe": 196},
-				"nature": "Jolly",
-				"moves": [["Flare Blitz"], ["Superpower"], ["Rock Slide"], ["U-turn"]]
-			}, {
-				"species": "Darumaka",
-				"item": ["Life Orb"],
-				"ability": ["Hustle"],
-				"evs": {"hp": 116, "atk": 196, "spe": 196},
-				"nature": "Jolly",
-				"moves": [["Fire Punch", "Flare Blitz"], ["Superpower"], ["Rock Slide"], ["U-turn"]]
-			}]
-		},
-		"deerling": {
-			"flags": {},
-			"sets": [{
-				"species": "Deerling",
-				"item": ["Life Orb"],
-				"ability": ["Sap Sipper"],
-				"evs": {"hp": 36, "atk": 196, "def": 36, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Return"], ["Seed Bomb"], ["Jump Kick"], ["Aromatherapy", "Thunder Wave"]]
-			}, {
-				"species": "Deerling",
-				"item": ["Choice Scarf"],
-				"ability": ["Serene Grace"],
-				"evs": {"hp": 36, "atk": 196, "def": 36, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Headbutt"], ["Jump Kick"], ["Seed Bomb"], ["Wild Charge"]]
-			}, {
-				"species": "Deerling",
-				"item": ["Life Orb"],
-				"ability": ["Serene Grace"],
-				"evs": {"hp": 36, "atk": 196, "def": 36, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Headbutt"], ["Jump Kick"], ["Seed Bomb"], ["Bounce"]]
-			}]
-		},
-		"dratini": {
-			"flags": {},
-			"sets": [{
-				"species": "Dratini",
-				"item": ["Life Orb"],
-				"ability": ["Shed Skin"],
-				"evs": {"atk": 244, "spd": 36, "spe": 196},
-				"ivs": {"hp": 0},
-				"nature": "Naughty",
-				"moves": [["Dragon Dance"], ["Outrage"], ["Fire Blast"], ["Extreme Speed"]]
-			}, {
-				"species": "Dratini",
-				"item": ["Life Orb"],
-				"ability": ["Shed Skin"],
-				"evs": {"atk": 244, "spd": 36, "spe": 196},
-				"ivs": {"hp": 0},
-				"nature": "Adamant",
-				"moves": [["Dragon Dance"], ["Outrage"], ["Iron Tail"], ["Extreme Speed"]]
-			}, {
-				"species": "Dratini",
-				"item": ["Life Orb"],
-				"ability": ["Shed Skin"],
-				"evs": {"atk": 164, "spa": 196, "spe": 116},
-				"ivs": {"hp": 0},
-				"nature": "Rash",
-				"moves": [["Draco Meteor"], ["Fire Blast"], ["Iron Tail"], ["Extreme Speed"]]
-			}]
-		},
-		"goldeen": {
-			"flags": {},
-			"sets": [{
-				"species": "Goldeen",
-				"item": ["Life Orb"],
-				"ability": ["Lightning Rod"],
-				"evs": {"hp": 220, "spd": 32, "spe": 252},
-				"ivs": {"hp": 9},
-				"nature": "Jolly",
-				"moves": [["Waterfall"], ["Knock Off"], ["Drill Run"], ["Megahorn"]]
-			}, {
-				"species": "Goldeen",
-				"item": ["Eviolite"],
-				"ability": ["Lightning Rod"],
-				"evs": {"hp": 220, "spd": 32, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Waterfall"], ["Knock Off"], ["Drill Run"], ["Poison Jab"]]
-			}]
-		},
-		"inkay": {
-			"flags": {},
-			"sets": [{
-				"species": "Inkay",
-				"item": ["Choice Scarf"],
-				"ability": ["Contrary"],
-				"evs": {"hp": 12, "atk": 244, "def": 12, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Knock Off"], ["Psycho Cut"], ["Superpower"], ["Switcheroo"]]
-			}, {
-				"species": "Inkay",
-				"item": ["Choice Scarf"],
-				"ability": ["Contrary"],
-				"evs": {"hp": 12, "atk": 244, "def": 12, "spe": 236},
-				"nature": "Adamant",
-				"moves": [["Knock Off"], ["Psycho Cut"], ["Superpower"], ["Switcheroo"]]
-			}, {
-				"species": "Inkay",
-				"item": ["Berry Juice"],
-				"ability": ["Contrary"],
-				"evs": {"hp": 12, "atk": 244, "def": 12, "spd": 228},
-				"ivs": {"spe": 0},
-				"nature": "Brave",
-				"moves": [["Trick Room"], ["Knock Off"], ["Superpower"], ["Psycho Cut", "Destiny Bond"]]
-			}]
-		},
-		"lileep": {
-			"flags": {},
-			"sets": [{
-				"species": "Lileep",
-				"item": ["Eviolite"],
-				"ability": ["Storm Drain"],
-				"evs": {"hp": 228, "def": 140, "spd": 140},
-				"ivs": {"atk": 0},
-				"nature": "Calm",
-				"moves": [["Stealth Rock"], ["Ancient Power"], ["Giga Drain"], ["Recover"]]
-			}, {
-				"species": "Lileep",
-				"item": ["Eviolite"],
-				"ability": ["Storm Drain"],
-				"evs": {"hp": 68, "def": 220, "spa": 108, "spd": 60, "spe": 12},
-				"nature": "Bold",
-				"moves": [["Stealth Rock"], ["Giga Drain"], ["Earth Power", "Toxic"], ["Recover"]]
-			}, {
-				"species": "Lileep",
-				"item": ["Eviolite"],
-				"ability": ["Storm Drain"],
-				"evs": {"hp": 68, "def": 220, "spa": 108, "spd": 60, "spe": 12},
-				"nature": "Bold",
-				"moves": [["Stealth Rock"], ["Giga Drain"], ["Mirror Coat", "Toxic"], ["Recover"]]
-			}]
-		},
-		"mankey": {
-			"flags": {},
-			"sets": [{
-				"species": "Mankey",
-				"item": ["Choice Scarf"],
-				"ability": ["Defiant"],
-				"evs": {"hp": 36, "atk": 196, "def": 76, "spe": 196},
-				"nature": "Adamant",
-				"moves": [["Close Combat"], ["Gunk Shot"], ["Ice Punch", "Night Slash"], ["U-turn"]]
-			}, {
-				"species": "Mankey",
-				"item": ["Choice Scarf"],
-				"ability": ["Vital Spirit"],
-				"evs": {"hp": 36, "atk": 196, "def": 76, "spe": 196},
-				"nature": "Jolly",
-				"moves": [["Close Combat"], ["Gunk Shot"], ["Earthquake"], ["U-turn"]]
-			}, {
-				"species": "Mankey",
-				"item": ["Life Orb"],
-				"ability": ["Defiant"],
-				"evs": {"hp": 36, "atk": 196, "def": 76, "spe": 196},
-				"ivs": {"hp": 0},
-				"nature": "Jolly",
-				"moves": [["Close Combat"], ["Gunk Shot"], ["Earthquake", "Taunt"], ["U-turn", "Bulk Up"]]
-			}]
-		},
-		"natu": {
-			"flags": {},
-			"sets": [{
-				"species": "Natu",
-				"item": ["Life Orb"],
-				"ability": ["Magic Bounce"],
-				"evs": {"atk": 116, "spa": 196, "spe": 196},
-				"ivs": {"hp": 0},
-				"nature": "Naive",
-				"moves": [["Psychic"], ["Heat Wave", "Dazzling Gleam"], ["Sucker Punch"], ["U-turn"]]
-			}, {
-				"species": "Natu",
-				"item": ["Eviolite"],
-				"ability": ["Magic Bounce"],
-				"evs": {"hp": 196, "def": 76, "spa": 116, "spd": 76, "spe": 36},
-				"nature": "Bold",
-				"moves": [["Psychic"], ["Heat Wave", "Dazzling Gleam"], ["U-turn", "Thunder Wave"], ["Roost"]]
-			}]
-		},
 		"numel": {
 			"flags": {},
 			"sets": [{
@@ -11680,64 +11455,6 @@
 				"evs": {"hp": 36, "spa": 236, "spe": 236},
 				"nature": "Timid",
 				"moves": [["Flame Charge"], ["Fire Blast"], ["Earth Power"], ["Ancient Power", "Growth"]]
-			}]
-		},
-		"sandile": {
-			"flags": {},
-			"sets": [{
-				"species": "Sandile",
-				"item": ["Choice Scarf"],
-				"ability": ["Moxie"],
-				"evs": {"atk": 180, "def": 76, "spe": 236},
-				"nature": "Adamant",
-				"moves": [["Earthquake"], ["Crunch"], ["Fire Fang"], ["Pursuit", "Rock Slide"]]
-			}, {
-				"species": "Sandile",
-				"item": ["Life Orb"],
-				"ability": ["Moxie"],
-				"evs": {"atk": 180, "def": 76, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Earthquake"], ["Crunch"], ["Fire Fang"], ["Pursuit"]]
-			}, {
-				"species": "Sandile",
-				"item": ["Life Orb"],
-				"ability": ["Moxie"],
-				"evs": {"atk": 180, "def": 76, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Earthquake"], ["Crunch"], ["Stealth Rock"], ["Pursuit"]]
-			}]
-		},
-		"stufful": {
-			"flags": {},
-			"sets": [{
-				"species": "Stufful",
-				"item": ["Eviolite"],
-				"ability": ["Fluffy"],
-				"evs": {"hp": 116, "atk": 156, "def": 196, "spd": 40},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Return"], ["Earthquake"], ["Brick Break", "Payback"]]
-			}]
-		},
-		"sandshrew": {
-			"flags": {},
-			"sets": [{
-				"species": "Sandshrew",
-				"item": ["Eviolite"],
-				"ability": ["Sand Rush"],
-				"evs": {"hp": 36, "atk": 156, "def": 76, "spd": 36, "spe": 196},
-				"nature": "Adamant",
-				"moves": [["Stealth Rock"], ["Rapid Spin"], ["Earthquake"], ["Knock Off"]]
-			}]
-		},
-		"tentacool": {
-			"flags": {},
-			"sets": [{
-				"species": "Tentacool",
-				"item": ["Berry Juice"],
-				"ability": ["Liquid Ooze"],
-				"evs": {"hp": 196, "def": 76, "spd": 196, "spe": 36},
-				"nature": "Calm",
-				"moves": [["Toxic Spikes"], ["Sludge Bomb"], ["Scald"], ["Knock Off", "Rapid Spin"]]
 			}]
 		},
 		"trapinch": {
@@ -11767,214 +11484,6 @@
 				"evs": {"hp": 116, "atk": 36, "def": 100, "spd": 20, "spe": 236},
 				"nature": "Jolly",
 				"moves": [["Toxic Spikes"], ["Gunk Shot"], ["Drain Punch"], ["Clear Smog"]]
-			}]
-		},
-		"budew": {
-			"flags": {},
-			"sets": [{
-				"species": "Budew",
-				"item": ["Eviolite"],
-				"ability": ["Natural Cure"],
-				"evs": {"hp": 36, "def": 236, "spa": 36, "spd": 196},
-				"nature": "Bold",
-				"moves": [["Sleep Powder"], ["Spikes"], ["Synthesis"], ["Giga Drain"]]
-			}, {
-				"species": "Budew",
-				"item": ["Eviolite"],
-				"ability": ["Natural Cure"],
-				"evs": {"hp": 36, "def": 236, "spa": 36, "spd": 196},
-				"nature": "Bold",
-				"moves": [["Sleep Powder"], ["Spikes"], ["Toxic Spikes"], ["Giga Drain"]]
-			}, {
-				"species": "Budew",
-				"item": ["Eviolite"],
-				"ability": ["Natural Cure"],
-				"evs": {"hp": 36, "def": 236, "spa": 36, "spd": 196},
-				"nature": "Bold",
-				"moves": [["Spikes"], ["Sleep Powder", "Sludge Bomb"], ["Giga Drain"], ["Hidden Power Fire"]]
-			}, {
-				"species": "Budew",
-				"item": ["Life Orb"],
-				"ability": ["Natural Cure"],
-				"evs": {"def": 76, "spa": 196, "spe": 236},
-				"ivs": {"hp": 19, "atk": 0},
-				"nature": "Modest",
-				"moves": [["Sludge Bomb"], ["Extrasensory"], ["Giga Drain", "Leaf Storm"], ["Dazzling Gleam", "Sleep Powder"]]
-			}]
-		},
-		"cubone": {
-			"flags": {},
-			"sets": [{
-				"species": "Cubone",
-				"item": ["Thick Club"],
-				"ability": ["Battle Armor"],
-				"evs": {"atk": 196, "def": 76, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Bonemerang"], ["Rock Slide"], ["Knock Off"], ["Fire Punch", "Swords Dance"]]
-			}]
-		},
-		"dewpider": {
-			"flags": {},
-			"sets": [{
-				"species": "Dewpider",
-				"item": ["Eviolite"],
-				"ability": ["Water Bubble"],
-				"evs": {"hp": 212, "def": 180, "spa": 36, "spd": 20, "spe": 60},
-				"nature": "Modest",
-				"moves": [["Scald"], ["Infestation"], ["Rest"], ["Sleep Talk"]]
-			}, {
-				"species": "Dewpider",
-				"item": ["Eviolite"],
-				"ability": ["Water Bubble"],
-				"evs": {"hp": 132, "def": 180, "spa": 116, "spd": 20, "spe": 60},
-				"ivs": {"atk": 0},
-				"nature": "Modest",
-				"moves": [["Scald"], ["Sticky Web"], ["Giga Drain", "Ice Beam"], ["Magic Coat", "Rest"]]
-			}, {
-				"species": "Dewpider",
-				"item": ["Eviolite"],
-				"ability": ["Water Bubble"],
-				"evs": {"hp": 132, "atk": 116, "def": 180, "spd": 20, "spe": 60},
-				"nature": "Adamant",
-				"moves": [["Sticky Web"], ["Leech Life"], ["Liquidation"], ["Magic Coat"]]
-			}]
-		},
-		"fletchling": {
-			"flags": {},
-			"sets": [{
-				"species": "Fletchling",
-				"item": ["Berry Juice"],
-				"ability": ["Gale Wings"],
-				"evs": {"atk": 196, "def": 92, "spe": 180},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Acrobatics"], ["Overheat", "Flame Charge"], ["U-turn"]]
-			}, {
-				"species": "Fletchling",
-				"item": ["Berry Juice"],
-				"ability": ["Gale Wings"],
-				"evs": {"atk": 196, "def": 92, "spe": 180},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Acrobatics"], ["Overheat", "Flame Charge"], ["Hidden Power Grass"]]
-			}, {
-				"species": "Fletchling",
-				"item": ["Berry Juice"],
-				"ability": ["Gale Wings"],
-				"evs": {"atk": 196, "def": 92, "spe": 180},
-				"nature": "Adamant",
-				"moves": [["Acrobatics"], ["Overheat", "Flame Charge"], ["Hidden Power Grass"], ["Substitute", "U-turn"]]
-			}]
-		},
-		"honedge": {
-			"flags": {},
-			"sets": [{
-				"species": "Honedge",
-				"item": ["Eviolite"],
-				"ability": ["No Guard"],
-				"evs": {"hp": 76, "atk": 116, "def": 116, "spd": 140, "spe": 52},
-				"nature": "Adamant",
-				"moves": [["Iron Head"], ["Sacred Sword"], ["Shadow Sneak"], ["Pursuit"]]
-			}, {
-				"species": "Honedge",
-				"item": ["Berry Juice"],
-				"ability": ["No Guard"],
-				"evs": {"hp": 76, "atk": 116, "def": 116, "spd": 140, "spe": 52},
-				"nature": "Adamant",
-				"moves": [["Iron Head"], ["Sacred Sword", "Rock Slide"], ["Shadow Sneak"], ["Pursuit", "Swords Dance"]]
-			}]
-		},
-		"lickitung": {
-			"flags": {},
-			"sets": [{
-				"species": "Lickitung",
-				"item": ["Eviolite"],
-				"ability": ["Oblivious"],
-				"evs": {"hp": 196, "def": 76, "spd": 236},
-				"nature": "Impish",
-				"moves": [["Body Slam"], ["Wish"], ["Protect"], ["Knock Off", "Heal Bell"]]
-			}, {
-				"species": "Lickitung",
-				"item": ["Eviolite"],
-				"ability": ["Oblivious"],
-				"evs": {"hp": 196, "def": 76, "spd": 236},
-				"nature": "Impish",
-				"moves": [["Body Slam"], ["Earthquake"], ["Knock Off"], ["Heal Bell"]]
-			}, {
-				"species": "Lickitung",
-				"item": ["Berry Juice"],
-				"ability": ["Oblivious"],
-				"evs": {"hp": 196, "atk": 236, "spd": 76},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Body Slam"], ["Knock Off"], ["Earthquake"]]
-			}, {
-				"species": "Lickitung",
-				"item": ["Berry Juice"],
-				"ability": ["Oblivious"],
-				"evs": {"hp": 196, "atk": 236, "spd": 76},
-				"nature": "Adamant",
-				"moves": [["Swords Dance"], ["Return"], ["Knock Off"], ["Earthquake"]]
-			}]
-		},
-		"remoraid": {
-			"flags": {},
-			"sets": [{
-				"species": "Remoraid",
-				"item": ["Choice Scarf"],
-				"ability": ["Hustle"],
-				"evs": {"spa": 236, "spe": 236},
-				"nature": "Naive",
-				"moves": [["Water Spout"], ["Hydro Pump", "Waterfall"], ["Fire Blast"], ["Bullet Seed"]]
-			}, {
-				"species": "Remoraid",
-				"item": ["Life Orb"],
-				"ability": ["Hustle"],
-				"evs": {"atk": 236, "spe": 236},
-				"ivs": {"hp": 29},
-				"nature": "Naive",
-				"moves": [["Waterfall"], ["Bullet Seed"], ["Rock Blast"], ["Fire Blast"]]
-			}]
-		},
-		"stunky": {
-			"flags": {},
-			"sets": [{
-				"species": "Stunky",
-				"item": ["Eviolite"],
-				"ability": ["Aftermath"],
-				"evs": {"atk": 252, "def": 60, "spd": 188, "spe": 4},
-				"nature": "Careful",
-				"moves": [["Sucker Punch"], ["Sludge Bomb", "Fire Blast", "Memento"], ["Defog"], ["Pursuit"]]
-			}]
-		},
-		"treecko": {
-			"flags": {},
-			"sets": [{
-				"species": "Treecko",
-				"item": ["Berry Juice"],
-				"ability": ["Unburden"],
-				"evs": {"hp": 116, "atk": 236, "def": 156},
-				"nature": "Jolly",
-				"moves": [["Swords Dance"], ["Bullet Seed"], ["Acrobatics"], ["Drain Punch"]]
-			}]
-		},
-		"teddiursa": {
-			"flags": {},
-			"sets": [{
-				"species": "Teddiursa",
-				"item": ["Toxic Orb"],
-				"ability": ["Quick Feet"],
-				"evs": {"hp": 36, "atk": 196, "def": 36, "spd": 36, "spe": 196},
-				"nature": "Jolly",
-				"moves": [["Facade"], ["Close Combat"], ["Crunch"], ["Protect", "Swords Dance"]]
-			}]
-		},
-		"minccino": {
-			"flags": {},
-			"sets": [{
-				"species": "Minccino",
-				"item": ["Life Orb"],
-				"ability": ["Skill Link"],
-				"evs": {"atk": 196, "def": 36, "spa": 36, "spe": 236},
-				"nature": "Jolly",
-				"moves": [["Grass Knot", "Aqua Tail"], ["Knock Off"], ["Tail Slap"], ["Wake-Up Slap", "U-turn"]]
 			}]
 		}
 	},

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1911,7 +1911,7 @@ class RandomTeams extends Dex.ModdedDex {
 		// no exploitable information is leaked from rolling the tier in getTeam(p1).
 		let availableTiers = ['Uber', 'OU', 'UU', 'RU', 'NU', 'PU', 'LC', 'Mono'];
 		if (!this.FactoryTier) this.FactoryTier = this.sample(availableTiers);
-		const chosenTier = this.FactoryTier;
+		const chosenTier = 'Mono';
 		const tierValues = {
 			'Uber': 5,
 			'OU': 4, 'UUBL': 4,
@@ -1971,8 +1971,11 @@ class RandomTeams extends Dex.ModdedDex {
 			if (itemData.megaStone) types = this.getTemplate(itemData.megaStone).types;
 
 			// Enforce Monotype
-			if (chosenTier === 'Mono' && types.indexOf(type) < 0) {
-				continue;
+			if (chosenTier === 'Mono') {
+				for (const type of types) {
+					if (!template.types.includes(type)) continue;
+				}
+				if (!types.includes(type)) continue;
 			} else {
 			// If not Monotype, limit to two of each type
 				let skip = false;

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1911,7 +1911,7 @@ class RandomTeams extends Dex.ModdedDex {
 		// no exploitable information is leaked from rolling the tier in getTeam(p1).
 		let availableTiers = ['Uber', 'OU', 'UU', 'RU', 'NU', 'PU', 'LC', 'Mono'];
 		if (!this.FactoryTier) this.FactoryTier = this.sample(availableTiers);
-		const chosenTier = 'Mono';
+		const chosenTier = this.FactoryTier;
 		const tierValues = {
 			'Uber': 5,
 			'OU': 4, 'UUBL': 4,

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1833,7 +1833,7 @@ class RandomTeams extends Dex.ModdedDex {
 
 		// Build a pool of eligible sets, given the team partners
 		// Also keep track of sets with moves the team requires
-		/**@type {{set: AnyObject, moveVariants?: number[], itemVariants?: number, abilityVariants?: number}[]} */
+		/**@type {{set: AnyObject, moveVariants?: number[]}[]} */
 		let effectivePool = [];
 		let priorityPool = [];
 		for (const curSet of setList) {
@@ -1880,34 +1880,22 @@ class RandomTeams extends Dex.ModdedDex {
 			moves.push(setData.moveVariants ? moveSlot[setData.moveVariants[i]] : this.sample(moveSlot));
 		}
 
-		let items = [];
-		if (Array.isArray(setData.set.item)) {
-			let randomItem = setData.set.item;
-			items.push(setData.itemVariants ? randomItem[setData.itemVariants] : this.sample(randomItem));
-		} else {
-			items.push(setData.set.item);
-		}
-
-		let abilities = [];
-		if (Array.isArray(setData.set.ability)) {
-			let randomAbility = setData.set.ability;
-			abilities.push(setData.abilityVariants ? randomAbility[setData.abilityVariants] : this.sample(randomAbility));
-		} else {
-			abilities.push(setData.set.ability);
-		}
+		let item = Array.isArray(setData.set.item) ? this.sample(setData.set.item) : setData.set.item;
+		let ability = Array.isArray(setData.set.ability) ? this.sample(setData.set.ability) : setData.set.ability;
+		let nature = Array.isArray(setData.set.nature) ? this.sample(setData.set.nature) : setData.set.nature;
 
 		return {
 			name: setData.set.name || template.baseSpecies,
 			species: setData.set.species,
 			gender: setData.set.gender || template.gender || (this.randomChance(1, 2) ? 'M' : 'F'),
-			item: items + '' || setData.set.item || '',
-			ability: abilities + '' || setData.set.ability || template.abilities['0'],
+			item: item || '',
+			ability: ability || template.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
-			level: tier === "LC" ? 5 : 100,
+			level: setData.set.level ? setData.set.level : tier === "LC" ? 5 : 100,
 			happiness: typeof setData.set.happiness === 'undefined' ? 255 : setData.set.happiness,
 			evs: Object.assign({hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0}, setData.set.evs),
 			ivs: Object.assign({hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31}, setData.set.ivs),
-			nature: setData.set.nature || 'Serious',
+			nature: nature || 'Serious',
 			moves: moves,
 		};
 	}
@@ -1979,6 +1967,9 @@ class RandomTeams extends Dex.ModdedDex {
 			if (teamData.zCount >= 1 && itemData.zMove) continue;
 
 			let types = template.types;
+			// Prevents Mega Evolutions from breaking the type limits
+			if (itemData.megaStone) types = this.getTemplate(itemData.megaStone).types;
+
 			// Enforce Monotype
 			if (chosenTier === 'Mono' && types.indexOf(type) < 0) {
 				continue;


### PR DESCRIPTION
OU set changes: https://pastebin.com/gsYEEnP6
NU set changes: https://pastebin.com/v3r3LduC https://pastebin.com/6rfDFCJT
PU set changes: https://pastebin.com/Yft1g9L1

LC set removal reasoning:
- [1:03 PM] Quote: remove axew, anorith, venipede, tyrunt, cranidos, skrelp, magby, spinarak, darumaka, deerling, dratini, goldeen, inkay, lileep, mankey, natu, sandile, stufful, sandshrew, tentacool, budew, cubone, dewpider, fletchling, honedge, lickitung, remoraid, stunky, treecko, teddiursa, minccino, rowlet
- [1:03 PM] Quote: that's mostly a list of shitmons that have no place in BF
- [1:04 PM] Kalalokki: wait all of those?
- [1:04 PM] Quote: yes. They're all mons that are super low on our VR
- [1:04 PM] Quote: or not even on the vr any more
- [1:04 PM] Kalalokki: aight


The changes in `random-teams.js` for items, abilities, and natures allows Pokemon to have multiple natures listed on a set, and this also cleans up the picking for all of them. I removed `itemVariants`/`abilityVariants` because they were never defined, modified, or used outside of the changed code and thus didn't do anything.

The change to ``level`` comes because OU's Pyukumuku set has it listed as level 96, which is what makes the set optimal.

The `megaStone` type check was added because people were reporting that Monotype allowed illegal combinations like Mega Altaria or Mega Charizard X on Flying teams.