### PR TITLE
Prevent using Leppa Berry from
triggering Endless Battle

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -2910,17 +2910,9 @@ let BattleItems = {
 			if (moveSlot.pp > moveSlot.maxpp) moveSlot.pp = moveSlot.maxpp;
 			this.add('-activate', pokemon, 'item: Leppa Berry', moveSlot.move, '[consumed]');
 			if (pokemon.item !== 'leppaberry') {
-				let foeIsStale = false;
-				for (const foeActive of pokemon.side.foe.active) {
-					if (foeActive.hp && foeActive.isStale >= 2) {
-						foeIsStale = true;
-						break;
-					}
-				}
-				if (!foeIsStale) return;
+				pokemon.isStale = 2;
+				pokemon.isStaleSource = 'useleppa';
 			}
-			pokemon.isStale = 2;
-			pokemon.isStaleSource = 'useleppa';
 		},
 		num: 154,
 		gen: 3,
@@ -6338,18 +6330,9 @@ let BattleItems = {
 			if (moveSlot.pp > moveSlot.maxpp) moveSlot.pp = moveSlot.maxpp;
 			this.add('-activate', pokemon, 'item: Mystery Berry', moveSlot.move);
 			if (pokemon.item !== 'leppaberry') {
-				let foeActive = pokemon.side.foe.active;
-				let foeIsStale = false;
-				for (let i = 0; i < foeActive.length; i++) {
-					if (foeActive[i].isStale >= 2) {
-						foeIsStale = true;
-						break;
-					}
-				}
-				if (!foeIsStale) return;
+				pokemon.isStale = 2;
+				pokemon.isStaleSource = 'useleppa';
 			}
-			pokemon.isStale = 2;
-			pokemon.isStaleSource = 'useleppa';
 		},
 		num: 154,
 		gen: 2,

--- a/test/common.js
+++ b/test/common.js
@@ -12,6 +12,7 @@ const RULE_FLAGS = {
 	preview: 4,
 	sleepClause: 8,
 	cancel: 16,
+	endlessBattleClause: 32,
 };
 
 function capitalize(word) {
@@ -84,6 +85,7 @@ class TestTools {
 		if (options.preview) format.ruleset.push('Team Preview');
 		if (options.sleepClause) format.ruleset.push('Sleep Clause Mod');
 		if (options.cancel) format.ruleset.push('Cancel Mod');
+		if (options.endlessBattleClause) format.ruleset.push('Endless Battle Clause');
 
 		this.dex.installFormat(formatId, format);
 		return format;

--- a/test/simulator/misc/endlessbattleclause.js
+++ b/test/simulator/misc/endlessbattleclause.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Endless Battle Clause', () => {
+	afterEach(() => battle.destroy());
+
+	it('should trigger on an infinite loop', () => {
+		battle = common.createBattle({endlessBattleClause: true});
+		const p1 = battle.join('p1', 'Guest 1', 1, [{species: "Caterpie", moves: ['tackle']}]);
+		const p2 = battle.join('p2', 'Guest 2', 1, [{species: "Slowbro", item: 'leppaberry', moves: ['slackoff', 'healpulse', 'recycle']}]);
+		for (let i = 0; i < 100; i++) {
+			if (battle.ended) return;
+			let move;
+			if (p1.active[0].hp < 150) {
+				move = 'healpulse';
+			} else if (p2.active[0].item === '') {
+				move = 'recycle';
+			} else {
+				move = 'slackoff';
+			}
+			battle.makeChoices('move tackle', `move ${move}`);
+		}
+		assert.fail("The battle did not end despite Endless Battle Clause");
+	});
+
+	it('should prevent forced switch loops', () => {
+		battle = common.gen(5).createBattle({endlessBattleClause: true});
+		battle.join('p1', 'Guest 1', 1, [
+			{species: "Riolu", ability: 'harvest', item: 'leppaberry', moves: ['assist']},
+			{species: 'Skarmory', moves: ['whirlwind']},
+		]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Caterpie", moves: ['tackle']},
+			{species: "Weedle", moves: ['tackle']},
+		]);
+		for (let i = 0; i < 41; i++) {
+			if (battle.ended) return;
+			battle.makeChoices('move assist', 'move tackle');
+		}
+		assert.fail("The battle did not end despite Endless Battle Clause");
+	});
+
+	it('should prevent picking up Leppa Berry with Pickup', () => {
+		battle = common.createBattle({endlessBattleClause: true});
+		battle.join('p1', 'Guest 1', 1, [{species: 'Meloetta', ability: 'pickup', item: 'leppaberry', moves: ['entrainment', 'synthesis', 'softboiled']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Sunkern', ability: 'chlorophyll', moves: ['softboiled']}]);
+		battle.makeChoices('move entrainment', 'move softboiled');
+		for (let i = 0; i < 8; i++) {
+			battle.makeChoices('move synthesis', 'move softboiled');
+		}
+		for (let i = 0; i < 20; i++) {
+			if (battle.ended) return;
+			battle.makeChoices('move softboiled', 'move softboiled');
+		}
+		assert.fail("The battle did not end despite Endless Battle Clause");
+	});
+
+	it('should prevent Ghost vs Ghost endless battles in Gen1', () => {
+		battle = common.gen(1).createBattle({endlessBattleClause: true});
+		battle.join('p1', 'Guest 1', 1, [{species: 'Gastly', moves: ['megakick']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Gastly', moves: ['megakick']}]);
+		for (let i = 0; i < 15; i++) {
+			if (battle.ended) return;
+			battle.makeChoices('move megakick', 'move megakick');
+		}
+		assert.fail("The battle did not end despite Endless Battle Clause");
+	});
+
+	it('should not trigger by both Pokemon eating a Leppa Berry they started with', () => {
+		battle = common.createBattle({endlessBattleClause: true});
+		battle.join('p1', 'Guest 1', 1, [{species: "Sunkern", item: 'leppaberry', moves: ['synthesis']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Sunkern", item: 'leppaberry', moves: ['synthesis']}]);
+		for (let i = 0; i < 10; i++) {
+			battle.makeChoices('move synthesis', 'move synthesis');
+		}
+		assert.false(battle.ended);
+	});
+
+	it('should prevent Recycle-only battles', () => {
+		battle = common.createBattle({endlessBattleClause: true});
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", item: 'leppaberry', moves: ['recycle']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Smeargle", item: 'leppaberry', moves: ['recycle']}]);
+		for (let i = 0; i < 20; i++) {
+			if (battle.ended) return;
+			battle.makeChoices('move recycle', 'recycle');
+		}
+		assert.fail("The battle did not end despite Endless Battle Clause");
+	});
+
+	it('should consider Leppa Berry Fling to be instant staleness', () => {
+		battle = common.createBattle({endlessBattleClause: true});
+		battle.join('p1', 'Guest 1', 1, [{species: "Riolu", item: 'leppaberry', moves: ['entrainment', 'fling']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: "Magikarp", moves: ['splash']}]);
+		battle.makeChoices('move fling', 'move splash');
+		assert(battle.log.some(line => line.includes("Magikarp is in an endless loop: it used a Leppa Berry it didn't start with.")));
+	});
+});


### PR DESCRIPTION
Frankly, I don't understand this code, so it's possible I did something wrong. It seems currently to always consider using held Leppa Berry to cause staleness, even when the loop reason for "useleppa" says "it used a Leppa Berry it didn't start with".

Previously, using Leppa Berry by itself caused Endless Battle Clause to consider Pokemon to be stale. However, it is reasonable to use Leppa Berry without an intent to cause an endless battle - for instance to increase the PP of a move with a low PP.