### PR TITLE
Fix Leppa Berry

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -2901,27 +2901,20 @@ let BattleItems = {
 		},
 		onUpdate: function (pokemon) {
 			if (!pokemon.hp) return;
-			let moveSlot = pokemon.lastMove && pokemon.getMoveData(pokemon.lastMove.id);
-			if (moveSlot && moveSlot.pp === 0) {
+			if (pokemon.moveSlots.some(move => move.pp === 0)) {
 				pokemon.addVolatile('leppaberry');
-				pokemon.volatiles['leppaberry'].moveSlot = moveSlot;
 				pokemon.eatItem();
 			}
 		},
 		onEat: function (pokemon) {
 			let moveSlot;
 			if (pokemon.volatiles['leppaberry']) {
-				moveSlot = pokemon.volatiles['leppaberry'].moveSlot;
+				moveSlot = pokemon.moveSlots.find(move => move.pp === 0);
 				pokemon.removeVolatile('leppaberry');
 			} else {
-				let pp = 99;
-				for (const possibleMoveSlot of pokemon.moveSlots) {
-					if (possibleMoveSlot.pp < pp) {
-						moveSlot = possibleMoveSlot;
-						pp = moveSlot.pp;
-					}
-				}
+				moveSlot = pokemon.moveSlots.find(move => move.pp < move.maxpp);
 			}
+			if (!moveSlot) return;
 			moveSlot.pp += 10;
 			if (moveSlot.pp > moveSlot.maxpp) moveSlot.pp = moveSlot.maxpp;
 			this.add('-activate', pokemon, 'item: Leppa Berry', moveSlot.move, '[consumed]');

--- a/data/items.js
+++ b/data/items.js
@@ -2902,18 +2902,12 @@ let BattleItems = {
 		onUpdate: function (pokemon) {
 			if (!pokemon.hp) return;
 			if (pokemon.moveSlots.some(move => move.pp === 0)) {
-				pokemon.addVolatile('leppaberry');
 				pokemon.eatItem();
 			}
 		},
 		onEat: function (pokemon) {
-			let moveSlot;
-			if (pokemon.volatiles['leppaberry']) {
-				moveSlot = pokemon.moveSlots.find(move => move.pp === 0);
-				pokemon.removeVolatile('leppaberry');
-			} else {
-				moveSlot = pokemon.moveSlots.find(move => move.pp < move.maxpp);
-			}
+			let moveSlot = pokemon.moveSlots.find(move => move.pp === 0) ||
+				pokemon.moveSlots.find(move => move.pp < move.maxpp);
 			if (!moveSlot) return;
 			moveSlot.pp += 10;
 			if (moveSlot.pp > moveSlot.maxpp) moveSlot.pp = moveSlot.maxpp;

--- a/test/simulator/items/leppaberry.js
+++ b/test/simulator/items/leppaberry.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Leppa Berry', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should restore PP to the first move with any PP missing when eaten forcibly', function () {
+		battle = common.createBattle([
+			[{species: 'Gyarados', ability: 'moxie', item: '', moves: ['sleeptalk', 'splash']}],
+			[{species: 'Geodude', ability: 'sturdy', item: 'leppaberry', moves: ['sleeptalk', 'fling']}],
+		]);
+
+		const pokemon = battle.p1.active[0];
+
+		battle.makeChoices('move sleeptalk', 'move sleeptalk');
+		battle.makeChoices('move splash', 'move fling');
+
+		assert.strictEqual(pokemon.getMoveData('sleeptalk').pp, 16);
+		assert.false.strictEqual(pokemon.getMoveData('splash').pp, 64);
+	});
+});


### PR DESCRIPTION
This fixes https://github.com/Zarel/Pokemon-Showdown/issues/2367#issuecomment-443505854

If I understand correctly, the Leppa Berry is normally eaten when any move is at 0 PP, and restores 10 PP to the first move with 0 PP. If the Leppa Berry is forcibly eaten through means such as Fling, it restores PP to the first move that has any PP missing. If all moves have full PP, nothing happens.

Thank @SadisticMystic for the research