### PR TITLE
Crabominable and Carracosta should be PU

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -5250,7 +5250,7 @@ let BattleFormatsData = {
 	carracosta: {
 		randomBattleMoves: ["shellsmash", "aquajet", "liquidation", "stoneedge", "earthquake", "stealthrock"],
 		randomDoubleBattleMoves: ["shellsmash", "aquajet", "liquidation", "stoneedge", "earthquake", "protect", "wideguard", "rockslide"],
-		tier: "(PU)",
+		tier: "PU",
 		doublesTier: "DUU",
 	},
 	archen: {
@@ -6597,7 +6597,7 @@ let BattleFormatsData = {
 	crabominable: {
 		randomBattleMoves: ["icehammer", "closecombat", "earthquake", "stoneedge"],
 		randomDoubleBattleMoves: ["icehammer", "closecombat", "stoneedge", "protect", "wideguard", "earthquake"],
-		tier: "(PU)",
+		tier: "PU",
 		doublesTier: "DUU",
 	},
 	oricorio: {


### PR DESCRIPTION
They were always PU by usage, but got looked over. Nobody noticed until now because they're both banned from ZU.