### PR TITLE
Random Battle: Lower Keen Eye rating

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1635,7 +1635,7 @@ let BattleAbilities = {
 		},
 		id: "keeneye",
 		name: "Keen Eye",
-		rating: 1,
+		rating: 0.5,
 		num: 51,
 	},
 	"klutz": {


### PR DESCRIPTION
Fixes Drapion, who has 3 different abilities with a rating of 1. Keen Eye is
less useful than Battle Armor or Sniper because of a lack of accuracy
reduction moves in random battle, so this ensures that it is not chosen.