### PR TITLE
Update command documentation

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1952,6 +1952,8 @@ const commands = {
 		const broadcastRoom = Rooms('staff') || room;
 		broadcastRoom.addByUser(user, `${user.name} unlocked the ${range ? "IP range" : "IP"}: ${target}`);
 	},
+	unlockiphelp: [`/unlockip [ip] - Unlocks a punished ip while leaving the original punishment intact. Requires: @ * & ~`],
+	unlocknamehelp: [`/unlockname [username] - Unlocks a punished alt while leaving the original punishment intact. Requires: % @ * & ~`],
 	unlockhelp: [
 		`/unlock [username] - Unlocks the user. Requires: % @ * & ~`,
 		`/unlockname [username] - Unlocks a punished alt while leaving the original punishment intact. Requires: % @ * & ~`,
@@ -4154,13 +4156,15 @@ const commands = {
 		if (target === 'help' || target === 'h' || target === '?' || target === 'commands') {
 			this.sendReply("/help OR /h OR /? - Gives you help.");
 		} else if (!target) {
-			this.sendReply("COMMANDS: /msg, /reply, /logout, /challenge, /search, /rating, /whois");
-			this.sendReply("OPTION COMMANDS: /nick, /avatar, /ignore, /away, /back, /timestamps, /highlight");
-			this.sendReply("INFORMATIONAL COMMANDS: /data, /dexsearch, /movesearch, /itemsearch, /groups, /faq, /rules, /intro, /formatshelp, /othermetas, /learn, /analysis, /calc (replace / with ! to broadcast. Broadcasting requires: + % @ * # & ~)");
+			this.sendReply("COMMANDS: /msg, /reply, /logout, /challenge, /search, /rating, /whois, /user, /report, /join, /leave, /makegroupchat, /userauth, /roomauth");
+			this.sendReply("BATTLE ROOM COMMANDS: /savereplay, /hideroom, /inviteonly, /invite, /timer, /forfeit");
+			this.sendReply("OPTION COMMANDS: /nick, /avatar, /ignore, /away, /back, /timestamps, /highlight, /showjoins, /hidejoins, /blockchallenges, /blockpms");
+			this.sendReply("INFORMATIONAL/RESOURCE COMMANDS: /groups, /faq, /rules, /intro, /formatshelp, /othermetas, /analysis, /punishments, /calc, /git, /cap, /roomhelp, /roomfaq (replace / with ! to broadcast. Broadcasting requires: + % @ * # & ~)");
+			this.sendReply("DATA COMMANDS: /data, /dexsearch, /movesearch, /itemsearch, /learn, /statcalc, /effectiveness, /weakness, /coverage, /randommove, /randompokemon (replace / with ! to broadcast. Broadcasting requires: + % @ * # & ~)");
 			if (user.group !== Config.groupsranking[0]) {
-				this.sendReply("DRIVER COMMANDS: /warn, /mute, /hourmute, /unmute, /alts, /forcerename, /modlog, /modnote, /lock, /unlock, /battleban, /unbattleban, /announce, /redirect");
-				this.sendReply("MODERATOR COMMANDS: /ban, /unban, /ip, /modchat");
-				this.sendReply("LEADER COMMANDS: /declare, /forcetie, /forcewin, /promote, /demote, /banip, /host, /unbanall");
+				this.sendReply("DRIVER COMMANDS: /warn, /mute, /hourmute, /unmute, /alts, /forcerename, /modlog, /modnote, /lock, /weeklock, /unlock, /battleban, /unbattleban, /announce, /redirect");
+				this.sendReply("MODERATOR COMMANDS: /globalban, /unglobalban, /ip, /modchat, /markshared, /unlockip");
+				this.sendReply("LEADER COMMANDS: /declare, /forcetie, /forcewin, /promote, /demote, /banip, /host, /unbanall, /ipsearch");
 			}
 			this.sendReply("For an overview of room commands, use /roomhelp");
 			this.sendReply("For details of a specific command, use something like: /help data");

--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -304,7 +304,7 @@ exports.commands = {
 	inviteonlyhelp: [
 		`/inviteonly [on|off] - Sets modjoin +. Users can't join unless invited with /invite. Requires: # & ~`,
 		`/ioo - Shortcut for /inviteonly on`,
-		`/ionext OR /inviteonlynext - Sets your next battle to be invite-only.`,
+		`/inviteonlynext OR /ionext - Sets your next battle to be invite-only.`,
 		`/ionext off - Sets your next battle to be publicly visible.`,
 	],
 

--- a/chat-plugins/roomsettings.js
+++ b/chat-plugins/roomsettings.js
@@ -278,6 +278,7 @@ exports.commands = {
 		return this.parse('/modjoin +');
 	},
 	'!ionext': true,
+	inviteonlynext: 'ionext',
 	ionext: function (target, room, user) {
 		if (this.meansNo(target)) {
 			user.inviteOnlyNextBattle = false;
@@ -303,6 +304,8 @@ exports.commands = {
 	inviteonlyhelp: [
 		`/inviteonly [on|off] - Sets modjoin +. Users can't join unless invited with /invite. Requires: # & ~`,
 		`/ioo - Shortcut for /inviteonly on`,
+		`/ionext OR /inviteonlynext - Sets your next battle to be invite-only.`,
+		`/ionext off - Sets your next battle to be publicly visible.`,
 	],
 
 	modjoin: function (target, room, user) {


### PR DESCRIPTION
`/help` is rather incomplete for how often it gets recommended in the Help room, so I added a lot of useful commands to it that people should know about.
I'm not entirely sure about these command categories, but I figured I should split off commands that just return some text or links or information about PS/smogon vs those that give information about dex data, because otherwise that's a long list, and their use cases differ.
I made another section for battle room stuff because players should know about it but they're not that well documented if you don't already know they exist.

I added the help text for unlockname/ip because `/help unlockname` does not return the "unlock" help entry because the commands are not aliases, so it just says "help not found", which has happened to me like three times by now.