### PR TITLE
Fix /coverage with type arguments

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -827,13 +827,13 @@ const commands = {
 			}
 
 			// arg is a type?
-			let type = arg.charAt(0).toUpperCase() + arg.slice(1);
+			let argType = arg.charAt(0).toUpperCase() + arg.slice(1);
 			let eff;
-			if (type in mod.data.TypeChart) {
-				sources.push(type);
+			if (argType in mod.data.TypeChart) {
+				sources.push(argType);
 				for (let type in bestCoverage) {
-					if (!mod.getImmunity(type, type) && !type.ignoreImmunity) continue;
-					eff = mod.getEffectiveness(type, type);
+					if (!mod.getImmunity(argType, type)) continue;
+					eff = mod.getEffectiveness(argType, type);
 					if (eff > bestCoverage[type]) bestCoverage[type] = eff;
 				}
 				continue;


### PR DESCRIPTION
The type from the argument was called ``type``, and the defensive type iteration var was also called ``type``. As a result, the result was actually a list of effectivenesses of each type against itself.