### PR TITLE
Random Battle: Add Defog to Delibird

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -2415,7 +2415,7 @@ let BattleFormatsData = {
 		doublesTier: "DUU",
 	},
 	delibird: {
-		randomBattleMoves: ["rapidspin", "iceshard", "icepunch", "aerialace", "spikes", "destinybond"],
+		randomBattleMoves: ["defog", "iceshard", "icepunch", "aerialace", "spikes", "destinybond"],
 		randomDoubleBattleMoves: ["fakeout", "iceshard", "icepunch", "aerialace", "brickbreak", "protect"],
 		eventPokemon: [
 			{"generation": 3, "level": 10, "gender": "M", "moves": ["present"], "pokeball": "pokeball"},


### PR DESCRIPTION
It learns it in USUM and it's much better hazard removal for it because
Hustle gives Rapid Spin a chance of missing, and the evasion reduction
helping its other moves affected by Hustle.