### PR TITLE
Updated sockets.js for helping ip merge issue

### DIFF
--- a/sockets.js
+++ b/sockets.js
@@ -529,6 +529,10 @@ if (cluster.isMaster) {
 		sockets.set(socketid, socket);
 
 		let socketip = socket.remoteAddress;
+		//ip merge problem fix for people trying to make side server using services like glitch.
+		if (socket.remoteAddress === '127.0.0.1' && socket.headers["x-forwarded-for"]) socketip = socket.headers["x-forwarded-for"].split(",")[0];
+		
+		
 		if (isTrustedProxyIp(socketip)) {
 			let ips = (socket.headers['x-forwarded-for'] || '')
 				.split(',')


### PR DESCRIPTION
Added a line of code which fixes the problem of ip merge while making side servers using services like glitch. This line of code changes the ip from '127.0.0.1' to the individual ip address of the user thus fixing the ip merge problem.