### PR TITLE
G&F: Fix Mega Evolution validation again

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -546,7 +546,7 @@ let Formats = [
 					if (item.megaStone && template.species === item.megaEvolves) {
 						template = this.getTemplate(item.megaStone);
 						let baseTemplate = this.getTemplate(item.megaEvolves);
-						followerTypes = baseTemplate.types.filter(type => template.types.includes(type));
+						followerTypes = baseTemplate.types.filter(type => template.types.includes(type)).concat(template.types.filter(type => types.includes(type)));
 					}
 					if (!followerTypes.some(type => types.includes(type))) problemsArray.push("Followers must share a type with the God.", `(${template.isMega ? template.baseSpecies : template.species} doesn't share a type with ${team[0].species}.)`);
 				}


### PR DESCRIPTION
This allows Pokemon that still share one type with the "God" after mega evolving to be on the team (i.e. Gyarados -> Mega Gyarados on Yveltal teams still should be legal, since Gyarados shares Flying and Mega Gyarados shares Dark).