### PR TITLE
Fix Stomping Tantrum interaction with spread moves and Protect

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -1032,7 +1032,6 @@ let BattleMovedex = {
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');
-				source.moveThisTurnResult = true;
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -2915,7 +2914,6 @@ let BattleMovedex = {
 			onTryHit: function (target, source, move) {
 				if (move && (move.target === 'self' || move.category !== 'Status')) return;
 				this.add('-activate', target, 'move: Crafty Shield');
-				source.moveThisTurnResult = true;
 				return null;
 			},
 		},
@@ -9009,7 +9007,6 @@ let BattleMovedex = {
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');
-				source.moveThisTurnResult = true;
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -10065,7 +10062,6 @@ let BattleMovedex = {
 				}
 				if (move && (move.target === 'self' || move.category === 'Status')) return;
 				this.add('-activate', target, 'move: Mat Block', move.name);
-				source.moveThisTurnResult = true;
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -12515,7 +12511,6 @@ let BattleMovedex = {
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');
-				source.moveThisTurnResult = true;
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -13035,7 +13030,6 @@ let BattleMovedex = {
 					return;
 				}
 				this.add('-activate', target, 'move: Quick Guard');
-				source.moveThisTurnResult = true;
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -15741,7 +15735,6 @@ let BattleMovedex = {
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');
-				source.moveThisTurnResult = true;
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -19005,7 +18998,6 @@ let BattleMovedex = {
 					return;
 				}
 				this.add('-activate', target, 'move: Wide Guard');
-				source.moveThisTurnResult = true;
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset

--- a/test/simulator/moves/stompingtantrum.js
+++ b/test/simulator/moves/stompingtantrum.js
@@ -40,6 +40,25 @@ describe('Stomping Tantrum', function () {
 		battle.makeChoices('move stompingtantrum', 'move protect');
 	});
 
+	it('should double its Base Power if the last move used was a spread move that partially hit protect and otherwise failed', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Cresselia', ability: 'levitate', moves: ['sunnyday']},
+			{species: 'Groudon', ability: 'drought', moves: ['stompingtantrum', 'precipiceblades']},
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: 'Tapu lele', ability: 'psychicsurge', moves: ['protect', 'calmmind']},
+			{species: 'Ho-Oh', ability: 'pressure', moves: ['recover']},
+		]);
+
+		battle.onEvent('BasePower', battle.getFormat(), function (basePower) {
+			assert.strictEqual(basePower, 150);
+		});
+
+		battle.makeChoices('move sunnyday, move precipiceblades', 'move protect, move recover');
+		battle.makeChoices('move sunnyday, move stompingtantrum', 'move calmmind, move recover');
+	});
+
 	it('should not double its Base Power if the last move used on the previous turn was a successful Celebrate', function () {
 		battle = common.createBattle([
 			[{species: 'Snorlax', ability: 'thickfat', moves: ['celebrate', 'stompingtantrum']}],


### PR DESCRIPTION
https://github.com/Zarel/Pokemon-Showdown/issues/2367#issuecomment-435642464
When I implemented this originally, I'd seen someone say this worked the other way around, so to get it to match on sim I had to put in some hard-coded hacks. Fixing this was as simple as taking them out.