### PR TITLE
Fix Crucibelle-Mega

### DIFF
--- a/sim/dex-data.js
+++ b/sim/dex-data.js
@@ -821,15 +821,15 @@ class Template extends BasicEffect {
 
 		/**
 		 * True if a pokemon is Mega
-		 * @type {boolean}
+		 * @type {boolean | undefined}
 		 */
-		this.isMega = !!(this.forme && ['Mega', 'Mega-X', 'Mega-Y'].includes(this.forme));
+		this.isMega = !!(this.forme && ['Mega', 'Mega-X', 'Mega-Y'].includes(this.forme)) || undefined;
 
 		/**
 		 * True if a pokemon is a forme that is only acessible in battle
-		 * @type {boolean}
+		 * @type {boolean | undefined}
 		 */
-		this.battleOnly = !!this.battleOnly || !!this.isMega;
+		this.battleOnly = !!this.battleOnly || !!this.isMega || undefined;
 
 		if (!this.gen && this.num >= 1) {
 			if (this.num >= 722 || this.forme.startsWith('Alola')) {

--- a/sim/dex-data.js
+++ b/sim/dex-data.js
@@ -819,18 +819,26 @@ class Template extends BasicEffect {
 		 */
 		this.eventPokemon = this.eventPokemon || undefined;
 
+		/**
+		 * True if a pokemon is Mega
+		 * @type {boolean}
+		 */
+		this.isMega = !!(this.forme && ['Mega', 'Mega-X', 'Mega-Y'].includes(this.forme));
+
+		/**
+		 * True if a pokemon is a forme that is only acessible in battle
+		 * @type {boolean}
+		 */
+		this.battleOnly = !!this.battleOnly || !!this.isMega;
+
 		if (!this.gen && this.num >= 1) {
 			if (this.num >= 722 || this.forme.startsWith('Alola')) {
 				this.gen = 7;
-			} else if (this.forme && ['Mega', 'Mega-X', 'Mega-Y'].includes(this.forme)) {
-				this.gen = 6;
-				this.isMega = true;
-				this.battleOnly = true;
 			} else if (this.forme === 'Primal') {
 				this.gen = 6;
 				this.isPrimal = true;
 				this.battleOnly = true;
-			} else if (this.num >= 650) {
+			} else if (this.num >= 650 || this.isMega) {
 				this.gen = 6;
 			} else if (this.num >= 494) {
 				this.gen = 5;

--- a/sim/dex-data.js
+++ b/sim/dex-data.js
@@ -820,13 +820,13 @@ class Template extends BasicEffect {
 		this.eventPokemon = this.eventPokemon || undefined;
 
 		/**
-		 * True if a pokemon is Mega
+		 * True if a pokemon is mega
 		 * @type {boolean | undefined}
 		 */
 		this.isMega = !!(this.forme && ['Mega', 'Mega-X', 'Mega-Y'].includes(this.forme)) || undefined;
 
 		/**
-		 * True if a pokemon is a forme that is only acessible in battle
+		 * True if a pokemon is a forme that is only accessible in battle
 		 * @type {boolean | undefined}
 		 */
 		this.battleOnly = !!this.battleOnly || !!this.isMega || undefined;


### PR DESCRIPTION
In https://github.com/Zarel/Pokemon-Showdown/commit/f65ad5ab81b80cb3be2b3110515c21a1ca2446eb, removing Crucibelle-Mega from being marked as Gen 6 also removed it from being marked as a Mega Evolution, so now you can't choose its forme in the teambuilder with a base forme's ability.