### PR TITLE
Allow SSL options to point to symlinks

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -65,8 +65,8 @@ const fs = require('fs');
 exports.ssl = {
 	port: 443,
 	options: {
-		key: fs.readFileSync('./config/ssl/privkey.pem'),
-		cert: fs.readFileSync('./config/ssl/fullchain.pem'),
+		key: './config/ssl/privkey.pem',
+		cert: './config/ssl/fullchain.pem',
 	},
 };
 */

--- a/sockets.js
+++ b/sockets.js
@@ -290,7 +290,7 @@ if (cluster.isMaster) {
 		let key;
 		try {
 			key = require('path').resolve(__dirname, Config.ssl.options.key);
-			if (!fs.lstatSync(key).isFile()) throw new Error();
+			if (!fs.statSync(key).isFile()) throw new Error();
 			try {
 				key = fs.readFileSync(key);
 			} catch (e) {
@@ -304,7 +304,7 @@ if (cluster.isMaster) {
 		let cert;
 		try {
 			cert = require('path').resolve(__dirname, Config.ssl.options.cert);
-			if (!fs.lstatSync(cert).isFile()) throw new Error();
+			if (!fs.statSync(cert).isFile()) throw new Error();
 			try {
 				cert = fs.readFileSync(cert);
 			} catch (e) {


### PR DESCRIPTION
The sockets code does an `lstat` of the path to check that it's a file, but that fails for a symlink. I think it should do a `stat` of the path instead.

Additionally, your example config includes the reading of the certificate file, but the sockets code already does this (and in fact it warns if you don't pass the path).