### PR TITLE
Random Battle: Reject Pursuit if 3 Dark moves

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -812,7 +812,7 @@ class RandomTeams extends Dex.ModdedDex {
 					if (hasMove['rest'] || hasMove['lightscreen'] && hasMove['reflect']) rejected = true;
 					break;
 				case 'pursuit':
-					if (counter.setupType || (hasMove['rest'] && hasMove['sleeptalk']) || (hasMove['knockoff'] && !hasType['Dark'])) rejected = true;
+					if (counter.setupType || (hasMove['rest'] && hasMove['sleeptalk']) || counter['Dark'] > 2 || (hasMove['knockoff'] && !hasType['Dark'])) rejected = true;
 					break;
 				case 'rapidspin':
 					if (counter.setupType || teamDetails.hazardClear) rejected = true;


### PR DESCRIPTION
Fixes Skuntank (Pursuit/Sucker Punch/Crunch) and Spiritomb (Pursuit/
Sucker Punch/Dark Pulse) among others. Compare Foul Play rejection check.