### PR TITLE
Gen 2 Randbats: Fix typo

### DIFF
--- a/mods/gen2/formats-data.js
+++ b/mods/gen2/formats-data.js
@@ -2427,7 +2427,7 @@ let BattleFormatsData = {
 		randomSet3: { // Defensive
 			chance: 16,
 			item: ["leftovers"],
-			baseMove1: "psychic", baseMove2: "recover",
+			baseMove1: "psychic", baseMove2: "softboiled",
 			fillerMoves1: ["thunderwave", "thunderwave", "thunderwave", "reflect"],
 			fillerMoves2: ["reflect", "reflect", "reflect", "reflect", "earthquake", "icebeam", "thunderbolt", "fireblast"],
 		},


### PR DESCRIPTION
Mew doesn't learn Recover. Probably a copy-paste error from the similar Mewtwo set.