### PR TITLE
Helptickets: Prevent superfluous messages when closing

### DIFF
--- a/chat-plugins/helptickets.js
+++ b/chat-plugins/helptickets.js
@@ -148,6 +148,7 @@ class HelpTicket extends Rooms.RoomGame {
 	forfeit(user) {
 		if (!(user.userid in this.players)) return;
 		this.removePlayer(user);
+		if (!this.ticket.open) return;
 		this.modnote(user, `${user.name} is no longer interested in this ticket.`);
 		if (this.playerCount - 1 > 0) return; // There are still users in the ticket room, dont close the ticket
 		this.close(user);


### PR DESCRIPTION
Currently, the "User is no longer interested in this ticket. User closed this ticket" will _always_ be shown, even if the ticket was closed already.