### PR TITLE
Fix terrain seed activation timing

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -1504,8 +1504,13 @@ let BattleItems = {
 		fling: {
 			basePower: 10,
 		},
-		onUpdate(pokemon) {
-			if (this.isTerrain('electricterrain') && pokemon.useItem()) {
+		onStart(pokemon) {
+			if (!pokemon.ignoringItem() && this.isTerrain('electricterrain') && pokemon.useItem()) {
+				this.boost({def: 1});
+			}
+		},
+		onAnyTerrainStart() {
+			if (this.isTerrain('electricterrain') && this.effectData.target.useItem()) {
 				this.boost({def: 1});
 			}
 		},
@@ -2165,8 +2170,13 @@ let BattleItems = {
 		fling: {
 			basePower: 10,
 		},
-		onUpdate(pokemon) {
-			if (this.isTerrain('grassyterrain') && pokemon.useItem()) {
+		onStart(pokemon) {
+			if (!pokemon.ignoringItem() && this.isTerrain('grassyterrain') && pokemon.useItem()) {
+				this.boost({def: 1});
+			}
+		},
+		onAnyTerrainStart() {
+			if (this.isTerrain('grassyterrain') && this.effectData.target.useItem()) {
 				this.boost({def: 1});
 			}
 		},
@@ -3617,8 +3627,13 @@ let BattleItems = {
 		fling: {
 			basePower: 10,
 		},
-		onUpdate(pokemon) {
-			if (this.isTerrain('mistyterrain') && pokemon.useItem()) {
+		onStart(pokemon) {
+			if (!pokemon.ignoringItem() && this.isTerrain('mistyterrain') && pokemon.useItem()) {
+				this.boost({spd: 1});
+			}
+		},
+		onAnyTerrainStart() {
+			if (this.isTerrain('mistyterrain') && this.effectData.target.useItem()) {
 				this.boost({spd: 1});
 			}
 		},
@@ -4419,8 +4434,13 @@ let BattleItems = {
 		fling: {
 			basePower: 10,
 		},
-		onUpdate(pokemon) {
-			if (this.isTerrain('psychicterrain') && pokemon.useItem()) {
+		onStart(pokemon) {
+			if (!pokemon.ignoringItem() && this.isTerrain('psychicterrain') && pokemon.useItem()) {
+				this.boost({spd: 1});
+			}
+		},
+		onAnyTerrainStart() {
+			if (this.isTerrain('psychicterrain') && this.effectData.target.useItem()) {
 				this.boost({spd: 1});
 			}
 		},

--- a/data/mods/ssb/scripts.js
+++ b/data/mods/ssb/scripts.js
@@ -287,6 +287,7 @@ let BattleScripts = {
 		}
 		// Always run a terrain end event to prevent a visual glitch with custom terrains
 		if (prevTerrain) this.singleEvent('End', this.getEffect(prevTerrain), prevTerrainData, this);
+		this.runEvent('TerrainStart', source, source, status);
 		return true;
 	},
 	pokemon: {

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -185,6 +185,7 @@ interface EventMethods {
 	onAnyDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: Effect) => void
 	onAnyBasePower?: (this: Battle, basePower: number, source: Pokemon, target: Pokemon, move: ActiveMove) => void
 	onAnySetWeather?: (this: Battle, target: Pokemon, source: Pokemon, weather: PureEffect) => void
+	onAnyTerrainStart?: (this: Battle) => void
 	onAnyModifyDamage?: (this: Battle, damage: number, source: Pokemon, target: Pokemon, move: ActiveMove) => void
 	onAnyRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: Pokemon, move: ActiveMove) => void
 	onAnyAccuracy?: (this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -321,6 +321,7 @@ class Battle extends Dex.ModdedDex {
 			this.terrainData = prevTerrainData;
 			return false;
 		}
+		this.runEvent('TerrainStart', source, source, status);
 		return true;
 	}
 

--- a/test/simulator/items/seeds.js
+++ b/test/simulator/items/seeds.js
@@ -11,14 +11,24 @@ describe('Seeds', function () {
 	});
 
 	it('should activate even in a double-switch-in', function () {
-		battle = common.createBattle();
-		const p1 = battle.join('p1', 'Guest 1', 1, [
-			{species: 'tapukoko', ability: 'electricsurge', item: 'grassyseed', moves: ['protect']},
+		battle = common.createBattle([
+			[{species: 'Tapu Koko', ability: 'electricsurge', item: 'grassyseed', moves: ['protect']}],
+			[{species: 'Tapu Bulu', ability: 'grassysurge', item: 'electricseed', moves: ['protect']}],
 		]);
-		const p2 = battle.join('p2', 'Guest 2', 1, [
-			{species: 'tapubulu', ability: 'grassysurge', item: 'electricseed', moves: ['protect']},
+		assert.false(battle.p1.active[0].item);
+		assert.false(battle.p2.active[0].item);
+	});
+
+	it('should not activate when Magic Room ends', function () {
+		battle = common.createBattle([
+			[
+				{species: 'Tapu Koko', ability: 'electricsurge', item: 'terrainextender', moves: ['protect']},
+				{species: 'Hawlucha', ability: 'unburden', item: 'electricseed', moves: ['protect']},
+			],
+			[{species: 'Alakazam', ability: 'magicguard', moves: ['magicroom']}],
 		]);
-		assert.false(p1.active[0].item);
-		assert.false(p2.active[0].item);
+		battle.makeChoices('move protect', 'move magicroom');
+		battle.makeChoices('switch 2', 'move magicroom');
+		assert.strictEqual(battle.p1.active[0].item, 'electricseed');
 	});
 });


### PR DESCRIPTION
Terrain seeds should activate only after switch-in abilities or when a new terrain starts, and should not activate after Magic Room ends.