### PR TITLE
dex: clarify unnerve's description

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -3829,6 +3829,7 @@ let BattleAbilities = {
 		num: 84,
 	},
 	"unnerve": {
+		desc: "While this Pokemon is active, it prevents opposing Pokemon from using their Berries. Activation message broadcasts before other Abilities regardless of the Pokemon's Speed tiers.",
 		shortDesc: "While this Pokemon is active, it prevents opposing Pokemon from using their Berries.",
 		onPreStart: function (pokemon) {
 			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);


### PR DESCRIPTION
needs to mention its activation message triggers before other abilities regardless of Speed tiers, unlike pressure / trace / whatever