### PR TITLE
Random Battle: Update Probopass

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -3033,7 +3033,7 @@ let BattleFormatsData = {
 		tier: "LC",
 	},
 	probopass: {
-		randomBattleMoves: ["stealthrock", "thunderwave", "toxic", "flashcannon", "powergem", "voltswitch", "painsplit"],
+		randomBattleMoves: ["stealthrock", "thunderwave", "toxic", "flashcannon", "voltswitch", "earthpower"],
 		randomDoubleBattleMoves: ["stealthrock", "thunderwave", "helpinghand", "earthpower", "powergem", "wideguard", "protect", "flashcannon"],
 		tier: "(PU)",
 		doublesTier: "Untiered",

--- a/data/mods/gen6/formats-data.js
+++ b/data/mods/gen6/formats-data.js
@@ -2095,7 +2095,7 @@ let BattleFormatsData = {
 		tier: "LC",
 	},
 	probopass: {
-		randomBattleMoves: ["stealthrock", "thunderwave", "toxic", "flashcannon", "powergem", "voltswitch", "painsplit"],
+		randomBattleMoves: ["stealthrock", "thunderwave", "toxic", "flashcannon", "earthpower", "voltswitch"],
 		randomDoubleBattleMoves: ["stealthrock", "thunderwave", "helpinghand", "earthpower", "powergem", "wideguard", "protect", "voltswitch"],
 		tier: "PU",
 		doublesTier: "Untiered",


### PR DESCRIPTION
Earth Power is one of its most used moves because of Steel trapping with
Magnet Pull, while Pain Split is almost unheard of in standard tiers,
and isn't very useful on it unless it has Sturdy (but Magnet Pull is the
better move and is rated higher)