### PR TITLE
Fix partial trapping moves in the statbar after having ended

### DIFF
--- a/data/statuses.js
+++ b/data/statuses.js
@@ -245,6 +245,7 @@ let BattleStatuses = {
 		onResidual: function (pokemon) {
 			if (this.effectData.source && (!this.effectData.source.isActive || this.effectData.source.hp <= 0 || !this.effectData.source.activeTurns)) {
 				delete pokemon.volatiles['partiallytrapped'];
+				this.add('-end', pokemon, this.effectData.sourceEffect, '[partiallytrapped]');
 				return;
 			}
 			if (this.effectData.source.hasItem('bindingband')) {


### PR DESCRIPTION
Send an `-end` if the source of the effect is no longer active. This is necessary for the client to remove the effect from the statbar. It also causes a message about the target being freed, is that the correct behavior?