### PR TITLE
Battle Factory: Fix Mega checking and remove Kingler from PU

### DIFF
--- a/data/factory-sets.json
+++ b/data/factory-sets.json
@@ -8101,24 +8101,6 @@
 				"moves": [["Heal Bell"], ["Roost"], ["Defog", "Toxic"], ["Freeze-Dry"]]
 			}]
 		},
-		"kingler": {
-			"flags": {},
-			"sets": [{
-				"species": "Kingler",
-				"item": ["Life Orb"],
-				"ability": ["Sheer Force"],
-				"evs": {"atk": 252, "spa": 4, "spe": 252},
-				"nature": "Naughty",
-				"moves": [["Liquidation"], ["Stomping Tantrum"], ["Agility"], ["Ice Beam"]]
-			}, {
-				"species": "Kingler",
-				"item": ["Life Orb"],
-				"ability": ["Sheer Force"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": "Adamant",
-				"moves": [["Liquidation"], ["Stomping Tantrum", "Superpower"], ["Agility"], ["Swords Dance"]]
-			}]
-		},
 		"mesprit": {
 			"flags": {},
 			"sets": [{

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1968,13 +1968,17 @@ class RandomTeams extends Dex.ModdedDex {
 			if (teamData.zCount >= 1 && itemData.zMove) continue;
 
 			let types = template.types;
-			// Prevents Mega Evolutions from breaking the type limits
-			if (itemData.megaStone) types = this.getTemplate(itemData.megaStone).types;
 
 			// Enforce Monotype
 			if (chosenTier === 'Mono') {
-				for (const type of types) {
-					if (!template.types.includes(type)) continue;
+				// Prevents Mega Evolutions from breaking the type limits
+				if (itemData.megaStone) {
+					let megaTemplate = this.getTemplate(itemData.megaStone);
+					if (types.length > megaTemplate.types.length) types = [template.types[0]];
+					// Only check the second type because a Mega Evolution should always share the first type with its base forme.
+					if (megaTemplate.types[1] && types[1] && megaTemplate.types[1] !== types[1]) {
+						types = [megaTemplate.types[0]];
+					}
 				}
 				if (!types.includes(type)) continue;
 			} else {


### PR DESCRIPTION
I also removed Kingler's PU sets since it was banned and I figured I might as well do that.

The issue with the current check is that it just completely skips over Mega Evolutions that change types on every team, including stuff like Mega Gyarados on a Water team.