### PR TITLE
Rename crash damage back to (High) Jump Kick

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -7973,7 +7973,7 @@ let BattleMovedex = {
 		flags: {contact: 1, protect: 1, mirror: 1, gravity: 1},
 		hasCustomRecoil: true,
 		onMoveFail: function (target, source, move) {
-			this.damage(source.maxhp / 2, source, source, 'crash');
+			this.damage(source.maxhp / 2, source, source, this.getEffect('High Jump Kick'));
 		},
 		secondary: null,
 		target: "normal",
@@ -8926,7 +8926,7 @@ let BattleMovedex = {
 		flags: {contact: 1, protect: 1, mirror: 1, gravity: 1},
 		hasCustomRecoil: true,
 		onMoveFail: function (target, source, move) {
-			this.damage(source.maxhp / 2, source, source, 'crash');
+			this.damage(source.maxhp / 2, source, source, this.getEffect('Jump Kick'));
 		},
 		secondary: null,
 		target: "normal",

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1925,7 +1925,7 @@ class Battle extends Dex.ModdedDex {
 	 * @param {number} damage
 	 * @param {Pokemon?} [target]
 	 * @param {Pokemon?} [source]
-	 * @param {'drain' | 'recoil' | 'crash' | Effect?} [effect]
+	 * @param {'drain' | 'recoil' | Effect?} [effect]
 	 * @param {boolean} [instafaint]
 	 */
 	damage(damage, target = null, source = null, effect = null, instafaint = false) {


### PR DESCRIPTION
As discussed in client PR 1210, and also alluded to in #5064 (comment regarding damage effects named after moves which should not be whitelisted).