### PR TITLE
Use default config for tests

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -28,6 +28,7 @@ before('initialization', function () {
 	}
 	require('./../lib/process-manager').disabled = true;
 
+	config = Object.assign(config, require('../config/config-example'));
 	// Actually crash if we crash
 	config.crashguard = false;
 	// Don't allow config to be overridden while test is running

--- a/test/main.js
+++ b/test/main.js
@@ -28,7 +28,7 @@ before('initialization', function () {
 	}
 	require('./../lib/process-manager').disabled = true;
 
-	config = Object.assign(config, require('../config/config-example'));
+	Object.assign(config, require('../config/config-example'));
 	// Actually crash if we crash
 	config.crashguard = false;
 	// Don't allow config to be overridden while test is running


### PR DESCRIPTION
A few tests rely on hardcoded groups, which breaks the test if they're different.