### PR TITLE
 Automatically add scrollbars when elements overflow roomintro 

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1159,7 +1159,7 @@ const commands = {
 		if (!target) {
 			if (!this.runBroadcast()) return;
 			if (!room.introMessage) return this.sendReply("This room does not have an introduction set.");
-			this.sendReply('|raw|<div class="infobox infobox-limited">' + room.introMessage.replace(/\n/g, '') + '</div>');
+			this.sendReply('|raw|<div class="infobox infobox-limited" style="overflow: auto;">' + room.introMessage.replace(/\n/g, '') + '</div>');
 			if (!this.broadcasting && user.can('declare', null, room) && cmd !== 'topic') {
 				this.sendReply('Source:');
 				const code = Chat.escapeHTML(room.introMessage).replace(/\n/g, '<br />');
@@ -1180,7 +1180,7 @@ const commands = {
 
 		room.introMessage = target.replace(/\r/g, '');
 		this.sendReply("(The room introduction has been changed to:)");
-		this.sendReply(`|raw|<div class="infobox infobox-limited">${room.introMessage.replace(/\n/g, '')}</div>`);
+		this.sendReply(`|raw|<div class="infobox infobox-limited" style="overflow: auto;">${room.introMessage.replace(/\n/g, '')}</div>`);
 
 		this.privateModAction(`(${user.name} changed the roomintro.)`);
 		this.modlog('ROOMINTRO');

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1159,11 +1159,11 @@ const commands = {
 		if (!target) {
 			if (!this.runBroadcast()) return;
 			if (!room.introMessage) return this.sendReply("This room does not have an introduction set.");
-			this.sendReply('|raw|<div class="infobox infobox-limited">' + room.introMessage.replace(/\n/g, '') + '</div>');
+			this.sendReply('|raw|<div class="infobox infobox-limited" style="overflow: auto;">' + room.introMessage.replace(/\n/g, '') + '</div>');
 			if (!this.broadcasting && user.can('declare', null, room) && cmd !== 'topic') {
 				this.sendReply('Source:');
 				const code = Chat.escapeHTML(room.introMessage).replace(/\n/g, '<br />');
-				this.sendReplyBox(`<code style="white-space: pre-wrap">/roomintro ${code}</code>`);
+				this.sendReplyBox(`<code style="white-space: pre-wrap;">/roomintro ${code}</code>`);
 			}
 			return;
 		}
@@ -1180,7 +1180,7 @@ const commands = {
 
 		room.introMessage = target.replace(/\r/g, '');
 		this.sendReply("(The room introduction has been changed to:)");
-		this.sendReply(`|raw|<div class="infobox infobox-limited">${room.introMessage.replace(/\n/g, '')}</div>`);
+		this.sendReply(`|raw|<div class="infobox infobox-limited" style="overflow: auto;">${room.introMessage.replace(/\n/g, '')}</div>`);
 
 		this.privateModAction(`(${user.name} changed the roomintro.)`);
 		this.modlog('ROOMINTRO');

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1461,9 +1461,9 @@ const commands = {
 		if (room.chatRoomData) Rooms.global.writeChatRoomData();
 	},
 	roompromotehelp: [
-		`/roompromote OR /roomdemote [username], [group symbol] - Promotes/demotes the user to the specified room rank. Requires: @ * # & ~`,
-		`/room[group] [username] - Promotes/demotes the user to the specified room rank. Requires: @ * # & ~`,
-		`/roomdeauth [username] - Removes all room rank from the user. Requires: @ * # & ~`,
+		`/roompromote OR /roomdemote [username], [group symbol] - Promotes/demotes the user to the specified room rank. Requires: @ # & ~`,
+		`/room[group] [username] - Promotes/demotes the user to the specified room rank. Requires: @ # & ~`,
+		`/roomdeauth [username] - Removes all room rank from the user. Requires: @ # & ~`,
 	],
 
 	'!roomauth': true,
@@ -1628,7 +1628,7 @@ const commands = {
 		}
 		return true;
 	},
-	banhelp: [`/roomban [username], [reason] - Bans the user from the room you are in. Requires: @ * # & ~`],
+	banhelp: [`/ban [username], [reason] - Bans the user from the room you are in. Requires: @ # & ~`],
 
 	unroomban: 'unban',
 	roomunban: 'unban',
@@ -1647,7 +1647,7 @@ const commands = {
 			this.errorReply(`User '${target}' is not banned from this room.`);
 		}
 	},
-	unbanhelp: [`/roomunban [username] - Unbans the user from the room you are in. Requires: @ * # & ~`],
+	unbanhelp: [`/unban [username] - Unbans the user from the room you are in. Requires: @ # & ~`],
 
 	'!autojoin': true,
 	autojoin(target, room, user, connection) {
@@ -1810,14 +1810,14 @@ const commands = {
 
 		room.mute(targetUser, muteDuration, false);
 	},
-	mutehelp: [`/mute OR /m [username], [reason] - Mutes a user with reason for 7 minutes. Requires: % @ * # & ~`],
+	mutehelp: [`/mute OR /m [username], [reason] - Mutes a user with reason for 7 minutes. Requires: % @ # & ~`],
 
 	hm: 'hourmute',
 	hourmute(target) {
 		if (!target) return this.parse('/help hourmute');
 		this.run('mute');
 	},
-	hourmutehelp: [`/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. Requires: % @ * # & ~`],
+	hourmutehelp: [`/hourmute OR /hm [username], [reason] - Mutes a user with reason for an hour. Requires: % @ # & ~`],
 
 	um: 'unmute',
 	unmute(target, room, user) {
@@ -1837,7 +1837,7 @@ const commands = {
 			this.errorReply(`${(targetUser ? targetUser.name : this.targetUsername)} is not muted.`);
 		}
 	},
-	unmutehelp: [`/unmute [username] - Removes mute from user. Requires: % @ * # & ~`],
+	unmutehelp: [`/unmute [username] - Removes mute from user. Requires: % @ # & ~`],
 
 	forcelock: 'lock',
 	l: 'lock',
@@ -1967,7 +1967,7 @@ const commands = {
 		return true;
 	},
 	lockhelp: [
-		`/lock OR /l [username], [reason] - Locks the user from talking in all chats. Requires: % @ * & ~`,
+		`/lock OR /l [username], [reason] - Locks the user from talking in all chats. Requires: % @ & ~`,
 		`/weeklock OR /wl [username], [reason] - Same as /lock, but locks users for a week.`,
 		`/lock OR /l [username], [reason] spoiler: [proof] - Marks proof in modlog only.`,
 	],
@@ -2055,12 +2055,12 @@ const commands = {
 		const broadcastRoom = Rooms('staff') || room;
 		broadcastRoom.addByUser(user, `${user.name} unlocked the ${range ? "IP range" : "IP"}: ${target}`);
 	},
-	unlockiphelp: [`/unlockip [ip] - Unlocks a punished ip while leaving the original punishment intact. Requires: @ * & ~`],
-	unlocknamehelp: [`/unlockname [username] - Unlocks a punished alt while leaving the original punishment intact. Requires: % @ * & ~`],
+	unlockiphelp: [`/unlockip [ip] - Unlocks a punished ip while leaving the original punishment intact. Requires: @ & ~`],
+	unlocknamehelp: [`/unlockname [username] - Unlocks a punished alt while leaving the original punishment intact. Requires: % @ & ~`],
 	unlockhelp: [
-		`/unlock [username] - Unlocks the user. Requires: % @ * & ~`,
-		`/unlockname [username] - Unlocks a punished alt while leaving the original punishment intact. Requires: % @ * & ~`,
-		`/unlockip [ip] - Unlocks a punished ip while leaving the original punishment intact. Requires: @ * & ~`,
+		`/unlock [username] - Unlocks the user. Requires: % @ & ~`,
+		`/unlockname [username] - Unlocks a punished alt while leaving the original punishment intact. Requires: % @ & ~`,
+		`/unlockip [ip] - Unlocks a punished ip while leaving the original punishment intact. Requires: @ & ~`,
 	],
 
 	forceglobalban: 'globalban',
@@ -2146,7 +2146,7 @@ const commands = {
 		return true;
 	},
 	globalbanhelp: [
-		`/globalban OR /gban [username], [reason] - Kick user from all rooms and ban user's IP address with reason. Requires: @ * & ~`,
+		`/globalban OR /gban [username], [reason] - Kick user from all rooms and ban user's IP address with reason. Requires: @ & ~`,
 		`/globalban OR /gban [username], [reason] spoiler: [proof] - Marks proof in modlog only.`,
 	],
 
@@ -2170,7 +2170,7 @@ const commands = {
 			this.errorReply(`User '${target}' is not globally banned.`);
 		}
 	},
-	unglobalbanhelp: [`/unglobalban [username] - Unban a user. Requires: @ * & ~`],
+	unglobalbanhelp: [`/unglobalban [username] - Unban a user. Requires: @ & ~`],
 
 	unbanall(target, room, user) {
 		if (!this.can('rangeban')) return false;
@@ -2301,7 +2301,7 @@ const commands = {
 		if (room.id === 'staff' || room.id === 'upperstaff') this.globalModlog('NOTE', null, ` by ${user.userid}: ${target}`);
 		return this.privateModAction(`(${user.name} notes: ${target})`);
 	},
-	modnotehelp: [`/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ * # & ~`],
+	modnotehelp: [`/modnote [note] - Adds a moderator note that can be read through modlog. Requires: % @ # & ~`],
 
 	globalpromote: 'promote',
 	promote(target, room, user, connection, cmd) {
@@ -2500,7 +2500,7 @@ const commands = {
 
 		return `/announce ${target}`;
 	},
-	announcehelp: [`/announce OR /wall [message] - Makes an announcement. Requires: % @ * # & ~`],
+	announcehelp: [`/announce OR /wall [message] - Makes an announcement. Requires: % @ # & ~`],
 
 	notifyoffrank: 'notifyrank',
 	notifyrank(target, room, user, connection, cmd) {
@@ -2563,7 +2563,7 @@ const commands = {
 		targetUser.trackRename = targetUser.name;
 		return true;
 	},
-	forcerenamehelp: [`/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. Requires: % @ * & ~`],
+	forcerenamehelp: [`/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. Requires: % @ & ~`],
 
 	nl: 'namelock',
 	namelock(target, room, user) {
@@ -2593,7 +2593,7 @@ const commands = {
 		targetUser.popup(`|modal|${user.name} has locked your name and you can't change names anymore${reasonText}`);
 		return true;
 	},
-	namelockhelp: [`/namelock OR /nl [username], [reason] - Name locks a user and shows them the [reason]. Requires: % @ * & ~`],
+	namelockhelp: [`/namelock OR /nl [username], [reason] - Name locks a user and shows them the [reason]. Requires: % @ & ~`],
 
 	unl: 'unnamelock',
 	unnamelock(target, room, user) {
@@ -2616,7 +2616,7 @@ const commands = {
 			this.errorReply(`User '${target}' is not namelocked.`);
 		}
 	},
-	unnamelockhelp: [`/unnamelock [username] - Unnamelocks the user. Requires: % @ * & ~`],
+	unnamelockhelp: [`/unnamelock [username] - Unnamelocks the user. Requires: % @ & ~`],
 
 	hidetextalts: 'hidetext',
 	hidealttext: 'hidetext',
@@ -2648,8 +2648,8 @@ const commands = {
 		}
 	},
 	hidetexthelp: [
-		`/hidetext [username] - Removes a user's messages from chat. Requires: % @ * # & ~`,
-		`/hidealtstext [username] - Removes a user's messages, and their alternate account's messages from the chat.  Requires: % @ * # & ~`,
+		`/hidetext [username] - Removes a user's messages from chat. Requires: % @ # & ~`,
+		`/hidealtstext [username] - Removes a user's messages, and their alternate account's messages from the chat.  Requires: % @ # & ~`,
 	],
 
 	ab: 'blacklist',
@@ -2791,7 +2791,7 @@ const commands = {
 			this.errorReply(`User ${target} is not banned from battling.`);
 		}
 	},
-	unbattlebanhelp: [`/unbattleban [username] - [DEPRECATED] Allows a user to battle again. Requires: % @ * & ~`],
+	unbattlebanhelp: [`/unbattleban [username] - [DEPRECATED] Allows a user to battle again. Requires: % @ & ~`],
 
 	nameblacklist: 'blacklistname',
 	blacklistname(target, room, user) {
@@ -3766,7 +3766,7 @@ const commands = {
 			battleRoom.add(`|html|<div class="broadcast broadcast-blue"><strong>This is an imported replay</strong><br />Players will need to be manually added with <code>/addplayer</code> or <code>/restoreplayers</code></div>`);
 		}, 500);
 	},
-	importinputloghelp: [`/importinputlog [inputlog] - Starts a battle with a given inputlog. Requires: + % @ * & ~`],
+	importinputloghelp: [`/importinputlog [inputlog] - Starts a battle with a given inputlog. Requires: + % @ & ~`],
 
 	inputlog() {
 		this.parse(`/help exportinputlog`);
@@ -3936,7 +3936,7 @@ const commands = {
 			this.errorReply("/kickbattle - User isn't in battle.");
 		}
 	},
-	kickbattlehelp: [`/kickbattle [username], [reason] - Kicks a user from a battle with reason. Requires: % @ * & ~`],
+	kickbattlehelp: [`/kickbattle [username], [reason] - Kicks a user from a battle with reason. Requires: % @ & ~`],
 
 	kickinactive(target, room, user) {
 		this.parse(`/timer on`);
@@ -4266,8 +4266,8 @@ const commands = {
 			this.sendReply("COMMANDS: /msg, /reply, /logout, /challenge, /search, /rating, /whois, /user, /report, /join, /leave, /makegroupchat, /userauth, /roomauth");
 			this.sendReply("BATTLE ROOM COMMANDS: /savereplay, /hideroom, /inviteonly, /invite, /timer, /forfeit");
 			this.sendReply("OPTION COMMANDS: /nick, /avatar, /ignore, /away, /back, /timestamps, /highlight, /showjoins, /hidejoins, /blockchallenges, /blockpms");
-			this.sendReply("INFORMATIONAL/RESOURCE COMMANDS: /groups, /faq, /rules, /intro, /formatshelp, /othermetas, /analysis, /punishments, /calc, /git, /cap, /roomhelp, /roomfaq (replace / with ! to broadcast. Broadcasting requires: + % @ * # & ~)");
-			this.sendReply("DATA COMMANDS: /data, /dexsearch, /movesearch, /itemsearch, /learn, /statcalc, /effectiveness, /weakness, /coverage, /randommove, /randompokemon (replace / with ! to broadcast. Broadcasting requires: + % @ * # & ~)");
+			this.sendReply("INFORMATIONAL/RESOURCE COMMANDS: /groups, /faq, /rules, /intro, /formatshelp, /othermetas, /analysis, /punishments, /calc, /git, /cap, /roomhelp, /roomfaq (replace / with ! to broadcast. Broadcasting requires: + % @ # & ~)");
+			this.sendReply("DATA COMMANDS: /data, /dexsearch, /movesearch, /itemsearch, /learn, /statcalc, /effectiveness, /weakness, /coverage, /randommove, /randompokemon (replace / with ! to broadcast. Broadcasting requires: + % @ # & ~)");
 			if (user.group !== Config.groupsranking[0]) {
 				this.sendReply("DRIVER COMMANDS: /warn, /mute, /hourmute, /unmute, /alts, /forcerename, /modlog, /modnote, /lock, /weeklock, /unlock, /announce");
 				this.sendReply("MODERATOR COMMANDS: /globalban, /unglobalban, /ip, /modchat, /markshared, /unlockip");

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1628,7 +1628,7 @@ const commands = {
 		}
 		return true;
 	},
-	banhelp: [`/ban [username], [reason] - Bans the user from the room you are in. Requires: @ * # & ~`],
+	banhelp: [`/roomban [username], [reason] - Bans the user from the room you are in. Requires: @ * # & ~`],
 
 	unroomban: 'unban',
 	roomunban: 'unban',
@@ -1647,7 +1647,7 @@ const commands = {
 			this.errorReply(`User '${target}' is not banned from this room.`);
 		}
 	},
-	unbanhelp: [`/unban [username] - Unbans the user from the room you are in. Requires: @ * # & ~`],
+	unbanhelp: [`/roomunban [username] - Unbans the user from the room you are in. Requires: @ * # & ~`],
 
 	'!autojoin': true,
 	autojoin(target, room, user, connection) {

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1628,7 +1628,7 @@ const commands = {
 		}
 		return true;
 	},
-	banhelp: [`/roomban [username], [reason] - Bans the user from the room you are in. Requires: @ # & ~`],
+	banhelp: [`/ban [username], [reason] - Bans the user from the room you are in. Requires: @ * # & ~`],
 
 	unroomban: 'unban',
 	roomunban: 'unban',
@@ -1647,7 +1647,7 @@ const commands = {
 			this.errorReply(`User '${target}' is not banned from this room.`);
 		}
 	},
-	unbanhelp: [`/roomunban [username] - Unbans the user from the room you are in. Requires: @ # & ~`],
+	unbanhelp: [`/unban [username] - Unbans the user from the room you are in. Requires: @ * # & ~`],
 
 	'!autojoin': true,
 	autojoin(target, room, user, connection) {

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1159,7 +1159,7 @@ const commands = {
 		if (!target) {
 			if (!this.runBroadcast()) return;
 			if (!room.introMessage) return this.sendReply("This room does not have an introduction set.");
-			this.sendReply('|raw|<div class="infobox infobox-limited" style="overflow: auto;">' + room.introMessage.replace(/\n/g, '') + '</div>');
+			this.sendReply('|raw|<div class="infobox infobox-limited">' + room.introMessage.replace(/\n/g, '') + '</div>');
 			if (!this.broadcasting && user.can('declare', null, room) && cmd !== 'topic') {
 				this.sendReply('Source:');
 				const code = Chat.escapeHTML(room.introMessage).replace(/\n/g, '<br />');
@@ -1180,7 +1180,7 @@ const commands = {
 
 		room.introMessage = target.replace(/\r/g, '');
 		this.sendReply("(The room introduction has been changed to:)");
-		this.sendReply(`|raw|<div class="infobox infobox-limited" style="overflow: auto;">${room.introMessage.replace(/\n/g, '')}</div>`);
+		this.sendReply(`|raw|<div class="infobox infobox-limited">${room.introMessage.replace(/\n/g, '')}</div>`);
 
 		this.privateModAction(`(${user.name} changed the roomintro.)`);
 		this.modlog('ROOMINTRO');

--- a/server/chat-plugins/chat-monitor.js
+++ b/server/chat-plugins/chat-monitor.js
@@ -424,7 +424,7 @@ let commands = {
 	filterhelp: [
 		`- /filter add list, word, reason - Adds a word to the given filter list. Requires: ~`,
 		`- /filter remove list, words - Removes words from the given filter list. Requires: ~`,
-		`- /filter view - Opens the list of filtered words. Requires: % @ * & ~`,
+		`- /filter view - Opens the list of filtered words. Requires: % @ & ~`,
 	],
 	allowname(target, room, user) {
 		if (!this.can('forcerename')) return false;

--- a/server/chat-plugins/daily-spotlight.js
+++ b/server/chat-plugins/daily-spotlight.js
@@ -168,10 +168,10 @@ const commands = {
 	dailyhelp: [
 		`Daily spotlights plugin:`,
 		`- /daily [name] - Shows the daily spotlight.`,
-		`- !daily [name] - Shows the daily spotlight to everyone. Requires: + % @ * # & ~`,
-		`- /setdaily [name], [image], [description] - Sets the daily spotlight. Image can be left out. Requires: % @ * # & ~`,
-		`- /queuedaily [name], [image], [description] - Queues a daily spotlight. At midnight, the spotlight with this name will automatically switch to the next queued spotlight. Image can be left out. Requires: % @ * # & ~`,
-		`- /removedaily [name][, queue number] - If no queue number is provided, deletes all queued and current spotlights with the given name. If a number is provided, removes a specific future spotlight from the queue. Requires: % @ * # & ~`,
+		`- !daily [name] - Shows the daily spotlight to everyone. Requires: + % @ # & ~`,
+		`- /setdaily [name], [image], [description] - Sets the daily spotlight. Image can be left out. Requires: % @ # & ~`,
+		`- /queuedaily [name], [image], [description] - Queues a daily spotlight. At midnight, the spotlight with this name will automatically switch to the next queued spotlight. Image can be left out. Requires: % @ # & ~`,
+		`- /removedaily [name][, queue number] - If no queue number is provided, deletes all queued and current spotlights with the given name. If a number is provided, removes a specific future spotlight from the queue. Requires: % @ # & ~`,
 		`- /viewspotlights - Shows all current spotlights in the room. For staff, also shows queued spotlights.`,
 	],
 };

--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -261,7 +261,7 @@ exports.commands = {
 	},
 	learnhelp: [
 		`/learn [ruleset], [pokemon], [move, move, ...] - Displays how the Pok\u00e9mon can learn the given moves, if it can at all.`,
-		`!learn [ruleset], [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ * # & ~`,
+		`!learn [ruleset], [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ # & ~`,
 		`Specifying a ruleset is entirely optional. The ruleset can be a format, a generation (e.g.: gen3) or 'pentagon'. A value of 'pentagon' indicates that trading from previous generations is not allowed.`,
 		`/learn5 displays how the Pok\u00e9mon can learn the given moves at level 5, if it can at all.`,
 		`/learnall displays all of the possible fathers for egg moves.`,

--- a/server/chat-plugins/hangman.js
+++ b/server/chat-plugins/hangman.js
@@ -252,7 +252,7 @@ const commands = {
 			this.modlog('HANGMAN');
 			return this.privateModAction(`(A game of hangman was started by ${user.name}.)`);
 		},
-		createhelp: ["/hangman create [word], [hint] - Makes a new hangman game. Requires: % @ * # & ~"],
+		createhelp: ["/hangman create [word], [hint] - Makes a new hangman game. Requires: % @ # & ~"],
 
 		guess(target, room, user) {
 			if (!target) return this.parse('/help guess');
@@ -278,7 +278,7 @@ const commands = {
 			this.modlog('ENDHANGMAN');
 			return this.privateModAction(`(The game of hangman was ended by ${user.name}.)`);
 		},
-		endhelp: ["/hangman end - Ends the game of hangman before the man is hanged or word is guessed. Requires: % @ * # & ~"],
+		endhelp: ["/hangman end - Ends the game of hangman before the man is hanged or word is guessed. Requires: % @ # & ~"],
 
 		disable(target, room, user) {
 			if (!this.can('gamemanagement', null, room)) return;
@@ -329,11 +329,11 @@ const commands = {
 	hangmanhelp: [
 		`/hangman allows users to play the popular game hangman in PS rooms.`,
 		`Accepts the following commands:`,
-		`/hangman create [word], [hint] - Makes a new hangman game. Requires: % @ * # & ~`,
+		`/hangman create [word], [hint] - Makes a new hangman game. Requires: % @ # & ~`,
 		`/hangman guess [letter] - Makes a guess for the letter entered.`,
 		`/hangman guess [word] - Same as a letter, but guesses an entire word.`,
 		`/hangman display - Displays the game.`,
-		`/hangman end - Ends the game of hangman before the man is hanged or word is guessed. Requires: % @ * # & ~`,
+		`/hangman end - Ends the game of hangman before the man is hanged or word is guessed. Requires: % @ # & ~`,
 		`/hangman [enable/disable] - Enables or disables hangman from being started in a room. Requires: # & ~`,
 	],
 

--- a/server/chat-plugins/helptickets.js
+++ b/server/chat-plugins/helptickets.js
@@ -931,14 +931,14 @@ let commands = {
 			ticketGame.escalate((toId(target) === 'upperstaff'), user);
 			return this.sendReply(`${ticket.creator}'s ticket was escalated.`);
 		},
-		escalatehelp: [`/helpticket escalate [user], (upperstaff) - Escalate a ticket. If upperstaff is included, escalate the ticket to upper staff. Requires: % @ * & ~`],
+		escalatehelp: [`/helpticket escalate [user], (upperstaff) - Escalate a ticket. If upperstaff is included, escalate the ticket to upper staff. Requires: % @ & ~`],
 
 		'!list': true,
 		list(target, room, user) {
 			if (!this.can('lock')) return;
 			this.parse('/join view-help-tickets');
 		},
-		listhelp: [`/helpticket list - Lists all tickets. Requires: % @ * & ~`],
+		listhelp: [`/helpticket list - Lists all tickets. Requires: % @ & ~`],
 
 		'!close': true,
 		close(target, room, user) {
@@ -958,7 +958,7 @@ let commands = {
 			ticket.claimed = user.name;
 			this.sendReply(`You closed ${ticket.creator}'s ticket.`);
 		},
-		closehelp: [`/helpticket close [user] - Closes an open ticket. Requires: % @ * & ~`],
+		closehelp: [`/helpticket close [user] - Closes an open ticket. Requires: % @ & ~`],
 
 		ban(target, room, user) {
 			if (!target) return this.parse('/help helpticket ban');
@@ -1046,7 +1046,7 @@ let commands = {
 			this.globalModlog(`TICKETBAN`, targetUser || userid, ` by ${user.name}${target}`);
 			return true;
 		},
-		banhelp: [`/helpticket ban [user], (reason) - Bans a user from creating tickets for 2 days. Requires: % @ * & ~`],
+		banhelp: [`/helpticket ban [user], (reason) - Bans a user from creating tickets for 2 days. Requires: % @ & ~`],
 
 		unban(target, room, user) {
 			if (!target) return this.parse('/help helpticket unban');
@@ -1076,7 +1076,7 @@ let commands = {
 			this.globalModlog("UNTICKETBAN", target, `by ${user.userid}`);
 			if (targetUser) targetUser.popup(`${user.name} has ticket unbanned you.`);
 		},
-		unbanhelp: [`/helpticket unban [user] - Ticket unbans a user. Requires: % @ * & ~`],
+		unbanhelp: [`/helpticket unban [user] - Ticket unbans a user. Requires: % @ & ~`],
 
 		ignore(target, room, user) {
 			if (!this.can('lock')) return;
@@ -1084,7 +1084,7 @@ let commands = {
 			user.ignoreTickets = true;
 			this.sendReply(`You are now ignoring help ticket notifications.`);
 		},
-		ignorehelp: [`/helpticket ignore - Ignore notifications for unclaimed help tickets. Requires: % @ * & ~`],
+		ignorehelp: [`/helpticket ignore - Ignore notifications for unclaimed help tickets. Requires: % @ & ~`],
 
 		unignore(target, room, user) {
 			if (!this.can('lock')) return;
@@ -1092,7 +1092,7 @@ let commands = {
 			user.ignoreTickets = false;
 			this.sendReply(`You will now receive help ticket notifications.`);
 		},
-		unignorehelp: [`/helpticket unignore - Stop ignoring notifications for help tickets. Requires: % @ * & ~`],
+		unignorehelp: [`/helpticket unignore - Stop ignoring notifications for help tickets. Requires: % @ & ~`],
 
 		delete(target, room, user) {
 			// This is a utility only to be used if something goes wrong
@@ -1116,13 +1116,13 @@ let commands = {
 	},
 	helptickethelp: [
 		`/helpticket create - Creates a new ticket, requesting help from global staff.`,
-		`/helpticket list - Lists all tickets. Requires: % @ * & ~`,
-		`/helpticket escalate [user], (upperstaff) - Escalates a ticket. If upperstaff is included, the ticket is escalated to upper staff. Requires: % @ * & ~`,
-		`/helpticket close [user] - Closes an open ticket. Requires: % @ * & ~`,
-		`/helpticket ban [user], (reason) - Bans a user from creating tickets for 2 days. Requires: % @ * & ~`,
-		`/helpticket unban [user] - Ticket unbans a user. Requires: % @ * & ~`,
-		`/helpticket ignore - Ignore notifications for unclaimed help tickets. Requires: % @ * & ~`,
-		`/helpticket unignore - Stop ignoring notifications for help tickets. Requires: % @ * & ~`,
+		`/helpticket list - Lists all tickets. Requires: % @ & ~`,
+		`/helpticket escalate [user], (upperstaff) - Escalates a ticket. If upperstaff is included, the ticket is escalated to upper staff. Requires: % @ & ~`,
+		`/helpticket close [user] - Closes an open ticket. Requires: % @ & ~`,
+		`/helpticket ban [user], (reason) - Bans a user from creating tickets for 2 days. Requires: % @ & ~`,
+		`/helpticket unban [user] - Ticket unbans a user. Requires: % @ & ~`,
+		`/helpticket ignore - Ignore notifications for unclaimed help tickets. Requires: % @ & ~`,
+		`/helpticket unignore - Stop ignoring notifications for help tickets. Requires: % @ & ~`,
 		`/helpticket delete [user] - Deletes a user's ticket. Requires: & ~`,
 	],
 };

--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -227,7 +227,7 @@ const commands = {
 	},
 	whoishelp: [
 		`/whois - Get details on yourself: alts, group, IP address, and rooms.`,
-		`/whois [username] - Get details on a username: alts (Requires: % @ * & ~), group, IP address (Requires: @ * & ~), and rooms.`,
+		`/whois [username] - Get details on a username: alts (Requires: % @ & ~), group, IP address (Requires: @ & ~), and rooms.`,
 	],
 
 	'!offlinewhois': true,
@@ -404,7 +404,7 @@ const commands = {
 		}
 		this.sendReplyBox(challenges.join(`<br />`));
 	},
-	checkchallengeshelp: [`!checkchallenges [user1], [user2] - Check if the specified users are challenging each other. Requires: @ * # & ~`],
+	checkchallengeshelp: [`!checkchallenges [user1], [user2] - Check if the specified users are challenging each other. Requires: @ # & ~`],
 
 	/*********************************************************
 	 * Client fallback
@@ -658,7 +658,7 @@ const commands = {
 	datahelp: [
 		`/data [pokemon/item/move/ability/nature] - Get details on this pokemon/item/move/ability/nature.`,
 		`/data [pokemon/item/move/ability/nature], Gen [generation number/format name] - Get details on this pokemon/item/move/ability/nature for that generation/format.`,
-		`!data [pokemon/item/move/ability/nature] - Show everyone these details. Requires: + % @ * # & ~`,
+		`!data [pokemon/item/move/ability/nature] - Show everyone these details. Requires: + % @ # & ~`,
 	],
 
 	'!details': true,
@@ -670,7 +670,7 @@ const commands = {
 	detailshelp: [
 		`/details [pokemon/item/move/ability/nature] - Get additional details on this pokemon/item/move/ability/nature.`,
 		`/details [pokemon/item/move/ability/nature], Gen [generation number/format name] - Get details on this pokemon/item/move/ability/nature for that generation/format.`,
-		`!details [pokemon/item/move/ability/nature] - Show everyone these details. Requires: + % @ * # & ~`,
+		`!details [pokemon/item/move/ability/nature] - Show everyone these details. Requires: + % @ # & ~`,
 	],
 
 	'!weakness': true,
@@ -761,8 +761,8 @@ const commands = {
 	weaknesshelp: [
 		`/weakness [pokemon] - Provides a Pok\u00e9mon's resistances, weaknesses, and immunities, ignoring abilities.`,
 		`/weakness [type 1]/[type 2] - Provides a type or type combination's resistances, weaknesses, and immunities, ignoring abilities.`,
-		`!weakness [pokemon] - Shows everyone a Pok\u00e9mon's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ * # & ~`,
-		`!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ * # & ~`,
+		`!weakness [pokemon] - Shows everyone a Pok\u00e9mon's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ # & ~`,
+		`!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ # & ~`,
 	],
 
 	'!effectiveness': true,
@@ -1522,7 +1522,7 @@ const commands = {
 	groupshelp: [
 		`/groups - Explains what the symbols (like % and @) before people's names mean.`,
 		`/groups [global|room] - Explains only global or room symbols.`,
-		`!groups - Shows everyone that information. Requires: + % @ * # & ~`,
+		`!groups - Shows everyone that information. Requires: + % @ # & ~`,
 	],
 
 	'!punishments': true,
@@ -1545,7 +1545,7 @@ const commands = {
 	},
 	punishmentshelp: [
 		`/punishments - Explains punishments.`,
-		`!punishments - Show everyone that information. Requires: + % @ * # & ~`,
+		`!punishments - Show everyone that information. Requires: + % @ # & ~`,
 	],
 
 	'!opensource': true,
@@ -1565,7 +1565,7 @@ const commands = {
 	},
 	opensourcehelp: [
 		`/opensource - Links to PS's source code repository.`,
-		`!opensource - Show everyone that information. Requires: + % @ * # & ~`,
+		`!opensource - Show everyone that information. Requires: + % @ # & ~`,
 	],
 
 	'!staff': true,
@@ -1620,7 +1620,7 @@ const commands = {
 	},
 	avatarshelp: [
 		`/avatars - Explains how to change avatars.`,
-		`!avatars - Show everyone that information. Requires: + % @ * # & ~`,
+		`!avatars - Show everyone that information. Requires: + % @ # & ~`,
 	],
 
 	'!optionsbutton': true,
@@ -1651,7 +1651,7 @@ const commands = {
 	},
 	introhelp: [
 		`/intro - Provides an introduction to competitive Pok\u00e9mon.`,
-		`!intro - Show everyone that information. Requires: + % @ * # & ~`,
+		`!intro - Show everyone that information. Requires: + % @ # & ~`,
 	],
 
 	'!smogintro': true,
@@ -1690,7 +1690,7 @@ const commands = {
 	calchelp: [
 		`/calc - Provides a link to a damage calculator`,
 		`/rcalc - Provides a link to the random battles damage calculator`,
-		`!calc - Shows everyone a link to a damage calculator. Requires: + % @ * # & ~`,
+		`!calc - Shows everyone a link to a damage calculator. Requires: + % @ # & ~`,
 	],
 
 	'!cap': true,
@@ -1707,7 +1707,7 @@ const commands = {
 	},
 	caphelp: [
 		`/cap - Provides an introduction to the Create-A-Pok\u00e9mon project.`,
-		`!cap - Show everyone that information. Requires: + % @ * # & ~`,
+		`!cap - Show everyone that information. Requires: + % @ # & ~`,
 	],
 
 	'!gennext': true,
@@ -1972,7 +1972,7 @@ const commands = {
 	},
 	ruleshelp: [
 		`/rules - Show links to room rules and global rules.`,
-		`!rules - Show everyone links to room rules and global rules. Requires: + % @ * # & ~`,
+		`!rules - Show everyone links to room rules and global rules. Requires: + % @ # & ~`,
 		`/rules [url] - Change the room rules URL. Requires: # & ~`,
 		`/rules remove - Removes a room rules URL. Requires: # & ~`,
 	],
@@ -2012,7 +2012,7 @@ const commands = {
 	},
 	faqhelp: [
 		`/faq [theme] - Provides a link to the FAQ. Add autoconfirmed, badges, coil, ladder, staff, or tiers for a link to these questions. Add all for all of them.`,
-		`!faq [theme] - Shows everyone a link to the FAQ. Add autoconfirmed, badges, coil, ladder, staff, or tiers for a link to these questions. Add all for all of them. Requires: + % @ * # & ~`,
+		`!faq [theme] - Shows everyone a link to the FAQ. Add autoconfirmed, badges, coil, ladder, staff, or tiers for a link to these questions. Add all for all of them. Requires: + % @ # & ~`,
 	],
 
 	'!smogdex': true,
@@ -2176,7 +2176,7 @@ const commands = {
 	},
 	smogdexhelp: [
 		`/analysis [pokemon], [generation], [format] - Links to the Smogon University analysis for this Pok\u00e9mon in the given generation.`,
-		`!analysis [pokemon], [generation], [format] - Shows everyone this link. Requires: + % @ * # & ~`,
+		`!analysis [pokemon], [generation], [format] - Shows everyone this link. Requires: + % @ # & ~`,
 	],
 
 	'!veekun': true,
@@ -2258,7 +2258,7 @@ const commands = {
 	},
 	veekunhelp: [
 		`/veekun [pokemon] - Links to Veekun website for this pokemon/item/move/ability/nature.`,
-		`!veekun [pokemon] - Shows everyone this link. Requires: + % @ * # & ~`,
+		`!veekun [pokemon] - Shows everyone this link. Requires: + % @ # & ~`,
 	],
 
 	'!register': true,

--- a/server/chat-plugins/mafia.js
+++ b/server/chat-plugins/mafia.js
@@ -178,7 +178,7 @@ class MafiaPlayer extends Rooms.RoomGamePlayer {
 		if (this.game.ended) return user.send(`>view-mafia-${this.game.room.id}\n|deinit`);
 		// @ts-ignore
 		const buf = Chat.pages.mafia([this.game.room.id], user);
-		this.send(`>view-mafia-${this.game.room.id}\n|init|html\n${buf}`);
+		this.send(`>view-mafia-${this.game.room.id}\n|init|html\n|title|Mafia\n|pagehtml|${buf}`);
 	}
 }
 
@@ -1351,7 +1351,7 @@ class MafiaTracker extends Rooms.RoomGame {
 			if (this.ended) return host.send(`>view-mafia-${this.room.id}\n|deinit`);
 			// @ts-ignore
 			const buf = Chat.pages.mafia([this.room.id], host);
-			host.send(`>view-mafia-${this.room.id}\n|init|html\n${buf}`);
+			host.send(`>view-mafia-${this.room.id}\n|init|html\n|title|Mafia\n|pagehtml|${buf}`);
 		}
 	}
 
@@ -1856,7 +1856,7 @@ const commands = {
 			room.game = new MafiaTracker(room, targetUser);
 
 			// @ts-ignore
-			targetUser.send(`>view-mafia-${room.id}\n|init|html\n${Chat.pages.mafia([room.id], targetUser)}`);
+			targetUser.send(`>view-mafia-${room.id}\n|init|html\n|title|Mafia\n|pagehtml|${Chat.pages.mafia([room.id], targetUser)}`);
 			room.addByUser(user, `${targetUser.name} was appointed the mafia host by ${user.name}.`);
 			if (room.id === 'mafia') {
 				const queueIndex = hostQueue.indexOf(targetUser.userid);
@@ -1866,7 +1866,7 @@ const commands = {
 			this.modlog('MAFIAHOST', targetUser, null, {noalts: true, noip: true});
 		},
 		hosthelp: [
-			`/mafia host [user] - Create a game of Mafia with [user] as the host. Requires + % @ * # & ~, voices can only host themselves`,
+			`/mafia host [user] - Create a game of Mafia with [user] as the host. Requires + % @ # & ~, voices can only host themselves`,
 		],
 
 		q: 'queue',
@@ -1990,7 +1990,7 @@ const commands = {
 			game.sendRoom(game.roomWindow(), {uhtml: true});
 			game.updatePlayers();
 		},
-		closehelp: [`/mafia close - Closes signups for the current game. Requires: host % @ * # & ~`],
+		closehelp: [`/mafia close - Closes signups for the current game. Requires: host % @ # & ~`],
 
 		'!closedsetup': true,
 		cs: 'closedsetup',
@@ -2013,7 +2013,7 @@ const commands = {
 			game.closedSetup = action === 'on';
 			game.updateHost();
 		},
-		closedsetuphelp: [`/mafia closedsetup [on|off] - Sets if the game is a closed setup. Closed setups don't show the role list to players. Requires host % @ * # & ~`],
+		closedsetuphelp: [`/mafia closedsetup [on|off] - Sets if the game is a closed setup. Closed setups don't show the role list to players. Requires host % @ # & ~`],
 
 		'!reveal': true,
 		reveal(target, room, user) {
@@ -2035,7 +2035,7 @@ const commands = {
 			game.sendRoom(`Revealing of roles has been ${action === 'off' ? 'disabled' : 'enabled'}.`, {declare: true});
 			game.updatePlayers();
 		},
-		revealhelp: [`/mafia reveal [on|off] - Sets if roles reveal on death or not. Requires host % @ * # & ~`],
+		revealhelp: [`/mafia reveal [on|off] - Sets if roles reveal on death or not. Requires host % @ # & ~`],
 
 		resetroles: 'setroles',
 		forceresetroles: 'setroles',
@@ -2069,8 +2069,8 @@ const commands = {
 			game.ideaInit(user, toId(target));
 		},
 		ideahelp: [
-			`/mafia idea [idea] - starts the IDEA module [idea]. Requires + % @ * # & ~, voices can only start for themselves`,
-			`/mafia ideareroll - rerolls the IDEA module. Requires host % @ * # & ~`,
+			`/mafia idea [idea] - starts the IDEA module [idea]. Requires + % @ # & ~, voices can only start for themselves`,
+			`/mafia ideareroll - rerolls the IDEA module. Requires host % @ # & ~`,
 			`/mafia ideapick [selection], [role] - selects a role`,
 			`/mafia ideadiscards - shows the discarded roles`,
 		],
@@ -2122,7 +2122,7 @@ const commands = {
 			if (game.hostid !== user.userid && !game.cohosts.includes(user.userid) && !this.can('mute', null, room)) return;
 			game.ideaDistributeRoles(user);
 		},
-		idearerollhelp: [`/mafia ideareroll - rerolls the roles for the current IDEA module. Requires host % @ * # & ~`],
+		idearerollhelp: [`/mafia ideareroll - rerolls the roles for the current IDEA module. Requires host % @ # & ~`],
 
 		discards: 'ideadiscards',
 		ideadiscards(target, room, user) {
@@ -2149,8 +2149,8 @@ const commands = {
 		},
 		ideadiscardshelp: [
 			`/mafia ideadiscards - shows the discarded roles`,
-			`/mafia ideadiscards off - hides discards from the players. Requires host % @ * # & ~`,
-			`/mafia ideadiscards on - shows discards to the players. Requires host % @ * # & ~`,
+			`/mafia ideadiscards off - hides discards from the players. Requires host % @ # & ~`,
+			`/mafia ideadiscards on - shows discards to the players. Requires host % @ # & ~`,
 		],
 
 		'!start': true,
@@ -2174,7 +2174,7 @@ const commands = {
 			}
 			game.start(user, cmd === 'nightstart');
 		},
-		starthelp: [`/mafia start - Start the game of mafia. Signups must be closed. Requires host % @ * # & ~`],
+		starthelp: [`/mafia start - Start the game of mafia. Signups must be closed. Requires host % @ # & ~`],
 
 		'!day': true,
 		extend: 'day',
@@ -2205,9 +2205,9 @@ const commands = {
 			}
 		},
 		dayhelp: [
-			`/mafia day - Move to the next game day. Requires host % @ * # & ~`,
-			`/mafia night - Move to the next game night. Requires host % @ * # & ~`,
-			`/mafia extend (minutes) - Return to the previous game day. If (minutes) is provided, set the deadline for (minutes) minutes. Requires host % @ * # & ~`,
+			`/mafia day - Move to the next game day. Requires host % @ # & ~`,
+			`/mafia night - Move to the next game night. Requires host % @ # & ~`,
+			`/mafia extend (minutes) - Return to the previous game day. If (minutes) is provided, set the deadline for (minutes) minutes. Requires host % @ # & ~`,
 		],
 
 		'!lynch': true,
@@ -2278,7 +2278,7 @@ const commands = {
 				return this.parse(`/help mafia selflynch`);
 			}
 		},
-		selflynchhelp: [`/mafia selflynch [on|hammer|off] - Allows players to self lynch themselves either at hammer or anytime. Requires host % @ * # & ~`],
+		selflynchhelp: [`/mafia selflynch [on|hammer|off] - Allows players to self lynch themselves either at hammer or anytime. Requires host % @ # & ~`],
 
 		'!kill': true,
 		treestump: 'kill',
@@ -2303,7 +2303,7 @@ const commands = {
 			game.eliminate(player, cmd);
 		},
 		killhelp: [
-			`/mafia kill [player] - Kill a player, eliminating them from the game. Requires host % @ * # & ~`,
+			`/mafia kill [player] - Kill a player, eliminating them from the game. Requires host % @ # & ~`,
 			`/mafia treestump [player] - Kills a player, but allows them to talk during the day still.`,
 			`/mafia spirit [player] - Kills a player, but allows them to vote on the lynch still.`,
 			`/mafia spiritstump [player] Kills a player, but allows them to talk during the day, and vote on the lynch.`,
@@ -2329,7 +2329,7 @@ const commands = {
 				game.revive(user, toId(targetUser), cmd === 'forceadd');
 			}
 		},
-		revivehelp: [`/mafia revive [player] - Revive a player who died or add a new player to the game. Requires host % @ * # & ~`],
+		revivehelp: [`/mafia revive [player] - Revive a player who died or add a new player to the game. Requires host % @ # & ~`],
 
 		dl: 'deadline',
 		deadline(target, room, user) {
@@ -2667,10 +2667,10 @@ const commands = {
 		subhelp: [
 			`/mafia sub in - Request to sub into the game, or cancel a request to sub out.`,
 			`/mafia sub out - Request to sub out of the game, or cancel a request to sub in.`,
-			`/mafia sub next, [player] - Forcibly sub [player] out of the game. Requires host % @ * # & ~`,
-			`/mafia sub remove, [user] - Remove [user] from the sublist. Requres host % @ * # & ~`,
-			`/mafia sub unrequest, [player] - Remove's a player's request to sub out of the game. Requires host % @ * # & ~`,
-			`/mafia sub [player], [user] - Forcibly sub [player] for [user]. Requires host % @ * # & ~`,
+			`/mafia sub next, [player] - Forcibly sub [player] out of the game. Requires host % @ # & ~`,
+			`/mafia sub remove, [user] - Remove [user] from the sublist. Requres host % @ # & ~`,
+			`/mafia sub unrequest, [player] - Remove's a player's request to sub out of the game. Requires host % @ # & ~`,
+			`/mafia sub [player], [user] - Forcibly sub [player] for [user]. Requires host % @ # & ~`,
 		],
 
 		"!autosub": true,
@@ -2699,7 +2699,7 @@ const commands = {
 				return this.parse(`/help mafia autosub`);
 			}
 		},
-		autosubhelp: [`/mafia autosub [yes|no] - Sets if players will automatically sub out if a user is on the sublist. Requires host % @ * # & ~`],
+		autosubhelp: [`/mafia autosub [yes|no] - Sets if players will automatically sub out if a user is on the sublist. Requires host % @ # & ~`],
 
 		cohost: 'subhost',
 		forcecohost: 'subhost',
@@ -2781,7 +2781,7 @@ const commands = {
 			this.room = targetRoom;
 			this.modlog('MAFIAEND', null);
 		},
-		endhelp: [`/mafia end - End the current game of mafia. Requires host + % @ * # & ~`],
+		endhelp: [`/mafia end - End the current game of mafia. Requires host + % @ # & ~`],
 
 		'!data': true,
 		role: 'data',
@@ -2969,7 +2969,7 @@ const commands = {
 		},
 		leaderboardhelp: [
 			`/mafia [leaderboard|mvpladder] - View the leaderboard or MVP ladder for the current or last month.`,
-			`/mafia [hostlost|playlogs|leaverlogs] - View the host, play, or leaver logs for the current or last month. Requires % @ * # & ~`,
+			`/mafia [hostlost|playlogs|leaverlogs] - View the host, play, or leaver logs for the current or last month. Requires % @ # & ~`,
 		],
 
 		unhostban: 'hostban',
@@ -3003,9 +3003,9 @@ const commands = {
 			room.add(`${targetUser} was ${isUnban ? 'un' : ''}banned from hosting games${!isUnban ? ` for ${duration} days` : ''} by ${user.name}.`).update();
 		},
 		hostbanhelp: [
-			`/mafia hostban [user], [duration] - Ban a user from hosting games for [duration] days. Requires % @ * # & ~`,
-			`/mafia unhostban [user] - Unbans a user from hosting games. Requires % @ * # & ~`,
-			`/mafia hostbans - Checks current hostbans. Requires % @ * # & ~`,
+			`/mafia hostban [user], [duration] - Ban a user from hosting games for [duration] days. Requires % @ # & ~`,
+			`/mafia unhostban [user] - Unbans a user from hosting games. Requires % @ # & ~`,
+			`/mafia hostbans - Checks current hostbans. Requires % @ # & ~`,
 		],
 
 		hostbans(target, room) {
@@ -3054,9 +3054,9 @@ const commands = {
 		buf += `<details><summary class="button">General Commands</summary>`;
 		buf += [
 			`<br/><strong>General Commands for the Mafia Plugin</strong>:<br/>`,
-			`/mafia host [user] - Create a game of Mafia with [user] as the host. Roomvoices can only host themselves. Requires + % @ * # & ~`,
-			`/mafia nexthost - Host the next user in the host queue. Only works in the Mafia Room. Requires + % @ * # & ~`,
-			`/mafia forcehost [user] - Bypass the host queue and host [user]. Only works in the Mafia Room. Requires % @ * # & ~`,
+			`/mafia host [user] - Create a game of Mafia with [user] as the host. Roomvoices can only host themselves. Requires + % @ # & ~`,
+			`/mafia nexthost - Host the next user in the host queue. Only works in the Mafia Room. Requires + % @ # & ~`,
+			`/mafia forcehost [user] - Bypass the host queue and host [user]. Only works in the Mafia Room. Requires % @ # & ~`,
 			`/mafia sub in - Request to sub into the game, or cancel a request to sub out.`,
 			`/mafia sub out - Request to sub out of the game, or cancel a request to sub in.`,
 			`/mafia spectate - Spectate the game of mafia.`,
@@ -3064,9 +3064,9 @@ const commands = {
 			`/mafia players - Display the current list of players, will highlight players.`,
 			`/mafia [rl|orl] - Display the role list or the original role list for the current game.`,
 			`/mafia data [alignment|role|modifier|theme|term] - Get information on a mafia alignment, role, modifier, theme, or term.`,
-			`/mafia subhost [user] - Substitues the user as the new game host. Requires % @ * # & ~`,
-			`/mafia cohost [user] - Adds the user as a cohost. Cohosts can talk during the game, as well as perform host actions. Requires % @ * # & ~`,
-			`/mafia uncohost [user] - Remove [user]'s cohost status. Requires % @ * # & ~`,
+			`/mafia subhost [user] - Substitues the user as the new game host. Requires % @ # & ~`,
+			`/mafia cohost [user] - Adds the user as a cohost. Cohosts can talk during the game, as well as perform host actions. Requires % @ # & ~`,
+			`/mafia uncohost [user] - Remove [user]'s cohost status. Requires % @ # & ~`,
 			`/mafia disable - Disables mafia in this room. Requires # & ~`,
 			`/mafia enable - Enables mafia in this room. Requires # & ~`,
 		].join('<br/>');
@@ -3085,48 +3085,48 @@ const commands = {
 		buf += [
 			`<br/><strong>Commands for game hosts and Cohosts to use</strong>:<br/>`,
 			`/mafia playercap [cap|none]- Limit the number of players able to join the game. Player cap cannot be more than 20 or less than 2. Requires: host % @ # & ~`,
-			`/mafia close - Closes signups for the current game. Requires: host % @ * # & ~`,
-			`/mafia closedsetup [on|off] - Sets if the game is a closed setup. Closed setups don't show the role list to players. Requires host % @ * # & ~`,
-			`/mafia reveal [on|off] - Sets if roles reveal on death or not. Requires host % @ * # & ~`,
-			`/mafia selflynch [on|hammer|off] - Allows players to self lynch themselves either at hammer or anytime. Requires host % @ * # & ~`,
+			`/mafia close - Closes signups for the current game. Requires: host % @ # & ~`,
+			`/mafia closedsetup [on|off] - Sets if the game is a closed setup. Closed setups don't show the role list to players. Requires host % @ # & ~`,
+			`/mafia reveal [on|off] - Sets if roles reveal on death or not. Requires host % @ # & ~`,
+			`/mafia selflynch [on|hammer|off] - Allows players to self lynch themselves either at hammer or anytime. Requires host % @ # & ~`,
 			`/mafia [enablenl|disablenl] - Allows or disallows players abstain from lynching. Requires host % @ # & ~`,
 			`/mafia setroles [comma seperated roles] - Set the roles for a game of mafia. You need to provide one role per player. Requires host % @ # & ~`,
 			`/mafia forcesetroles [comma seperated roles] - Forcibly set the roles for a game of mafia. No role PM information or alignment will be set. Requires host % @ # & ~`,
-			`/mafia start - Start the game of mafia. Signups must be closed. Requires host % @ * # & ~`,
-			`/mafia day - Move to the next game day. Requires host % @ * # & ~`,
-			`/mafia night - Move to the next game night. Requires host % @ * # & ~`,
-			`/mafia extend (minutes) - Return to the previous game day. If (minutes) is provided, set the deadline for (minutes) minutes. Requires host % @ * # & ~`,
-			`/mafia kill [player] - Kill a player, eliminating them from the game. Requires host % @ * # & ~`,
-			`/mafia treestump [player] - Kills a player, but allows them to talk during the day still. Requires host % @ * # & ~`,
-			`/mafia spirit [player] - Kills a player, but allows them to vote on the lynch still. Requires host % @ * # & ~`,
-			`/mafia spiritstump [player] - Kills a player, but allows them to talk during the day, and vote on the lynch. Requires host % @ * # & ~`,
-			`/mafia kick [player] - Kicks a player from the game without revealing their role. Requires host % @ * # & ~`,
-			`/mafia revive [player] - Revive a player who died or add a new player to the game. Requires host % @ * # & ~`,
+			`/mafia start - Start the game of mafia. Signups must be closed. Requires host % @ # & ~`,
+			`/mafia day - Move to the next game day. Requires host % @ # & ~`,
+			`/mafia night - Move to the next game night. Requires host % @ # & ~`,
+			`/mafia extend (minutes) - Return to the previous game day. If (minutes) is provided, set the deadline for (minutes) minutes. Requires host % @ # & ~`,
+			`/mafia kill [player] - Kill a player, eliminating them from the game. Requires host % @ # & ~`,
+			`/mafia treestump [player] - Kills a player, but allows them to talk during the day still. Requires host % @ # & ~`,
+			`/mafia spirit [player] - Kills a player, but allows them to vote on the lynch still. Requires host % @ # & ~`,
+			`/mafia spiritstump [player] - Kills a player, but allows them to talk during the day, and vote on the lynch. Requires host % @ # & ~`,
+			`/mafia kick [player] - Kicks a player from the game without revealing their role. Requires host % @ # & ~`,
+			`/mafia revive [player] - Revive a player who died or add a new player to the game. Requires host % @ # & ~`,
 			`/mafia deadline [minutes|off] - Sets or removes the deadline for the game. Cannot be more than 20 minutes.`,
-			`/mafia sub next, [player] - Forcibly sub [player] out of the game. Requires host % @ * # & ~`,
-			`/mafia sub remove, [user] - Forcibly remove [user] from the sublist. Requres host % @ * # & ~`,
-			`/mafia sub unrequest, [player] - Remove's a player's request to sub out of the game. Requires host % @ * # & ~`,
-			`/mafia sub [player], [user] - Forcibly sub [player] for [user]. Requires host % @ * # & ~`,
-			`/mafia autosub [yes|no] - Sets if players will automatically sub out if a user is on the sublist. Defaults to yes. Requires host % @ * # & ~`,
-			`/mafia [love|hate] [player] - Makes it take 1 more (love) or less (hate) lynch to hammer [player]. Requires host % @ * # & ~`,
-			`/mafia [unlove|unhate] [player] - Removes loved or hated status from [player]. Requires host % @ * # & ~`,
-			`/mafia [mayor|voteless] [player] - Makes [player]'s' lynch worth 2 votes (mayor) or makes [player]'s lynch worth 0 votes (voteless). Requires host % @ * # & ~`,
-			`/mafia [unmayor|unvoteless] [player] - Removes mayor or voteless status from [player]. Requires host % @ * # & ~`,
+			`/mafia sub next, [player] - Forcibly sub [player] out of the game. Requires host % @ # & ~`,
+			`/mafia sub remove, [user] - Forcibly remove [user] from the sublist. Requres host % @ # & ~`,
+			`/mafia sub unrequest, [player] - Remove's a player's request to sub out of the game. Requires host % @ # & ~`,
+			`/mafia sub [player], [user] - Forcibly sub [player] for [user]. Requires host % @ # & ~`,
+			`/mafia autosub [yes|no] - Sets if players will automatically sub out if a user is on the sublist. Defaults to yes. Requires host % @ # & ~`,
+			`/mafia [love|hate] [player] - Makes it take 1 more (love) or less (hate) lynch to hammer [player]. Requires host % @ # & ~`,
+			`/mafia [unlove|unhate] [player] - Removes loved or hated status from [player]. Requires host % @ # & ~`,
+			`/mafia [mayor|voteless] [player] - Makes [player]'s' lynch worth 2 votes (mayor) or makes [player]'s lynch worth 0 votes (voteless). Requires host % @ # & ~`,
+			`/mafia [unmayor|unvoteless] [player] - Removes mayor or voteless status from [player]. Requires host % @ # & ~`,
 			`/mafia hammer [hammer] - sets the hammer count to [hammer] and resets lynches`,
 			`/mafia shifthammer [hammer] - sets the hammer count to [hammer] without resetting lynches`,
 			`/mafia resethammer - sets the hammer to the default, resetting lynches`,
 			`/mafia playerroles - View all the player's roles in chat. Requires host`,
-			`/mafia end - End the current game of mafia. Requires host % @ * # & ~`,
+			`/mafia end - End the current game of mafia. Requires host % @ # & ~`,
 		].join('<br/>');
 		buf += `</details><details><summary class="button">IDEA Module Commands</summary>`;
 		buf += [
 			`<br/><strong>Commands for using IDEA modules</strong><br/>`,
-			`/mafia idea [idea] - starts the IDEA module [idea]. Requires + % @ * # & ~, voices can only start for themselves`,
-			`/mafia ideareroll - rerolls the IDEA module. Requires host % @ * # & ~`,
+			`/mafia idea [idea] - starts the IDEA module [idea]. Requires + % @ # & ~, voices can only start for themselves`,
+			`/mafia ideareroll - rerolls the IDEA module. Requires host % @ # & ~`,
 			`/mafia ideapick [selection], [role] - selects a role`,
 			`/mafia ideadiscards - shows the discarded roles`,
-			`/mafia ideadiscards off - hides discards from the players. Requires host % @ * # & ~`,
-			`/mafia ideadiscards on - shows discards to the players. Requires host % @ * # & ~`,
+			`/mafia ideadiscards off - hides discards from the players. Requires host % @ # & ~`,
+			`/mafia ideadiscards on - shows discards to the players. Requires host % @ # & ~`,
 			`/mafia customidea choices, picks (new line here, shift+enter)`,
 			`(comma or newline separated rolelist) - Starts an IDEA module with custom roles. Requires % @ # & ~`,
 		].join('<br/>');
@@ -3134,18 +3134,18 @@ const commands = {
 		buf += `</details><details><summary class="button">Mafia Room Specific Commands</summary>`;
 		buf += [
 			`<br/><strong>Commands that are only useable in the Mafia Room</strong>:<br/>`,
-			`/mafia queue add, [user] - Adds the user to the host queue. Requires % @ * # & ~.`,
-			`/mafia queue remove, [user] - Removes the user from the queue. You can remove yourself regardless of rank. Requires % @ * # & ~.`,
+			`/mafia queue add, [user] - Adds the user to the host queue. Requires % @ # & ~.`,
+			`/mafia queue remove, [user] - Removes the user from the queue. You can remove yourself regardless of rank. Requires % @ # & ~.`,
 			`/mafia queue - Shows the list of users who are in queue to host.`,
 			`/mafia win (points) [user1], [user2], [user3], ... - Award the specified users points to the mafia leaderboard for this month. The amount of points can be negative to take points. Defaults to 10 points.`,
-			`/mafia winfaction (points), [faction] - Award the specified points to all the players in the given faction. Requires % @ * # & ~`,
+			`/mafia winfaction (points), [faction] - Award the specified points to all the players in the given faction. Requires % @ # & ~`,
 			`/mafia mvp [user1], [user2], ... - Gives a MVP point and 10 leaderboard points to the users specified.`,
 			`/mafia unmvp [user1], [user2], ... - Takes away a MVP point and 10 leaderboard points from the users specified.`,
 			`/mafia [leaderboard|mvpladder] - View the leaderboard or MVP ladder for the current or last month.`,
-			`/mafia [hostlost|playlogs] - View the host logs or play logs for the current or last month. Requires % @ * # & ~`,
-			`/mafia hostban [user], [duration] - Ban a user from hosting games for [duration] days. Requires % @ * # & ~`,
-			`/mafia unhostban [user] - Unbans a user from hosting games. Requires % @ * # & ~`,
-			`/mafia hostbans - Checks current hostbans. Requires % @ * # & ~`,
+			`/mafia [hostlost|playlogs] - View the host logs or play logs for the current or last month. Requires % @ # & ~`,
+			`/mafia hostban [user], [duration] - Ban a user from hosting games for [duration] days. Requires % @ # & ~`,
+			`/mafia unhostban [user] - Unbans a user from hosting games. Requires % @ # & ~`,
+			`/mafia hostbans - Checks current hostbans. Requires % @ # & ~`,
 		].join('<br/>');
 		buf += `</details>`;
 

--- a/server/chat-plugins/modlog.js
+++ b/server/chat-plugins/modlog.js
@@ -527,7 +527,7 @@ exports.commands = {
 	modloghelp: [
 		`/modlog OR /ml [roomid], [search] - Searches the moderator log - defaults to the current room unless specified otherwise.`,
 		`If you set [roomid] as [all], it searches for [search] on all rooms' moderator logs.`,
-		`If you set [roomid] as [public], it searches for [search] in all public rooms' moderator logs, excluding battles. Requires: % @ * # & ~`,
+		`If you set [roomid] as [public], it searches for [search] in all public rooms' moderator logs, excluding battles. Requires: % @ # & ~`,
 	],
 
 	battlesearch(target, room, user, connection) {

--- a/server/chat-plugins/othermetas.js
+++ b/server/chat-plugins/othermetas.js
@@ -61,7 +61,7 @@ const commands = {
 	},
 	othermetashelp: [
 		`/om - Provides links to information on the Other Metagames.`,
-		`!om - Show everyone that information. Requires: + % @ * # & ~`,
+		`!om - Show everyone that information. Requires: + % @ # & ~`,
 	],
 
 	'!mixandmega': true,

--- a/server/chat-plugins/poll.js
+++ b/server/chat-plugins/poll.js
@@ -265,7 +265,7 @@ const commands = {
 			this.modlog('POLL');
 			return this.privateModAction(`(A poll was started by ${user.name}.)`);
 		},
-		newhelp: [`/poll create [question], [option1], [option2], [...] - Creates a poll. Requires: % @ * # & ~`],
+		newhelp: [`/poll create [question], [option1], [option2], [...] - Creates a poll. Requires: % @ # & ~`],
 
 		vote(target, room, user) {
 			if (!room.poll) return this.errorReply("There is no poll running in this room.");
@@ -318,8 +318,8 @@ const commands = {
 			}
 		},
 		timerhelp: [
-			`/poll timer [minutes] - Sets the poll to automatically end after [minutes] minutes. Requires: % @ * # & ~`,
-			`/poll timer clear - Clears the poll's timer. Requires: % @ * # & ~`,
+			`/poll timer [minutes] - Sets the poll to automatically end after [minutes] minutes. Requires: % @ # & ~`,
+			`/poll timer clear - Clears the poll's timer. Requires: % @ # & ~`,
 		],
 
 		results(target, room, user) {
@@ -342,7 +342,7 @@ const commands = {
 			this.modlog('POLL END');
 			return this.privateModAction(`(The poll was ended by ${user.name}.)`);
 		},
-		endhelp: [`/poll end - Ends a poll and displays the results. Requires: % @ * # & ~`],
+		endhelp: [`/poll end - Ends a poll and displays the results. Requires: % @ # & ~`],
 
 		show: 'display',
 		display(target, room, user, connection) {
@@ -365,13 +365,13 @@ const commands = {
 	pollhelp: [
 		`/poll allows rooms to run their own polls. These polls are limited to one poll at a time per room.`,
 		`Accepts the following commands:`,
-		`/poll create [question], [option1], [option2], [...] - Creates a poll. Requires: % @ * # & ~`,
+		`/poll create [question], [option1], [option2], [...] - Creates a poll. Requires: % @ # & ~`,
 		`/poll htmlcreate [question], [option1], [option2], [...] - Creates a poll, with HTML allowed in the question and options. Requires: # & ~`,
 		`/poll vote [number] - Votes for option [number].`,
-		`/poll timer [minutes] - Sets the poll to automatically end after [minutes]. Requires: % @ * # & ~`,
+		`/poll timer [minutes] - Sets the poll to automatically end after [minutes]. Requires: % @ # & ~`,
 		`/poll results - Shows the results of the poll without voting. NOTE: you can't go back and vote after using this.`,
 		`/poll display - Displays the poll`,
-		`/poll end - Ends a poll and displays the results. Requires: % @ * # & ~`,
+		`/poll end - Ends a poll and displays the results. Requires: % @ # & ~`,
 	],
 };
 

--- a/server/chat-plugins/roomsettings.js
+++ b/server/chat-plugins/roomsettings.js
@@ -438,8 +438,8 @@ exports.commands = {
 		}
 	},
 	slowchathelp: [
-		`/slowchat [number] - Sets a limit on how often users in the room can send messages, between 2 and 60 seconds. Requires @ * # & ~`,
-		`/slowchat off - Disables slowchat in the room. Requires @ * # & ~`,
+		`/slowchat [number] - Sets a limit on how often users in the room can send messages, between 2 and 60 seconds. Requires @ # & ~`,
+		`/slowchat off - Disables slowchat in the room. Requires @ # & ~`,
 	],
 
 	stretching: 'stretchfilter',
@@ -637,7 +637,7 @@ exports.commands = {
 	banwordhelp: [
 		`/banword add [words] - Adds the comma-separated list of phrases (& or ~ can also input regex) to the banword list of the current room. Requires: # & ~`,
 		`/banword delete [words] - Removes the comma-separated list of phrases from the banword list. Requires: # & ~`,
-		`/banword list - Shows the list of banned words in the current room. Requires: % @ * # & ~`,
+		`/banword list - Shows the list of banned words in the current room. Requires: % @ # & ~`,
 	],
 
 	hightraffic(target, room, user) {

--- a/server/chat-plugins/thecafe.js
+++ b/server/chat-plugins/thecafe.js
@@ -206,11 +206,11 @@ const commands = {
 	},
 	foodfighthelp: [
 		`/foodfight <generator> - Gives you a randomly generated Foodfight dish, ingredient list and team. Generator can be either 'random', 'ou', 'ag', or left blank. If left blank, uses Battle Factory to generate an importable team.`,
-		`/checkfoodfight <username> - Gives you the last team and dish generated for the entered user, or your own if left blank. Anyone can check their own info, checking other people requires: % @ * # & ~`,
-		`/adddish <dish>, <ingredient>, <ingredient>, ... - Adds a dish to the database. Requires: % @ * # & ~`,
-		`/addingredients <dish>, <ingredient>, <ingredient>, ... - Adds extra ingredients to a dish in the database. Requires: % @ * # & ~`,
-		`/removedish <dish> - Removes a dish from the database. Requires: % @ * # & ~`,
-		`/viewdishes - Shows the entire database of dishes. Requires: % @ * # & ~`,
+		`/checkfoodfight <username> - Gives you the last team and dish generated for the entered user, or your own if left blank. Anyone can check their own info, checking other people requires: % @ # & ~`,
+		`/adddish <dish>, <ingredient>, <ingredient>, ... - Adds a dish to the database. Requires: % @ # & ~`,
+		`/addingredients <dish>, <ingredient>, <ingredient>, ... - Adds extra ingredients to a dish in the database. Requires: % @ # & ~`,
+		`/removedish <dish> - Removes a dish from the database. Requires: % @ # & ~`,
+		`/viewdishes - Shows the entire database of dishes. Requires: % @ # & ~`,
 	],
 };
 

--- a/server/chat-plugins/thing-of-the-day.js
+++ b/server/chat-plugins/thing-of-the-day.js
@@ -505,7 +505,7 @@ let commands = {
 			this.sendReply(`User '${target}' has no nomination for the ${handler.name} of the ${handler.timeLabel}.`);
 		}
 	},
-	removehelp: [`/-otd remove [username] - Remove a user's nomination for the Thing of the Day and prevent them from voting again until the next round. Requires: % @ * # & ~`],
+	removehelp: [`/-otd remove [username] - Remove a user's nomination for the Thing of the Day and prevent them from voting again until the next round. Requires: % @ # & ~`],
 
 	force(target, room, user) {
 		if (!this.canTalk()) return;
@@ -604,7 +604,7 @@ let commands = {
 			return this.privateModAction(`(${user.name} changed the following propert${Chat.plural(keys, 'ies', 'y')} of the ${handler.name} of the ${handler.timeLabel}: ${keys.join(', ')})`);
 		}
 	},
-	sethelp: [`/-otd set property: value[, property: value] - Set the winner, quote, song, link or image for the current Thing of the Day. Requires: % @ * # & ~`],
+	sethelp: [`/-otd set property: value[, property: value] - Set the winner, quote, song, link or image for the current Thing of the Day. Requires: % @ # & ~`],
 
 	winners(target, room, user, connection) {
 		if (!this.canTalk()) return;
@@ -663,11 +663,11 @@ const help = [
 	`- /-otd - View the current Thing of the Day.`,
 	`- /-otd start - Starts nominations for the Thing of the Day. Requires: % @ # & ~`,
 	`- /-otd nom [nomination] - Nominate something for Thing of the Day.`,
-	`- /-otd remove [username] - Remove a user's nomination for the Thing of the Day and prevent them from voting again until the next round. Requires: % @ * # & ~`,
+	`- /-otd remove [username] - Remove a user's nomination for the Thing of the Day and prevent them from voting again until the next round. Requires: % @ # & ~`,
 	`- /-otd end - End nominations for the Thing of the Day and set it to a randomly selected nomination. Requires: % @ # & ~`,
 	`- /-otd force [nomination] - Forcibly sets the Thing of the Day without a nomination round. Requires: # & ~`,
 	`- /-otd delay - Turns off the automatic 20 minute timer for Thing of the Day voting rounds. Requires: % @ # & ~`,
-	`- /-otd set property: value[, property: value] - Set the winner, quote, song, link or image for the current Thing of the Day. Requires: % @ * # & ~`,
+	`- /-otd set property: value[, property: value] - Set the winner, quote, song, link or image for the current Thing of the Day. Requires: % @ # & ~`,
 	`- /-otd winners - Displays a list of previous things of the day.`,
 ];
 

--- a/server/chat-plugins/uno.js
+++ b/server/chat-plugins/uno.js
@@ -954,12 +954,12 @@ const commands = {
 	},
 
 	unohelp: [
-		`/uno create [player cap] - creates a new UNO game with an optional player cap (default player cap at 6). Use the command [createpublic] to force a public game or [createprivate] to force a private game. Requires: % @ * # & ~`,
-		`/uno timer [amount] - sets an auto disqualification timer for [amount] seconds. Requires: % @ * # & ~`,
-		`/uno autostart [amount] - sets an auto starting timer for [amount] seconds. Requires: % @ * # & ~`,
-		`/uno end - ends the current game of UNO. Requires: % @ * # & ~`,
-		`/uno start - starts the current game of UNO. Requires: % @ * # & ~`,
-		`/uno disqualify [player] - disqualifies the player from the game. Requires: % @ * # & ~`,
+		`/uno create [player cap] - creates a new UNO game with an optional player cap (default player cap at 6). Use the command [createpublic] to force a public game or [createprivate] to force a private game. Requires: % @ # & ~`,
+		`/uno timer [amount] - sets an auto disqualification timer for [amount] seconds. Requires: % @ # & ~`,
+		`/uno autostart [amount] - sets an auto starting timer for [amount] seconds. Requires: % @ # & ~`,
+		`/uno end - ends the current game of UNO. Requires: % @ # & ~`,
+		`/uno start - starts the current game of UNO. Requires: % @ # & ~`,
+		`/uno disqualify [player] - disqualifies the player from the game. Requires: % @ # & ~`,
 		`/uno hand - displays your own hand.`,
 		`/uno getusers - displays the players still in the game.`,
 		`/uno [spectate|unspectate] - spectate / unspectate the current private UNO game.`,

--- a/server/chat-plugins/wifi.js
+++ b/server/chat-plugins/wifi.js
@@ -948,23 +948,23 @@ let commands = {
 		case 'staff':
 			if (!this.can('broadcast', null, room)) return;
 			reply = '<strong>Staff commands:</strong><br />' +
-			        '- question or qg <em>User | OT | TID | Friend Code | Prize | Question | Answer[ | Answer2 | Answer3]</em> - Start a new question giveaway (voices can only host for themselves, staff can for all users) (Requires: + % @ * # & ~)<br />' +
-			        '- lottery or lg <em>User | OT | TID | Friend Code | Prize[| Number of Winners]</em> - Starts a lottery giveaway (voices can only host for themselves, staff can for all users) (Requires: + % @ * # & ~)<br />' +
+			        '- question or qg <em>User | OT | TID | Friend Code | Prize | Question | Answer[ | Answer2 | Answer3]</em> - Start a new question giveaway (voices can only host for themselves, staff can for all users) (Requires: + % @ # & ~)<br />' +
+			        '- lottery or lg <em>User | OT | TID | Friend Code | Prize[| Number of Winners]</em> - Starts a lottery giveaway (voices can only host for themselves, staff can for all users) (Requires: + % @ # & ~)<br />' +
 			        '- changequestion - Changes the question of a question giveaway (Requires: giveaway host)<br />' +
 			        '- changeanswer - Changes the answer of a question giveaway (Requires: giveaway host)<br />' +
 					'- viewanswer - Shows the answer in a question giveaway (only to giveaway host/giver)<br />' +
-					'- ban - Temporarily bans a user from entering giveaways (Requires: % @ * # & ~)<br />' +
-			        '- end - Forcibly ends the current giveaway (Requires: % @ * # & ~)<br />' +
+					'- ban - Temporarily bans a user from entering giveaways (Requires: % @ # & ~)<br />' +
+			        '- end - Forcibly ends the current giveaway (Requires: % @ # & ~)<br />' +
 					'- count <em>Mon</em> - Displays how often a certain mon has been given away. Use <code>!giveaway count</code> to broadcast this to the entire room<br />';
 			break;
 		case 'gts':
 			if (!this.can('broadcast', null, room)) return;
 			reply = '<strong>GTS giveaway commands:</strong><br />' +
-			        '- gts start <em>User | Amount | Summary of given mon | What to deposit | What to look for</em> - Starts a gts giveaway (Requires: % @ * # & ~)<br />' +
+			        '- gts start <em>User | Amount | Summary of given mon | What to deposit | What to look for</em> - Starts a gts giveaway (Requires: % @ # & ~)<br />' +
 					'- gts left <em>Amount</em> - Updates the amount left for the current GTS giveaway. Without an amount specified, shows how many Pokémon are left, and who the latest winners are.<br />' +
 					'- gts sent <em>IGN</em> - Adds an ign to the list of latest winners, and updates left count accordingly.<br />' +
 					'- gts full - Signifies enough mons have been received, and will update the GTS giveaway to reflect that.<br />' +
-			        '- gts end - Forcibly ends the current gts giveaway (Requires: % @ * # & ~)<br />';
+			        '- gts end - Forcibly ends the current gts giveaway (Requires: % @ # & ~)<br />';
 			break;
 		case 'game':
 		case 'giveaway':
@@ -981,8 +981,8 @@ let commands = {
 			if (!this.runBroadcast()) return;
 			reply = '<b>Wi-Fi room Giveaway help and info</b><br />' +
 			'- help user - shows list of participation commands<br />' +
-			'- help staff - shows giveaway staff commands (Requires: + % @ * # & ~)<br />' +
-			'- help gts - shows gts giveaway commands (Requires: + % @ * # & ~)';
+			'- help staff - shows giveaway staff commands (Requires: + % @ # & ~)<br />' +
+			'- help gts - shows gts giveaway commands (Requires: + % @ # & ~)';
 		}
 		this.sendReplyBox(reply);
 	},


### PR DESCRIPTION
As suggested by PartMan, when elements overflow the roomintro, automatically add scroll bars. This is mostly for mobile users as certian elements can be unusable. Though both infobox and infobox both have overflow: auto; built in for some reason this does not fix the issue. This is probably not the best way to go about fixing this so any other suggestions would be appreciated.