### PR TITLE
Fix bug in Skill Swap in Partners in Crime

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -765,7 +765,7 @@ let Formats = [
 		// searchShow: false,
 		ruleset: ['[Gen 7] Doubles OU', 'Sleep Clause Mod'],
 		banlist: [
-			'Kangaskhanite', 'Mawilite', 'Medichamite', 'Skill Swap',
+			'Kangaskhanite', 'Mawilite', 'Medichamite',
 			'Huge Power', 'Imposter', 'Normalize', 'Pure Power', 'Wonder Guard', 'Mimic', 'Sketch', 'Sweet Scent', 'Transform',
 		],
 		onSwitchInPriority: 2,

--- a/mods/pic/moves.js
+++ b/mods/pic/moves.js
@@ -58,9 +58,9 @@ exports.BattleMovedex = {
 				}
 			}
 			this.singleEvent('Start', targetAbility, source.abilityData, source);
-			if (sourceAlly) this.singleEvent('Start', sourceAlly.innate, sourceAlly.volatiles[sourceAlly.innate], sourceAlly);
+			if (sourceAlly && sourceAlly.innate) this.singleEvent('Start', targetAbility, sourceAlly.volatiles[sourceAlly.innate], sourceAlly);
 			this.singleEvent('Start', sourceAbility, target.abilityData, target);
-			if (targetAlly) this.singleEvent('Start', targetAlly.innate, targetAlly.volatiles[targetAlly.innate], targetAlly);
+			if (targetAlly && targetAlly.innate) this.singleEvent('Start', sourceAbility, targetAlly.volatiles[targetAlly.innate], targetAlly);
 		},
 	},
 };


### PR DESCRIPTION
This bug was reported on December 14th, at which time I wrote a fix for my side server and then promptly forgot about it:

> I also had a game where (under trick room) my gastro got skill swapped Download but it didn’t activate on my stakataka is this a bug or not?

Then on January 3rd that the same user tripped over a crash:

> https://www.smogon.com/forums/attachments/07f5997d-bf3b-4b38-9593-e943ef5fdfff-png.153898/

I asked them to try playing on my side server in case my bug fix also helps with the crash, which apparently it does.