### PR TITLE
Suppress LGTM's URL sanitization warning

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -2723,7 +2723,8 @@ const commands = {
 		if (!reason) {
 			return this.errorReply(`Battle bans require a reason.`);
 		}
-		if (!room.battle && (!reason.includes('.pokemonshowdown.com/') && cmd !== 'forcebattleban')) {
+		const includesUrl = reason.includes('.pokemonshowdown.com/'); // lgtm [js/incomplete-url-substring-sanitization]
+		if (!room.battle && !includesUrl && cmd !== 'forcebattleban') {
 			 return this.errorReply(`Battle bans require a battle replay if used outside of a battle; if the battle has expired, use /forcebattleban.`);
 		}
 		if (!this.can('rangeban', targetUser)) {


### PR DESCRIPTION
This warning is strictly speaking correct, the URL isn't verified properly. However, in this case, this isn't a practical issue, as it's possible to use /forcebattleban command anyways.