### PR TITLE
Fix Fairy Lock

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4820,7 +4820,7 @@ let BattleMovedex = {
 		effect: {
 			duration: 2,
 			onStart: function (target) {
-				this.add('-activate', target, 'move: Fairy Lock');
+				this.add('-fieldactivate', 'move: Fairy Lock');
 			},
 			onTrapPokemon: function (pokemon) {
 				pokemon.tryTrap();


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/8010364), with [replay](https://replay.pokemonshowdown.com/gen7metronomebattle-847846848).

Fairy Lock is a field effect, so it shouldn't be using `-activate` or `-start`.

This depends on client PR 1212.

(Trying to use `-fieldstart` would be awkward, as that's designed for 5-turn effects.)