### PR TITLE
Random Battle: Give Ariados Stomping Tantrum

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -2036,7 +2036,7 @@ let BattleFormatsData = {
 		tier: "LC",
 	},
 	ariados: {
-		randomBattleMoves: ["megahorn", "toxicspikes", "poisonjab", "suckerpunch", "stickyweb"],
+		randomBattleMoves: ["megahorn", "toxicspikes", "poisonjab", "suckerpunch", "stickyweb", "stompingtantrum"],
 		randomDoubleBattleMoves: ["protect", "megahorn", "stringshot", "poisonjab", "stickyweb", "ragepowder"],
 		tier: "(PU)",
 		doublesTier: "DUU",


### PR DESCRIPTION
Ground coverage helps it deal with Poison and Steel Pokemon, which resist both of Ariados' STAB moves.