### PR TITLE
Restore animation behaviour for Solar Beam in Sun

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -4260,8 +4260,6 @@ let BattleItems = {
 		onChargeMove: function (pokemon, target, move) {
 			if (pokemon.useItem()) {
 				this.debug('power herb - remove charge turn for ' + move.id);
-				this.attrLastMove('[still]');
-				this.add('-anim', pokemon, move.name, target);
 				return false; // skip charge turn
 			}
 		},

--- a/data/moves.js
+++ b/data/moves.js
@@ -1664,6 +1664,11 @@ let BattleMovedex = {
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
+		},
 		effect: {
 			duration: 2,
 			onTryImmunity: function (target, source, move) {
@@ -3415,6 +3420,11 @@ let BattleMovedex = {
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
+		},
 		effect: {
 			duration: 2,
 			onImmunity: function (type, pokemon) {
@@ -3578,6 +3588,11 @@ let BattleMovedex = {
 			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
+		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
 		},
 		effect: {
 			duration: 2,
@@ -5672,6 +5687,11 @@ let BattleMovedex = {
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
+		},
 		effect: {
 			duration: 2,
 			onTryImmunity: function (target, source, move) {
@@ -6002,6 +6022,11 @@ let BattleMovedex = {
 			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
+		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
 		},
 		secondary: {
 			chance: 30,
@@ -6411,6 +6436,11 @@ let BattleMovedex = {
 			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
+		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
 		},
 		boosts: {
 			spa: 2,
@@ -8430,6 +8460,11 @@ let BattleMovedex = {
 			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
+		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
 		},
 		secondary: {
 			chance: 30,
@@ -11825,6 +11860,11 @@ let BattleMovedex = {
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
+		},
 		effect: {
 			duration: 2,
 			onTryImmunity: function (target, source, move) {
@@ -13263,6 +13303,12 @@ let BattleMovedex = {
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+				delete move.onTry;
+			}
+		},
 		critRatio: 2,
 		secondary: null,
 		target: "allAdjacentFoes",
@@ -14594,6 +14640,11 @@ let BattleMovedex = {
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
+		onTry: function (attacker, defender, move) {
+			if (attacker.removeVolatile('twoturnmove')) {
+				this.add('-anim', attacker, move.name, defender);
+			}
+		},
 		effect: {
 			duration: 2,
 			onTryImmunity: function (target, source, move) {
@@ -15084,6 +15135,11 @@ let BattleMovedex = {
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
+		},
 		secondary: null,
 		target: "normal",
 		type: "Normal",
@@ -15113,6 +15169,11 @@ let BattleMovedex = {
 			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
+		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
 		},
 		secondary: {
 			chance: 30,
@@ -15851,6 +15912,11 @@ let BattleMovedex = {
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
+		},
 		onBasePowerPriority: 4,
 		onBasePower: function (basePower, pokemon, target) {
 			if (this.isWeather(['raindance', 'primordialsea', 'sandstorm', 'hail'])) {
@@ -15886,6 +15952,11 @@ let BattleMovedex = {
 			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
+		},
+		onTry: function (attacker, defender, move) {
+			if (!attacker.volatiles['twoturnmove']) {
+				this.add('-anim', attacker, move.name, defender);
+			}
 		},
 		onBasePowerPriority: 4,
 		onBasePower: function (basePower, pokemon, target) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -184,6 +184,10 @@ let BattleScripts = {
 
 		let attrs = '';
 
+		if (move.flags['charge'] && !pokemon.volatiles[move.id]) {
+			attrs = '|[still]'; // suppress the default move animation
+		}
+
 		let movename = move.name;
 		if (move.id === 'hiddenpower') movename = 'Hidden Power';
 		if (sourceEffect) attrs += '|[from]' + this.getEffect(sourceEffect);

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -298,7 +298,6 @@ let BattleStatuses = {
 		onStart: function (target, source, effect) {
 			this.effectData.move = effect.id;
 			target.addVolatile(effect.id, source);
-			this.attrLastMove('[still]');
 		},
 		onEnd: function (target) {
 			target.removeVolatile(this.effectData.move);


### PR DESCRIPTION
In #4974 I tried to fix Solar Beam in Sun but unfortunately I hadn't realised that this meant that the move animated before it got prepared. This reverts the changes dealing with animating fully charged two-turn moves including moving the animation back to the `onTry` handler, so it only happens if the fully charged move has a target. Razor Wind is a bit hacky though.