### PR TITLE
Gen 4: Fix Nature Power

### DIFF
--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -1158,6 +1158,9 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "This move calls another move for use based on the battle terrain. Tri Attack in Wi-Fi battles.",
 		shortDesc: "Attack changes based on terrain. (Tri Attack)",
+		onHit: function (pokemon) {
+			this.useMove('triattack', pokemon);
+		},
 	},
 	odorsleuth: {
 		inherit: true,


### PR DESCRIPTION
At least the description was correct

EDIT: Maybe I should actually explain what the PR does. Right now, using Nature Power in a Gen 4 game will call Earthquake. This makes it call Tri Attack as expected.