### PR TITLE
Fortemons: Trigger 'Hit' events of the forte

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -605,6 +605,11 @@ let Formats = [
 				}
 			}
 		},
+		onHitPriority: 999,
+		onHit: function(target, source, move) {
+			// @ts-ignore
+			if (move.category !== 'Status' && source.forte && source.forte.onHit) this.singleEvent('Hit', source.forte, {}, target, source, move);
+		},
 	},
 	{
 		name: "[Gen 7] Averagemons",


### PR DESCRIPTION
From my filter, this properly implements the following fortes: Bug Bite, Clear Smog, Core Enforcer, Fire Pledge, Flame Burst, Fury Cutter, Grass Pledge, Incinerate, Pay Day, Pluck, Relic Song, Sky Drop, Smelling Salts, Splintered Stormshards, Thousand Waves, Wake-Up Slap, Water Pledge.