### PR TITLE
Optimize Dex#getEffect by caching the result.

### DIFF
--- a/sim/dex.js
+++ b/sim/dex.js
@@ -130,6 +130,8 @@ class ModdedDex {
 		this.abilityCache = new Map();
 		/** @type {Map<string, TypeInfo>} */
 		this.typeCache = new Map();
+		/** @type {Map<string, PureEffect>} */
+		this.effectCache = new Map();
 
 		if (!isOriginal) {
 			const original = dexes['base'].mod(mod).includeData();
@@ -458,10 +460,8 @@ class ModdedDex {
 		moveCopy.hit = 0;
 		return moveCopy;
 	}
+
 	/**
-	 * While this function can technically return any kind of effect at
-	 * all, that's not a feature TypeScript needs to know about.
-	 *
 	 * @param {?string | Effect} [name]
 	 * @return {PureEffect}
 	 */
@@ -473,6 +473,22 @@ class ModdedDex {
 			// @ts-ignore
 			return name;
 		}
+
+		let cached = this.effectCache.get(name);
+		if (!cached) {
+			cached = this.getEffectInner(name);
+			this.effectCache.set(name, cached);
+		}
+		return cached;
+	}
+
+	/**
+	* While this function can technically return any kind of effect at
+	* all, that's not a feature TypeScript needs to know about.
+	* @param {string} name
+	* @return {PureEffect}
+	*/
+	getEffectInner(name) {
 		if (name.startsWith('move:')) {
 			// @ts-ignore
 			return this.getMove(name.slice(5));


### PR DESCRIPTION
I've been taking a look at optimizing the simulator (see [pkmn.cc/optimize](https://pkmn.cc/optimize) - comments welcome), and `getEffect` seems ripe for improvements. I can't confirm this caching is 100% safe - I don't know if `Effect`s are supposed to be immutable or not, but the 'tests pass', for whatever that's worth. There's already caching for `Move`/`Ability`/`Item` etc, but `getEffect` only very rarely hits those code paths, so it's actually missing out on most of the benefit. 

This change should result in a **~30% increase in overall battle performance** over repeated runs, but if this caching would break things theres still some other options for restructuring the method for performance, as outlined in the doc. I think there's more performance gains to be had by refactoring `getRelevantEffects`, but it would require a substantially larger change architecturally, so I'd hope to get some buy in before tackling that.