### PR TITLE
Help Tickets: Require users to explain their issue before getting help

### DIFF
--- a/server/chat.js
+++ b/server/chat.js
@@ -351,6 +351,10 @@ class CommandContext {
 			}
 		}
 
+		if (this.room && this.room.game && this.room.game.onLogMessage) {
+			this.room.game.onLogMessage(message, this.user);
+		}
+
 		this.update();
 
 		return message;

--- a/server/room-game.js
+++ b/server/room-game.js
@@ -251,6 +251,15 @@ class RoomGame {
 	onChatMessage(message, user) {
 		return false;
 	}
+
+	/**
+	 * Called for every message a user sends while this game is active.
+	 * Unlike onChatMessage, this function runs after the message has been added to the room's log.
+	 * Do not try to use this to block messages, use onChatMessage for that.
+	 * @param {string} message
+	 * @param {User} user
+	 */
+	onLogMessage(message, user) {}
 }
 
 // these exports are traditionally attached to rooms.js


### PR DESCRIPTION
1. `~Staff` will prompt users to explain their issue when they open a ticket.
2. Tickets will not trigger highlights or be visible in the staff rooms until the user speaks in the ticket room.
3. Hovering over the view/claim buttons will now show a preview of the last two chat lines.
4. IP-Appeal and ISP-Appeal are exceptions to points 1 and 2, since the user doesn't need to provide any information.
5. Removed "Battle Ban Appeal" (depreciated punishment) and "Inappropriate Content" (misused 99% of the time) tickets.