### PR TITLE
"But it failed!" messages should not reveal the target

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -1977,7 +1977,7 @@ let BattleMovedex = {
 		onTryMove: function (pokemon, target, move) {
 			if (pokemon.hasType('Fire')) return;
 			this.add('-fail', pokemon, 'move: Burn Up');
-			this.hideLastTarget();
+			this.attrLastMove('[still]');
 			return null;
 		},
 		self: {
@@ -4773,7 +4773,7 @@ let BattleMovedex = {
 		flags: {contact: 1, protect: 1, mirror: 1},
 		onTry: function (pokemon, target) {
 			if (pokemon.activeTurns > 1) {
-				this.hideLastTarget();
+				this.attrLastMove('[still]');
 				this.add('-fail', pokemon);
 				this.add('-hint', "Fake Out only works on your first turn out.");
 				return null;
@@ -5143,7 +5143,7 @@ let BattleMovedex = {
 		onTry: function (pokemon, target) {
 			if (pokemon.activeTurns > 1) {
 				this.add('-fail', pokemon);
-				this.hideLastTarget();
+				this.attrLastMove('[still]');
 				this.add('-hint', "First Impression only works on your first turn out.");
 				return null;
 			}
@@ -16502,8 +16502,8 @@ let BattleMovedex = {
 				}
 				let damage = this.getDamage(source, target, move);
 				if (!damage && damage !== 0) {
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', source);
+					this.attrLastMove('[still]');
 					return null;
 				}
 				damage = this.runEvent('SubDamage', target, source, move, damage);
@@ -16574,8 +16574,8 @@ let BattleMovedex = {
 		onTry: function (source, target) {
 			let action = this.willMove(target);
 			if (!action || action.choice !== 'move' || (action.move.category === 'Status' && action.move.id !== 'mefirst') || target.volatiles.mustrecharge) {
-				this.add('-fail');
-				this.hideLastTarget();
+				this.add('-fail', source);
+				this.attrLastMove('[still]');
 				return null;
 			}
 		},

--- a/data/moves.js
+++ b/data/moves.js
@@ -1977,6 +1977,7 @@ let BattleMovedex = {
 		onTryMove: function (pokemon, target, move) {
 			if (pokemon.hasType('Fire')) return;
 			this.add('-fail', pokemon, 'move: Burn Up');
+			this.hideLastTarget();
 			return null;
 		},
 		self: {
@@ -4772,7 +4773,7 @@ let BattleMovedex = {
 		flags: {contact: 1, protect: 1, mirror: 1},
 		onTry: function (pokemon, target) {
 			if (pokemon.activeTurns > 1) {
-				this.attrLastMove('[still]');
+				this.hideLastTarget();
 				this.add('-fail', pokemon);
 				this.add('-hint', "Fake Out only works on your first turn out.");
 				return null;
@@ -5142,6 +5143,7 @@ let BattleMovedex = {
 		onTry: function (pokemon, target) {
 			if (pokemon.activeTurns > 1) {
 				this.add('-fail', pokemon);
+				this.hideLastTarget();
 				this.add('-hint', "First Impression only works on your first turn out.");
 				return null;
 			}
@@ -16500,7 +16502,8 @@ let BattleMovedex = {
 				}
 				let damage = this.getDamage(source, target, move);
 				if (!damage && damage !== 0) {
-					this.add('-fail', target);
+					this.add('-fail');
+					this.hideLastTarget();
 					return null;
 				}
 				damage = this.runEvent('SubDamage', target, source, move, damage);
@@ -16571,8 +16574,8 @@ let BattleMovedex = {
 		onTry: function (source, target) {
 			let action = this.willMove(target);
 			if (!action || action.choice !== 'move' || (action.move.category === 'Status' && action.move.id !== 'mefirst') || target.volatiles.mustrecharge) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
+				this.add('-fail');
+				this.hideLastTarget();
 				return null;
 			}
 		},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -302,7 +302,10 @@ let BattleScripts = {
 
 		let hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
 		if (!hitResult) {
-			if (hitResult === false) this.add('-fail', target);
+			if (hitResult === false) {
+				this.add('-fail');
+				this.hideLastTarget();
+			}
 			return false;
 		}
 		this.runEvent('PrepareHit', pokemon, target, move);
@@ -318,7 +321,10 @@ let BattleScripts = {
 				hitResult = this.runEvent('TryHitSide', target, pokemon, move);
 			}
 			if (!hitResult) {
-				if (hitResult === false) this.add('-fail', target);
+				if (hitResult === false) {
+					this.add('-fail');
+					this.hideLastTarget();
+				}
 				return false;
 			}
 			return this.moveHit(target, pokemon, move);
@@ -343,7 +349,10 @@ let BattleScripts = {
 
 		hitResult = this.runEvent('TryHit', target, pokemon, move);
 		if (!hitResult) {
-			if (hitResult === false) this.add('-fail', target);
+			if (hitResult === false) {
+				this.add('-fail');
+				this.hideLastTarget();
+			}
 			return false;
 		}
 
@@ -610,7 +619,10 @@ let BattleScripts = {
 			hitResult = this.singleEvent('TryHit', moveData, {}, target, pokemon, move);
 		}
 		if (!hitResult) {
-			if (hitResult === false) this.add('-fail', target);
+			if (hitResult === false) {
+				this.add('-fail');
+				this.hideLastTarget();
+			}
 			return false;
 		}
 
@@ -655,7 +667,8 @@ let BattleScripts = {
 
 			if (damage === false || damage === null) {
 				if (damage === false && !isSecondary && !isSelf) {
-					this.add('-fail', target);
+					this.add('-fail');
+					this.hideLastTarget();
 				}
 				this.debug('damage calculation interrupted');
 				return false;
@@ -682,7 +695,8 @@ let BattleScripts = {
 			if (moveData.heal && !target.fainted) {
 				let d = target.heal((this.gen < 5 ? Math.floor : Math.round)(target.maxhp * moveData.heal[0] / moveData.heal[1]));
 				if (!d && d !== 0) {
-					this.add('-fail', target);
+					this.add('-fail');
+					this.hideLastTarget();
 					this.debug('heal interrupted');
 					return false;
 				}
@@ -763,7 +777,10 @@ let BattleScripts = {
 
 			if (!didSomething && !moveData.self && !moveData.selfdestruct) {
 				if (!isSelf && !isSecondary) {
-					if (didSomething === false) this.add('-fail', pokemon);
+					if (didSomething === false) {
+						this.add('-fail');
+						this.hideLastTarget();
+					}
 				}
 				this.debug('move failed because it did nothing');
 				return false;
@@ -795,7 +812,8 @@ let BattleScripts = {
 			if (hitResult) {
 				target.forceSwitchFlag = true;
 			} else if (hitResult === false && move.category === 'Status') {
-				this.add('-fail', target);
+				this.add('-fail');
+				this.hideLastTarget();
 				return false;
 			}
 		}

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -303,8 +303,8 @@ let BattleScripts = {
 		let hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
 		if (!hitResult) {
 			if (hitResult === false) {
-				this.add('-fail');
-				this.hideLastTarget();
+				this.add('-fail', pokemon);
+				this.attrLastMove('[still]');
 			}
 			return false;
 		}
@@ -322,8 +322,8 @@ let BattleScripts = {
 			}
 			if (!hitResult) {
 				if (hitResult === false) {
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', pokemon);
+					this.attrLastMove('[still]');
 				}
 				return false;
 			}
@@ -350,8 +350,8 @@ let BattleScripts = {
 		hitResult = this.runEvent('TryHit', target, pokemon, move);
 		if (!hitResult) {
 			if (hitResult === false) {
-				this.add('-fail');
-				this.hideLastTarget();
+				this.add('-fail', pokemon);
+				this.attrLastMove('[still]');
 			}
 			return false;
 		}
@@ -620,8 +620,8 @@ let BattleScripts = {
 		}
 		if (!hitResult) {
 			if (hitResult === false) {
-				this.add('-fail');
-				this.hideLastTarget();
+				this.add('-fail', pokemon);
+				this.attrLastMove('[still]');
 			}
 			return false;
 		}
@@ -667,8 +667,8 @@ let BattleScripts = {
 
 			if (damage === false || damage === null) {
 				if (damage === false && !isSecondary && !isSelf) {
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', pokemon);
+					this.attrLastMove('[still]');
 				}
 				this.debug('damage calculation interrupted');
 				return false;
@@ -695,8 +695,8 @@ let BattleScripts = {
 			if (moveData.heal && !target.fainted) {
 				let d = target.heal((this.gen < 5 ? Math.floor : Math.round)(target.maxhp * moveData.heal[0] / moveData.heal[1]));
 				if (!d && d !== 0) {
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', pokemon);
+					this.attrLastMove('[still]');
 					this.debug('heal interrupted');
 					return false;
 				}
@@ -778,8 +778,8 @@ let BattleScripts = {
 			if (!didSomething && !moveData.self && !moveData.selfdestruct) {
 				if (!isSelf && !isSecondary) {
 					if (didSomething === false) {
-						this.add('-fail');
-						this.hideLastTarget();
+						this.add('-fail', pokemon);
+						this.attrLastMove('[still]');
 					}
 				}
 				this.debug('move failed because it did nothing');
@@ -812,8 +812,8 @@ let BattleScripts = {
 			if (hitResult) {
 				target.forceSwitchFlag = true;
 			} else if (hitResult === false && move.category === 'Status') {
-				this.add('-fail');
-				this.hideLastTarget();
+				this.add('-fail', pokemon);
+				this.attrLastMove('[still]');
 				return false;
 			}
 		}

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -523,7 +523,8 @@ let BattleStatuses = {
 		onTryMove: function (target, source, effect) {
 			if (effect.type === 'Fire' && effect.category !== 'Status') {
 				this.debug('Primordial Sea fire suppress');
-				this.add('-fail', source, effect, '[from] Primordial Sea');
+				this.add('-fail', '', effect, '[from] Primordial Sea');
+				this.hideLastTarget();
 				return null;
 			}
 		},
@@ -596,7 +597,8 @@ let BattleStatuses = {
 		onTryMove: function (target, source, effect) {
 			if (effect.type === 'Water' && effect.category !== 'Status') {
 				this.debug('Desolate Land water suppress');
-				this.add('-fail', source, effect, '[from] Desolate Land');
+				this.add('-fail', '', effect, '[from] Desolate Land');
+				this.hideLastTarget();
 				return null;
 			}
 		},

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -520,11 +520,11 @@ let BattleStatuses = {
 		num: 0,
 		effectType: 'Weather',
 		duration: 0,
-		onTryMove: function (target, source, effect) {
-			if (effect.type === 'Fire' && effect.category !== 'Status') {
+		onTryMove: function (attacker, defender, move) {
+			if (move.type === 'Fire' && move.category !== 'Status') {
 				this.debug('Primordial Sea fire suppress');
-				this.add('-fail', '', effect, '[from] Primordial Sea');
-				this.hideLastTarget();
+				this.add('-fail', attacker, move, '[from] Primordial Sea');
+				this.attrLastMove('[still]');
 				return null;
 			}
 		},
@@ -594,11 +594,11 @@ let BattleStatuses = {
 		num: 0,
 		effectType: 'Weather',
 		duration: 0,
-		onTryMove: function (target, source, effect) {
-			if (effect.type === 'Water' && effect.category !== 'Status') {
+		onTryMove: function (attacker, defender, move) {
+			if (move.type === 'Water' && move.category !== 'Status') {
 				this.debug('Desolate Land water suppress');
-				this.add('-fail', '', effect, '[from] Desolate Land');
-				this.hideLastTarget();
+				this.add('-fail', attacker, move, '[from] Desolate Land');
+				this.attrLastMove('[still]');
 				return null;
 			}
 		},

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -317,13 +317,13 @@ let BattleMovedex = {
 			durationCallback: function () {
 				return this.random(3, 7);
 			},
-			onStart: function (target) {
+			onStart: function (target, source) {
 				let noEncore = ['encore', 'mimic', 'mirrormove', 'sketch', 'struggle', 'transform'];
 				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
 				if (!target.lastMove || noEncore.includes(target.lastMove.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', source);
+					this.attrLastMove('[still]');
 					delete target.volatiles['encore'];
 					return;
 				}

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -322,7 +322,8 @@ let BattleMovedex = {
 				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
 				if (!target.lastMove || noEncore.includes(target.lastMove.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
-					this.add('-fail', target);
+					this.add('-fail');
+					this.hideLastTarget();
 					delete target.volatiles['encore'];
 					return;
 				}

--- a/mods/gen3/scripts.js
+++ b/mods/gen3/scripts.js
@@ -27,8 +27,8 @@ let BattleScripts = {
 		let hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
 		if (!hitResult) {
 			if (hitResult === false) {
-				this.add('-fail');
-				this.hideLastTarget();
+				this.add('-fail', pokemon);
+				this.attrLastMove('[still]');
 			}
 			return false;
 		}
@@ -46,8 +46,8 @@ let BattleScripts = {
 			}
 			if (!hitResult) {
 				if (hitResult === false) {
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', pokemon);
+					this.attrLastMove('[still]');
 				}
 				return false;
 			}
@@ -121,8 +121,8 @@ let BattleScripts = {
 			hitResult = this.runEvent('TryHit', target, pokemon, move);
 			if (!hitResult) {
 				if (hitResult === false) {
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', pokemon);
+					this.attrLastMove('[still]');
 				}
 				return false;
 			} else if (naturalImmunity) {

--- a/mods/gen3/scripts.js
+++ b/mods/gen3/scripts.js
@@ -26,7 +26,10 @@ let BattleScripts = {
 
 		let hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
 		if (!hitResult) {
-			if (hitResult === false) this.add('-fail', target);
+			if (hitResult === false) {
+				this.add('-fail');
+				this.hideLastTarget();
+			}
 			return false;
 		}
 		this.runEvent('PrepareHit', pokemon, target, move);
@@ -42,7 +45,10 @@ let BattleScripts = {
 				hitResult = this.runEvent('TryHitSide', target, pokemon, move);
 			}
 			if (!hitResult) {
-				if (hitResult === false) this.add('-fail', target);
+				if (hitResult === false) {
+					this.add('-fail');
+					this.hideLastTarget();
+				}
 				return false;
 			}
 			return this.moveHit(target, pokemon, move);
@@ -114,7 +120,10 @@ let BattleScripts = {
 		if (accPass) {
 			hitResult = this.runEvent('TryHit', target, pokemon, move);
 			if (!hitResult) {
-				if (hitResult === false) this.add('-fail', target);
+				if (hitResult === false) {
+					this.add('-fail');
+					this.hideLastTarget();
+				}
 				return false;
 			} else if (naturalImmunity) {
 				this.add('-immune', target, '[msg]');

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -517,13 +517,13 @@ let BattleMovedex = {
 			durationCallback: function () {
 				return this.random(4, 9);
 			},
-			onStart: function (target) {
+			onStart: function (target, source) {
 				let noEncore = ['encore', 'mimic', 'mirrormove', 'sketch', 'struggle', 'transform'];
 				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
 				if (!target.lastMove || noEncore.includes(target.lastMove.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', source);
+					this.attrLastMove('[still]');
 					delete target.volatiles['encore'];
 					return;
 				}

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -522,7 +522,8 @@ let BattleMovedex = {
 				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
 				if (!target.lastMove || noEncore.includes(target.lastMove.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
-					this.add('-fail', target);
+					this.add('-fail');
+					this.hideLastTarget();
 					delete target.volatiles['encore'];
 					return;
 				}

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -94,7 +94,10 @@ let BattleScripts = {
 
 		let hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
 		if (!hitResult) {
-			if (hitResult === false) this.add('-fail', target);
+			if (hitResult === false) {
+				this.add('-fail');
+				this.hideLastTarget();
+			}
 			return false;
 		}
 		this.runEvent('PrepareHit', pokemon, target, move);
@@ -110,7 +113,10 @@ let BattleScripts = {
 				hitResult = this.runEvent('TryHitSide', target, pokemon, move);
 			}
 			if (!hitResult) {
-				if (hitResult === false) this.add('-fail', target);
+				if (hitResult === false) {
+					this.add('-fail');
+					this.hideLastTarget();
+				}
 				return false;
 			}
 			return this.moveHit(target, pokemon, move);
@@ -182,7 +188,10 @@ let BattleScripts = {
 		}
 		hitResult = this.runEvent('TryHit', target, pokemon, move);
 		if (!hitResult) {
-			if (hitResult === false) this.add('-fail', target);
+			if (hitResult === false) {
+				this.add('-fail');
+				this.hideLastTarget();
+			}
 			return false;
 		}
 

--- a/mods/gen4/scripts.js
+++ b/mods/gen4/scripts.js
@@ -95,8 +95,8 @@ let BattleScripts = {
 		let hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
 		if (!hitResult) {
 			if (hitResult === false) {
-				this.add('-fail');
-				this.hideLastTarget();
+				this.add('-fail', pokemon);
+				this.attrLastMove('[still]');
 			}
 			return false;
 		}
@@ -114,8 +114,8 @@ let BattleScripts = {
 			}
 			if (!hitResult) {
 				if (hitResult === false) {
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', pokemon);
+					this.attrLastMove('[still]');
 				}
 				return false;
 			}
@@ -189,8 +189,8 @@ let BattleScripts = {
 		hitResult = this.runEvent('TryHit', target, pokemon, move);
 		if (!hitResult) {
 			if (hitResult === false) {
-				this.add('-fail');
-				this.hideLastTarget();
+				this.add('-fail', pokemon);
+				this.attrLastMove('[still]');
 			}
 			return false;
 		}

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -987,7 +987,8 @@ let BattleMovedex = {
 				}
 				let damage = this.getDamage(source, target, move);
 				if (!damage && damage !== 0) {
-					this.add('-fail', target);
+					this.add('-fail');
+					this.hideLastTarget();
 					return null;
 				}
 				damage = this.runEvent('SubDamage', target, source, move, damage);

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -987,8 +987,8 @@ let BattleMovedex = {
 				}
 				let damage = this.getDamage(source, target, move);
 				if (!damage && damage !== 0) {
-					this.add('-fail');
-					this.hideLastTarget();
+					this.add('-fail', source);
+					this.attrLastMove('[still]');
 					return null;
 				}
 				damage = this.runEvent('SubDamage', target, source, move, damage);

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -3212,6 +3212,12 @@ class Battle extends Dex.ModdedDex {
 	 * @param {(string | number | Function | AnyObject)[]} args
 	 */
 	attrLastMove(...args) {
+		if (args.includes('[still]')) {
+			// If no animation plays, the target should never be known
+			let parts = this.log[this.lastMoveLine].split('|');
+			parts[4] = '';
+			this.log[this.lastMoveLine] = parts.join('|');
+		}
 		this.log[this.lastMoveLine] += `|${args.join('|')}`;
 	}
 
@@ -3222,16 +3228,6 @@ class Battle extends Dex.ModdedDex {
 		let parts = this.log[this.lastMoveLine].split('|');
 		parts[4] = newTarget.toString();
 		this.log[this.lastMoveLine] = parts.join('|');
-	}
-
-	/**
-	 * Ambiguates the target of the last move.
-	 */
-	hideLastTarget() {
-		let parts = this.log[this.lastMoveLine].split('|');
-		parts[4] = '';
-		this.log[this.lastMoveLine] = parts.join('|');
-		this.attrLastMove('[still]');
 	}
 
 	/**

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -3225,6 +3225,16 @@ class Battle extends Dex.ModdedDex {
 	}
 
 	/**
+	 * Ambiguates the target of the last move.
+	 */
+	hideLastTarget() {
+		let parts = this.log[this.lastMoveLine].split('|');
+		parts[4] = '';
+		this.log[this.lastMoveLine] = parts.join('|');
+		this.attrLastMove('[still]');
+	}
+
+	/**
 	 * @param {string} activity
 	 */
 	debug(activity) {

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -1234,8 +1234,8 @@ class Pokemon {
 			if (sourceEffect && sourceEffect.status === this.status) {
 				this.battle.add('-fail', this, this.status);
 			} else if (sourceEffect && sourceEffect.status) {
-				this.battle.add('-fail');
-				this.battle.hideLastTarget();
+				this.battle.add('-fail', source);
+				this.battle.attrLastMove('[still]');
 			}
 			return false;
 		}

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -1234,7 +1234,8 @@ class Pokemon {
 			if (sourceEffect && sourceEffect.status === this.status) {
 				this.battle.add('-fail', this, this.status);
 			} else if (sourceEffect && sourceEffect.status) {
-				this.battle.add('-fail', this);
+				this.battle.add('-fail');
+				this.battle.hideLastTarget();
 			}
 			return false;
 		}

--- a/test/simulator/misc/typechange.js
+++ b/test/simulator/misc/typechange.js
@@ -50,7 +50,7 @@ describe('Type addition', function () {
 						const target = battle.p2.active[0];
 						battle.makeChoices('move ' + moveData.name, 'move spikes');
 						assert.constant(() => target.getTypes().join('/'), () => battle.makeChoices('move ' + moveData.name, 'move spikes'));
-						assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail'));
+						assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
 					});
 				} else {
 					it('should override ' + moveData2.name, function () {

--- a/test/simulator/misc/typechange.js
+++ b/test/simulator/misc/typechange.js
@@ -50,7 +50,7 @@ describe('Type addition', function () {
 						const target = battle.p2.active[0];
 						battle.makeChoices('move ' + moveData.name, 'move spikes');
 						assert.constant(() => target.getTypes().join('/'), () => battle.makeChoices('move ' + moveData.name, 'move spikes'));
-						assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
+						assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail'));
 					});
 				} else {
 					it('should override ' + moveData2.name, function () {

--- a/test/simulator/moves/roost.js
+++ b/test/simulator/moves/roost.js
@@ -16,7 +16,7 @@ describe('Roost', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Clefable", item: 'leftovers', ability: 'unaware', moves: ['calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", item: 'laggingtail', ability: 'multiscale', moves: ['roost']}]);
 		battle.makeChoices('move calmmind', 'move roost');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail'));
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
 	});
 
 	it('should heal the user', function () {

--- a/test/simulator/moves/roost.js
+++ b/test/simulator/moves/roost.js
@@ -16,7 +16,7 @@ describe('Roost', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Clefable", item: 'leftovers', ability: 'unaware', moves: ['calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Dragonite", item: 'laggingtail', ability: 'multiscale', moves: ['roost']}]);
 		battle.makeChoices('move calmmind', 'move roost');
-		assert.strictEqual(battle.log[battle.lastMoveLine + 1], '|-fail|' + battle.p2.active[0]);
+		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail'));
 	});
 
 	it('should heal the user', function () {


### PR DESCRIPTION
From #2367:

>The target of a failed [move] should be ambiguous to both players; that is, the animation shouldn't play out. This happens with...moves that bring up the message "But it failed!", like Fake Out, Disable, etc., so it can probably be generalized in this way.

>Using a move blocked by Primal weather should not reveal which slot was targeted

~~This adds a new method to battles: `hideLastTarget`. It removes the target from the last `move` message and suppresses its animation.~~

This makes the `[still]` attribute hide the target from the same `move` message whenever it is added.

In addition, the target is ~~removed from~~ replaced with the source in `-fail` minors where it shouldn't be revealed.

Currently, changes are only applied to `-fail` minors where the target could have been one of several Pokemon, but would not be revealed to the players in-game. This may cause inconsistencies in whether or not animations play when moves fail, but this seems like a less urgent issue than preventing an information leak.

I appreciate your feedback!