### PR TITLE
Fix Skull Bash variants

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -828,14 +828,12 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "This attack charges on the first turn and executes on the second.",
 		shortDesc: "Charges turn 1. Hits turn 2.",
-		onTry: function (attacker, defender, move) {
+		onTryMove: function (attacker, defender, move) {
 			if (attacker.removeVolatile(move.id)) {
 				return;
 			}
 			this.add('-prepare', attacker, move.name, defender);
 			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				this.addMove('-anim', attacker, move.name, defender);
-				attacker.removeVolatile(move.id);
 				return;
 			}
 			attacker.addVolatile('twoturnmove', defender);

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -339,15 +339,13 @@ let BattleMovedex = {
 		onTryHit: function (target) {
 			target.removeVolatile('substitute');
 		},
-		onTry: function (attacker, defender, move) {
+		onTryMove: function (attacker, defender, move) {
 			if (attacker.removeVolatile(move.id)) {
 				return;
 			}
 			this.add('-prepare', attacker, move.name, defender);
 			this.boost({def: 1, spd: 1, accuracy: 1}, attacker, attacker, this.getMove('skullbash'));
 			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				this.addMove('-anim', attacker, move.name, defender);
-				attacker.removeVolatile(move.id);
 				return;
 			}
 			attacker.addVolatile('twoturnmove', defender);


### PR DESCRIPTION
Another follow up to PR #4974.

For Gen Next, the charged `-anim` will be inherited from PR #4978. (I don't think Skull Bash can be charged in Gen 1, can it?)