### PR TITLE
Check that the father learns the move in the right gen

### DIFF
--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -1137,6 +1137,9 @@ class Validator {
 							if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
 								// can tradeback
 								sources.push('1ET' + father.id);
+							// father must be able to learn the move in this gen
+							} else if (!fromSelf && !fatherSources.some(source => parseInt(source.charAt(0)) <= learnedGen)) {
+								continue;
 							}
 							sources.push(learned + father.id);
 							if (limitedEgg !== false) limitedEgg = true;


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/7883623).

In the case of Curse + Drill Peck, the validator is finding a father that learns both moves in Gen 7. It needs to find a father that learns both moves in the egg move gen instead.

(I added the code after the tradeback check because I don't understand that check so I didn't want to accidentally prevent a valid move from being learned.)