### PR TITLE
Fortemons: Fix several moves

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -564,18 +564,16 @@ let Formats = [
 				// @ts-ignore
 				if (pokemon.forte.self) {
 					// @ts-ignore
-					if (pokemon.forte.self.onHit) {
-						if (move.self && move.self.onHit) {
+					if (pokemon.forte.self.onHit && move.self && move.self.onHit) {
+						// @ts-ignore
+						for (let i in pokemon.forte.self) {
+							if (i.startsWith('onHit')) continue;
 							// @ts-ignore
-							for (let i in pokemon.forte.self) {
-								if (i.startsWith('onHit')) continue;
-								// @ts-ignore
-								move.self[i] = pokemon.forte.self[i];
-							}
-						} else {
-							// @ts-ignore
-							move.self = Object.assign(move.self || {}, pokemon.forte.self);
+							move.self[i] = pokemon.forte.self[i];
 						}
+					} else {
+						// @ts-ignore
+						move.self = Object.assign(move.self || {}, pokemon.forte.self);
 					}
 				}
 				// @ts-ignore
@@ -603,13 +601,22 @@ let Formats = [
 			// @ts-ignore
 			if (move && move.category !== 'Status' && source.forte && source.forte.onHit) this.singleEvent('Hit', source.forte, {}, target, source, move);
 			// @ts-ignore
-			if (move && move.category !== 'Status' && source.forte && source.forte.self && source.forte.self.onHit) this.singleEvent('Hit', source.forte, {}, target, source, move);
+			if (move && move.category !== 'Status' && source.forte && source.forte.self && source.forte.self.onHit) this.singleEvent('Hit', source.forte.self, {}, source, source, move);
 		},
 		// @ts-ignore
 		onAfterSubDamagePriority: 1,
 		onAfterSubDamage: function (damage, target, source, move) {
 			// @ts-ignore
 			if (move && move.category !== 'Status' && source.forte && source.forte.onAfterSubDamage) this.singleEvent('AfterSubDamage', source.forte, null, target, source, move);
+		},
+		onModifySecondaries: function (secondaries, target, source, move) {
+			if (secondaries.some(s => !!s.self)) move.selfDropped = false;
+		},
+		// @ts-ignore
+		onAfterMoveSecondarySelfPriority: 1,
+		onAfterMoveSecondarySelf: function (source, target, move) {
+			// @ts-ignore
+			if (move && move.category !== 'Status' && source.forte && source.forte.onAfterMoveSecondarySelf) this.singleEvent('AfterMoveSecondarySelf', source.forte, null, source, target, move);
 		},
 	},
 	{

--- a/config/formats.js
+++ b/config/formats.js
@@ -578,7 +578,9 @@ let Formats = [
 				}
 				// @ts-ignore
 				if (pokemon.forte.secondaries) move.secondaries = (move.secondaries || []).concat(pokemon.forte.secondaries);
-				for (let prop of ['basePowerCallback', 'breaksProtect', 'critRatio', 'defensiveCategory', 'drain', 'forceSwitch', 'ignoreAbility', 'ignoreDefensive', 'ignoreEvasion', 'ignoreImmunity', 'pseudoWeather', 'recoil', 'selfSwitch', 'sleepUsable', 'stealsBoosts', 'thawsTarget', 'useTargetOffensive', 'volatileStatus', 'willCrit']) {
+				// @ts-ignore
+				move.critRatio = (move.critRatio - 1) + (pokemon.forte.critRatio - 1) + 1;
+				for (let prop of ['basePowerCallback', 'breaksProtect', 'defensiveCategory', 'drain', 'forceSwitch', 'ignoreAbility', 'ignoreDefensive', 'ignoreEvasion', 'ignoreImmunity', 'pseudoWeather', 'recoil', 'selfSwitch', 'sleepUsable', 'stealsBoosts', 'thawsTarget', 'useTargetOffensive', 'volatileStatus', 'willCrit']) {
 					// @ts-ignore
 					if (pokemon.forte[prop]) {
 						// @ts-ignore

--- a/config/formats.js
+++ b/config/formats.js
@@ -601,9 +601,14 @@ let Formats = [
 		onHitPriority: 1,
 		onHit: function (target, source, move) {
 			// @ts-ignore
-			if (move && move.category !== 'Status' && source.forte && source.forte.onHit) this.singleEvent('Hit', source.forte, {}, target, source, move);
-			// @ts-ignore
-			if (move && move.category !== 'Status' && source.forte && source.forte.self && source.forte.self.onHit) this.singleEvent('Hit', source.forte.self, {}, source, source, move);
+			if (move && move.category !== 'Status' && source.forte) {
+				// @ts-ignore
+				if (source.forte.onHit) this.singleEvent('Hit', source.forte, {}, target, source, move);
+				// @ts-ignore
+				if (source.forte.self && source.forte.self.onHit) this.singleEvent('Hit', source.forte.self, {}, source, source, move);
+				// @ts-ignore
+				if (source.forte.onAfterHit) this.singleEvent('AfterHit', source.forte, {}, target, source, move);
+			}
 		},
 		// @ts-ignore
 		onAfterSubDamagePriority: 1,

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -236,7 +236,7 @@ interface EventMethods {
 	onModifyDef?: (this: Battle, def: number, pokemon: Pokemon) => number | void
 	onModifyMove?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon) => void
 	onModifyPriority?: (this: Battle, priority: number, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => number | void
-	onModifySecondaries?: (this: Battle, secondaries: SecondaryEffect[]) => void
+	onModifySecondaries?: (this: Battle, secondaries: SecondaryEffect[], target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onModifySpA?: (this: Battle, atk: number, attacker: Pokemon, defender: Pokemon, move: ActiveMove) => number | void
 	onModifySpD?: (this: Battle, spd: number, pokemon: Pokemon) => number | void
 	onModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void


### PR DESCRIPTION
* Fix a bug from #4949 that made self-effects not always merge
* If the forte has a `self.onHit` it is now triggered properly (Burn Up, Rapid Spin fortes)
* Allow primary self-boosts and secondary self-boosts to both happen (the weird `onModifySecondaries` hack) e.g. Flame Charge -> V-Create
* Properly implement Fell Stinger and Relic Song as fortes
* Fix crit ratio adding (previously it was causing way too many crits which people were complaining about)
* Implement Knock Off as a forte