### PR TITLE
Refactor OMs to use "m" property of Pokemon

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -869,16 +869,16 @@ let Formats = [
 		},
 		onBegin() {
 			for (const pokemon of this.getAllPokemon()) {
-				pokemon.originalSpecies = pokemon.baseTemplate.species;
+				pokemon.m.originalSpecies = pokemon.baseTemplate.species;
 			}
 		},
 		onSwitchIn(pokemon) {
 			// @ts-ignore
 			let oMegaTemplate = this.getTemplate(pokemon.template.originalMega);
-			if (oMegaTemplate.exists && pokemon.originalSpecies !== oMegaTemplate.baseSpecies) {
+			if (oMegaTemplate.exists && pokemon.m.originalSpecies !== oMegaTemplate.baseSpecies) {
 				// Place volatiles on the Pokémon to show its mega-evolved condition and details
 				this.add('-start', pokemon, oMegaTemplate.requiredItem || oMegaTemplate.requiredMove, '[silent]');
-				let oTemplate = this.getTemplate(pokemon.originalSpecies);
+				let oTemplate = this.getTemplate(pokemon.m.originalSpecies);
 				if (oTemplate.types.length !== pokemon.template.types.length || oTemplate.types[1] !== pokemon.template.types[1]) {
 					this.add('-start', pokemon, 'typechange', pokemon.template.types.join('/'), '[silent]');
 				}
@@ -887,7 +887,7 @@ let Formats = [
 		onSwitchOut(pokemon) {
 			// @ts-ignore
 			let oMegaTemplate = this.getTemplate(pokemon.template.originalMega);
-			if (oMegaTemplate.exists && pokemon.originalSpecies !== oMegaTemplate.baseSpecies) {
+			if (oMegaTemplate.exists && pokemon.m.originalSpecies !== oMegaTemplate.baseSpecies) {
 				this.add('-end', pokemon, oMegaTemplate.requiredItem || oMegaTemplate.requiredMove, '[silent]');
 			}
 		},
@@ -1041,38 +1041,38 @@ let Formats = [
 			}
 			let ally = pokemon.side.active.find(ally => ally && ally !== pokemon && !ally.fainted);
 			if (ally && ally.ability !== pokemon.ability) {
-				if (!pokemon.innate) {
-					pokemon.innate = 'ability' + ally.ability;
-					delete pokemon.volatiles[pokemon.innate];
-					pokemon.addVolatile(pokemon.innate);
+				if (!pokemon.m.innate) {
+					pokemon.m.innate = 'ability' + ally.ability;
+					delete pokemon.volatiles[pokemon.m.innate];
+					pokemon.addVolatile(pokemon.m.innate);
 				}
-				if (!ally.innate) {
-					ally.innate = 'ability' + pokemon.ability;
-					delete ally.volatiles[ally.innate];
-					ally.addVolatile(ally.innate);
+				if (!ally.m.innate) {
+					ally.m.innate = 'ability' + pokemon.ability;
+					delete ally.volatiles[ally.m.innate];
+					ally.addVolatile(ally.m.innate);
 				}
 			}
 		},
 		onSwitchOut(pokemon) {
-			if (pokemon.innate) {
-				pokemon.removeVolatile(pokemon.innate);
-				delete pokemon.innate;
+			if (pokemon.m.innate) {
+				pokemon.removeVolatile(pokemon.m.innate);
+				delete pokemon.m.innate;
 			}
 			let ally = pokemon.side.active.find(ally => ally && ally !== pokemon && !ally.fainted);
-			if (ally && ally.innate) {
-				ally.removeVolatile(ally.innate);
-				delete ally.innate;
+			if (ally && ally.m.innate) {
+				ally.removeVolatile(ally.m.innate);
+				delete ally.m.innate;
 			}
 		},
 		onFaint(pokemon) {
-			if (pokemon.innate) {
-				pokemon.removeVolatile(pokemon.innate);
-				delete pokemon.innate;
+			if (pokemon.m.innate) {
+				pokemon.removeVolatile(pokemon.m.innate);
+				delete pokemon.m.innate;
 			}
 			let ally = pokemon.side.active.find(ally => ally && ally !== pokemon && !ally.fainted);
-			if (ally && ally.innate) {
-				ally.removeVolatile(ally.innate);
-				delete ally.innate;
+			if (ally && ally.m.innate) {
+				ally.removeVolatile(ally.m.innate);
+				delete ally.m.innate;
 			}
 		},
 	},

--- a/data/mods/gennext/abilities.js
+++ b/data/mods/gennext/abilities.js
@@ -508,8 +508,8 @@ let BattleAbilities = {
 		onResidualOrder: 26,
 		onResidualSubOrder: 1,
 		onResidual(pokemon) {
-			if (!pokemon.gluttonyFlag && !pokemon.item && this.getItem(pokemon.lastItem).isBerry) {
-				pokemon.gluttonyFlag = true;
+			if (!pokemon.m.gluttonyFlag && !pokemon.item && this.getItem(pokemon.lastItem).isBerry) {
+				pokemon.m.gluttonyFlag = true;
 				pokemon.setItem(pokemon.lastItem);
 				pokemon.lastItem = '';
 				this.add("-item", pokemon, pokemon.item, '[from] ability: Gluttony');

--- a/data/mods/mixandmega/items.js
+++ b/data/mods/mixandmega/items.js
@@ -12,8 +12,8 @@ let BattleItems = {
 		onPrimal(pokemon) {
 			/**@type {Template} */
 			// @ts-ignore
-			let template = this.getMixedTemplate(pokemon.originalSpecies, 'Kyogre-Primal');
-			if (pokemon.originalSpecies === 'Kyogre') {
+			let template = this.getMixedTemplate(pokemon.m.originalSpecies, 'Kyogre-Primal');
+			if (pokemon.m.originalSpecies === 'Kyogre') {
 				pokemon.formeChange(template, this.effect, true);
 			} else {
 				pokemon.formeChange(template, this.effect, true);
@@ -35,14 +35,14 @@ let BattleItems = {
 		onPrimal(pokemon) {
 			/**@type {Template} */
 			// @ts-ignore
-			let template = this.getMixedTemplate(pokemon.originalSpecies, 'Groudon-Primal');
-			if (pokemon.originalSpecies === 'Groudon') {
+			let template = this.getMixedTemplate(pokemon.m.originalSpecies, 'Groudon-Primal');
+			if (pokemon.m.originalSpecies === 'Groudon') {
 				pokemon.formeChange(template, this.effect, true);
 			} else {
 				pokemon.formeChange(template, this.effect, true);
 				pokemon.baseTemplate = template;
 				this.add('-start', pokemon, 'Red Orb', '[silent]');
-				let apparentSpecies = pokemon.illusion ? pokemon.illusion.template.species : pokemon.originalSpecies;
+				let apparentSpecies = pokemon.illusion ? pokemon.illusion.template.species : pokemon.m.originalSpecies;
 				let oTemplate = this.getTemplate(apparentSpecies);
 				if (pokemon.illusion) {
 					let types = oTemplate.types;

--- a/data/mods/mixandmega/scripts.js
+++ b/data/mods/mixandmega/scripts.js
@@ -27,7 +27,7 @@ let BattleScripts = {
 		const isUltraBurst = !pokemon.canMegaEvo;
 		/**@type {Template} */
 		// @ts-ignore
-		const template = this.getMixedTemplate(pokemon.originalSpecies, pokemon.canMegaEvo || pokemon.canUltraBurst);
+		const template = this.getMixedTemplate(pokemon.m.originalSpecies, pokemon.canMegaEvo || pokemon.canUltraBurst);
 		const side = pokemon.side;
 
 		// Pokémon affected by Sky Drop cannot Mega Evolve. Enforce it here for now.
@@ -38,11 +38,11 @@ let BattleScripts = {
 		}
 
 		// Do we have a proper sprite for it?
-		// @ts-ignore
-		if (this.getTemplate(pokemon.canMegaEvo).baseSpecies === pokemon.originalSpecies || isUltraBurst) {
+		// @ts-ignore assert non-null pokemon.canMegaEvo
+		if (isUltraBurst || this.getTemplate(pokemon.canMegaEvo).baseSpecies === pokemon.m.originalSpecies) {
 			pokemon.formeChange(template, pokemon.getItem(), true);
 		} else {
-			let oTemplate = this.getTemplate(pokemon.originalSpecies);
+			let oTemplate = this.getTemplate(pokemon.m.originalSpecies);
 			// @ts-ignore
 			let oMegaTemplate = this.getTemplate(template.originalMega);
 			pokemon.formeChange(template, pokemon.getItem(), true);

--- a/data/mods/pic/moves.js
+++ b/data/mods/pic/moves.js
@@ -14,15 +14,15 @@ exports.BattleMovedex = {
 			}
 			this.singleEvent('End', sourceAbility, source.abilityData, source);
 			let sourceAlly = source.side.active.find(ally => ally && ally !== source && !ally.fainted);
-			if (sourceAlly && sourceAlly.innate) {
-				sourceAlly.removeVolatile(sourceAlly.innate);
-				delete sourceAlly.innate;
+			if (sourceAlly && sourceAlly.m.innate) {
+				sourceAlly.removeVolatile(sourceAlly.m.innate);
+				delete sourceAlly.m.innate;
 			}
 			this.singleEvent('End', targetAbility, target.abilityData, target);
 			let targetAlly = target.side.active.find(ally => ally && ally !== target && !ally.fainted);
-			if (targetAlly && targetAlly.innate) {
-				targetAlly.removeVolatile(targetAlly.innate);
-				delete targetAlly.innate;
+			if (targetAlly && targetAlly.m.innate) {
+				targetAlly.removeVolatile(targetAlly.m.innate);
+				delete targetAlly.m.innate;
 			}
 			if (targetAbility.id !== sourceAbility.id) {
 				source.ability = targetAbility.id;
@@ -31,13 +31,13 @@ exports.BattleMovedex = {
 				target.abilityData = {id: target.ability, target: target};
 			}
 			if (sourceAlly && sourceAlly.ability !== source.ability) {
-				let volatile = sourceAlly.innate = 'ability' + source.ability;
+				let volatile = sourceAlly.m.innate = 'ability' + source.ability;
 				sourceAlly.volatiles[volatile] = {id: volatile};
 				sourceAlly.volatiles[volatile].target = sourceAlly;
 				sourceAlly.volatiles[volatile].source = source;
 				sourceAlly.volatiles[volatile].sourcePosition = source.position;
-				if (!source.innate) {
-					volatile = source.innate = 'ability' + sourceAlly.ability;
+				if (!source.m.innate) {
+					volatile = source.m.innate = 'ability' + sourceAlly.ability;
 					source.volatiles[volatile] = {id: volatile};
 					source.volatiles[volatile].target = source;
 					source.volatiles[volatile].source = sourceAlly;
@@ -45,13 +45,13 @@ exports.BattleMovedex = {
 				}
 			}
 			if (targetAlly && targetAlly.ability !== target.ability) {
-				let volatile = targetAlly.innate = 'ability' + target.ability;
+				let volatile = targetAlly.m.innate = 'ability' + target.ability;
 				targetAlly.volatiles[volatile] = {id: volatile};
 				targetAlly.volatiles[volatile].target = targetAlly;
 				targetAlly.volatiles[volatile].source = target;
 				targetAlly.volatiles[volatile].sourcePosition = target.position;
-				if (!target.innate) {
-					volatile = target.innate = 'ability' + targetAlly.ability;
+				if (!target.m.innate) {
+					volatile = target.m.innate = 'ability' + targetAlly.ability;
 					target.volatiles[volatile] = {id: volatile};
 					target.volatiles[volatile].target = target;
 					target.volatiles[volatile].source = targetAlly;
@@ -59,9 +59,9 @@ exports.BattleMovedex = {
 				}
 			}
 			this.singleEvent('Start', targetAbility, source.abilityData, source);
-			if (sourceAlly && sourceAlly.innate) this.singleEvent('Start', targetAbility, sourceAlly.volatiles[sourceAlly.innate], sourceAlly);
+			if (sourceAlly && sourceAlly.m.innate) this.singleEvent('Start', targetAbility, sourceAlly.volatiles[sourceAlly.m.innate], sourceAlly);
 			this.singleEvent('Start', sourceAbility, target.abilityData, target);
-			if (targetAlly && targetAlly.innate) this.singleEvent('Start', sourceAbility, targetAlly.volatiles[targetAlly.innate], targetAlly);
+			if (targetAlly && targetAlly.m.innate) this.singleEvent('Start', sourceAbility, targetAlly.volatiles[targetAlly.m.innate], targetAlly);
 		},
 	},
 };

--- a/data/mods/pic/scripts.js
+++ b/data/mods/pic/scripts.js
@@ -21,17 +21,17 @@ exports.BattleScripts = {
 			}
 			this.battle.singleEvent('End', this.battle.getAbility(oldAbility), this.abilityData, this, source);
 			let ally = this.side.active.find(ally => ally && ally !== this && !ally.fainted);
-			if (ally && ally.innate) {
-				ally.removeVolatile(ally.innate);
-				delete ally.innate;
+			if (ally && ally.m.innate) {
+				ally.removeVolatile(ally.m.innate);
+				delete ally.m.innate;
 			}
 			this.ability = ability.id;
 			this.abilityData = {id: ability.id, target: this};
 			if (ability.id) {
 				this.battle.singleEvent('Start', ability, this.abilityData, this, source);
 				if (ally && ally.ability !== this.ability) {
-					ally.innate = 'ability' + ability.id;
-					ally.addVolatile(ally.innate);
+					ally.m.innate = 'ability' + ability.id;
+					ally.addVolatile(ally.m.innate);
 				}
 			}
 			this.abilityOrder = this.battle.abilityOrder++;

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -1388,8 +1388,8 @@ let BattleMovedex = {
 					pokemon.types = [type1, type2];
 					this.add('-start', pokemon, 'typechange', `${type1}/${type2}`);
 				}
-				// @ts-ignore track percentages to keep purple pills from resetting pp
-				pokemon.ppPercentages = pokemon.moveSlots.map(m =>
+				// track percentages to keep purple pills from resetting pp
+				pokemon.m.ppPercentages = pokemon.moveSlots.map(m =>
 					m.pp / m.maxpp
 				);
 				// Get all possible moves sorted for convience in coding
@@ -1431,8 +1431,8 @@ let BattleMovedex = {
 					pokemon.moveSlots.push({
 						move: move.name,
 						id: move.id,
-						// @ts-ignore hacky way to reduce purple pill's PP
-						pp: Math.floor(((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5) * (pokemon.ppPercentages ? pokemon.ppPercentages[i] : 1)),
+						// hacky way to reduce purple pill's PP
+						pp: Math.floor(((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5) * (pokemon.m.ppPercentages ? pokemon.m.ppPercentages[i] : 1)),
 						maxpp: ((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5),
 						target: move.target,
 						disabled: false,
@@ -1452,8 +1452,8 @@ let BattleMovedex = {
 				this.add('-end', pokemon, 'Purple Pills', '[silent]');
 				pokemon.types = ['Psychic'];
 				this.add('-start', pokemon, 'typechange', 'Psychic');
-				// @ts-ignore track percentages to keep purple pills from resetting pp
-				pokemon.ppPercentages = pokemon.moveSlots.slice().map(m => {
+				// track percentages to keep purple pills from resetting pp
+				pokemon.m.ppPercentages = pokemon.moveSlots.slice().map(m => {
 					return m.pp / m.maxpp;
 				});
 				// Update movepool
@@ -1465,8 +1465,8 @@ let BattleMovedex = {
 					pokemon.moveSlots.push({
 						move: move.name,
 						id: move.id,
-						// @ts-ignore hacky way to reduce purple pill's PP
-						pp: Math.floor(((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5) * (pokemon.ppPercentages ? pokemon.ppPercentages[i] : 1)),
+						// hacky way to reduce purple pill's PP
+						pp: Math.floor(((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5) * (pokemon.m.ppPercentages ? pokemon.m.ppPercentages[i] : 1)),
 						maxpp: ((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5),
 						target: move.target,
 						disabled: false,
@@ -2245,13 +2245,11 @@ let BattleMovedex = {
 		onHit(target, source, move) {
 			let napWeather = this.field.pseudoWeather['naptime'];
 			// Trigger sleep clause if not the original user
-			// @ts-ignore
 			if (!target.setStatus('slp', napWeather.source, move)) return false;
 			target.statusData.time = 2;
 			target.statusData.startTime = 2;
 			this.heal(target.maxhp / 2); // Aesthetic only as the healing happens after you fall asleep in-game
 			this.add('-status', target, 'slp', '[from] move: Rest');
-			// @ts-ignore
 			if (napWeather.source === target) {
 				for (const curMon of this.getAllActive()) {
 					if (curMon === source) continue;
@@ -3358,7 +3356,7 @@ let BattleMovedex = {
 			}
 			// Update HP
 			// @ts-ignore Hack for Snaquaza's Z Move
-			pokemon.claimHP = pokemon.hp;
+			pokemon.m.claimHP = pokemon.hp;
 			pokemon.heal(pokemon.maxhp - pokemon.hp, pokemon);
 			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 			this.add('message', `${pokemon.name} claims to be a ${set.species}!`);

--- a/data/mods/ssb/scripts.js
+++ b/data/mods/ssb/scripts.js
@@ -76,8 +76,7 @@ let BattleScripts = {
 				this.singleEvent('End', this.getAbility('Illusion'), pokemon.abilityData, pokemon);
 			}
 			this.add('-zpower', pokemon);
-			// @ts-ignore pokemon.zMoveUsed only exists in this mod
-			pokemon.zMoveUsed = true;
+			pokemon.m.zMoveUsed = true;
 		}
 		let moveDidSomething = this.useMove(baseMove, pokemon, target, sourceEffect, zMove);
 		if (this.activeMove) move = this.activeMove;
@@ -183,8 +182,7 @@ let BattleScripts = {
 	},
 	// Modded to allow each Pokemon on a team to use a Z move once per battle
 	canZMove(pokemon) {
-		// @ts-ignore pokemon.zMoveUsed only exists in this mod
-		if (pokemon.zMoveUsed || (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra"))) return;
+		if (pokemon.m.zMoveUsed || (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra"))) return;
 		let item = pokemon.getItem();
 		if (!item.zMove) return;
 		if (item.zMoveUser && !item.zMoveUser.includes(pokemon.template.species)) return;

--- a/data/mods/ssb/statuses.js
+++ b/data/mods/ssb/statuses.js
@@ -1133,8 +1133,7 @@ let BattleStatuses = {
 		},
 		onSwitchOut(pokemon) {
 			this.add(`c|%Snaquaza|Lynch Hoeen while I'm away...`);
-			// @ts-ignore Hack for Snaquaza's Z move
-			if (pokemon.claimHP) delete pokemon.claimHP;
+			if (pokemon.m.claimHP) pokemon.m.claimHP = null;
 		},
 		onFaint() {
 			this.add(`c|%Snaquaza|How did you know I was scum?`);
@@ -1153,7 +1152,7 @@ let BattleStatuses = {
 			pokemon.formeChange(pokemon.baseTemplate.id);
 			pokemon.moveSlots = pokemon.moveSlots.slice(0, 4);
 			this.add('message', `${pokemon.name}'s fake claim was uncovered!`);
-			delete pokemon.m.claimHP;
+			pokemon.m.claimHP = null;
 			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 		},
 	},

--- a/data/mods/ssb/statuses.js
+++ b/data/mods/ssb/statuses.js
@@ -454,8 +454,7 @@ let BattleStatuses = {
 				target.moveSlots.push({
 					move: move.name,
 					id: move.id,
-					// @ts-ignore hacky change for EV's set
-					pp: Math.floor(((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5) * (target.ppPercentages ? target.ppPercentages[i] : 1)),
+					pp: Math.floor(((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5) * (target.m.ppPercentages ? target.m.ppPercentages[i] : 1)),
 					maxpp: ((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5),
 					target: move.target,
 					disabled: false,
@@ -467,8 +466,7 @@ let BattleStatuses = {
 		},
 		onBeforeSwitchOut(pokemon) {
 			if (pokemon.illusion) return;
-			// @ts-ignore hacky change for EV's set
-			pokemon.ppPercentages = pokemon.moveSlots.slice().map(m => {
+			pokemon.m.ppPercentages = pokemon.moveSlots.slice().map(m => {
 				return m.pp / m.maxpp;
 			});
 		},
@@ -511,15 +509,14 @@ let BattleStatuses = {
 			let i = 0;
 			for (const moveSlot of pokemon.moveSlots) {
 				let move = this.getMove(moveSlot.id);
-				// @ts-ignore hacky way to reduce purple pill's PP
-				moveSlot.pp = Math.floor(((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5) * (pokemon.ppPercentages ? pokemon.ppPercentages[i] : 1));
+				moveSlot.pp = Math.floor(((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5) * (pokemon.m.ppPercentages ? pokemon.m.ppPercentages[i] : 1));
 				i++;
 			}
 		},
 		onBeforeSwitchOut(pokemon) {
 			if (pokemon.illusion) return;
-			// @ts-ignore track percentages to keep purple pills from resetting pp
-			pokemon.ppPercentages = pokemon.moveSlots.slice().map(m => {
+			// track percentages to keep purple pills from resetting pp
+			pokemon.m.ppPercentages = pokemon.moveSlots.slice().map(m => {
 				return m.pp / m.maxpp;
 			});
 		},
@@ -1143,22 +1140,20 @@ let BattleStatuses = {
 			this.add(`c|%Snaquaza|How did you know I was scum?`);
 		},
 		onDamage(damage, pokemon) {
-			// @ts-ignore Hack for Snaquaza's Z move
-			if (!pokemon.claimHP) return;
+			// Hack for Snaquaza's Z move
+			if (!pokemon.m.claimHP) return;
 			// Prevent Snaquaza from fainting while using a fake claim to prevent visual bug
 			if (pokemon.hp - damage <= 0) return (pokemon.hp - 1);
 		},
 		onAfterDamage(damage, pokemon) {
-			// @ts-ignore Hack for Snaquaza's Z move
-			if (!pokemon.claimHP || pokemon.hp > 1) return;
+			// Hack for Snaquaza's Z move
+			if (!pokemon.m.claimHP || pokemon.hp > 1) return;
 			// Now we handle the fake claim "fainting"
-			// @ts-ignore Hack for Snaquaza's Z move
-			pokemon.hp = pokemon.claimHP;
+			pokemon.hp = pokemon.m.claimHP;
 			pokemon.formeChange(pokemon.baseTemplate.id);
 			pokemon.moveSlots = pokemon.moveSlots.slice(0, 4);
 			this.add('message', `${pokemon.name}'s fake claim was uncovered!`);
-			// @ts-ignore Hack for Snaquaza's Z move
-			delete pokemon.claimHP;
+			delete pokemon.m.claimHP;
 			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 		},
 	},

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -1006,3 +1006,10 @@ interface RandomTeamsTypes {
 		fillerMoves4?: string[]
 	}
 }
+
+interface PokemonModData {
+	gluttonyFlag?: boolean; // Gen-NEXT
+	innate?: string; // Partners in Crime
+	originalSpecies?: string; // Mix and Mega
+	[key: string]: any;
+}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -207,7 +207,7 @@ export class Pokemon {
 	modifyStat?: (this: Pokemon, statName: StatNameExceptHP, modifier: number) => void;
 
 	// OMs
-	m: AnyObject;
+	m: PokemonModData;
 
 	constructor(set: string | AnyObject, side: Side) {
 		this.side = side;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -377,7 +377,7 @@ export class Pokemon {
 		this.staleWarned = false;
 
 		/**
-		 * An Object that can store miscelaneous data. Mostly for OMs.
+		 * An object for storing untyped data, for mods to use.
 		 */
 		this.m = {};
 	}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -207,10 +207,7 @@ export class Pokemon {
 	modifyStat?: (this: Pokemon, statName: StatNameExceptHP, modifier: number) => void;
 
 	// OMs
-	innate?: string;
-	innates?: string[];
-	originalSpecies?: string;
-	gluttonyFlag: boolean | null;
+	m: AnyObject;
 
 	constructor(set: string | AnyObject, side: Side) {
 		this.side = side;
@@ -379,10 +376,10 @@ export class Pokemon {
 		this.isStalePPTurns = 0;
 		this.staleWarned = false;
 
-		this.innate = undefined;
-		this.innates = undefined;
-		this.originalSpecies = undefined;
-		this.gluttonyFlag = null;
+		/**
+		 * An Object that can store miscelaneous data. Mostly for OMs.
+		 */
+		this.m = {};
 	}
 
 	get moves() {


### PR DESCRIPTION
Quite often temporary OMs wind up needing to store arbitrary properties to a Pokemon, which TypeScript won't allow. The solution, brought up on #4952 , was to give Pokemon a "data" property with type `AnyObject`. This reduces the need for ts-ignores and properties that were only defined to be used by one OM.

~~"data" is a working name; other possibilities include clearer names like "miscData" or "otherData", or single-letter names like "d"~~ The name "m" was decided