### PR TITLE
Fix double Sky Drop message

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -14951,7 +14951,6 @@ let BattleMovedex = {
 
 				if (target.hasType('Flying')) {
 					this.add('-immune', target, '[msg]');
-					this.add('-end', target, 'Sky Drop');
 					return null;
 				}
 			} else {


### PR DESCRIPTION
When using Sky Drop on a Flying-type, the "freed from Sky Drop!" message displays twice.

[Before fix](https://imgur.com/kyhws2H)

[After fix](https://imgur.com/o2LXBKh)