### PR TITLE
Allow /dt to find CAPmons by their dex number

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -406,7 +406,7 @@ const commands = {
 		target = sep[0].trim();
 		let targetId = toId(target);
 		if (!targetId) return this.parse('/help data');
-		let targetNum = parseInt(targetId);
+		let targetNum = parseInt(target);
 		if (!isNaN(targetNum) && '' + targetNum === target) {
 			for (let p in Dex.data.Pokedex) {
 				let pokemon = Dex.getTemplate(p);


### PR DESCRIPTION
A user asked me about this, so apparently some people actually do this. The parsed dex number is being compared to the full, non-id target anyway, so I don't think this will introduce any other weird cases.