### PR TITLE
Fix up Forewarn powers

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1107,8 +1107,9 @@ let BattleAbilities = {
 				for (const moveSlot of target.moveSlots) {
 					let move = this.getMove(moveSlot.move);
 					let bp = move.basePower;
-					if (move.ohko) bp = 160;
+					if (move.ohko) bp = 150;
 					if (move.id === 'counter' || move.id === 'metalburst' || move.id === 'mirrorcoat') bp = 120;
+					if (bp === 1) bp = 80;
 					if (!bp && move.category !== 'Status') bp = 80;
 					if (bp > warnBp) {
 						warnMoves = [[move, target]];


### PR DESCRIPTION
In-game, I tested Forewarn against a moveset with both Horn Drill and Prismatic Laser; Prismatic Laser was the alerted move 20 consecutive times. Figuring that's a particularly unlikely cold streak, I then tested Horn Drill vs. Hyper Beam and both moves were able to get noticed, showing that it's really a tie at 150, and not a tie with 160.

The extra clause for CFZs isn't particularly relevant, but it's true so we might as well be complete there.