### PR TITLE
Introduce ActiveMove; make Template/Move/Ability/Item read-only

### DIFF
--- a/chat-plugins/othermetas.js
+++ b/chat-plugins/othermetas.js
@@ -131,16 +131,13 @@ const commands = {
 			deltas.type = megaTemplate.types[1];
 		}
 		//////////////////////////////////////////
-		let mixedTemplate = Object.assign({}, template);
-		mixedTemplate.abilities = Object.assign({}, megaTemplate.abilities);
+		let mixedTemplate = Dex.deepClone(template);
 		if (mixedTemplate.types[0] === deltas.type) { // Add any type gains
 			mixedTemplate.types = [deltas.type];
 		} else if (deltas.type) {
 			mixedTemplate.types = [mixedTemplate.types[0], deltas.type];
 		}
-		mixedTemplate.baseStats = Object.assign({}, mixedTemplate.baseStats);
 		for (let statName in template.baseStats) { // Add the changed stats and weight
-			// @ts-ignore
 			mixedTemplate.baseStats[statName] = Dex.clampIntRange(mixedTemplate.baseStats[statName] + deltas.baseStats[statName], 1, 255);
 		}
 		mixedTemplate.weightkg = Math.round(Math.max(0.1, template.weightkg + deltas.weightkg) * 100) / 100;
