### PR TITLE
Fix user popup for locked alts in /ip

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -96,7 +96,7 @@ const commands = {
 
 				const punishment = Punishments.userids.get(targetAlt.userid);
 				const punishMsg = punishment ? ` (${Punishments.punishmentTypes.get(punishment[0]) || 'punished'}${punishment[1] !== targetAlt.userid ? ` as ${punishment[1]}` : ''})` : '';
-				buf += Chat.html`<br />Alt: <span class="username">${targetAlt.name}${punishMsg}</span>`;
+				buf += Chat.html`<br />Alt: <span class="username">${targetAlt.name}</span>${punishMsg}`;
 				if (!targetAlt.connected) buf += ` <em style="color:gray">(offline)</em>`;
 				prevNames = Object.keys(targetAlt.prevNames).map(userid => {
 					const punishment = Punishments.userids.get(userid);


### PR DESCRIPTION
What's in the username span will be part of the user page link (both in terms of linkification and URL), so the punishment message being in there screws that up.