### PR TITLE
Fix Assurance never doubling when called from other moves

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -931,10 +931,10 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
-			let hurtByTarget = pokemon.hurtBy.some(p =>
+			let damagedByTarget = pokemon.attackedBy.some(p =>
 				p.source === target && p.damage > 0 && p.thisTurn
 			);
-			if (hurtByTarget) {
+			if (damagedByTarget) {
 				this.debug('Boosted for getting hit by ' + target);
 				return move.basePower * 2;
 			}
@@ -13379,10 +13379,10 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
-			let hurtByTarget = pokemon.hurtBy.some(p =>
+			let damagedByTarget = pokemon.attackedBy.some(p =>
 				p.source === target && p.damage > 0 && p.thisTurn
 			);
-			if (hurtByTarget) {
+			if (damagedByTarget) {
 				this.debug('Boosted for getting hit by ' + target);
 				return move.basePower * 2;
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -662,7 +662,7 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
-			if (pokemon.volatiles.assurance && pokemon.volatiles.assurance.hurt[target.position]) {
+			if (target.hurt) {
 				this.debug('Boosted for being damaged this turn');
 				return move.basePower * 2;
 			}
@@ -676,20 +676,6 @@ let BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		beforeTurnCallback: function (pokemon, target) {
-			pokemon.addVolatile('assurance');
-			pokemon.volatiles.assurance.hurt = [];
-		},
-		effect: {
-			duration: 1,
-			onFoeAfterDamage: function (damage, target) {
-				this.effectData.hurt[target.position] = true;
-				this.debug('damaged this turn');
-			},
-			onFoeSwitchOut: function (pokemon) {
-				this.effectData.hurt[pokemon.position] = false;
-			},
-		},
 		secondary: null,
 		target: "normal",
 		type: "Dark",

--- a/data/moves.js
+++ b/data/moves.js
@@ -662,7 +662,7 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
-			if (target.hurt) {
+			if (target.hurtThisTurn) {
 				this.debug('Boosted for being damaged this turn');
 				return move.basePower * 2;
 			}

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -967,12 +967,12 @@ let BattleMovedex = {
 				}
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
-				let lastHurtBy = target.getLastHurtBy();
-				if (!lastHurtBy) {
-					target.hurtBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
+				let lastAttackedBy = target.getLastAttackedBy();
+				if (!lastAttackedBy) {
+					target.attackedBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
 				} else {
-					lastHurtBy.move = move.id;
-					lastHurtBy.damage = damage;
+					lastAttackedBy.move = move.id;
+					lastAttackedBy.damage = damage;
 				}
 				return 0;
 			},

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -144,9 +144,9 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a physical attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a physical attack this turn, or if the user did not lose HP from the attack. If the opposing Pokemon used Fissure or Horn Drill and missed, this move deals 65535 damage.",
 		damageCallback: function (pokemon, target) {
-			let lastHurtBy = pokemon.getLastHurtBy();
-			if (lastHurtBy && lastHurtBy.move && lastHurtBy.thisTurn && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower') && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
-				return 2 * lastHurtBy.damage;
+			let lastAttackedBy = pokemon.getLastAttackedBy();
+			if (lastAttackedBy && lastAttackedBy.move && lastAttackedBy.thisTurn && (this.getCategory(lastAttackedBy.move) === 'Physical' || this.getMove(lastAttackedBy.move).id === 'hiddenpower') && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
+				return 2 * lastAttackedBy.damage;
 			}
 			return false;
 		},
@@ -493,9 +493,9 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a special attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a special attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon, target) {
-			let lastHurtBy = pokemon.getLastHurtBy();
-			if (lastHurtBy && lastHurtBy.move && lastHurtBy.thisTurn && this.getCategory(lastHurtBy.move) === 'Special' && this.getMove(lastHurtBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
-				return 2 * lastHurtBy.damage;
+			let lastAttackedBy = pokemon.getLastAttackedBy();
+			if (lastAttackedBy && lastAttackedBy.move && lastAttackedBy.thisTurn && this.getCategory(lastAttackedBy.move) === 'Special' && this.getMove(lastAttackedBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
+				return 2 * lastAttackedBy.damage;
 			}
 			return false;
 		},

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -187,10 +187,10 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the last opposing Pokemon to hit the user with a physical attack this turn equal to twice the HP lost by the user from that attack. If that opposing Pokemon's position is no longer in use and there is another opposing Pokemon on the field, the damage is done to it instead. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user was not hit by an opposing Pokemon's physical attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon) {
-			let lastHurtBy = pokemon.getLastHurtBy();
-			if (lastHurtBy && lastHurtBy.move && lastHurtBy.thisTurn && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower')) {
+			let lastAttackedBy = pokemon.getLastAttackedBy();
+			if (lastAttackedBy && lastAttackedBy.move && lastAttackedBy.thisTurn && (this.getCategory(lastAttackedBy.move) === 'Physical' || this.getMove(lastAttackedBy.move).id === 'hiddenpower')) {
 				// @ts-ignore
-				return 2 * lastHurtBy.damage;
+				return 2 * lastAttackedBy.damage;
 			}
 			return false;
 		},
@@ -558,11 +558,11 @@ let BattleMovedex = {
 		onTryHit: function () { },
 		onHit: function (pokemon) {
 			let noMirror = ['assist', 'curse', 'doomdesire', 'focuspunch', 'futuresight', 'magiccoat', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'psychup', 'roleplay', 'sketch', 'sleeptalk', 'spikes', 'spitup', 'taunt', 'teeterdance', 'transform'];
-			let lastHurtBy = pokemon.getLastHurtBy();
-			if (!lastHurtBy || !lastHurtBy.source.lastMove || !lastHurtBy.move || noMirror.includes(lastHurtBy.move) || !lastHurtBy.source.hasMove(lastHurtBy.move)) {
+			let lastAttackedBy = pokemon.getLastAttackedBy();
+			if (!lastAttackedBy || !lastAttackedBy.source.lastMove || !lastAttackedBy.move || noMirror.includes(lastAttackedBy.move) || !lastAttackedBy.source.hasMove(lastAttackedBy.move)) {
 				return false;
 			}
-			this.useMove(lastHurtBy.move, pokemon);
+			this.useMove(lastAttackedBy.move, pokemon);
 		},
 		target: "self",
 	},

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -1101,11 +1101,11 @@ let BattleMovedex = {
 		onTryHit: function () { },
 		onHit: function (pokemon) {
 			let noMirror = ['acupressure', 'aromatherapy', 'assist', 'chatter', 'copycat', 'counter', 'curse', 'doomdesire', 'feint', 'focuspunch', 'futuresight', 'gravity', 'hail', 'haze', 'healbell', 'helpinghand', 'lightscreen', 'luckychant', 'magiccoat', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'mist', 'mudsport', 'naturepower', 'perishsong', 'psychup', 'raindance', 'reflect', 'roleplay', 'safeguard', 'sandstorm', 'sketch', 'sleeptalk', 'snatch', 'spikes', 'spitup', 'stealthrock', 'struggle', 'sunnyday', 'tailwind', 'toxicspikes', 'transform', 'watersport'];
-			let lastHurtBy = pokemon.getLastHurtBy();
-			if (!lastHurtBy || !lastHurtBy.source.lastMove || !lastHurtBy.move || noMirror.includes(lastHurtBy.move) || !lastHurtBy.source.hasMove(lastHurtBy.move)) {
+			let lastAttackedBy = pokemon.getLastAttackedBy();
+			if (!lastAttackedBy || !lastAttackedBy.source.lastMove || !lastAttackedBy.move || noMirror.includes(lastAttackedBy.move) || !lastAttackedBy.source.hasMove(lastAttackedBy.move)) {
 				 return false;
 			}
-			this.useMove(lastHurtBy.move, pokemon);
+			this.useMove(lastAttackedBy.move, pokemon);
 		},
 		target: "self",
 	},

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -975,10 +975,10 @@ let BattleMovedex = {
 	avalanche: {
 		inherit: true,
 		basePowerCallback: function (pokemon, source) {
-			let lastHurtBy = pokemon.getLastHurtBy();
-			if (lastHurtBy) {
-				if (lastHurtBy.damage > 0 && lastHurtBy.thisTurn) {
-					this.debug('Boosted for getting hit by ' + lastHurtBy.move);
+			let lastAttackedBy = pokemon.getLastAttackedBy();
+			if (lastAttackedBy) {
+				if (lastAttackedBy.damage > 0 && lastAttackedBy.thisTurn) {
+					this.debug('Boosted for getting hit by ' + lastAttackedBy.move);
 					return this.isWeather('hail') ? 180 : 120;
 				}
 			}

--- a/mods/stadium/moves.js
+++ b/mods/stadium/moves.js
@@ -159,12 +159,12 @@ let BattleMovedex = {
 				}
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
-				let lastHurtBy = target.getLastHurtBy();
-				if (!lastHurtBy) {
-					target.hurtBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
+				let lastAttackedBy = target.getLastAttackedBy();
+				if (!lastAttackedBy) {
+					target.attackedBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
 				} else {
-					lastHurtBy.move = move.id;
-					lastHurtBy.damage = damage;
+					lastAttackedBy.move = move.id;
+					lastAttackedBy.damage = damage;
 				}
 				return 0;
 			},

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1549,14 +1549,14 @@ class Battle extends Dex.ModdedDex {
 				if (!pokemon.ateBerry) pokemon.disableMove('belch');
 
 				// If it was an illusion, it's not any more
-				if (pokemon.getLastHurtBy() && this.gen >= 7) pokemon.knownType = true;
+				if (pokemon.getLastAttackedBy() && this.gen >= 7) pokemon.knownType = true;
 
-				for (let i = pokemon.hurtBy.length - 1; i >= 0; i--) {
-					let attack = pokemon.hurtBy[i];
+				for (let i = pokemon.attackedBy.length - 1; i >= 0; i--) {
+					let attack = pokemon.attackedBy[i];
 					if (attack.source.isActive) {
 						attack.thisTurn = false;
 					} else {
-						pokemon.hurtBy.slice(pokemon.hurtBy.indexOf(attack), 1);
+						pokemon.attackedBy.slice(pokemon.attackedBy.indexOf(attack), 1);
 					}
 				}
 

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1538,6 +1538,7 @@ class Battle extends Dex.ModdedDex {
 				pokemon.newlySwitched = false;
 				pokemon.moveLastTurnResult = pokemon.moveThisTurnResult;
 				pokemon.moveThisTurnResult = undefined;
+				pokemon.hurt = false;
 
 				pokemon.maybeDisabled = false;
 				for (const moveSlot of pokemon.moveSlots) {
@@ -1977,7 +1978,7 @@ class Battle extends Dex.ModdedDex {
 		if (!damage) return 0;
 		damage = this.clampIntRange(damage, 1);
 
-		damage = target.damage(damage, source, effect);
+		damage = target.damage(damage, source, effect, true);
 		switch (effect && effect.id) {
 		case 'strugglerecoil':
 			this.add('-damage', target, target.getHealth, '[from] recoil');

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1538,7 +1538,7 @@ class Battle extends Dex.ModdedDex {
 				pokemon.newlySwitched = false;
 				pokemon.moveLastTurnResult = pokemon.moveThisTurnResult;
 				pokemon.moveThisTurnResult = undefined;
-				pokemon.hurt = false;
+				pokemon.hurtThisTurn = false;
 
 				pokemon.maybeDisabled = false;
 				for (const moveSlot of pokemon.moveSlots) {

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1922,7 +1922,9 @@ class Battle extends Dex.ModdedDex {
 		}
 		if (damage !== 0) damage = this.clampIntRange(damage, 1);
 		damage = target.damage(damage, source, effect);
+		if (damage !== 0) target.hurtThisTurn = true;
 		if (source && effect.effectType === 'Move') source.lastDamage = damage;
+
 		let name = effect.fullname;
 		if (name === 'tox') name = 'psn';
 		switch (effect.id) {
@@ -1978,7 +1980,7 @@ class Battle extends Dex.ModdedDex {
 		if (!damage) return 0;
 		damage = this.clampIntRange(damage, 1);
 
-		damage = target.damage(damage, source, effect, true);
+		damage = target.damage(damage, source, effect);
 		switch (effect && effect.id) {
 		case 'strugglerecoil':
 			this.add('-damage', target, target.getHealth, '[from] recoil');

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -157,7 +157,7 @@ class Pokemon {
 		this.hurt = false;
 		this.lastDamage = 0;
 		/**@type {{source: Pokemon, damage: number, thisTurn: boolean, move?: string}[]} */
-		this.hurtBy = [];
+		this.attackedBy = [];
 		this.usedItemThisTurn = false;
 		this.newlySwitched = false;
 		this.beingCalledBack = false;
@@ -612,18 +612,18 @@ class Pokemon {
 	gotAttacked(move, damage, source) {
 		if (!damage) damage = 0;
 		move = this.battle.getMove(move);
-		let lastHurtBy = {
+		let lastAttackedBy = {
 			source: source,
 			damage: damage,
 			move: move.id,
 			thisTurn: true,
 		};
-		this.hurtBy.push(lastHurtBy);
+		this.attackedBy.push(lastAttackedBy);
 	}
 
-	getLastHurtBy() {
-		if (this.hurtBy.length === 0) return undefined;
-		return this.hurtBy[this.hurtBy.length - 1];
+	getLastAttackedBy() {
+		if (this.attackedBy.length === 0) return undefined;
+		return this.attackedBy[this.attackedBy.length - 1];
 	}
 
 	/**
@@ -1045,7 +1045,7 @@ class Pokemon {
 		this.moveThisTurn = '';
 
 		this.lastDamage = 0;
-		this.hurtBy = [];
+		this.attackedBy = [];
 		this.hurt = false;
 		this.newlySwitched = true;
 		this.beingCalledBack = false;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -154,6 +154,7 @@ class Pokemon {
 		 */
 		this.moveThisTurnResult = undefined;
 
+		this.hurt = false;
 		this.lastDamage = 0;
 		/**@type {{source: Pokemon, damage: number, thisTurn: boolean, move?: string}[]} */
 		this.hurtBy = [];
@@ -1045,6 +1046,7 @@ class Pokemon {
 
 		this.lastDamage = 0;
 		this.hurtBy = [];
+		this.hurt = false;
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 
@@ -1094,12 +1096,13 @@ class Pokemon {
 	 * @param {Pokemon?} source
 	 * @param {Effect?} effect
 	 */
-	damage(d, source = null, effect = null) {
+	damage(d, source = null, effect = null, direct = false) {
 		if (!this.hp) return 0;
 		if (d < 1 && d > 0) d = 1;
 		d = Math.floor(d);
 		if (isNaN(d)) return 0;
 		if (d <= 0) return 0;
+		if(!direct) this.hurt = true;
 		this.hp -= d;
 		if (this.hp <= 0) {
 			d += this.hp;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -154,6 +154,7 @@ class Pokemon {
 		 */
 		this.moveThisTurnResult = undefined;
 
+		/** used for Assurance check */
 		this.hurtThisTurn = false;
 		this.lastDamage = 0;
 		/**@type {{source: Pokemon, damage: number, thisTurn: boolean, move?: string}[]} */
@@ -1096,13 +1097,10 @@ class Pokemon {
 	 * @param {Pokemon?} source
 	 * @param {Effect?} effect
 	 */
-	damage(d, source = null, effect = null, direct = false) {
-		if (!this.hp) return 0;
+	damage(d, source = null, effect = null) {
+		if (!this.hp || isNaN(d) || d <= 0) return 0;
 		if (d < 1 && d > 0) d = 1;
 		d = Math.floor(d);
-		if (isNaN(d)) return 0;
-		if (d <= 0) return 0;
-		if (!direct) this.hurtThisTurn = true;
 		this.hp -= d;
 		if (this.hp <= 0) {
 			d += this.hp;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -154,7 +154,7 @@ class Pokemon {
 		 */
 		this.moveThisTurnResult = undefined;
 
-		this.hurt = false;
+		this.hurtThisTurn = false;
 		this.lastDamage = 0;
 		/**@type {{source: Pokemon, damage: number, thisTurn: boolean, move?: string}[]} */
 		this.attackedBy = [];
@@ -1046,7 +1046,7 @@ class Pokemon {
 
 		this.lastDamage = 0;
 		this.attackedBy = [];
-		this.hurt = false;
+		this.hurtThisTurn = false;
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 
@@ -1102,7 +1102,7 @@ class Pokemon {
 		d = Math.floor(d);
 		if (isNaN(d)) return 0;
 		if (d <= 0) return 0;
-		if (!direct) this.hurt = true;
+		if (!direct) this.hurtThisTurn = true;
 		this.hp -= d;
 		if (this.hp <= 0) {
 			d += this.hp;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -1102,7 +1102,7 @@ class Pokemon {
 		d = Math.floor(d);
 		if (isNaN(d)) return 0;
 		if (d <= 0) return 0;
-		if(!direct) this.hurt = true;
+		if (!direct) this.hurt = true;
 		this.hp -= d;
 		if (this.hp <= 0) {
 			d += this.hp;


### PR DESCRIPTION
A pull was recently merged to fix the issue of assurance not functioning properly in doubles (specifically, assurance doubling based on its original target, even if its target changed). The move still does not function appropriately, however, when called by other moves (e.g. see https://replay.pokemonshowdown.com/gen7doublescustomgame-797443987, when it is used by Me First). This pull fixes this by removing the reliance on a volatile status condition and instead applying a "hurt" tag to Pokemon when they receive (non-direct) damage.