### PR TITLE
Implement correct 0 Happiness behaviour in Lets Go

### DIFF
--- a/mods/letsgo/scripts.js
+++ b/mods/letsgo/scripts.js
@@ -47,7 +47,8 @@ let BattleScripts = {
 		if (nature.plus) stats[nature.plus] = Math.floor(stats[nature.plus] * 1.1);
 		// @ts-ignore
 		if (nature.minus) stats[nature.minus] = Math.floor(stats[nature.minus] * 0.9);
-		let friendshipValue = Math.floor((set.happiness / 255 / 10 + 1) * 100);
+		let friendshipValue = 100;
+		if (set.happiness != 0) friendshipValue += Math.floor(((set.happiness || 255) / 255 / 10) * 100);
 		for (const stat in stats) {
 			if (stat !== 'hp') {
 				// @ts-ignore

--- a/mods/letsgo/scripts.js
+++ b/mods/letsgo/scripts.js
@@ -47,7 +47,7 @@ let BattleScripts = {
 		if (nature.plus) stats[nature.plus] = Math.floor(stats[nature.plus] * 1.1);
 		// @ts-ignore
 		if (nature.minus) stats[nature.minus] = Math.floor(stats[nature.minus] * 0.9);
-		let friendshipValue = Math.floor((this.clampIntRange(set.happiness || 255, 0, 255) / 255 / 10 + 1) * 100);
+		let friendshipValue = Math.floor((set.happiness / 255 / 10 + 1) * 100);
 		for (const stat in stats) {
 			if (stat !== 'hp') {
 				// @ts-ignore


### PR DESCRIPTION
Fixes an issue that causes 0 Happiness to act as 255 Happiness and therefore grant the maximum Happiness boost of 1.1x. (This will need to be replicated for client)