### PR TITLE
Fix permission parsing for subrooms

### DIFF
--- a/users.js
+++ b/users.js
@@ -616,7 +616,7 @@ class User {
 			targetUser = target;
 		}
 
-		if (room && room.auth) {
+		if (room && (room.auth || room.parent && room.parent.auth)) {
 			group = room.getAuth(this);
 			if (targetUser) targetGroup = room.getAuth(targetUser);
 			if (room.isPrivate === true && this.can('makeroom')) group = this.group;


### PR DESCRIPTION
Currently a subroom without any roomauth (no roomowner) will default to using global auth for permission checking instead of inheriting auth from the parent room.