### PR TITLE
Refactor Dex#getEffect + Dex#getEffectInner back to one method

### DIFF
--- a/sim/dex.js
+++ b/sim/dex.js
@@ -476,7 +476,7 @@ class ModdedDex {
 			// @ts-ignore
 			return name;
 		}
-		/** @type {Effect|undefined} */
+
 		let effect = this.effectCache.get(name);
 		if (effect) {
 			// @ts-ignore

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -465,7 +465,7 @@ class ModdedDex {
 	* While this function can technically return any kind of effect at
 	* all, that's not a feature TypeScript needs to know about.
 	*
-	* @param {string?|Effect} [name]
+	* @param {string? | Effect} [name]
 	* @return {PureEffect}
 	*/
 	getEffect(name) {

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -130,7 +130,7 @@ class ModdedDex {
 		this.abilityCache = new Map();
 		/** @type {Map<string, TypeInfo>} */
 		this.typeCache = new Map();
-		/** @type {Map<string, Effect>} */
+		/** @type {Map<string, Effect | Move>} */
 		this.effectCache = new Map();
 
 		if (!isOriginal) {
@@ -484,7 +484,6 @@ class ModdedDex {
 		}
 
 		if (name.startsWith('move:')) {
-			// @ts-ignore
 			effect = this.getMove(name.slice(5));
 		} else if (name.startsWith('item:')) {
 			effect = this.getItem(name.slice(5));
@@ -519,9 +518,7 @@ class ModdedDex {
 			effect = new Data.PureEffect({name, exists: false});
 		}
 
-		if (effect) {
-			this.effectCache.set(name, effect);
-		}
+		this.effectCache.set(name, effect);
 		// @ts-ignore
 		return effect;
 	}

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -473,14 +473,12 @@ class ModdedDex {
 			return nullEffect;
 		}
 		if (typeof name !== 'string') {
-			// @ts-ignore
-			return name;
+			return /** @type {PureEffect} */ (name);
 		}
 
 		let effect = this.effectCache.get(name);
 		if (effect) {
-			// @ts-ignore
-			return effect;
+			return /** @type {PureEffect} */ (effect);
 		}
 
 		if (name.startsWith('move:')) {
@@ -519,8 +517,7 @@ class ModdedDex {
 		}
 
 		this.effectCache.set(name, effect);
-		// @ts-ignore
-		return effect;
+		return /** @type {PureEffect} */ (effect);
 	}
 	/**
 	 * Returns a sanitized format ID if valid, or throws if invalid.


### PR DESCRIPTION
Not ideal from a static typing POV - I don't think this `@ts-ignore`s `PureEffect`/`Effect` any more than the original code did, but its still not very pretty.