### PR TITLE
Permit multi-line modnotes

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2191,25 +2191,12 @@ const commands = {
 	modnote: function (target, room, user, connection) {
 		if (!target) return this.parse('/help modnote');
 		if (!this.canTalk()) return;
-
 		if (target.length > MAX_REASON_LENGTH) {
 			return this.errorReply(`The note is too long. It cannot exceed ${MAX_REASON_LENGTH} characters.`);
 		}
 		if (!this.can('receiveauthmessages', null, room)) return false;
-		if (target.startsWith('\n')) target = target.slice(1);
-		const separator = '\n';
-		if (target.includes(separator) || target.length > 150) {
-			const params = target.split(separator);
-			let output = [];
-			for (const param of params) {
-				output.push(Chat.escapeHTML(param));
-			}
-			let code = `${output.join('; ')}`;
-			this.modlog('NOTE', null, code);
-		} else {
-			this.modlog('NOTE', null, target);
-		}
-		if (room.id === 'staff' || room.id === 'upperstaff') this.globalModlog('NOTE', null, ` by ${user.userid}: ${target}`);
+		target = target.replace(/\n/g, "; ");
+		this.modlog('NOTE', null, target);
 		return this.privateModAction(`(${user.name} notes: ${target})`);
 	},
 	modnotehelp: [`/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ * # & ~`],

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -4218,7 +4218,7 @@ exports.commands = commands;
 process.nextTick(() => {
 	// We might want to migrate most of this to a JSON schema of command attributes.
 	Chat.multiLinePattern.register(
-		'>>>? ', '/(?:room|staff)intro ', '/(?:staff)?topic ', '/(?:add|widen)datacenters ', '/bash ', '!code ', '/code ', '/modnote ',
+		'>>>? ', '/(?:room|staff)intro ', '/(?:staff)?topic ', '/(?:add|widen)datacenters ', '/bash ', '!code ', '/code ', '/modnote ', '/mn ',
 		'/importinputlog '
 	);
 });

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2191,12 +2191,14 @@ const commands = {
 	modnote: function (target, room, user, connection) {
 		if (!target) return this.parse('/help modnote');
 		if (!this.canTalk()) return;
+
 		if (target.length > MAX_REASON_LENGTH) {
 			return this.errorReply(`The note is too long. It cannot exceed ${MAX_REASON_LENGTH} characters.`);
 		}
 		if (!this.can('receiveauthmessages', null, room)) return false;
 		target = target.replace(/\n/g, "; ");
 		this.modlog('NOTE', null, target);
+		if (room.id === 'staff' || room.id === 'upperstaff') this.globalModlog('NOTE', null, ` by ${user.userid}: ${target}`);
 		return this.privateModAction(`(${user.name} notes: ${target})`);
 	},
 	modnotehelp: [`/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ * # & ~`],

--- a/chat-commands.js
+++ b/chat-commands.js
@@ -2196,7 +2196,19 @@ const commands = {
 			return this.errorReply(`The note is too long. It cannot exceed ${MAX_REASON_LENGTH} characters.`);
 		}
 		if (!this.can('receiveauthmessages', null, room)) return false;
-		this.modlog('NOTE', null, target);
+		if (target.startsWith('\n')) target = target.slice(1);
+		const separator = '\n';
+		if (target.includes(separator) || target.length > 150) {
+			const params = target.split(separator);
+			let output = [];
+			for (const param of params) {
+				output.push(Chat.escapeHTML(param));
+			}
+			let code = `${output.join('; ')}`;
+			this.modlog('NOTE', null, code);
+		} else {
+			this.modlog('NOTE', null, target);
+		}
 		if (room.id === 'staff' || room.id === 'upperstaff') this.globalModlog('NOTE', null, ` by ${user.userid}: ${target}`);
 		return this.privateModAction(`(${user.name} notes: ${target})`);
 	},
@@ -4217,7 +4229,7 @@ exports.commands = commands;
 process.nextTick(() => {
 	// We might want to migrate most of this to a JSON schema of command attributes.
 	Chat.multiLinePattern.register(
-		'>>>? ', '/(?:room|staff)intro ', '/(?:staff)?topic ', '/(?:add|widen)datacenters ', '/bash ', '!code ', '/code ',
+		'>>>? ', '/(?:room|staff)intro ', '/(?:staff)?topic ', '/(?:add|widen)datacenters ', '/bash ', '!code ', '/code ', '/modnote ',
 		'/importinputlog '
 	);
 });


### PR DESCRIPTION
Allowing modnotes to use multiple lines (but still appearing in modnotes unified) would make it easier to copy/paste user messages as needed for room moderation in the modlog.