### PR TITLE
Random Battle: Enforce coverage for dual-Normal Pokemon

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1154,6 +1154,7 @@ class RandomTeams extends Dex.ModdedDex {
 					(hasType['Ghost'] && !hasType['Dark'] && !counter['Ghost'] && !hasAbility['Steelworker']) ||
 					(hasType['Ground'] && !counter['Ground'] && !hasMove['rest'] && !hasMove['sleeptalk']) ||
 					(hasType['Ice'] && !counter['Ice'] && !hasAbility['Refrigerate']) ||
+					(hasType['Normal'] && template.types.length > 1 && !hasType['Fighting'] && !hasAbility['Scrappy'] && counter['Normal'] + counter['Fighting'] >= counter.damagingMoves.length) ||
 					(hasType['Psychic'] && !!counter['Psychic'] && !hasType['Flying'] && !hasAbility['Pixilate'] && template.types.length > 1 && counter.stab < 2) ||
 					(((hasType['Steel'] && hasAbility['Technician']) || hasAbility['Steelworker']) && !counter['Steel']) ||
 					(hasType['Water'] && (!counter['Water'] || !counter.stab) && !hasAbility['Protean']) ||


### PR DESCRIPTION
Prevents issues with the Pokemon being walled by Ghost Pokemon.