### PR TITLE
Fix Defog move attribution

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -3259,7 +3259,7 @@ let BattleMovedex = {
 			for (const targetCondition of removeTarget) {
 				if (target.side.removeSideCondition(targetCondition)) {
 					if (!removeAll.includes(targetCondition)) continue;
-					this.add('-sideend', target.side, this.getEffect(targetCondition).name, '[from] move: Defog', '[of] ' + target);
+					this.add('-sideend', target.side, this.getEffect(targetCondition).name, '[from] move: Defog', '[of] ' + source);
 					success = true;
 				}
 			}


### PR DESCRIPTION
Not sure if this matters for anything, but since the [of] presumably describes who used the move in the [from], it should always be the source.