### PR TITLE
Fake out form change when clearing volatiles so OMs still work

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -734,7 +734,7 @@ let Formats = [
 		ruleset: ['[Gen 7] OU'],
 		banlist: ['Kartana', 'Kyurem-Black', 'Shedinja'],
 		onModifyTemplate(template, target, source) {
-			if (!source) return;
+			if (source && ['imposter', 'transform'].includes(source.id)) return;
 			let types = [...new Set(target.baseMoveSlots.slice(0, 2).map(move => this.getMove(move.id).type))];
 			return Object.assign({}, template, {types: types});
 		},

--- a/data/mods/pokebilities/scripts.js
+++ b/data/mods/pokebilities/scripts.js
@@ -37,7 +37,7 @@ exports.BattleScripts = {
 			if (!template.abilities || (pokemon && pokemon.transformed && this.battle.gen >= 2) || (this.transformed && this.battle.gen >= 5)) {
 				return false;
 			}
-			if (!this.formeChange(template, null)) {
+			if (!this.formeChange(template)) {
 				return false;
 			}
 			this.transformed = true;

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -873,7 +873,7 @@ class Pokemon {
 		if ((pokemon.transformed && this.battle.gen >= 2) || (this.transformed && this.battle.gen >= 5)) {
 			return false;
 		}
-		if (!this.formeChange(template, null)) {
+		if (!this.formeChange(template)) {
 			return false;
 		}
 		this.transformed = true;
@@ -1077,7 +1077,7 @@ class Pokemon {
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 
-		this.formeChange(this.baseTemplate, /** @type {Effect} */ ({id: ''}));
+		this.formeChange(this.baseTemplate, null);
 	}
 
 	/**

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -1077,7 +1077,7 @@ class Pokemon {
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 
-		this.formeChange(this.baseTemplate, null);
+		this.formeChange(this.baseTemplate, /** @type {Effect} */ ({id: ''}));
 	}
 
 	/**

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -873,7 +873,7 @@ class Pokemon {
 		if ((pokemon.transformed && this.battle.gen >= 2) || (this.transformed && this.battle.gen >= 5)) {
 			return false;
 		}
-		if (!this.formeChange(template)) {
+		if (!this.setTemplate(template)) {
 			return false;
 		}
 		this.transformed = true;
@@ -945,20 +945,16 @@ class Pokemon {
 	}
 
 	/**
-	 * Changes this Pokemon's forme to match the given templateId (or template).
-	 * This function handles all changes to stats, ability, type, template, etc.
-	 * as well as sending all relevant messages sent to the client.
-	 * @param {string | Template} templateId
+	 * Changes this Pokemon's template to the given templateId (or template).
+	 * This function only handles changes to stats and type.
+	 * Use formChange to handle changes to ability and sending client messages.
+	 * @param {Template} rawTemplate
 	 * @param {Effect | null} source
-	 * @param {boolean} [isPermanent]
-	 * @param {string} [message]
 	 */
-	formeChange(templateId, source = this.battle.effect, isPermanent, message, abilitySlot = '0') {
-		let rawTemplate = this.battle.getTemplate(templateId);
-
+	setTemplate(rawTemplate, source = this.battle.effect) {
 		let template = this.battle.singleEvent('ModifyTemplate', this.battle.getFormat(), null, this, source, null, rawTemplate);
 
-		if (!template) return false;
+		if (!template) return null;
 
 		this.template = template;
 
@@ -987,8 +983,26 @@ class Pokemon {
 			if (this.status === 'brn') this.modifyStat('atk', 0.5);
 		}
 		this.speed = this.stats.spe;
+		return template;
+	}
 
-		if (!source || (!source.id && !source.effectType) || this.battle.gen <= 2) return true;
+	/**
+	 * Changes this Pokemon's forme to match the given templateId (or template).
+	 * This function handles all changes to stats, ability, type, template, etc.
+	 * as well as sending all relevant messages sent to the client.
+	 * @param {string | Template} templateId
+	 * @param {Effect} source
+	 * @param {boolean} [isPermanent]
+	 * @param {string} [message]
+	 * @param {'0' | '1' | 'H' | 'S'} [abilitySlot]
+	 */
+	formeChange(templateId, source = this.battle.effect, isPermanent, message, abilitySlot = '0') {
+		let rawTemplate = this.battle.getTemplate(templateId);
+
+		let template = this.setTemplate(rawTemplate, source);
+		if (!template) return false;
+
+		if (this.battle.gen <= 2) return true;
 
 		let apparentSpecies = this.illusion ? this.illusion.template.species : template.baseSpecies; // The species the opponent sees
 		if (isPermanent) {
@@ -1077,7 +1091,7 @@ class Pokemon {
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 
-		this.formeChange(this.baseTemplate, null);
+		this.setTemplate(this.baseTemplate);
 	}
 
 	/**


### PR DESCRIPTION
Prior to commit c8d4463 this used to say `this.formeChange(this.baseTemplate);`. Typically this would pick up the empty effect created at the start of a battle. Because that effect has no effect type, this would exit early from the `formChange` code. However, that wasn't the only case, and so commit c8d4463 explicitly passed a null effect instead, so that the early exit would always apply. Unfortunately this means that `onModifyTemplate` cannot distinguish between a `clearVolatile` and a `transformInfo`. Since passing the empty effect used to fake everything out at the start of a battle, my best idea was to explicitly pass an empty effect so that everything else works again as they expect.

Note that passing an explicit `this.battle.getEffect('')` doesn't work because that effect still has an effect type, so it won't trigger the early return. Maybe it should ignore the effect type and early return on an empty id?