### PR TITLE
Magic Guard should block crash damage

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -7975,7 +7975,7 @@ let BattleMovedex = {
 		flags: {contact: 1, protect: 1, mirror: 1, gravity: 1},
 		hasCustomRecoil: true,
 		onMoveFail: function (target, source, move) {
-			this.damage(source.maxhp / 2, source, source, move);
+			this.damage(source.maxhp / 2, source, source, 'crash');
 		},
 		secondary: null,
 		target: "normal",
@@ -8928,7 +8928,7 @@ let BattleMovedex = {
 		flags: {contact: 1, protect: 1, mirror: 1, gravity: 1},
 		hasCustomRecoil: true,
 		onMoveFail: function (target, source, move) {
-			this.damage(source.maxhp / 2, source, source, move);
+			this.damage(source.maxhp / 2, source, source, 'crash');
 		},
 		secondary: null,
 		target: "normal",

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1923,7 +1923,7 @@ class Battle extends Dex.ModdedDex {
 	 * @param {number} damage
 	 * @param {Pokemon?} [target]
 	 * @param {Pokemon?} [source]
-	 * @param {'drain' | 'recoil' | Effect?} [effect]
+	 * @param {'drain' | 'recoil' | 'crash' | Effect?} [effect]
 	 * @param {boolean} [instafaint]
 	 */
 	damage(damage, target = null, source = null, effect = null, instafaint = false) {

--- a/test/simulator/abilities/magicguard.js
+++ b/test/simulator/abilities/magicguard.js
@@ -14,15 +14,16 @@ describe('Magic Guard', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']},
-			{species: 'Clefable', ability: 'magicguard', item: 'lifeorb', moves: ['doubleedge', 'mindblown']},
+			{species: 'Clefable', ability: 'magicguard', item: 'lifeorb', moves: ['doubleedge', 'mindblown', 'highjumpkick']},
 		]);
-		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'roughskin', moves: ['spikes', 'toxic']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Crobat', ability: 'roughskin', moves: ['spikes', 'toxic', 'protect']}]);
 		battle.makeChoices('move splash', 'move spikes');
 		battle.makeChoices('switch 2', 'move toxic');
 		assert.strictEqual(battle.p1.active[0].status, 'tox');
 		assert.fullHP(battle.p1.active[0]);
 		battle.makeChoices('move mindblown', 'move toxic');
 		battle.makeChoices('move doubleedge', 'move spikes');
+		battle.makeChoices('move highjumpkick', 'move protect');
 		assert.fullHP(battle.p1.active[0]);
 	});
 


### PR DESCRIPTION
I wasn't really sure what a more appropriate way to do this would have been, since just using `recoil` would make Rock Head block the damage, I believe.