### PR TITLE
Help tickets: Correctly display hint in intro

### DIFF
--- a/chat-plugins/helptickets.js
+++ b/chat-plugins/helptickets.js
@@ -789,7 +789,8 @@ let commands = {
 				'Inappropriate Pokemon Nicknames': 'Please save a replay of the battle and put it in chat so global staff can check.',
 				'Timerstalling': 'Please place the link to the battle in chat so global staff can check.',
 			};
-			const introMessage = Chat.html`<h2 style="margin-top:0">Help Ticket - ${user.name}</h2><p><b>Issue</b>: ${ticket.type}<br />${upper ? `An Upper` : `A Global`} Staff member will be with you shortly.</p>${contexts[target] ? `<p style="text-decoration: underline">${contexts[target]}</p>` : ``}`;
+			const introMessage = Chat.html`<h2 style="margin-top:0">Help Ticket - ${user.name}</h2><p><b>Issue</b>: ${ticket.type}<br />${upper ? `An Upper` : `A Global`} Staff member will be with you shortly.</p>`;
+			const introHintMessage = contexts[target] ? Chat.html`<p style="text-decoration: underline">${contexts[target]}</p>` : ``;
 			const staffMessage = `${upper ? `<p><h3>Do not post sensitive information in this room.</h3>Drivers and moderators can access this room's logs via the log viewer; please PM the user instead.</p>` : ``}<p><button class="button" name="send" value="/helpticket close ${user.userid}">Close Ticket</button> <button class="button" name="send" value="/helpticket escalate ${user.userid}">Escalate</button> ${upper ? `` : `<button class="button" name="send" value="/helpticket escalate ${user.userid}, upperstaff">Escalate to Upper Staff</button>`} <button class="button" name="send" value="/helpticket ban ${user.userid}"><small>Ticketban</small></button></p>`;
 			let helpRoom = /** @type {ChatRoom?} */ (Rooms(`help-${user.userid}`));
 			if (!helpRoom) {
@@ -799,7 +800,7 @@ let commands = {
 					isPrivate: 'hidden',
 					modjoin: (upper ? '&' : '%'),
 					auth: {[user.userid]: '+'},
-					introMessage: introMessage,
+					introMessage: introMessage + introHintMessage,
 					staffMessage: staffMessage,
 				});
 				helpRoom.game = new HelpTicket(helpRoom, ticket);
@@ -816,7 +817,7 @@ let commands = {
 				} else if (!upper && helpRoom.modjoin === '&') {
 					helpRoom.modjoin = '%';
 				}
-				helpRoom.introMessage = introMessage;
+				helpRoom.introMessage = introMessage + introHintMessage;
 				helpRoom.staffMessage = staffMessage;
 				if (helpRoom.game) helpRoom.game.destroy();
 				helpRoom.game = new HelpTicket(helpRoom, ticket);


### PR DESCRIPTION
Chat.html escapes all HTML within interpolated values. This was unfortunate in this case, because it tried to interpolate actual HTML for the roomintro hint. I've split it off into a separate string..