### PR TITLE
Let's Go: Add happiness to random battles, remove AVs

### DIFF
--- a/mods/letsgo/random-teams.js
+++ b/mods/letsgo/random-teams.js
@@ -207,12 +207,13 @@ class RandomLetsGoTeams extends RandomTeams {
 			name: template.baseSpecies,
 			species: species,
 			level: 100,
+			happiness: 70,
 			gender: template.gender,
 			shiny: this.randomChance(1, 1024),
 			item: (template.requiredItem || ''),
 			ability: 'No Ability',
 			moves: moves,
-			evs: {hp: 200, atk: 200, def: 200, spa: 200, spd: 200, spe: 200},
+			evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0},
 			ivs: ivs,
 		};
 	}


### PR DESCRIPTION
Removing AVs allows for level scaling to come in the near future, and the happiness being set to 70 makes the battles match in-game wifi mechanics. @TheImmortal 