@@ -280,16 +277,13 @@ const commands = {
 	'350cup': function (target, room, user) {
 		if (!this.runBroadcast()) return;
 		if (!toId(target)) return this.parse('/help 350cup');
-		let template = Object.assign({}, Dex.getTemplate(target));
+		let template = Dex.deepClone(Dex.getTemplate(target));
 		if (!template.exists) return this.errorReply("Error: Pokemon not found.");
 		let bst = 0;
 		for (let i in template.baseStats) {
-			// @ts-ignore
 			bst += template.baseStats[i];
 		}
-		template.baseStats = Object.assign({}, template.baseStats);
 		for (let i in template.baseStats) {
-			// @ts-ignore
 			template.baseStats[i] = template.baseStats[i] * (bst <= 350 ? 2 : 1);
 		}
 		this.sendReply(`|html|${Chat.getDataPokemonHTML(template)}`);
@@ -301,7 +295,7 @@ const commands = {
 	tiershift: function (target, room, user) {
 		if (!this.runBroadcast()) return;
 		if (!toId(target)) return this.parse('/help tiershift');
-		let template = Object.assign({}, Dex.getTemplate(target));
+		let template = Dex.deepClone(Dex.getTemplate(target));
 		if (!template.exists) return this.errorReply("Error: Pokemon not found.");
 		/** @type {{[k: string]: number}} */
 		let boosts = {
@@ -320,12 +314,9 @@ const commands = {
 		if (tier[0] === '(') tier = tier.slice(1, -1);
 		if (!(tier in boosts)) return this.sendReply(`|html|${Chat.getDataPokemonHTML(template)}`);
 		let boost = boosts[tier];
-		let newStats = Object.assign({}, template.baseStats);
 		for (let statName in template.baseStats) {
-			// @ts-ignore
-			newStats[statName] = Dex.clampIntRange(newStats[statName] + boost, 1, 255);
+			template.baseStats[statName] = Dex.clampIntRange(template.baseStats[statName] + boost, 1, 255);
 		}
-		template.baseStats = Object.assign({}, newStats);
 		this.sendReply(`|raw|${Chat.getDataPokemonHTML(template)}`);
 	},
 	tiershifthelp: [`/ts OR /tiershift <pokemon> - Shows the base stats that a Pokemon would have in Tier Shift.`],
@@ -335,18 +326,14 @@ const commands = {
 	scalemons: function (target, room, user) {
 		if (!this.runBroadcast()) return;
 		if (!toId(target)) return this.parse(`/help scalemons`);
-		let template = Object.assign({}, Dex.getTemplate(target));
+		let template = Dex.deepClone(Dex.getTemplate(target));
 		if (!template.exists) return this.errorReply(`Error: Pokemon ${target} not found.`);
-		let newStats = Object.assign({}, template.baseStats);
 		let stats = ['atk', 'def', 'spa', 'spd', 'spe'];
-		// @ts-ignore
 		let pst = stats.map(stat => template.baseStats[stat]).reduce((x, y) => x + y);
 		let scale = 600 - template.baseStats['hp'];
 		for (const stat of stats) {
-			// @ts-ignore
-			newStats[stat] = Dex.clampIntRange(template.baseStats[stat] * scale / pst, 1, 255);
+			template.baseStats[stat] = Dex.clampIntRange(template.baseStats[stat] * scale / pst, 1, 255);
 		}
-		template.baseStats = Object.assign({}, newStats);
 		this.sendReply(`|raw|${Chat.getDataPokemonHTML(template)}`);
 	},
 	scalemonshelp: [`/scale OR /scalemons <pokemon> - Shows the base stats that a Pokemon would have in Scalemons.`],

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1780,7 +1780,7 @@ let BattleAbilities = {
 			if (target === source || move.hasBounced || !move.flags['reflectable']) {
 				return;
 			}
-			let newMove = this.getMoveCopy(move.id);
+			let newMove = this.getActiveMove(move.id);
 			newMove.hasBounced = true;
 			newMove.pranksterBoosted = false;
 			this.useMove(newMove, target, source);
@@ -1790,7 +1790,7 @@ let BattleAbilities = {
 			if (target.side === source.side || move.hasBounced || !move.flags['reflectable']) {
 				return;
 			}
-			let newMove = this.getMoveCopy(move.id);
+			let newMove = this.getActiveMove(move.id);
 			newMove.hasBounced = true;
 			newMove.pranksterBoosted = false;
 			this.useMove(newMove, this.effectData.target, source);
@@ -2277,16 +2277,15 @@ let BattleAbilities = {
 			if (['iceball', 'rollout'].includes(move.id)) return;
 			if (move.category !== 'Status' && !move.selfdestruct && !move.multihit && !move.flags['charge'] && !move.spreadHit && !move.isZ) {
 				move.multihit = 2;
-				move.hasParentalBond = true;
-				move.hit = 0;
+				move.multihitType = 'parentalbond';
 			}
 		},
 		onBasePowerPriority: 8,
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.hasParentalBond && typeof move.hit === 'number' && ++move.hit > 1) return this.chainModify(0.25);
+			if (move.multihitType === 'parentalbond' && move.hit > 1) return this.chainModify(0.25);
 		},
 		onSourceModifySecondaries: function (secondaries, target, source, move) {
-			if (move.hasParentalBond && move.id === 'secretpower' && move.hit && move.hit < 2) {
+			if (move.multihitType === 'parentalbond' && move.id === 'secretpower' && move.hit < 2) {
 				// hack to prevent accidentally suppressing King's Rock/Razor Fang
 				return secondaries.filter(effect => effect.volatileStatus === 'flinch');
 			}
@@ -4130,7 +4129,7 @@ let BattleAbilities = {
 			if (target === source || move.hasBounced || !move.flags['reflectable']) {
 				return;
 			}
-			let newMove = this.getMoveCopy(move.id);
+			let newMove = this.getActiveMove(move.id);
 			newMove.hasBounced = true;
 			this.useMove(newMove, target, source);
 			return null;
@@ -4141,7 +4140,7 @@ let BattleAbilities = {
 			if (target.side === source.side || move.hasBounced || !move.flags['reflectable']) {
 				return;
 			}
-			let newMove = this.getMoveCopy(move.id);
+			let newMove = this.getActiveMove(move.id);
 			newMove.hasBounced = true;
 			this.useMove(newMove, this.effectData.target, source);
 			return null;

--- a/data/moves.js
+++ b/data/moves.js
@@ -9627,7 +9627,7 @@ let BattleMovedex = {
 			onStart: function (target, source, effect) {
 				this.add('-singleturn', target, 'move: Magic Coat');
 				if (effect && effect.effectType === 'Move') {
-					this.effectData.pranksterBoosted = effect.pranksterBoosted;
+					this.effectData.pranksterBoosted = /** @type {ActiveMove} */ (effect).pranksterBoosted;
 				}
 			},
 			onTryHitPriority: 2,
@@ -9635,7 +9635,7 @@ let BattleMovedex = {
 				if (target === source || move.hasBounced || !move.flags['reflectable']) {
 					return;
 				}
-				let newMove = this.getMoveCopy(move.id);
+				let newMove = this.getActiveMove(move.id);
 				newMove.hasBounced = true;
 				newMove.pranksterBoosted = this.effectData.pranksterBoosted;
 				this.useMove(newMove, target, source);
@@ -9645,7 +9645,7 @@ let BattleMovedex = {
 				if (target.side === source.side || move.hasBounced || !move.flags['reflectable']) {
 					return;
 				}
-				let newMove = this.getMoveCopy(move.id);
+				let newMove = this.getActiveMove(move.id);
 				newMove.hasBounced = true;
 				newMove.pranksterBoosted = false;
 				this.useMove(newMove, this.effectData.target, source);
@@ -9947,7 +9947,7 @@ let BattleMovedex = {
 				let noMeFirst = [
 					'chatter', 'counter', 'covet', 'focuspunch', 'mefirst', 'metalburst', 'mirrorcoat', 'struggle', 'thief',
 				];
-				let move = this.getMoveCopy(action.move.id);
+				let move = this.getActiveMove(action.move.id);
 				if (move.category !== 'Status' && !noMeFirst.includes(move.id)) {
 					pokemon.addVolatile('mefirst');
 					this.useMove(move, pokemon, target);
@@ -17947,11 +17947,6 @@ let BattleMovedex = {
 		accuracy: 90,
 		basePower: 10,
 		basePowerCallback: function (pokemon, target, move) {
-			if (move.hit) {
-				move.hit++;
-			} else {
-				move.hit = 1;
-			}
 			return 10 * move.hit;
 		},
 		category: "Physical",

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1772,8 +1772,10 @@ class RandomTeams extends Dex.ModdedDex {
 				if (pokemon.length === 1) {
 					template = potd;
 					if (template.species === 'Magikarp') {
+						// @ts-ignore
 						template.randomBattleMoves = ['bounce', 'flail', 'splash', 'magikarpsrevenge'];
 					} else if (template.species === 'Delibird') {
+						// @ts-ignore
 						template.randomBattleMoves = ['present', 'bestow'];
 					}
 				} else if (template.species === potd.species) {

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -155,51 +155,51 @@ interface EventMethods {
 	beforeTurnCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon) => void
 	damageCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon) => number | false
 	durationCallback?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => number
-	onAfterDamage?: (this: Battle, damage: number, target: Pokemon, soruce: Pokemon, move: Move) => void
-	onAfterMoveSecondary?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAfterDamage?: (this: Battle, damage: number, target: Pokemon, soruce: Pokemon, move: ActiveMove) => void
 	onAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
-	onAfterHit?: (this: Battle, source: Pokemon, target: Pokemon, move: Move) => void
+	onAfterHit?: (this: Battle, source: Pokemon, target: Pokemon, move: ActiveMove) => void
 	onAfterSetStatus?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
 	onAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void
 	onAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
 	onAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onAfterMoveSecondarySelf?: (this: Battle, source: Pokemon, target: Pokemon, move: Move) => void
-	onAfterMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onAfterMoveSecondarySelf?: (this: Battle, source: Pokemon, target: Pokemon, move: ActiveMove) => void
+	onAfterMoveSecondary?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onAfterMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void
 	onAfterMoveSelf?: (this: Battle, pokemon: Pokemon) => void
 	onAllyTryAddVolatile?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onAllyBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onAllyBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => void
 	onAllyModifyAtk?: (this: Battle, atk: number) => void
 	onAllyModifySpD?: (this: Battle, spd: number) => void
 	onAllyBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
 	onAllySetStatus?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onAllyTryHitSide?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAllyTryHitSide?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onAllyFaint?: (this: Battle, target: Pokemon) => void
 	onAllyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
-	onAllyModifyMove?: (this: Battle, move: Move) => void
-	onAnyTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
-	onAnyTryMove?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAllyModifyMove?: (this: Battle, move: ActiveMove) => void
+	onAnyTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onAnyTryMove?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onAnyDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onAnyBasePower?: (this: Battle, basePower: number, source: Pokemon, target: Pokemon, move: Move) => void
+	onAnyBasePower?: (this: Battle, basePower: number, source: Pokemon, target: Pokemon, move: ActiveMove) => void
 	onAnySetWeather?: (this: Battle, target: Pokemon, source: Pokemon, weather: Weather) => void
-	onAnyModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: Move) => void
-	onAnyRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: Pokemon, move: Move) => void
-	onAnyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: Move) => void
-	onAnyTryImmunity?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAnyModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: ActiveMove) => void
+	onAnyRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: Pokemon, move: ActiveMove) => void
+	onAnyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onAnyTryImmunity?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onAnyFaint?: (this: Battle) => void
 	onAnyModifyBoost?: (this: Battle, boosts: SparseBoostsTable, target: Pokemon) => void
 	onAnyDragOut?: (this: Battle, pokemon: Pokemon) => void
 	onAnySetStatus?: (this: Battle, status: Status, pokemon: Pokemon) => void
 	onAttract?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: Move) => number | boolean | null | void
-	onBasePower?: (this: Battle, basePower: number, pokemon: Pokemon, target: Pokemon, move: Move) => void
-	onTryImmunity?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: ActiveMove) => number | boolean | null | void
+	onBasePower?: (this: Battle, basePower: number, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void
+	onTryImmunity?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onBeforeFaint?: (this: Battle, pokemon: Pokemon) => void
-	onBeforeMove?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onBeforeMove?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => void
 	onBeforeSwitchIn?: (this: Battle, pokemon: Pokemon) => void
 	onBeforeSwitchOut?: (this: Battle, pokemon: Pokemon) => void
 	onBeforeTurn?: (this: Battle, pokemon: Pokemon) => void
 	onBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onChargeMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onChargeMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void
 	onCheckShow?: (this: Battle, pokemon: Pokemon) => void
 	onCopy?: (this: Battle, pokemon: Pokemon) => void
 	onDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
@@ -212,39 +212,39 @@ interface EventMethods {
 	onFaint?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
 	onFlinch?: ((this: Battle, pokemon: Pokemon) => void) | boolean
 	onFoeAfterDamage?: (this: Battle, damage: number, target: Pokemon) => void
-	onFoeBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: Move) => void
-	onFoeBeforeMove?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onFoeBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => void
+	onFoeBeforeMove?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => void
 	onFoeDisableMove?: (this: Battle, pokemon: Pokemon) => void
 	onFoeMaybeTrapPokemon?: (this: Battle, pokemon: Pokemon, source: Pokemon) => void
 	onFoeModifyDef?: (this: Battle, def: number, pokemon: Pokemon) => number
-	onFoeRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: UnknownEffect, move: Move) => void
+	onFoeRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: UnknownEffect, move: ActiveMove) => void
 	onFoeSwitchOut?: (this: Battle, pokemon: Pokemon) => void
 	onFoeTrapPokemon?: (this: Battle, pokemon: Pokemon) => void
-	onFoeTryMove?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
-	onHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
-	onHitField?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => boolean | void
+	onFoeTryMove?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onHitField?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => boolean | void
 	onHitSide?: (this: Battle, side: Side, source: Pokemon) => void
 	onImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void
 	onLockMove?: string | ((this: Battle, pokemon: Pokemon) => void)
 	onLockMoveTarget?: (this: Battle) => number
-	onModifyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: Move) => number | void
-	onModifyAtk?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+	onModifyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: ActiveMove) => number | void
+	onModifyAtk?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => number | void
 	onModifyBoost?: (this: Battle, boosts: SparseBoostsTable) => void
 	onModifyCritRatio?: (this: Battle, critRatio: number, source: Pokemon, target: Pokemon) => number | void
-	onModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: Move) => number | void
+	onModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: ActiveMove) => number | void
 	onModifyDef?: (this: Battle, def: number, pokemon: Pokemon) => number | void
-	onModifyMove?: (this: Battle, move: Move, pokemon: Pokemon, target: Pokemon) => void
-	onModifyPriority?: (this: Battle, priority: number, pokemon: Pokemon, target: Pokemon, move: Move) => number | void
+	onModifyMove?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon) => void
+	onModifyPriority?: (this: Battle, priority: number, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => number | void
 	onModifySecondaries?: (this: Battle, secondaries: SecondaryEffect[]) => void
-	onModifySpA?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+	onModifySpA?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => number | void
 	onModifySpD?: (this: Battle, spd: number, pokemon: Pokemon) => number | void
 	onModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void
 	onModifyWeight?: (this: Battle, weight: number, pokemon: Pokemon) => number | void
-	onMoveAborted?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
-	onMoveFail?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onMoveAborted?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void
+	onMoveFail?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => void) | boolean
-	onOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
-	onPrepareHit?: (this: Battle, source: Pokemon, target: Pokemon, move: Move) => void
+	onOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void
+	onPrepareHit?: (this: Battle, source: Pokemon, target: Pokemon, move: ActiveMove) => void
 	onPreStart?: (this: Battle, pokemon: Pokemon) => void
 	onPrimal?: (this: Battle, pokemon: Pokemon) => void
 	onRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: UnknownEffect) => void
@@ -252,38 +252,38 @@ interface EventMethods {
 	onRestart?: (this: Battle, pokemon: Pokemon, source: Pokemon) => void
 	onSetAbility?: (this: Battle, ability: string, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
 	onSetStatus?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onSourceAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: Move) => void
-	onSourceBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onSourceAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onSourceBasePower?: (this: Battle, basePower: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => void
 	onSourceFaint?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onSourceHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onSourceHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onSourceModifyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon) => number | void
-	onSourceModifyAtk?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
-	onSourceModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: Move) => number | void
-	onSourceModifySecondaries?: (this: Battle, secondaries: SecondaryEffect[], target: Pokemon, source: Pokemon, move: Move) => void
-	onSourceModifySpA?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+	onSourceModifyAtk?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => number | void
+	onSourceModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: ActiveMove) => number | void
+	onSourceModifySecondaries?: (this: Battle, secondaries: SecondaryEffect[], target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onSourceModifySpA?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => number | void
 	onSourceTryHeal?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onSourceTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onSourceTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onStallMove?: (this: Battle, pokemon: Pokemon) => void
-	onStart?: (this: Battle, target: Pokemon & Side, source: Pokemon, effect: UnknownEffect, move: Move) => void
+	onStart?: (this: Battle, target: Pokemon & Side, source: Pokemon, effect: UnknownEffect, move: ActiveMove) => void
 	onSwitchIn?: (this: Battle, pokemon: Pokemon) => void
 	onSwitchOut?: (this: Battle, pokemon: Pokemon) => void
 	onTakeItem?: ((this: Battle, item: Item, pokemon: Pokemon, source: Pokemon) => void) | false
 	onTerrain?: (this: Battle, pokemon: Pokemon) => void
 	onTrapPokemon?: (this: Battle, pokemon: Pokemon) => void
-	onTry?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: Move) => void
+	onTry?: (this: Battle, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => void
 	onTryAddVolatile?: (this: Battle, status: Status, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
 	onTryEatItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
 	onTryHeal?: ((this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void) | boolean
-	onTryHit?: ((this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void) | boolean
+	onTryHit?: ((this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void) | boolean
 	onTryHitField?: (this: Battle, target: Pokemon, source: Pokemon) => boolean | void
 	onTryHitSide?: (this: Battle, side: Side, source: Pokemon) => void
-	onTryMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
-	onTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: Move) => void
+	onTryMove?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void
+	onTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onType?: (this: Battle, types: string[], pokemon: Pokemon) => void
 	onUpdate?: (this: Battle, pokemon: Pokemon) => void
-	onUseMoveMessage?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => void
+	onUseMoveMessage?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void
 	onWeather?: (this: Battle, target: Pokemon, source: Pokemon, effect: UnknownEffect) => void
-	onWeatherModifyDamage?: (this: Battle, damage: number, attacker: Pokemon, defender: Pokemon, move: Move) => number | void
+	onWeatherModifyDamage?: (this: Battle, damage: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => number | void
 
 	// multiple definitions due to relayVar (currently not supported)
 	onAfterSubDamage?: (this: Battle, damage: any, target: any, source: any, effect: any) => void
@@ -358,7 +358,7 @@ interface EffectData extends EventMethods {
 interface ModdedEffectData extends Partial<EffectData> {
 	effect?: Partial<ModdedEffectData>
 	inherit?: string | boolean
-	onAnyModifyDamagePhase1?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: Move) => number | void
+	onAnyModifyDamagePhase1?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: ActiveMove) => number | void
 	onAnyModifyDamagePhase2?: ModdedEffectData["onAnyModifyDamagePhase1"]
 	onModifyDamagePhase1?: ModdedEffectData["onAnyModifyDamagePhase1"]
 	onModifyDamagePhase2?: ModdedEffectData["onAnyModifyDamagePhase1"]
@@ -395,9 +395,8 @@ interface ModdedAbilityData extends Partial<AbilityData>, ModdedEffectData {
 	inherit?: boolean
 }
 
-interface Ability extends Effect, AbilityData {
-	effectType: 'Ability'
-	gen: number
+interface Ability extends Readonly<Effect & AbilityData> {
+	readonly effectType: 'Ability'
 }
 
 interface FlingData {
@@ -434,9 +433,8 @@ interface ModdedItemData extends Partial<ItemData>, ModdedEffectData {
 	onCustap?: (this: Battle, pokemon: Pokemon) => void
 }
 
-interface Item extends Effect, ItemData {
-	effectType: 'Item'
-	gen: number
+interface Item extends Readonly<Effect & ItemData> {
+	readonly effectType: 'Item'
 }
 
 interface MoveData extends EffectData {
@@ -476,6 +474,7 @@ interface MoveData extends EffectData {
 	mindBlownRecoil?: boolean
 	multiaccuracy?: boolean
 	multihit?: number | number[]
+	multihitType?: string
 	noDamageVariance?: boolean
 	noFaint?: boolean
 	noMetronome?: string[]
@@ -504,7 +503,7 @@ interface MoveData extends EffectData {
 	zMovePower?: number
 	zMoveEffect?: string
 	zMoveBoost?: SparseBoostsTable
-	basePowerCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: Move) => number | boolean | null
+	basePowerCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => number | boolean | null
 }
 
 interface ModdedMoveData extends Partial<MoveData>, ModdedEffectData {
@@ -512,10 +511,14 @@ interface ModdedMoveData extends Partial<MoveData>, ModdedEffectData {
 	inherit?: boolean
 }
 
-interface Move extends Effect, MoveData {
-	effectType: 'Move'
-	gen: number
+interface Move extends Readonly<Effect & MoveData> {
+	readonly effectType: 'Move'
+}
+
+interface ActiveMove extends Effect, MoveData {
+	readonly effectType: 'Move'
 	typeMod: number
+	hit: number
 	ability?: Ability
 	aerilateBoosted?: boolean
 	allies?: Pokemon[]
@@ -526,10 +529,8 @@ interface Move extends Effect, MoveData {
 	galvanizeBoosted?: boolean
 	hasAuraBreak?: boolean
 	hasBounced?: boolean
-	hasParentalBond?: boolean
 	hasSheerForce?: boolean
 	hasSTAB?: boolean
-	hit?: number
 	isExternal?: boolean
 	magnitude?: number
 	negateSecondary?: boolean
@@ -609,28 +610,27 @@ interface ModdedTemplateFormatsData extends Partial<TemplateFormatsData> {
 	randomSet5?: RandomTeamsTypes["TemplateRandomSet"]
 }
 
-interface Template extends Effect, TemplateData, TemplateFormatsData {
-	effectType: 'Pokemon'
-	baseSpecies: string
-	doublesTier: string
-	eventOnly: boolean
-	evos: string[]
-	forme: string
-	formeLetter: string
-	gen: number
-	gender: GenderName
-	genderRatio: {M: number, F: number}
-	maleOnlyHidden: boolean
-	nfe: boolean
-	prevo: string
-	speciesid: string
-	spriteid: string
-	tier: string
-	addedType?: string
-	isMega?: boolean
-	isPrimal?: boolean
-	learnset?: {[k: string]: MoveSource[]}
-	originalMega?: string
+interface Template extends Readonly<Effect & TemplateData & TemplateFormatsData> {
+	readonly effectType: 'Pokemon'
+	readonly baseSpecies: string
+	readonly doublesTier: string
+	readonly eventOnly: boolean
+	readonly evos: string[]
+	readonly forme: string
+	readonly formeLetter: string
+	readonly gender: GenderName
+	readonly genderRatio: {M: number, F: number}
+	readonly maleOnlyHidden: boolean
+	readonly nfe: boolean
+	readonly prevo: string
+	readonly speciesid: string
+	readonly spriteid: string
+	readonly tier: string
+	readonly addedType?: string
+	readonly isMega?: boolean
+	readonly isPrimal?: boolean
+	readonly learnset?: {[k: string]: MoveSource[]}
+	readonly originalMega?: string
 }
 
 type GameType = 'singles' | 'doubles' | 'triples' | 'rotation'
@@ -717,16 +717,16 @@ interface BattleScriptsData {
 	canUltraBurst?: (this: Battle, pokemon: Pokemon) => string | null
 	canZMove?: (this: Battle, pokemon: Pokemon) => (AnyObject | null)[] | void
 	getZMove?: (this: Battle, move: Move, pokemon: Pokemon, skipChecks?: boolean) => string | undefined
-	getZMoveCopy?: (this: Battle, move: Move, pokemon: Pokemon) => Move
+	getActiveZMove?: (this: Battle, move: Move, pokemon: Pokemon) => ActiveMove
 	isAdjacent?: (this: Battle, pokemon1: Pokemon, pokemon2: Pokemon) => boolean
-	moveHit?: (this: Battle, target: Pokemon | null, pokemon: Pokemon, move: string | Move, moveData?: Move, isSecondary?: boolean, isSelf?: boolean) => number | false
+	moveHit?: (this: Battle, target: Pokemon | null, pokemon: Pokemon, move: ActiveMove, moveData?: ActiveMove, isSecondary?: boolean, isSelf?: boolean) => number | false
 	resolveAction?: (this: Battle, action: AnyObject, midTurn?: boolean) => Actions["Action"]
 	runAction?: (this: Battle, action: Actions["Action"]) => void
 	runMegaEvo?: (this: Battle, pokemon: Pokemon) => boolean
 	runMove?: (this: Battle, move: Move, pokemon: Pokemon, targetLoc: number, sourceEffect?: Effect | null, zMove?: string, externalMove?: boolean) => void
-	runZPower?: (this: Battle, move: Move, pokemon: Pokemon) => void
+	runZPower?: (this: Battle, move: ActiveMove, pokemon: Pokemon) => void
 	targetTypeChoices?: (this: Battle, targetType: string) => boolean
-	tryMoveHit?: (this: Battle, target: Pokemon, pokemon: Pokemon, move: Move) => number | false
+	tryMoveHit?: (this: Battle, target: Pokemon, pokemon: Pokemon, move: ActiveMove) => number | false
 	useMove?: (this: Battle, move: Move, pokemon: Pokemon, target: Pokemon | false, sourceEffect?: Effect | null, zMove?: string) => boolean
 	useMoveInner?: (this: Battle, move: Move, pokemon: Pokemon, target: Pokemon | false, sourceEffect?: Effect | null, zMove?: string) => boolean
 }
@@ -752,9 +752,9 @@ interface ModdedBattleScriptsData extends Partial<BattleScriptsData> {
 	damage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: Effect) => number
 	debug?: (this: Battle, activity: string) => void
 	directDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: Effect) => number
-	getDamage?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: string | number | Move, suppressMessages: boolean) => number
+	getDamage?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: string | number | ActiveMove, suppressMessages: boolean) => number
 	init?: (this: Battle) => void
-	modifyDamage?: (this: Battle, baseDamage: number, pokemon: Pokemon, target: Pokemon, move: Move, suppressMessages?: boolean) => void
+	modifyDamage?: (this: Battle, baseDamage: number, pokemon: Pokemon, target: Pokemon, move: ActiveMove, suppressMessages?: boolean) => void
 
 	// oms
 	doGetMixedTemplate?: (this: Battle, template: Template, deltas: AnyObject) => Template

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -106,7 +106,7 @@ let BattleMovedex = {
 					}
 					this.add('-end', pokemon, 'Bide');
 					let target = this.effectData.sourceSide.active[this.effectData.sourcePosition];
-					this.moveHit(target, pokemon, 'bide', /** @type {Move} */ ({damage: this.effectData.totalDamage * 2}));
+					this.moveHit(target, pokemon, 'bide', /** @type {ActiveMove} */ ({damage: this.effectData.totalDamage * 2}));
 					return false;
 				}
 				this.add('-activate', pokemon, 'Bide');

--- a/mods/gen2/statuses.js
+++ b/mods/gen2/statuses.js
@@ -144,8 +144,7 @@ let BattleStatuses = {
 			if (this.randomChance(1, 2)) {
 				return;
 			}
-			// @ts-ignore
-			move = {
+			move = /** @type {ActiveMove} */ ({
 				basePower: 40,
 				type: '???',
 				baseMoveType: move.type,
@@ -154,7 +153,7 @@ let BattleStatuses = {
 				isSelfHit: true,
 				noDamageVariance: true,
 				flags: {},
-			};
+			});
 			this.directDamage(this.getDamage(pokemon, pokemon, move));
 			return false;
 		},

--- a/mods/gen3/scripts.js
+++ b/mods/gen3/scripts.js
@@ -4,7 +4,7 @@
 let BattleScripts = {
 	inherit: 'gen4',
 	gen: 3,
-	init: function () {
+	init() {
 		for (let i in this.data.Pokedex) {
 			delete this.data.Pokedex[i].abilities['H'];
 		}
@@ -19,7 +19,7 @@ let BattleScripts = {
 			}
 		}
 	},
-	tryMoveHit: function (target, pokemon, move) {
+	tryMoveHit(target, pokemon, move) {
 		this.setActiveMove(move, pokemon, target);
 		let hitResult = true;
 		let naturalImmunity = false;
@@ -221,7 +221,7 @@ let BattleScripts = {
 		return damage;
 	},
 
-	calcRecoilDamage: function (damageDealt, move) {
+	calcRecoilDamage(damageDealt, move) {
 		// @ts-ignore
 		return this.clampIntRange(Math.floor(damageDealt * move.recoil[0] / move.recoil[1]), 1);
 	},

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -429,16 +429,14 @@ let BattleMovedex = {
 			if (target.side.sideConditions['futuremove'].positions[target.position]) {
 				return false;
 			}
-			/**@type {Move} */
-			// @ts-ignore
-			let moveData = {
+			let moveData = /** @type {ActiveMove} */ ({
 				name: "Doom Desire",
 				basePower: 120,
 				category: "Special",
 				flags: {},
 				willCrit: false,
 				type: '???',
-			};
+			});
 			let damage = this.getDamage(source, target, moveData, true);
 			target.side.sideConditions['futuremove'].positions[target.position] = {
 				duration: 3,
@@ -691,16 +689,14 @@ let BattleMovedex = {
 			if (target.side.sideConditions['futuremove'].positions[target.position]) {
 				return false;
 			}
-			/**@type {Move} */
-			// @ts-ignore
-			let moveData = {
+			let moveData = /** @type {ActiveMove} */ ({
 				name: "Future Sight",
 				basePower: 80,
 				category: "Special",
 				flags: {},
 				willCrit: false,
 				type: '???',
-			};
+			});
 			let damage = this.getDamage(source, target, moveData, true);
 			target.side.sideConditions['futuremove'].positions[target.position] = {
 				duration: 3,
@@ -984,7 +980,7 @@ let BattleMovedex = {
 					return;
 				}
 				target.removeVolatile('magiccoat');
-				let newMove = this.getMoveCopy(move.id);
+				let newMove = this.getActiveMove(move.id);
 				newMove.hasBounced = true;
 				this.useMove(newMove, target, source);
 				return null;

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -4,13 +4,13 @@
 let BattleScripts = {
 	inherit: 'gen5',
 	gen: 4,
-	init: function () {
+	init() {
 		for (let i in this.data.Pokedex) {
 			delete this.data.Pokedex[i].abilities['H'];
 		}
 	},
 
-	modifyDamage: function (baseDamage, pokemon, target, move, suppressMessages = false) {
+	modifyDamage(baseDamage, pokemon, target, move, suppressMessages = false) {
 		// DPP divides modifiers into several mathematically important stages
 		// The modifiers run earlier than other generations are called with ModifyDamagePhase1 and ModifyDamagePhase2
 
@@ -89,7 +89,7 @@ let BattleScripts = {
 
 		return Math.floor(baseDamage);
 	},
-	tryMoveHit: function (target, pokemon, move) {
+	tryMoveHit(target, pokemon, move) {
 		this.setActiveMove(move, pokemon, target);
 		let hitResult = true;
 
@@ -290,7 +290,7 @@ let BattleScripts = {
 		return damage;
 	},
 
-	calcRecoilDamage: function (damageDealt, move) {
+	calcRecoilDamage(damageDealt, move) {
 		// @ts-ignore
 		return this.clampIntRange(Math.floor(damageDealt * move.recoil[0] / move.recoil[1]), 1);
 	},

--- a/mods/gen6/abilities.js
+++ b/mods/gen6/abilities.js
@@ -81,7 +81,7 @@ let BattleAbilities = {
 		desc: "This Pokemon's damaging moves become multi-hit moves that hit twice. The second hit has its damage halved. Does not affect multi-hit moves or moves that have multiple targets.",
 		shortDesc: "This Pokemon's damaging moves hit twice. The second hit has its damage halved.",
 		onBasePower: function (basePower, pokemon, target, move) {
-			if (move.hasParentalBond && typeof move.hit === 'number' && ++move.hit > 1) return this.chainModify(0.5);
+			if (move.multihitType === 'parentalbond' && move.hit > 1) return this.chainModify(0.5);
 		},
 	},
 	"pixilate": {

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -677,11 +677,9 @@ let BattleMovedex = {
 					}
 					this.add('-end', pokemon, 'Bide');
 					let target = this.effectData.sourceSide.active[this.effectData.sourcePosition];
-					/**@type {Move} */
-					// @ts-ignore
-					let moveData = {
+					let moveData = /** @type {ActiveMove} */ ({
 						damage: this.effectData.totalDamage * 2,
-					};
+					});
 					this.moveHit(target, pokemon, 'bide', moveData);
 					return false;
 				}

--- a/mods/gennext/scripts.js
+++ b/mods/gennext/scripts.js
@@ -2,7 +2,7 @@
 
 /**@type {ModdedBattleScriptsData} */
 let BattleScripts = {
-	init: function () {
+	init() {
 		this.modData('Pokedex', 'cherrimsunshine').types = ['Grass', 'Fire'];
 
 		// Give Hurricane to all the Bug/Flying Quiver-dancers

--- a/mods/mixandmega/scripts.js
+++ b/mods/mixandmega/scripts.js
@@ -2,13 +2,13 @@
 
 /**@type {ModdedBattleScriptsData} */
 let BattleScripts = {
-	init: function () {
+	init() {
 		for (let id in this.data.Items) {
 			if (!this.data.Items[id].megaStone) continue;
 			this.modData('Items', id).onTakeItem = false;
 		}
 	},
-	canMegaEvo: function (pokemon) {
+	canMegaEvo(pokemon) {
 		if (pokemon.template.isMega || pokemon.template.isPrimal) return null;
 
 		const item = pokemon.getItem();
@@ -21,7 +21,7 @@ let BattleScripts = {
 			return null;
 		}
 	},
-	runMegaEvo: function (pokemon) {
+	runMegaEvo(pokemon) {
 		if (pokemon.template.isMega || pokemon.template.isPrimal) return false;
 
 		const isUltraBurst = !pokemon.canMegaEvo;
@@ -55,7 +55,7 @@ let BattleScripts = {
 		if (isUltraBurst) pokemon.canUltraBurst = null;
 		return true;
 	},
-	getMixedTemplate: function (originalSpecies, megaSpecies) {
+	getMixedTemplate(originalSpecies, megaSpecies) {
 		let originalTemplate = this.getTemplate(originalSpecies);
 		let megaTemplate = this.getTemplate(megaSpecies);
 		if (originalTemplate.baseSpecies === megaTemplate.baseSpecies) return megaTemplate;
@@ -65,7 +65,7 @@ let BattleScripts = {
 		let template = this.doGetMixedTemplate(originalTemplate, deltas);
 		return template;
 	},
-	getMegaDeltas: function (megaTemplate) {
+	getMegaDeltas(megaTemplate) {
 		let baseTemplate = this.getTemplate(megaTemplate.baseSpecies);
 		/**@type {{ability: string, baseStats: {[k: string]: number}, weightkg: number, originalMega: string, requiredItem: string | undefined, type?: string, isMega?: boolean, isPrimal?: boolean}} */
 		let deltas = {
@@ -90,10 +90,12 @@ let BattleScripts = {
 		if (megaTemplate.isPrimal) deltas.isPrimal = true;
 		return deltas;
 	},
-	doGetMixedTemplate: function (template, deltas) {
+	doGetMixedTemplate(templateOrTemplateName, deltas) {
 		if (!deltas) throw new TypeError("Must specify deltas!");
-		if (!template || typeof template === 'string') template = this.getTemplate(template);
-		template = Object.assign({}, template);
+		if (!templateOrTemplateName || typeof templateOrTemplateName === 'string') {
+			templateOrTemplateName = this.getTemplate(templateOrTemplateName);
+		}
+		let template = this.deepClone(templateOrTemplateName);
 		template.abilities = {'0': deltas.ability};
 		if (template.types[0] === deltas.type) {
 			template.types = [deltas.type];
@@ -101,11 +103,8 @@ let BattleScripts = {
 			template.types = [template.types[0], deltas.type];
 		}
 		let baseStats = template.baseStats;
-		// @ts-ignore
-		template.baseStats = {};
 		for (let statName in baseStats) {
-			// @ts-ignore
-			template.baseStats[statName] = this.clampIntRange(baseStats[statName] + deltas.baseStats[statName], 1, 255);
+			baseStats[statName] = this.clampIntRange(baseStats[statName] + deltas.baseStats[statName], 1, 255);
 		}
 		template.weightkg = Math.max(0.1, template.weightkg + deltas.weightkg);
 		template.originalMega = deltas.originalMega;

--- a/mods/stadium/scripts.js
+++ b/mods/stadium/scripts.js
@@ -10,7 +10,7 @@ let BattleScripts = {
 	// BattlePokemon scripts.
 	pokemon: {
 		// Stadium shares gen 1 code but it fixes some problems with it.
-		getStat: function (statName, unmodified) {
+		getStat(statName, unmodified) {
 			statName = toId(statName);
 			if (statName === 'hp') return this.maxhp;
 			if (unmodified) return this.stats[statName];
@@ -19,13 +19,13 @@ let BattleScripts = {
 		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.
-		modifyStat: function (stat, modifier) {
+		modifyStat(stat, modifier) {
 			if (!(stat in this.stats)) return;
 			// @ts-ignore
 			this.modifiedStats[stat] = this.battle.clampIntRange(Math.floor(this.modifiedStats[stat] * modifier), 1);
 		},
 		// This is run on Stadium after boosts and status changes.
-		recalculateStats: function () {
+		recalculateStats() {
 			for (let statName in this.stats) {
 				/**@type {number} */
 				// @ts-ignore
@@ -55,7 +55,7 @@ let BattleScripts = {
 			}
 		},
 		// Stadium's fixed boosting function.
-		boostBy: function (boost) {
+		boostBy(boost) {
 			let changed = false;
 			for (let i in boost) {
 				// @ts-ignore
@@ -85,9 +85,9 @@ let BattleScripts = {
 		},
 	},
 	// Battle scripts.
-	runMove: function (move, pokemon, targetLoc, sourceEffect) {
-		let target = this.getTarget(pokemon, move, targetLoc);
-		move = this.getMove(move);
+	runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect) {
+		let target = this.getTarget(pokemon, moveOrMoveName, targetLoc);
+		let move = this.getActiveMove(moveOrMoveName);
 		if (!target) target = this.resolveTarget(pokemon, move);
 		if (target.subFainted) delete target.subFainted;
 
@@ -139,7 +139,7 @@ let BattleScripts = {
 			} // If we move to here, the move failed and there's no partial trapping lock
 		}
 	},
-	tryMoveHit: function (target, pokemon, move) {
+	tryMoveHit(target, pokemon, move) {
 		let boostTable = [1, 4 / 3, 5 / 3, 2, 7 / 3, 8 / 3, 3];
 		let doSelfDestruct = true;
 		/**@type {number | false} */
@@ -272,10 +272,10 @@ let BattleScripts = {
 
 		return damage;
 	},
-	moveHit: function (target, pokemon, move, moveData, isSecondary, isSelf) {
+	moveHit(target, pokemon, moveOrMoveName, moveData, isSecondary, isSelf) {
 		/**@type {number | false} */
 		let damage = 0;
-		move = this.getMoveCopy(move);
+		let move = this.getActiveMove(moveOrMoveName);
 
 		if (!isSecondary && !isSelf) this.setActiveMove(move, pokemon, target);
 		/**@type {number | boolean} */
@@ -432,22 +432,19 @@ let BattleScripts = {
 
 		return damage;
 	},
-	getDamage: function (pokemon, target, move, suppressMessages) {
+	getDamage(pokemon, target, move, suppressMessages) {
 		// First of all, we get the move.
 		if (typeof move === 'string') {
-			move = this.getMove(move);
+			move = this.getActiveMove(move);
 		} else if (typeof move === 'number') {
-			// @ts-ignore
-			move = {
+			move = /** @type {ActiveMove} */ ({
 				basePower: move,
 				type: '???',
 				category: 'Physical',
 				willCrit: false,
 				flags: {},
-			};
+			});
 		}
-
-		move = /**@type {Move} */ (move); // eslint-disable-line no-self-assign
 
 		// Let's see if the target is immune to the move.
 		if (!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) {
@@ -664,7 +661,7 @@ let BattleScripts = {
 		return Math.floor(damage);
 	},
 	// @ts-ignore
-	damage: function (damage, target, source, effect) {
+	damage(damage, target, source, effect) {
 		if (this.event) {
 			if (!target) target = this.event.target;
 			if (!source) source = this.event.source;
@@ -719,7 +716,7 @@ let BattleScripts = {
 
 		return damage;
 	},
-	directDamage: function (damage, target, source, effect) {
+	directDamage(damage, target, source, effect) {
 		if (this.event) {
 			if (!target) target = this.event.target;
 			if (!source) source = this.event.source;

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -46,6 +46,7 @@ class Battle extends Dex.ModdedDex {
 	constructor(options) {
 		let format = Dex.getFormat(options.formatid, true);
 		super(format.mod);
+		/** @type {{[k: string]: string}} */
 		this.zMoveTable = {};
 		Object.assign(this, this.data.Scripts);
 
@@ -114,6 +115,7 @@ class Battle extends Dex.ModdedDex {
 		this.eventDepth = 0;
 		/** @type {?Move} */
 		this.lastMove = null;
+		/** @type {?ActiveMove} */
 		this.activeMove = null;
 		this.activePokemon = null;
 		this.activeTarget = null;
@@ -417,7 +419,7 @@ class Battle extends Dex.ModdedDex {
 	}
 
 	/**
-	 * @param {?Move} [move]
+	 * @param {?ActiveMove} [move]
 	 * @param {?Pokemon} [pokemon]
 	 * @param {?Pokemon | false} [target]
 	 */
@@ -2107,20 +2109,21 @@ class Battle extends Dex.ModdedDex {
 	/**
 	 * @param {Pokemon} pokemon
 	 * @param {Pokemon} target
-	 * @param {string | number | Move} move
+	 * @param {string | number | ActiveMove} move
 	 * @param {boolean} [suppressMessages]
 	 */
 	getDamage(pokemon, target, move, suppressMessages = false) {
-		if (typeof move === 'string') move = this.getMove(move);
+		if (typeof move === 'string') move = this.getActiveMove(move);
 
 		if (typeof move === 'number') {
 			let basePower = move;
-			move = new Data.Move({
+			move = /** @type {ActiveMove} */ (new Data.Move({
 				basePower,
 				type: '???',
 				category: 'Physical',
 				willCrit: false,
-			});
+			}));
+			move.hit = 0;
 		}
 
 		if (!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) {
@@ -2250,7 +2253,7 @@ class Battle extends Dex.ModdedDex {
 	 * @param {number} baseDamage
 	 * @param {Pokemon} pokemon
 	 * @param {Pokemon} target
-	 * @param {Move} move
+	 * @param {ActiveMove} move
 	 * @param {boolean} [suppressMessages]
 	 */
 	modifyDamage(baseDamage, pokemon, target, move, suppressMessages = false) {
@@ -2554,7 +2557,7 @@ class Battle extends Dex.ModdedDex {
 		if (!action) throw new Error(`Action not passed to resolveAction`);
 
 		if (!action.side && action.pokemon) action.side = action.pokemon.side;
-		if (!action.move && action.moveid) action.move = this.getMoveCopy(action.moveid);
+		if (!action.move && action.moveid) action.move = this.getActiveMove(action.moveid);
 		if (!action.choice && action.move) action.choice = 'move';
 		if (!action.priority && action.priority !== 0) {
 			let priorities = {
@@ -2600,7 +2603,7 @@ class Battle extends Dex.ModdedDex {
 		let deferPriority = this.gen >= 7 && action.mega && action.mega !== 'done';
 		if (action.move) {
 			let target = null;
-			action.move = this.getMoveCopy(action.move);
+			action.move = this.getActiveMove(action.move);
 
 			if (!action.targetLoc) {
 				target = this.resolveTarget(action.pokemon, action.move);
@@ -3384,7 +3387,7 @@ class Battle extends Dex.ModdedDex {
 	 * @param {?Pokemon} target
 	 * @param {Pokemon} pokemon
 	 * @param {string | Move} move
-	 * @param {Move | SelfEffect | SecondaryEffect} [moveData]
+	 * @param {ActiveMove | SelfEffect | SecondaryEffect} [moveData]
 	 * @param {boolean} [isSecondary]
 	 * @param {boolean} [isSelf]
 	 * @return {number | false}
@@ -3450,14 +3453,14 @@ class Battle extends Dex.ModdedDex {
 	/**
 	 * @param {string | Move} move
 	 * @param {Pokemon} pokemon
-	 * @return {Move}
+	 * @return {ActiveMove}
 	 */
-	getZMoveCopy(move, pokemon) {
-		throw new Error(`The getZMoveCopy function needs to be implemented in scripts.js or the battle format.`);
+	getActiveZMove(move, pokemon) {
+		throw new Error(`The getActiveZMove function needs to be implemented in scripts.js or the battle format.`);
 	}
 
 	/**
-	 * @param {Move} move
+	 * @param {ActiveMove} move
 	 * @param {Pokemon} pokemon
 	 */
 	runZPower(move, pokemon) {

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -328,6 +328,7 @@ class ModdedDex {
 		} else if (id === 'nidoran' && name.slice(-1) === '♂') {
 			id = 'nidoranm';
 		}
+		/** @type {any} */
 		let template = this.templateCache.get(id);
 		if (template) return template;
 		if (this.data.Aliases.hasOwnProperty(id)) {
@@ -442,20 +443,20 @@ class ModdedDex {
 	 * Ensure we're working on a copy of a move (and make a copy if we aren't)
 	 *
 	 * Remember: "ensure" - by default, it won't make a copy of a copy:
-	 *     moveCopy === Dex.getMoveCopy(moveCopy)
+	 *     moveCopy === Dex.getActiveMove(moveCopy)
 	 *
 	 * If you really want to, use:
-	 *     moveCopyCopy = Dex.getMoveCopy(moveCopy.id)
+	 *     moveCopyCopy = Dex.getActiveMove(moveCopy.id)
 	 *
 	 * @param {Move | string} move - Move ID, move object, or movecopy object describing move to copy
-	 * @return {Move} movecopy object
+	 * @return {ActiveMove}
 	 */
-	getMoveCopy(move) {
+	getActiveMove(move) {
 		// @ts-ignore
-		if (move && move.isCopy) return move;
+		if (move && typeof move.hit === 'number') return move;
 		move = this.getMove(move);
-		let moveCopy = this.deepClone(move);
-		moveCopy.isCopy = true;
+		let moveCopy = /** @type {ActiveMove} */ (this.deepClone(move));
+		moveCopy.hit = 0;
 		return moveCopy;
 	}
 	/**
@@ -1338,11 +1339,12 @@ class ModdedDex {
 	 * @return {any}
 	 */
 	deepClone(obj) {
-		if (typeof obj === 'function') return obj;
 		if (obj === null || typeof obj !== 'object') return obj;
+		// @ts-ignore
 		if (Array.isArray(obj)) return obj.map(prop => this.deepClone(prop));
 		const clone = Object.create(Object.getPrototypeOf(obj));
 		for (const key of Object.keys(obj)) {
+			// @ts-ignore
 			clone[key] = this.deepClone(obj[key]);
 		}
 		return clone;


### PR DESCRIPTION
The types `Template`, `Move`, `Ability`, and `Item` are now read-only. This should guard against accidental writing to types that shouldn't be written to.

A new type, `ActiveMove`, has been introduced. Like it sounds, it's used for moves that are currently actively being used. A lot of attributes that are only relevant to active moves, such as `hasBounced`, are now only available on `ActiveMove`, not on `Move`. `ActiveMove`s are mutable, unlike `Move`s.

`Dex.getMoveCopy` has been renamed `Dex.getActiveMove`, to better reflect its role. `.isCopy` has been deprecated, and distinguishing `Move`s from `ActiveMove`s is now done by `typeof move.hit === 'number'` where necessary.

`ActiveMove`s now internally track which hit of a multihit move they're on, in `move.hit`, so `move.hit` doesn't need to be manually incremented by Triple Kick and Parental Bond anymore.

`move.hasParentalBond` has been replaced by a more generic `move.multihitType`.