### PR TITLE
Ensure spread moves log a valid target

### DIFF
--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -525,6 +525,9 @@ class Pokemon {
 					}
 				}
 			}
+			if (targets.length && !targets.includes(target)) {
+				this.battle.retargetLastMove(targets[targets.length - 1]);
+			}
 			break;
 		case 'allAdjacent':
 		case 'allAdjacentFoes':
@@ -539,6 +542,9 @@ class Pokemon {
 				if (this.battle.isAdjacent(this, foeActive)) {
 					targets.push(foeActive);
 				}
+			}
+			if (targets.length && !targets.includes(target)) {
+				this.battle.retargetLastMove(targets[targets.length - 1]);
 			}
 			break;
 		default:


### PR DESCRIPTION
When a move is used, a target is resolved, and then later an array of targets is determined.

In the case of a single-target move, the target is adjusted for validity when it is resolved, and then again in case of redirection, and the log is updated to show the actual target.

In the case of a spread move, a random target is initially chosen and logged, and this does not get updated. Fortunately if the move turns out to have multiple targets then these targets are logged and the move animates correctly. However if the move only turns out to have a single target then it animates to the random target and not the actual target.

This is usually only a problem in triples battles as the random target may not be a suitable target, but I think the problem might also surface in doubles if both foes faint and the move therefore should actually target the ally.

I'm not sure what the right fix is; a number of possibilities spring to mind:
- Just check for one target, because `[spread]` means that truly spread moves animate correctly anyway
- Always make sure that the logged target is one of the legitimate targets
- Change `resolveTarget` to prefer an adjacent foe in more cases