### PR TITLE
Apply modifiers even when they are exactly x1

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -897,7 +897,7 @@ class Battle extends Dex.ModdedDex {
 		}
 
 		this.eventDepth--;
-		if (typeof relayVar === 'number' && relayVar === Math.floor(relayVar)) {
+		if (typeof relayVar === 'number' && relayVar === Math.abs(Math.floor(relayVar))) {
 			// this.debug(eventid + ' modifier: 0x' + ('0000' + (this.event.modifier * 4096).toString(16)).slice(-4).toUpperCase());
 			relayVar = this.modify(relayVar, this.event.modifier);
 		}

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -897,7 +897,7 @@ class Battle extends Dex.ModdedDex {
 		}
 
 		this.eventDepth--;
-		if (typeof relayVar === 'number') {
+		if (typeof relayVar === 'number' && relayVar === Math.floor(relayVar)) {
 			// this.debug(eventid + ' modifier: 0x' + ('0000' + (this.event.modifier * 4096).toString(16)).slice(-4).toUpperCase());
 			relayVar = this.modify(relayVar, this.event.modifier);
 		}

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -897,7 +897,7 @@ class Battle extends Dex.ModdedDex {
 		}
 
 		this.eventDepth--;
-		if (this.event.modifier !== 1 && typeof relayVar === 'number') {
+		if ( typeof relayVar === 'number') {
 			// this.debug(eventid + ' modifier: 0x' + ('0000' + (this.event.modifier * 4096).toString(16)).slice(-4).toUpperCase());
 			relayVar = this.modify(relayVar, this.event.modifier);
 		}

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -897,7 +897,7 @@ class Battle extends Dex.ModdedDex {
 		}
 
 		this.eventDepth--;
-		if ( typeof relayVar === 'number') {
+		if (typeof relayVar === 'number') {
 			// this.debug(eventid + ' modifier: 0x' + ('0000' + (this.event.modifier * 4096).toString(16)).slice(-4).toUpperCase());
 			relayVar = this.modify(relayVar, this.event.modifier);
 		}


### PR DESCRIPTION
It would make sense to short-circuit past a modifier step if it's just going to be *4096 and then /4096. But if you're going for accuracy, it makes a difference in the case where the preexisting value is an exact multiple of 1048576 (in which case it becomes 0), and I can prove that the actual game does apply these seemingly useless modifiers, so here we go.