### PR TITLE
Fix charge moves in Gen 1 again

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -772,6 +772,7 @@ let BattleMovedex = {
 	rest: {
 		inherit: true,
 		desc: "The user falls asleep for the next two turns and restores all of its HP, curing itself of any major status condition in the process. This does not remove the user's stat penalty for burn or paralysis. Fails if the user has full HP.",
+		onTryMove: function () {},
 		onHit: function (target) {
 			// Fails if the difference between
 			// max HP and current HP is 0, 255, or 511

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -215,7 +215,8 @@ let BattleScripts = {
 		if (!this.singleEvent('Try', move, null, pokemon, target, move)) {
 			return true;
 		}
-		if (!this.runEvent('TryMove', pokemon, target, move)) {
+		if (!this.singleEvent('TryMove', move, null, pokemon, target, move) ||
+			!this.runEvent('TryMove', pokemon, target, move)) {
 			return true;
 		}
 


### PR DESCRIPTION
Gen 1's script didn't have the `singleEvent` for `TryMove`.

I also removed the inheritance for Rest's `TryMove`, because I'm not sure Gen 1 wants it.