### PR TITLE
Support staff-only HTML boxes

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -2169,7 +2169,7 @@ const commands = {
 	},
 	showimagehelp: [`/showimage [url], [width], [height] - Show an image. Any CSS units may be used for the width or height (default: px). Requires: # & ~`],
 
-	htmlbox: function (target, room, user, connection, cmd, message) {
+	htmlbox: function (target, room, user) {
 		if (!target) return this.parse('/help htmlbox');
 		target = this.canHTML(target);
 		if (!target) return;
@@ -2181,8 +2181,13 @@ const commands = {
 
 		this.sendReplyBox(target);
 	},
-	addhtmlbox: function (target, room, user, connection, cmd, message) {
-		if (!target) return this.parse('/help htmlbox');
+	htmlboxhelp: [
+		`/htmlbox [message] - Displays a message, parsing HTML code contained.`,
+		`!htmlbox [message] - Shows everyone a message, parsing HTML code contained. Requires: ~ & #`,
+	],
+	addmodhtmlbox: 'addhtmlbox',
+	addhtmlbox: function (target, room, user, connection, cmd) {
+		if (!target) return this.parse('/help ' + cmd);
 		if (!this.canTalk()) return;
 		target = this.canHTML(target);
 		if (!target) return;
@@ -2192,12 +2197,20 @@ const commands = {
 			target += Chat.html`<div style="float:right;color:#888;font-size:8pt">[${user.name}]</div><div style="clear:both"></div>`;
 		}
 
-		this.addBox(target);
+		if (cmd === 'addmodhtmlbox') {
+			this.addModBox(target);
+		} else {
+			this.addBox(target);
+		}
 	},
-	htmlboxhelp: [
-		`/htmlbox [message] - Displays a message, parsing HTML code contained.`,
-		`!htmlbox [message] - Shows everyone a message, parsing HTML code contained. Requires: ~ & #`,
+	addhtmlboxhelp: [
+		`/addhtmlbox [message] - Shows everyone a message, parsing HTML code contained. Requires: ~ & #`,
 	],
+	addmodhtmlboxhelp: [
+		`/addmodhtmlbox [message] - Shows staff a message, parsing HTML code contained. Requires: ~ & #`,
+	],
+	changemoduhtml: 'adduhtml',
+	addmoduhtml: 'adduhtml',
 	changeuhtml: 'adduhtml',
 	adduhtml: function (target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help ' + cmd);
@@ -2213,13 +2226,24 @@ const commands = {
 			html += Chat.html`<div style="float:right;color:#888;font-size:8pt">[${user.name}]</div><div style="clear:both"></div>`;
 		}
 
-		this.add(`|uhtml${(cmd === 'changeuhtml' ? 'change' : '')}|${name}|${html}`);
+		html = `|uhtml${(cmd === 'changeuhtml' || cmd === 'changemoduhtml' ? 'change' : '')}|${name}|${html}`;
+		if (cmd === 'addmoduhtml' || cmd === 'changemoduhtml') {
+			this.room.sendMods(html);
+		} else {
+			this.add(html);
+		}
 	},
 	adduhtmlhelp: [
-		`/adduhtml [name], [message] - Shows everyone a message that can change, parsing HTML code contained.`,
+		`/adduhtml [name], [message] - Shows everyone a message that can change, parsing HTML code contained.  Requires: ~ & #`,
 	],
 	changeuhtmlhelp: [
-		`/changeuhtml [name], [message] - Changes a message previously shown with /adduhtml`,
+		`/changeuhtml [name], [message] - Changes the message previously shown with /adduhtml [name]. Requires: ~ & #`,
+	],
+	addmoduhtmlhelp: [
+		`/addmoduhtml [name], [message] - Shows staff a message that can change, parsing HTML code contained. Requires: ~ & #`,
+	],
+	changemoduhtmlhelp: [
+		`/changemoduhtml [name], [message] - Changes the staff message previously shown with /addmoduhtml [name]. Requires: ~ & #`,
 	],
 };
 

--- a/chat.js
+++ b/chat.js
@@ -572,6 +572,12 @@ class CommandContext {
 	/**
 	 * @param {string} html
 	 */
+	addModBox(html) {
+		this.room.sendMods(`|html|<div class="infobox">${html}</div>`);
+	}
+	/**
+	 * @param {string} html
+	 */
 	sendReplyBox(html) {
 		this.sendReply(`|html|<div class="infobox">${html}</div>`);
 	}


### PR DESCRIPTION
Also inlined Chat.addBox to prevent code duplication and updated relevant help commands.

This is currently planned to be used with hosting in Tournaments, but it could be useful for other rooms too.