### PR TITLE
Test links with parenthesis

### DIFF
--- a/test/application/chat.js
+++ b/test/application/chat.js
@@ -41,6 +41,10 @@ describe('Chat', function () {
 			`hi <a href="http://google.com/__a__" rel="noopener" target="_blank">google.com/__a__</a> bye &gt;w&lt;`
 		);
 		assert.strictEqual(
+			Chat.formatText(`(https://en.wikipedia.org/wiki/Pokémon_(video_game_series))`),
+			`(<a href="https://en.wikipedia.org/wiki/Pokémon_(video_game_series)" rel="noopener" target="_blank">https://en.wikipedia.org/wiki/Pokémon_(video_game_series)</a>)`
+		);
+		assert.strictEqual(
 			Chat.formatText(`hi email@email.com bye >w<`),
 			`hi <a href="mailto:email@email.com" rel="noopener" target="_blank">email@email.com</a> bye &gt;w&lt;`
 		);


### PR DESCRIPTION
A lot of complexity in a chat formatter link regular expression is to support links with parentheses in them. This commit introduces a test of this to avoid accidentally breaking this functionality.