### PR TITLE
Notify after, not before, deleting a help ticket

### DIFF
--- a/chat-plugins/helptickets.js
+++ b/chat-plugins/helptickets.js
@@ -209,9 +209,9 @@ class HelpTicket extends Rooms.RoomGame {
 	deleteTicket(staff) {
 		this.close(staff);
 		this.modnote(staff, `${staff.name} deleted this ticket.`);
-		notifyStaff(this.ticket.escalated);
 		delete tickets[this.ticket.userid];
 		writeTickets();
+		notifyStaff(this.ticket.escalated);
 		this.room.destroy();
 	}
 }
@@ -1061,9 +1061,9 @@ let commands = {
 				// @ts-ignore
 				targetRoom.game.deleteTicket(user);
 			} else {
-				notifyStaff(ticket.escalated);
 				delete tickets[ticket.userid];
 				writeTickets();
+				notifyStaff(ticket.escalated);
 			}
 			this.sendReply(`You deleted ${target}'s ticket.`);
 		},


### PR DESCRIPTION
I had to delete a few help tickets on my side server and noticed that the display still showed the ticket I'd just deleted until after I'd deleted the next ticket (which itself didn't go away until I deleted a third ticket.)