### PR TITLE
Validator: Validate Hidden Power Type

### DIFF
--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -217,6 +217,9 @@ class Validator {
 		if (set.happiness !== undefined && isNaN(set.happiness)) {
 			problems.push(`${name} has an invalid happiness.`);
 		}
+		if (set.hpType && (!dex.getType(set.hpType).exists || ['normal', 'fairy'].includes(toId(set.hpType)))) {
+			problems.push(`${name}'s Hidden Power type (${set.hpType}) is invalid.`);
+		}
 
 		let banReason = ruleTable.check('pokemon:' + template.id, setHas);
 		let templateOverride = ruleTable.has('+pokemon:' + template.id);


### PR DESCRIPTION
The move being listed as `hiddenpowerfairy` is handled by the "does the move exist" check.

This validates that the set's `hpType` slot is a valid type in the generation that is being played (and that its not Fairy ever).