### PR TITLE
Disabling effects should disable every slot the move is in

### DIFF
--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -1172,7 +1172,6 @@ class Pokemon {
 			if (moveSlot.id === moveid && moveSlot.disabled !== true) {
 				moveSlot.disabled = (isHidden || true);
 				moveSlot.disabledSource = (sourceEffect ? sourceEffect.fullname : '');
-				break;
 			}
 		}
 	}


### PR DESCRIPTION
Slightly interesting anecdote: I first came across this bug when bruteforcing Metronome battles on TwitchPlaysPokemon.