### PR TITLE
Refactor lastAttackedBy to hurtBy

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -945,8 +945,11 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
-			if (target.lastDamage > 0 && pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.pokemon === target) {
-				this.debug('Boosted for getting hit by ' + pokemon.lastAttackedBy.move);
+			let hurtByTarget = pokemon.hurtBy.find(function (x) {
+				return x.source === target && x.damage > 0 && x.thisTurn;
+			});
+			if (hurtByTarget) {
+				this.debug('Boosted for getting hit by ' + hurtByTarget.move);
 				return move.basePower * 2;
 			}
 			return move.basePower;
@@ -13390,8 +13393,11 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
-			if (target.lastDamage > 0 && pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.pokemon === target) {
-				this.debug('Boosted for getting hit by ' + pokemon.lastAttackedBy.move);
+			let hurtByTarget = pokemon.hurtBy.find(function (x) {
+				return x.source === target && x.damage > 0 && x.thisTurn;
+			});
+			if (hurtByTarget) {
+				this.debug('Boosted for getting hit by ' + hurtByTarget.move);
 				return move.basePower * 2;
 			}
 			return move.basePower;

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -967,11 +967,11 @@ let BattleMovedex = {
 				}
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
-				if (!target.lastAttackedBy) {
-					target.lastAttackedBy = {pokemon: source, move: move.id, thisTurn: true, damage: damage};
+				if (!target.lastHurtBy) {
+					target.hurtBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
 				} else {
-					target.lastAttackedBy.move = move.id;
-					target.lastAttackedBy.damage = damage;
+					target.lastHurtBy.move = move.id;
+					target.lastHurtBy.damage = damage;
 				}
 				return 0;
 			},

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -493,15 +493,9 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a special attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a special attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon, target) {
-<<<<<<< Updated upstream
-			if (pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.move && this.getCategory(pokemon.lastAttackedBy.move) === 'Special' &&
-				this.getMove(pokemon.lastAttackedBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
-				return 2 * pokemon.lastAttackedBy.damage;
-=======
 			if (!pokemon.lastHurtBy) return false;
 			if (pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && this.getCategory(pokemon.lastHurtBy.move) === 'Special' && this.getMove(pokemon.lastHurtBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
 				return 2 * pokemon.lastHurtBy.damage;
->>>>>>> Stashed changes
 			}
 			return false;
 		},

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -144,9 +144,9 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a physical attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a physical attack this turn, or if the user did not lose HP from the attack. If the opposing Pokemon used Fissure or Horn Drill and missed, this move deals 65535 damage.",
 		damageCallback: function (pokemon, target) {
-			if (pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.move && (this.getCategory(pokemon.lastAttackedBy.move) === 'Physical' || this.getMove(pokemon.lastAttackedBy.move).id === 'hiddenpower') &&
-				(!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
-				return 2 * pokemon.lastAttackedBy.damage;
+			if (!pokemon.lastHurtBy) return false;
+			if (pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && (this.getCategory(pokemon.lastHurtBy.move) === 'Physical' || this.getMove(pokemon.lastHurtBy.move).id === 'hiddenpower') && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
+				return 2 * pokemon.lastHurtBy.damage;
 			}
 			return false;
 		},
@@ -493,9 +493,15 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a special attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a special attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon, target) {
+<<<<<<< Updated upstream
 			if (pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.move && this.getCategory(pokemon.lastAttackedBy.move) === 'Special' &&
 				this.getMove(pokemon.lastAttackedBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
 				return 2 * pokemon.lastAttackedBy.damage;
+=======
+			if (!pokemon.lastHurtBy) return false;
+			if (pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && this.getCategory(pokemon.lastHurtBy.move) === 'Special' && this.getMove(pokemon.lastHurtBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
+				return 2 * pokemon.lastHurtBy.damage;
+>>>>>>> Stashed changes
 			}
 			return false;
 		},

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -144,8 +144,7 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a physical attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a physical attack this turn, or if the user did not lose HP from the attack. If the opposing Pokemon used Fissure or Horn Drill and missed, this move deals 65535 damage.",
 		damageCallback: function (pokemon, target) {
-			if (!pokemon.lastHurtBy) return false;
-			if (pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && (this.getCategory(pokemon.lastHurtBy.move) === 'Physical' || this.getMove(pokemon.lastHurtBy.move).id === 'hiddenpower') && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
+			if (pokemon.lastHurtBy && pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && (this.getCategory(pokemon.lastHurtBy.move) === 'Physical' || this.getMove(pokemon.lastHurtBy.move).id === 'hiddenpower') && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
 				return 2 * pokemon.lastHurtBy.damage;
 			}
 			return false;
@@ -493,8 +492,7 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a special attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a special attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon, target) {
-			if (!pokemon.lastHurtBy) return false;
-			if (pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && this.getCategory(pokemon.lastHurtBy.move) === 'Special' && this.getMove(pokemon.lastHurtBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
+			if (pokemon.lastHurtBy && pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && this.getCategory(pokemon.lastHurtBy.move) === 'Special' && this.getMove(pokemon.lastHurtBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
 				return 2 * pokemon.lastHurtBy.damage;
 			}
 			return false;

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -187,8 +187,7 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the last opposing Pokemon to hit the user with a physical attack this turn equal to twice the HP lost by the user from that attack. If that opposing Pokemon's position is no longer in use and there is another opposing Pokemon on the field, the damage is done to it instead. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user was not hit by an opposing Pokemon's physical attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon) {
-			if (!pokemon.lastHurtBy) return false;
-			if (pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && (this.getCategory(pokemon.lastHurtBy.move) === 'Physical' || this.getMove(pokemon.lastHurtBy.move).id === 'hiddenpower')) {
+			if (pokemon.lastHurtBy && pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && (this.getCategory(pokemon.lastHurtBy.move) === 'Physical' || this.getMove(pokemon.lastHurtBy.move).id === 'hiddenpower')) {
 				// @ts-ignore
 				return 2 * pokemon.lastHurtBy.damage;
 			}
@@ -558,8 +557,7 @@ let BattleMovedex = {
 		onTryHit: function () { },
 		onHit: function (pokemon) {
 			let noMirror = ['assist', 'curse', 'doomdesire', 'focuspunch', 'futuresight', 'magiccoat', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'psychup', 'roleplay', 'sketch', 'sleeptalk', 'spikes', 'spitup', 'taunt', 'teeterdance', 'transform'];
-			if (!pokemon.lastHurtBy) return false;
-			if (!pokemon.lastHurtBy.source.lastMove || !pokemon.lastHurtBy.move || noMirror.includes(pokemon.lastHurtBy.move) || !pokemon.lastHurtBy.source.hasMove(pokemon.lastHurtBy.move)) {
+			if (!pokemon.lastHurtBy || !pokemon.lastHurtBy.source.lastMove || !pokemon.lastHurtBy.move || noMirror.includes(pokemon.lastHurtBy.move) || !pokemon.lastHurtBy.source.hasMove(pokemon.lastHurtBy.move)) {
 				return false;
 			}
 			this.useMove(pokemon.lastHurtBy.move, pokemon);

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -187,9 +187,10 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the last opposing Pokemon to hit the user with a physical attack this turn equal to twice the HP lost by the user from that attack. If that opposing Pokemon's position is no longer in use and there is another opposing Pokemon on the field, the damage is done to it instead. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user was not hit by an opposing Pokemon's physical attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon) {
-			if (pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.move && (this.getCategory(pokemon.lastAttackedBy.move) === 'Physical' || this.getMove(pokemon.lastAttackedBy.move).id === 'hiddenpower')) {
+			if (!pokemon.lastHurtBy) return false;
+			if (pokemon.lastHurtBy.move && pokemon.lastHurtBy.thisTurn && (this.getCategory(pokemon.lastHurtBy.move) === 'Physical' || this.getMove(pokemon.lastHurtBy.move).id === 'hiddenpower')) {
 				// @ts-ignore
-				return 2 * pokemon.lastAttackedBy.damage;
+				return 2 * pokemon.lastHurtBy.damage;
 			}
 			return false;
 		},
@@ -557,10 +558,11 @@ let BattleMovedex = {
 		onTryHit: function () { },
 		onHit: function (pokemon) {
 			let noMirror = ['assist', 'curse', 'doomdesire', 'focuspunch', 'futuresight', 'magiccoat', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'psychup', 'roleplay', 'sketch', 'sleeptalk', 'spikes', 'spitup', 'taunt', 'teeterdance', 'transform'];
-			if (!pokemon.lastAttackedBy || !pokemon.lastAttackedBy.pokemon.lastMove || !pokemon.lastAttackedBy.move || noMirror.includes(pokemon.lastAttackedBy.move) || !pokemon.lastAttackedBy.pokemon.hasMove(pokemon.lastAttackedBy.move)) {
+			if (!pokemon.lastHurtBy) return false;
+			if (!pokemon.lastHurtBy.source.lastMove || !pokemon.lastHurtBy.move || noMirror.includes(pokemon.lastHurtBy.move) || !pokemon.lastHurtBy.source.hasMove(pokemon.lastHurtBy.move)) {
 				return false;
 			}
-			this.useMove(pokemon.lastAttackedBy.move, pokemon);
+			this.useMove(pokemon.lastHurtBy.move, pokemon);
 		},
 		target: "self",
 	},

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -1105,10 +1105,11 @@ let BattleMovedex = {
 		onTryHit: function () { },
 		onHit: function (pokemon) {
 			let noMirror = ['acupressure', 'aromatherapy', 'assist', 'chatter', 'copycat', 'counter', 'curse', 'doomdesire', 'feint', 'focuspunch', 'futuresight', 'gravity', 'hail', 'haze', 'healbell', 'helpinghand', 'lightscreen', 'luckychant', 'magiccoat', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'mist', 'mudsport', 'naturepower', 'perishsong', 'psychup', 'raindance', 'reflect', 'roleplay', 'safeguard', 'sandstorm', 'sketch', 'sleeptalk', 'snatch', 'spikes', 'spitup', 'stealthrock', 'struggle', 'sunnyday', 'tailwind', 'toxicspikes', 'transform', 'watersport'];
-			if (!pokemon.lastAttackedBy || !pokemon.lastAttackedBy.pokemon.lastMove || !pokemon.lastAttackedBy.move || noMirror.includes(pokemon.lastAttackedBy.move) || !pokemon.lastAttackedBy.pokemon.hasMove(pokemon.lastAttackedBy.move)) {
-				return false;
+			if (!pokemon.lastHurtBy) return false;
+			if (!pokemon.lastHurtBy.source.lastMove || !pokemon.lastHurtBy.move || noMirror.includes(pokemon.lastHurtBy.move) || !pokemon.lastHurtBy.source.hasMove(pokemon.lastHurtBy.move)) {
+				 return false;
 			}
-			this.useMove(pokemon.lastAttackedBy.move, pokemon);
+			this.useMove(pokemon.lastHurtBy.move, pokemon);
 		},
 		target: "self",
 	},

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -1105,8 +1105,7 @@ let BattleMovedex = {
 		onTryHit: function () { },
 		onHit: function (pokemon) {
 			let noMirror = ['acupressure', 'aromatherapy', 'assist', 'chatter', 'copycat', 'counter', 'curse', 'doomdesire', 'feint', 'focuspunch', 'futuresight', 'gravity', 'hail', 'haze', 'healbell', 'helpinghand', 'lightscreen', 'luckychant', 'magiccoat', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'mist', 'mudsport', 'naturepower', 'perishsong', 'psychup', 'raindance', 'reflect', 'roleplay', 'safeguard', 'sandstorm', 'sketch', 'sleeptalk', 'snatch', 'spikes', 'spitup', 'stealthrock', 'struggle', 'sunnyday', 'tailwind', 'toxicspikes', 'transform', 'watersport'];
-			if (!pokemon.lastHurtBy) return false;
-			if (!pokemon.lastHurtBy.source.lastMove || !pokemon.lastHurtBy.move || noMirror.includes(pokemon.lastHurtBy.move) || !pokemon.lastHurtBy.source.hasMove(pokemon.lastHurtBy.move)) {
+			if (!pokemon.lastHurtBy || !pokemon.lastHurtBy.source.lastMove || !pokemon.lastHurtBy.move || noMirror.includes(pokemon.lastHurtBy.move) || !pokemon.lastHurtBy.source.hasMove(pokemon.lastHurtBy.move)) {
 				 return false;
 			}
 			this.useMove(pokemon.lastHurtBy.move, pokemon);

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -977,9 +977,11 @@ let BattleMovedex = {
 	avalanche: {
 		inherit: true,
 		basePowerCallback: function (pokemon, source) {
-			if ((source.lastDamage > 0 && pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn)) {
-				this.debug('Boosted for getting hit by ' + pokemon.lastAttackedBy.move);
-				return this.isWeather('hail') ? 180 : 120;
+			if (pokemon.lastHurtBy) {
+				if (pokemon.lastHurtBy.damage > 0 && pokemon.lastHurtBy.thisTurn) {
+					this.debug('Boosted for getting hit by ' + pokemon.lastHurtBy.move);
+					return this.isWeather('hail') ? 180 : 120;
+				}
 			}
 			return this.isWeather('hail') ? 90 : 60;
 		},

--- a/mods/stadium/moves.js
+++ b/mods/stadium/moves.js
@@ -159,11 +159,11 @@ let BattleMovedex = {
 				}
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
-				if (!target.lastAttackedBy) {
-					target.lastAttackedBy = {pokemon: source, move: move.id, thisTurn: true, damage: damage};
+				if (!target.lastHurtBy) {
+					target.hurtBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
 				} else {
-					target.lastAttackedBy.move = move.id;
-					target.lastAttackedBy.damage = damage;
+					target.lastHurtBy.move = move.id;
+					target.lastHurtBy.damage = damage;
 				}
 				return 0;
 			},

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1545,13 +1545,16 @@ class Battle extends Dex.ModdedDex {
 				this.runEvent('DisableMove', pokemon);
 				if (!pokemon.ateBerry) pokemon.disableMove('belch');
 
-				if (pokemon.lastAttackedBy) {
-					if (pokemon.lastAttackedBy.pokemon.isActive) {
-						pokemon.lastAttackedBy.thisTurn = false;
+				// If it was an illusion, it's not any more
+				if (pokemon.lastHurtBy && this.gen >= 7) pokemon.knownType = true;
+
+				for (let i = pokemon.hurtBy.length - 1; i >= 0; i--) {
+					let attack = pokemon.hurtBy[i];
+					if (attack.source.isActive) {
+						attack.thisTurn = false;
 					} else {
-						pokemon.lastAttackedBy = null;
+						pokemon.hurtBy.slice(pokemon.hurtBy.indexOf(attack), 1);
 					}
-					if (this.gen >= 7) pokemon.knownType = true; // If it was an illusion, it's not any more
 				}
 
 				if (this.gen >= 7) {

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -618,6 +618,11 @@ class Pokemon {
 			thisTurn: true,
 		};
 	}
+	
+	get lastHurtBy() {
+		if (this.hurtBy.length === 0) return undefined;
+		return this.hurtBy[this.hurtBy.length - 1];
+	}
 
 	/**
 	 * @return {string | null}

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -156,7 +156,7 @@ class Pokemon {
 
 		this.lastDamage = 0;
 		/**@type {?{pokemon: Pokemon, damage: number, thisTurn: boolean, move?: string}} */
-		this.lastAttackedBy = null;
+		this.hurtBy = [];
 		this.usedItemThisTurn = false;
 		this.newlySwitched = false;
 		this.beingCalledBack = false;
@@ -611,12 +611,13 @@ class Pokemon {
 	gotAttacked(move, damage, source) {
 		if (!damage) damage = 0;
 		move = this.battle.getMove(move);
-		this.lastAttackedBy = {
+		let lastHurtBy = {
 			pokemon: source,
 			damage: damage,
 			move: move.id,
 			thisTurn: true,
 		};
+		this.hurtBy.push(lastHurtBy);
 	}
 	
 	get lastHurtBy() {
@@ -1037,7 +1038,7 @@ class Pokemon {
 		this.moveThisTurn = '';
 
 		this.lastDamage = 0;
-		this.lastAttackedBy = null;
+		this.hurtBy = [];
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 


### PR DESCRIPTION
Messed up pretty bad with my last pull request and had to open a new one. I apologize, still getting used to git.

Original description:
Replaced the 'lastAttackedBy' attribute of a Pokemon with an array of attacks that the Pokemon has recently received. This corrects a bug in double battles arising from lastAttackedBy always getting replaced by the most recent attack, which caused Avalanche and Revenge to not double in power when they otherwise should have (e.g. see https://replay.pokemonshowdown.com/gen7doublescustomgame-796785834). This also addresses the corresponding task in #2444.