### PR TITLE
Modlog: Don't include main account in list of alts

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -645,7 +645,7 @@ class CommandContext {
 				let userid = user.getLastId();
 				buf += `[${userid}]`;
 				if (user.autoconfirmed && user.autoconfirmed !== userid) buf += ` ac:[${user.autoconfirmed}]`;
-				const alts = user.getAltUsers(false, true).map(user => user.getLastId()).join('], [');
+				const alts = user.getAltUsers(false, true).slice(1).map(user => user.getLastId()).join('], [');
 				if (alts.length) buf += ` alts:[${alts}]`;
 				buf += ` [${user.latestIp}]`;
 			}
@@ -671,7 +671,7 @@ class CommandContext {
 				buf += `[${userid}]`;
 				if (!options.noalts) {
 					if (user.autoconfirmed && user.autoconfirmed !== userid) buf += ` ac:[${user.autoconfirmed}]`;
-					const alts = user.getAltUsers(false, true).map(user => user.getLastId()).join('], [');
+					const alts = user.getAltUsers(false, true).slice(1).map(user => user.getLastId()).join('], [');
 					if (alts.length) buf += ` alts:[${alts}]`;
 				}
 				if (!options.noip) buf += ` [${user.latestIp}]`;


### PR DESCRIPTION
Currently, all modlog entries look like "LOCK: [username] alts:[username], [...]".
Ultimately this is because of the second argument in `Users#getAltUsers()`, if it's ``true`` then it always includes the main target in its list. However, there's a bunch of other behavior tied to that flag, so I don't think I should jut set that to ``false`` and instead just cut out the superpluous name manually.