### PR TITLE
Mix and Mega: Fix Illusion

### DIFF
--- a/mods/mixandmega/items.js
+++ b/mods/mixandmega/items.js
@@ -42,11 +42,9 @@ let BattleItems = {
 				pokemon.formeChange(template, this.effect, true);
 				pokemon.baseTemplate = template;
 				this.add('-start', pokemon, 'Red Orb', '[silent]');
-				// @ts-ignore
-				let oTemplate = this.getTemplate(pokemon.illusion || pokemon.originalSpecies);
-				this.add('-start', pokemon, 'Red Orb', '[silent]');
+				let apparentSpecies = pokemon.illusion ? pokemon.illusion.template.species : pokemon.originalSpecies;
+				let oTemplate = this.getTemplate(apparentSpecies);
 				if (pokemon.illusion) {
-					pokemon.ability = '';
 					let types = oTemplate.types;
 					if (types.length > 1 || types[types.length - 1] !== 'Fire') {
 						this.add('-start', pokemon, 'typechange', (types[0] !== 'Fire' ? types[0] + '/' : '') + 'Fire', '[silent]');

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -966,7 +966,12 @@ class Pokemon {
 						this.battle.add('-burst', this, apparentSpecies, template.requiredItem);
 						this.moveThisTurnResult = true; // Ultra Burst counts as an action for Truant
 					} else if (source.onPrimal) {
-						this.battle.add('-primal', !this.illusion && this);
+						if (this.illusion) {
+							this.ability = '';
+							this.battle.add('-primal', this.illusion);
+						} else {
+							this.battle.add('-primal', this);
+						}
 					} else {
 						this.battle.add('-mega', this, apparentSpecies, template.requiredItem);
 						this.moveThisTurnResult = true; // Mega Evolution counts as an action for Truant


### PR DESCRIPTION
This fixes permanent Desolate Land and a crash when using a primal Orb on a Pokemon with Illusion in Mix and Mega.

Replays showcasing said crash:
https://replay.pokemonshowdown.com/gen7mixandmega-818477762 (Red Orb)
https://replay.pokemonshowdown.com/gen7mixandmega-818477500 (Blue Orb)

@TheImmortal (or anyone who can merge this, really)