### PR TITLE
Trying another fix for Fake Out

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -8779,6 +8779,8 @@ let BattleMovedex = {
 			if (noInstruct.includes(lastMove.id) || lastMove.isZ || lastMove.flags['charge'] || lastMove.flags['recharge'] || target.volatiles['beakblast'] || target.volatiles['focuspunch'] || target.volatiles['shelltrap'] || (target.moveSlots[moveIndex] && target.moveSlots[moveIndex].pp <= 0)) {
 				return false;
 			}
+			// Instructed Fake Out etc. should fail
+			target.activeTurns++;
 			this.add('-singleturn', target, 'move: Instruct', '[of] ' + source);
 			this.runMove(target.lastMove.id, target, target.lastMoveTargetLoc);
 		},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -113,6 +113,8 @@ let BattleScripts = {
 				if (this.faintMessages()) break;
 				this.add('-activate', dancer, 'ability: Dancer');
 				this.runMove(move.id, dancer, 0, this.getAbility('dancer'), undefined, true);
+				// Using a Dancer move is enough to spoil Fake Out etc.
+				dancer.activeTurns++;
 			}
 		}
 		if (noLock && pokemon.volatiles.lockedmove) delete pokemon.volatiles.lockedmove;

--- a/test/simulator/moves/fakeout.js
+++ b/test/simulator/moves/fakeout.js
@@ -27,4 +27,30 @@ describe('Fake Out', function () {
 		battle.makeChoices('move fakeout', 'move swift');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
+
+	it('should flinch after switching out and back in to refresh the move', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Chansey', ability: 'naturalcure', moves: ['fakeout']},
+			{species: 'Blissey', ability: 'naturalcure', moves: ['fakeout']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['swift', 'sleeptalk']}]);
+		battle.makeChoices('move fakeout', 'move swift');
+		battle.makeChoices('switch 2', 'move sleeptalk');
+		battle.makeChoices('switch 1', 'move sleeptalk');
+		battle.makeChoices('move fakeout', 'move swift');
+		assert.StrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
+
+	it('should not flinch if the user has already used a Dancer move first', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [
+			{species: 'Chansey', ability: 'naturalcure', moves: ['fakeout']},
+			{species: 'Oricorio', ability: 'dancer', moves: ['fakeout']}
+		]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['swift', 'quiverdance']}]);
+		battle.makeChoices('switch 2', 'move quiverdance');
+		battle.makeChoices('move fakeout', 'move swift');
+		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	});
 });

--- a/test/simulator/moves/fakeout.js
+++ b/test/simulator/moves/fakeout.js
@@ -32,7 +32,7 @@ describe('Fake Out', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Chansey', ability: 'naturalcure', moves: ['fakeout']},
-			{species: 'Blissey', ability: 'naturalcure', moves: ['fakeout']}
+			{species: 'Blissey', ability: 'naturalcure', moves: ['fakeout']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['swift', 'sleeptalk']}]);
 		battle.makeChoices('move fakeout', 'move swift');
@@ -46,7 +46,7 @@ describe('Fake Out', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Chansey', ability: 'naturalcure', moves: ['fakeout']},
-			{species: 'Oricorio', ability: 'dancer', moves: ['fakeout']}
+			{species: 'Oricorio', ability: 'dancer', moves: ['fakeout']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['swift', 'quiverdance']}]);
 		battle.makeChoices('switch 2', 'move quiverdance');

--- a/test/simulator/moves/fakeout.js
+++ b/test/simulator/moves/fakeout.js
@@ -39,7 +39,7 @@ describe('Fake Out', function () {
 		battle.makeChoices('switch 2', 'move sleeptalk');
 		battle.makeChoices('switch 1', 'move sleeptalk');
 		battle.makeChoices('move fakeout', 'move swift');
-		assert.StrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should not flinch if the user has already used a Dancer move first', function () {

--- a/test/simulator/moves/fakeout.js
+++ b/test/simulator/moves/fakeout.js
@@ -37,7 +37,7 @@ describe('Fake Out', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['swift', 'sleeptalk']}]);
 		battle.makeChoices('move fakeout', 'move swift');
 		battle.makeChoices('switch 2', 'move sleeptalk');
-		battle.makeChoices('switch 1', 'move sleeptalk');
+		battle.makeChoices('switch 2', 'move sleeptalk');
 		battle.makeChoices('move fakeout', 'move swift');
 		assert.strictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});


### PR DESCRIPTION
The approach from #5090 doesn't work since lastMove is evidently set too early in the process, and the sim thought that the currently-executing move was an existing lastMove.

This approach doesn't allow for the distinct hint messages handling each case, but the cases where it matters (trying to Instruct Fake Out, or having a Pokemon with Fake Out switch in, acquire Dancer, and use a dance move all in the same turn) are presumably rare enough that the people who attempt such things will understand about the slightly inaccurate hint message.