### PR TITLE
Make Dancer copy the called Dance move

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -116,7 +116,7 @@ let BattleScripts = {
 			for (const dancer of dancers) {
 				if (this.faintMessages()) break;
 				this.add('-activate', dancer, 'ability: Dancer');
-				this.runMove(baseMove.id, dancer, 0, this.getAbility('dancer'), undefined, true);
+				this.runMove(move.id, dancer, 0, this.getAbility('dancer'), undefined, true);
 			}
 		}
 		if (noLock && pokemon.volatiles.lockedmove) delete pokemon.volatiles.lockedmove;


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/7876938) and elaborated on in the next post.

Note that prior to commit d46abff the called move did not get checked, so `baseMove` would have been the same as `move` when it was a dance move, and Dancer didn't get to copy called moves.

Copying a Z-powered status Dance move, or a Dance move called from a Z-powered move, still seems to work.