### PR TITLE
Random Battle: Update Rhyperior

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1294,7 +1294,7 @@ let BattleFormatsData = {
 		doublesTier: "NFE",
 	},
 	rhyperior: {
-		randomBattleMoves: ["stoneedge", "earthquake", "icepunch", "megahorn", "stealthrock", "rockpolish", "dragontail"],
+		randomBattleMoves: ["stoneedge", "earthquake", "icepunch", "megahorn", "stealthrock", "rockblast", "rockpolish", "dragontail"],
 		randomDoubleBattleMoves: ["stoneedge", "earthquake", "hammerarm", "megahorn", "stealthrock", "rockslide", "icepunch", "protect"],
 		tier: "RU",
 		doublesTier: "Untiered",

--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1294,8 +1294,8 @@ let BattleFormatsData = {
 		doublesTier: "NFE",
 	},
 	rhyperior: {
-		randomBattleMoves: ["stoneedge", "earthquake", "aquatail", "megahorn", "stealthrock", "rockblast", "rockpolish", "dragontail"],
-		randomDoubleBattleMoves: ["stoneedge", "earthquake", "hammerarm", "megahorn", "stealthrock", "rockslide", "aquatail", "protect"],
+		randomBattleMoves: ["stoneedge", "earthquake", "icepunch", "megahorn", "stealthrock", "rockpolish", "dragontail"],
+		randomDoubleBattleMoves: ["stoneedge", "earthquake", "hammerarm", "megahorn", "stealthrock", "rockslide", "icepunch", "protect"],
 		tier: "RU",
 		doublesTier: "Untiered",
 	},

--- a/data/mods/gen6/formats-data.js
+++ b/data/mods/gen6/formats-data.js
@@ -843,7 +843,7 @@ let BattleFormatsData = {
 		doublesTier: "NFE",
 	},
 	rhyperior: {
-		randomBattleMoves: ["stoneedge", "earthquake", "icepunch", "megahorn", "stealthrock", "rockpolish", "dragontail"],
+		randomBattleMoves: ["stoneedge", "earthquake", "icepunch", "megahorn", "stealthrock", "rockblast", "rockpolish", "dragontail"],
 		randomDoubleBattleMoves: ["stoneedge", "earthquake", "hammerarm", "megahorn", "stealthrock", "rockslide", "protect"],
 		tier: "RU",
 		doublesTier: "DUU",

--- a/data/mods/gen6/formats-data.js
+++ b/data/mods/gen6/formats-data.js
@@ -843,7 +843,7 @@ let BattleFormatsData = {
 		doublesTier: "NFE",
 	},
 	rhyperior: {
-		randomBattleMoves: ["stoneedge", "earthquake", "aquatail", "megahorn", "stealthrock", "rockblast", "rockpolish", "dragontail"],
+		randomBattleMoves: ["stoneedge", "earthquake", "icepunch", "megahorn", "stealthrock", "rockpolish", "dragontail"],
 		randomDoubleBattleMoves: ["stoneedge", "earthquake", "hammerarm", "megahorn", "stealthrock", "rockslide", "protect"],
 		tier: "RU",
 		doublesTier: "DUU",


### PR DESCRIPTION
Aqua Tail gives very minimal meaningful coverage since it mostly is
super effective on Pokemon already weak to Ground. Instead, give it Ice
Punch since it's much more common on it.