### PR TITLE
Faint Pokemon after every residual

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -588,6 +588,8 @@ class Battle extends Dex.ModdedDex {
 				}
 			}
 			this.singleEvent(eventid, status, statusObj.statusData, statusObj.thing, relayVar);
+      this.faintMessages();
+      if (this.ended) return;
 		}
 	}
 

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -588,8 +588,8 @@ class Battle extends Dex.ModdedDex {
 				}
 			}
 			this.singleEvent(eventid, status, statusObj.statusData, statusObj.thing, relayVar);
-      this.faintMessages();
-      if (this.ended) return;
+			this.faintMessages();
+			if (this.ended) return;
 		}
 	}
 


### PR DESCRIPTION
It's a big pet peeve, but it did also cause information leaks, such as http://replay.pokemonshowdown.com/gen7vgc2019sunseries-832087568 where Jynx's speed was revealed via Perish when it should have already fainted.