### PR TITLE
Fix Forme Change and Autotomize Interaction (Server Side)

### DIFF
--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -931,7 +931,7 @@ class Pokemon {
 		this.apparentType = rawTemplate.types.join('/');
 		this.addedType = template.addedType || '';
 		this.knownType = true;
-
+		this.removeVolatile('autotomize')
 		if (source) {
 			let stats = this.battle.spreadModify(this.template.baseStats, this.set);
 			if (!this.baseStats) this.baseStats = stats;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -931,7 +931,7 @@ class Pokemon {
 		this.apparentType = rawTemplate.types.join('/');
 		this.addedType = template.addedType || '';
 		this.knownType = true;
-		this.removeVolatile('autotomize')
+		this.removeVolatile('autotomize');
 		if (source) {
 			let stats = this.battle.spreadModify(this.template.baseStats, this.set);
 			if (!this.baseStats) this.baseStats = stats;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -932,7 +932,7 @@ class Pokemon {
 		this.addedType = template.addedType || '';
 		this.knownType = true;
 		if (this.battle.gen >= 7) this.removeVolatile('autotomize');
-		
+
 		if (source) {
 			let stats = this.battle.spreadModify(this.template.baseStats, this.set);
 			if (!this.baseStats) this.baseStats = stats;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -931,7 +931,8 @@ class Pokemon {
 		this.apparentType = rawTemplate.types.join('/');
 		this.addedType = template.addedType || '';
 		this.knownType = true;
-		this.removeVolatile('autotomize');
+		if (this.battle.gen >= 7) this.removeVolatile('autotomize');
+		
 		if (source) {
 			let stats = this.battle.spreadModify(this.template.baseStats, this.set);
 			if (!this.baseStats) this.baseStats = stats;


### PR DESCRIPTION
From issue: https://github.com/Zarel/Pokemon-Showdown/issues/2367#issuecomment-381371924

Removed Autotomize from pokemon who undergo formeChange in battle
Needs fix for Client representation to represent this and have the change be silent (submitted fix there)

Replay download showing it works on the server side: https://drive.google.com/file/d/1LdIgE0evOpPWvAbbGFrFL-GLa51XXWmQ/view?usp=sharing
