### PR TITLE
Ban Type: Null from ZU

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -721,8 +721,8 @@ let Formats = [
 		mod: 'gen7',
 		ruleset: ['[Gen 7] PU'],
 		banlist: [
-			'PU', 'Carracosta', 'Crabominable', 'Exeggutor-Base', 'Gorebyss', 'Jynx', 'Musharna',
-			'Raticate-Alola', 'Raticate-Alola-Totem', 'Throh', 'Turtonator', 'Ursaring', 'Victreebel', 'Zangoose',
+			'PU', 'Carracosta', 'Crabominable', 'Exeggutor-Base', 'Gorebyss', 'Jynx', 'Musharna', 'Raticate-Alola',
+			'Raticate-Alola-Totem', 'Throh', 'Turtonator', 'Type: Null', 'Ursaring', 'Victreebel', 'Zangoose',
 		],
 	},
 	{


### PR DESCRIPTION
[10:00:13] Skull Knight (Kalalokki): Kris or anyone that does tiering pullreqs, Type:Null is supposed to be ZUBL but it's allowed in ZU still after the tier shifts