### PR TITLE
Fix Redirection of Counter Moves

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -2767,6 +2767,7 @@ let BattleMovedex = {
 			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
+				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return;
 				return source.side.foe.active[this.effectData.position];
 			},
 			onAfterDamage: function (damage, target, source, effect) {
@@ -10161,6 +10162,7 @@ let BattleMovedex = {
 			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
+				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return;
 				return source.side.foe.active[this.effectData.position];
 			},
 			onAfterDamage: function (damage, target, source, effect) {
@@ -10498,6 +10500,7 @@ let BattleMovedex = {
 			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
+				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return;
 				return source.side.foe.active[this.effectData.position];
 			},
 			onAfterDamage: function (damage, target, source, effect) {

--- a/data/moves.js
+++ b/data/moves.js
@@ -2767,7 +2767,7 @@ let BattleMovedex = {
 			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
-				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return;
+				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return target;
 				return source.side.foe.active[this.effectData.position];
 			},
 			onAfterDamage: function (damage, target, source, effect) {
@@ -10162,7 +10162,7 @@ let BattleMovedex = {
 			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
-				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return;
+				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return target;
 				return source.side.foe.active[this.effectData.position];
 			},
 			onAfterDamage: function (damage, target, source, effect) {
@@ -10500,7 +10500,7 @@ let BattleMovedex = {
 			onRedirectTargetPriority: -1,
 			onRedirectTarget: function (target, source, source2) {
 				if (source !== this.effectData.target) return;
-				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return;
+				if (target.volatiles['followme'] || target.volatiles['ragepowder']) return target;
 				return source.side.foe.active[this.effectData.position];
 			},
 			onAfterDamage: function (damage, target, source, effect) {

--- a/test/simulator/moves/counter.js
+++ b/test/simulator/moves/counter.js
@@ -57,7 +57,7 @@ describe('Counter', function () {
 		assert.false.fullHP(battle.p2.active[1]);
 	});
 
-	it('should bypass Follow Me', function () {
+	it('should not bypass Follow Me', function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Bastiodon', ability: 'sturdy', moves: ['counter']},
@@ -68,8 +68,8 @@ describe('Counter', function () {
 			{species: 'Clefable', ability: 'unaware', moves: ['followme']},
 		]);
 		battle.makeChoices('move counter, move splash', 'move acrobatics 1, move followme');
-		assert.fullHP(battle.p2.active[1]);
-		assert.false.fullHP(battle.p2.active[0]);
+		assert.fullHP(battle.p2.active[0]);
+		assert.false.fullHP(battle.p2.active[1]);
 	});
 });
 
@@ -123,7 +123,7 @@ describe('Mirror Coat', function () {
 		assert.false.fullHP(battle.p2.active[1]);
 	});
 
-	it('should bypass Follow Me', function () {
+	it('should not bypass Follow Me', function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Mew', ability: 'synchronize', moves: ['mirrorcoat']},
@@ -134,7 +134,7 @@ describe('Mirror Coat', function () {
 			{species: 'Clefable', ability: 'unaware', moves: ['followme']},
 		]);
 		battle.makeChoices('move mirrorcoat, move splash', 'move venoshock 1, move followme');
-		assert.fullHP(battle.p2.active[1]);
-		assert.false.fullHP(battle.p2.active[0]);
+		assert.fullHP(battle.p2.active[0]);
+		assert.false.fullHP(battle.p2.active[1]);
 	});
 });


### PR DESCRIPTION
Issue: https://github.com/Zarel/Pokemon-Showdown/issues/2367#issuecomment-421827399 

Bug:
- Redirection was broken last time because it was following the premise that counters don't redirect automatically when the source of damage faints

Fix:
- Added check in Counter, Mirror Coat, Metal Burst for redirection that came from moves Follow Me and Rage Powder 
