### PR TITLE
Fix Flower Veil interaction with Self Inflicted Status and Yawn

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1032,9 +1032,22 @@ let BattleAbilities = {
 		},
 		onAllySetStatus: function (status, target, source, effect) {
 			if (target.hasType('Grass')) {
-				if (!effect || !effect.status) return false;
-				this.add('-activate', this.effectData.target, 'ability: Flower Veil', '[of] ' + target);
-				return null;
+				if (source && target !== source && effect && target.side === source.side) {
+					this.debug('interrupting setStatus with Flower Veil');
+					if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
+						this.add('-activate', this.effectData.target, 'ability: Flower Veil', '[of] ' + target);
+					}
+					return null;
+				}
+			}
+		},
+		onAllyTryAddVolatile: function (status, target) {
+			if (target.hasType('Grass')) {
+				if (status.id === 'yawn') {
+					this.debug('Flower Veil blocking yawn');
+					this.add('-activate', target, 'ability: Flower Veil', '[of] ' + target);
+					return null;
+				}
 			}
 		},
 		id: "flowerveil",

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1031,23 +1031,19 @@ let BattleAbilities = {
 			if (showMsg && !effect.secondaries) this.add('-fail', this.effectData.target, 'unboost', '[from] ability: Flower Veil', '[of] ' + target);
 		},
 		onAllySetStatus: function (status, target, source, effect) {
-			if (target.hasType('Grass')) {
-				if (source && target !== source && effect && target.side === source.side) {
-					this.debug('interrupting setStatus with Flower Veil');
-					if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
-						this.add('-activate', this.effectData.target, 'ability: Flower Veil', '[of] ' + target);
-					}
-					return null;
+			if (target.hasType('Grass') && source && target !== source && effect) {
+				this.debug('interrupting setStatus with Flower Veil');
+				if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
+					this.add('-activate', this.effectData.target, 'ability: Flower Veil', '[of] ' + target);
 				}
+				return null;
 			}
 		},
 		onAllyTryAddVolatile: function (status, target) {
-			if (target.hasType('Grass')) {
-				if (status.id === 'yawn') {
-					this.debug('Flower Veil blocking yawn');
-					this.add('-activate', target, 'ability: Flower Veil', '[of] ' + target);
-					return null;
-				}
+			if (target.hasType('Grass') && status.id === 'yawn') {
+				this.debug('Flower Veil blocking yawn');
+				this.add('-activate', this.effectData.target, 'ability: Flower Veil', '[of] ' + target);
+				return null;
 			}
 		},
 		id: "flowerveil",


### PR DESCRIPTION
Changed ability to allow pokemon under Flower veil to inflict statuses onto themselves using Safeguard as reference
Changed ability to follow the yawn interactions like Safeguard does

Issue brought up by User doipy hooves in https://www.smogon.com/forums/threads/bug-reports-v3-0-read-op-before-posting.3634749/page-17 

Other references:
https://bulbapedia.bulbagarden.net/wiki/Flower_Veil_(Ability)#In_battle
https://bulbapedia.bulbagarden.net/wiki/Safeguard_(move)#Generation_V_onward