### PR TITLE
Refactor remaining tests to use Battle#makeChoices

### DIFF
--- a/test/simulator/abilities/disguise.js
+++ b/test/simulator/abilities/disguise.js
@@ -12,22 +12,22 @@ describe('Disguise', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mimikyu', ability: 'disguise', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Mewtwo', ability: 'pressure', moves: ['psystrike']}]);
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 
 	it('should only block damage from the first hit of a move', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mimikyu', ability: 'disguise', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Beedrill', ability: 'swarm', moves: ['twineedle']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 
 	it('should block a hit from confusion', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mimikyu', ability: 'disguise', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Sableye', ability: 'prankster', moves: ['confuseray']}]);
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices());
 		assert.ok(battle.p1.active[0].abilityData.busted);
 	});
 
@@ -35,7 +35,7 @@ describe('Disguise', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mimikyu', ability: 'disguise', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Tyranitar', ability: 'sandstream', moves: ['rest']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 
 	it('should not block damage from entry hazards', function () {
@@ -45,7 +45,7 @@ describe('Disguise', function () {
 			{species: 'Mimikyu', ability: 'disguise', moves: ['splash']},
 		]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'forretress', ability: 'sturdy', item: 'redcard', moves: ['spikes']}]);
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.false.fullHP(battle.p1.active[0]);
 	});
 
@@ -54,7 +54,7 @@ describe('Disguise', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mimikyu', ability: 'disguise', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Ariados', ability: 'swarm', moves: ['toxicthread']}]);
 		let pokemon = battle.p1.active[0];
-		assert.sets(() => pokemon.status, 'psn', () => battle.commitDecisions());
+		assert.sets(() => pokemon.status, 'psn', () => battle.makeChoices());
 		assert.statStage(pokemon, 'spe', -1);
 		assert.false.fullHP(pokemon);
 	});
@@ -64,7 +64,7 @@ describe('Disguise', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mimikyu', ability: 'disguise', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Pikachu', ability: 'lightningrod', moves: ['nuzzle']}]);
 		let pokemon = battle.p1.active[0];
-		assert.sets(() => pokemon.status, 'par', () => battle.commitDecisions());
+		assert.sets(() => pokemon.status, 'par', () => battle.makeChoices());
 		assert.fullHP(pokemon);
 	});
 
@@ -72,7 +72,7 @@ describe('Disguise', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Mimikyu', ability: 'disguise', moves: ['counter']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Weavile', ability: 'pressure', moves: ['feintattack']}]);
-		assert.hurtsBy(battle.p2.active[0], 1, () => battle.commitDecisions());
+		assert.hurtsBy(battle.p2.active[0], 1, () => battle.makeChoices());
 	});
 
 	it.skip('should not trigger critical hits while active', function () {
@@ -86,7 +86,7 @@ describe('Disguise', function () {
 				assert.ok(!move.crit);
 			}
 		});
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.ok(successfulEvent);
 	});
 });

--- a/test/simulator/abilities/prankster.js
+++ b/test/simulator/abilities/prankster.js
@@ -65,8 +65,9 @@ describe('Prankster', function () {
 			[{species: "Liepard", ability: 'prankster', moves: ['encore', 'nastyplot']}, {species: "Tapu Fini", ability: 'mistysurge', moves: ['calmmind']}],
 			[{species: "Meowstic", ability: 'prankster', moves: ['frustration', 'leer']}, {species: "Lopunny", ability: 'limber', moves: ['agility']}],
 		]);
-		battle.p1.chooseMove('encore', 1).chooseMove('calmmind').foe.chooseMove('frustration', 2).chooseMove('agility');
-		battle.p1.chooseMove('encore', 1).chooseMove('calmmind').foe.chooseMove('leer').chooseMove('agility');
+
+		battle.makeChoices('move encore 1, move calmmind', 'move frustration 2, move agility');
+		battle.makeChoices('move encore 1, move calmmind', 'move leer, move agility');
 		assert(battle.p2.active[0].volatiles.encore, `Meowstic should be encored`);
 		assert.fullHP(battle.p1.active[0]);
 	});

--- a/test/simulator/abilities/rockhead.js
+++ b/test/simulator/abilities/rockhead.js
@@ -43,6 +43,6 @@ describe('Rock Head', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Rampardos', ability: 'rockhead', moves: ['splash']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Abomasnow', ability: 'snowwarning', moves: ['splash']}]);
-		assert.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 });

--- a/test/simulator/abilities/truant.js
+++ b/test/simulator/abilities/truant.js
@@ -16,8 +16,8 @@ describe('Truant', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Steelix", ability: 'sturdy', moves: ['endure']}]);
 		let pokemon = battle.p2.active[0];
 
-		assert.hurts(pokemon, () => battle.commitDecisions());
-		assert.false.hurts(pokemon, () => battle.commitDecisions());
+		assert.hurts(pokemon, () => battle.makeChoices());
+		assert.false.hurts(pokemon, () => battle.makeChoices());
 	});
 
 	it('should allow the user to act after a recharge turn', function () {
@@ -26,9 +26,9 @@ describe('Truant', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Steelix", ability: 'sturdy', moves: ['endure']}]);
 		let pokemon = battle.p2.active[0];
 
-		assert.hurts(pokemon, () => battle.commitDecisions());
-		assert.false.hurts(pokemon, () => battle.commitDecisions());
-		assert.hurts(pokemon, () => battle.commitDecisions());
+		assert.hurts(pokemon, () => battle.makeChoices());
+		assert.false.hurts(pokemon, () => battle.makeChoices());
+		assert.hurts(pokemon, () => battle.makeChoices());
 	});
 
 	it('should not allow the user to act the turn it wakes up, if it moved the turn it fell asleep', function () {
@@ -65,8 +65,8 @@ describe('Truant', function () {
 		battle.join('p2', 'Guest 2', 1, [{species: "Steelix", ability: 'sturdy', moves: ['endure']}]);
 		let pokemon = battle.p2.active[0];
 
-		assert.false.hurts(pokemon, () => battle.commitDecisions());
-		assert.false.hurts(pokemon, () => battle.commitDecisions());
+		assert.false.hurts(pokemon, () => battle.makeChoices());
+		assert.false.hurts(pokemon, () => battle.makeChoices());
 	});
 
 	it('should prevent a newly-Mega Evolved Pokemon from acting if given the ability', function () {

--- a/test/simulator/items/protectivepads.js
+++ b/test/simulator/items/protectivepads.js
@@ -15,7 +15,7 @@ describe('Protective Pads', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Cofagrigus", ability: 'mummy', moves: ['calmmind']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Hariyama", ability: 'thickfat', item: 'protectivepads', moves: ['bulletpunch']}]);
 		const attacker = battle.p2.active[0];
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.strictEqual(attacker.ability, 'thickfat');
 		const mummyActivationMessages = battle.log.filter(logStr => logStr.startsWith('|-activate|') && logStr.includes('Mummy'));
 		assert.strictEqual(mummyActivationMessages.length, 1, "Mummy should activate only once");
@@ -27,7 +27,7 @@ describe('Protective Pads', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Purrloin", ability: 'prankster', item: 'protectivepads', moves: ['scratch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Ferrothorn", ability: 'ironbarbs', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.fullHP(battle.p1.active[0], "Attacker should not be hurt");
 	});
 
@@ -35,7 +35,7 @@ describe('Protective Pads', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Purrloin", ability: 'prankster', item: 'protectivepads', moves: ['scratch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Goodra", ability: 'gooey', moves: ['rest']}]);
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.statStage(battle.p1.active[0], 'spe', 0, "Speed should not be lowered");
 	});
 
@@ -43,7 +43,7 @@ describe('Protective Pads', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Weavile", ability: 'pickpocket', moves: ['swordsdance']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Liepard", ability: 'prankster', item: 'protectivepads', moves: ['scratch']}]);
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.false(battle.p2.active[0].item, "Attacker should lose their item");
 		assert.strictEqual(battle.p1.active[0].item, 'protectivepads', "Target should receive stolen item");
 	});
@@ -52,7 +52,7 @@ describe('Protective Pads', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Purrloin", ability: 'prankster', item: 'protectivepads', moves: ['scratch']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Cacnea", ability: 'waterabsorb', item: 'rockyhelmet', moves: ['synthesis']}]);
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.fullHP(battle.p1.active[0], "Attacker should not be hurt");
 	});
 
@@ -60,7 +60,7 @@ describe('Protective Pads', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', item: 'protectivepads', moves: ['rest']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Galvantula", ability: 'swarm', moves: ['lunge']}]);
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.statStage(battle.p1.active[0], 'atk', -1, "Attack should be lowered");
 	});
 });

--- a/test/simulator/misc/choice-parser.js
+++ b/test/simulator/misc/choice-parser.js
@@ -176,7 +176,7 @@ describe('Choice parser', function () {
 					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 				]);
 				battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense'); // Both p1 active Pokémon faint
-				battle.choose('p1', 'pass, switch 3'); // Koffing switches in at slot #2
+				battle.makeChoices('pass, switch 3', 'pass'); // Koffing switches in at slot #2
 
 				assert.fainted(p1.active[0]);
 				assert.species(p1.active[1], 'Koffing');
@@ -292,7 +292,7 @@ describe('Choice parser', function () {
 				]);
 				battle.makeChoices('move selfdestruct, move selfdestruct, move lunardance', 'move roost, move irondefense, move defensecurl'); // All p1 active Pokémon faint
 
-				p1.choosePass().chooseSwitch(4).chooseDefault(); // Forretress switches in to slot #2
+				battle.makeChoices('pass, switch 4, default', 'pass'); // Forretress switches in to slot #2
 				assert.species(p1.active[1], 'Forretress');
 
 				const validChoices = ['move spikes', 'move 1'];

--- a/test/simulator/misc/decisions.js
+++ b/test/simulator/misc/decisions.js
@@ -553,8 +553,7 @@ describe('Choices', function () {
 				[{species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl']}],
 				[{species: "Charmander", ability: 'blaze', moves: ['scratch', 'growl']}],
 			]);
-			battle.p1.chooseMove(1);
-			battle.p2.chooseMove('growl');
+			battle.makeChoices('move 1', 'move growl');
 
 			const logText = battle.inputLog.join('\n');
 			const subString = '>p1 move tackle\n>p2 move growl';
@@ -569,8 +568,7 @@ describe('Choices', function () {
 				{species: "Charmander", ability: 'blaze', moves: ['scratch']},
 				{species: "Charizard", ability: 'blaze', moves: ['scratch']},
 			]]);
-			battle.p1.chooseMove(1, 1).chooseMove(1, 2);
-			battle.p2.chooseMove(1, 2).chooseMove(1, 1);
+			battle.makeChoices('move tackle 1, move tackle 2', 'move scratch 2, move scratch 1');
 
 			const logText = battle.inputLog.join('\n');
 			const subString = '>p1 move tackle 1, move tackle 2\n>p2 move scratch 2, move scratch 1';
@@ -585,8 +583,7 @@ describe('Choices', function () {
 				{species: "Charmander", ability: 'blaze', moves: ['scratch']},
 				{species: "Charizard", ability: 'blaze', moves: ['scratch']},
 			]]);
-			battle.p1.chooseMove(1).chooseMove(1);
-			battle.p2.chooseMove(1, 1).chooseMove(1, 1);
+			battle.makeChoices('move magnitude, move rockslide', 'move scratch 1, move scratch 1');
 
 			const logText = battle.inputLog.join('\n');
 			const subString = '>p1 move magnitude, move rockslide\n>p2 move scratch 1, move scratch 1';

--- a/test/simulator/misc/decisions.js
+++ b/test/simulator/misc/decisions.js
@@ -224,20 +224,17 @@ describe('Choices', function () {
 				{species: 'Charizard', ability: 'blaze', moves: ['scratch']},
 			]]);
 
-			battle.p1.chooseSwitch(2);
-			battle.p2.chooseSwitch(3);
+			battle.makeChoices('switch 2', 'switch 3');
 
 			assert.species(battle.p1.active[0], 'Ivysaur');
 			assert.species(battle.p2.active[0], 'Charizard');
 
-			battle.p1.chooseSwitch(3);
-			battle.p2.chooseSwitch(3);
+			battle.makeChoices('switch 3', 'switch 3');
 
 			assert.species(battle.p1.active[0], 'Venusaur');
 			assert.species(battle.p2.active[0], 'Charmander');
 
-			battle.p1.chooseSwitch(2);
-			battle.p2.chooseSwitch(2);
+			battle.makeChoices('switch 2', 'switch 2');
 
 			assert.species(battle.p1.active[0], 'Bulbasaur');
 			assert.species(battle.p2.active[0], 'Charmeleon');
@@ -255,11 +252,10 @@ describe('Choices', function () {
 				{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 				{species: "Golem", ability: 'sturdy', moves: ['defensecurl']},
 			]);
-			p1.chooseMove(1).chooseMove(1).chooseShift();
-			p2.chooseMove(1).chooseMove(1).chooseShift();
+			battle.makeChoices('move harden, move defensecurl, shift', 'move roost, move irondefense, shift');
 
-			['Pineco', 'Gastly', 'Geodude'].forEach((species, index) => assert.species(battle.p1.active[index], species));
-			['Skarmory', 'Golem', 'Aggron'].forEach((species, index) => assert.species(battle.p2.active[index], species));
+			['Pineco', 'Gastly', 'Geodude'].forEach((species, index) => assert.species(p1.active[index], species));
+			['Skarmory', 'Golem', 'Aggron'].forEach((species, index) => assert.species(p2.active[index], species));
 		});
 
 		it('should allow shifting the Pokémon on the right to the center', function () {

--- a/test/simulator/misc/fusion-combo.js
+++ b/test/simulator/misc/fusion-combo.js
@@ -16,14 +16,13 @@ describe('Fusion Bolt + Fusion Flare', function () {
 			[{species: 'Dragonite', ability: 'Multiscale', moves: ['roost']}, {species: 'Lugia', ability: 'Multiscale', moves: ['roost']}],
 		]);
 
-		battle.commitDecisions();
+		battle.makeChoices();
 
 		let bpModifiers = new Map();
 		battle.onEvent('BasePower', battle.getFormat(), -100, function (bp, attacker, defender, move) {
 			bpModifiers.set(move.id, this.event.modifier);
 		});
-		battle.p1.chooseMove('fusionbolt', 1).chooseMove('fusionflare', 1);
-		battle.commitDecisions();
+		battle.makeChoices('move fusionbolt 1, move fusionflare 1');
 
 		assert.strictEqual(bpModifiers.get('fusionbolt'), 1);
 		assert.strictEqual(bpModifiers.get('fusionflare'), 2);
@@ -35,14 +34,13 @@ describe('Fusion Bolt + Fusion Flare', function () {
 			[{species: 'Dragonite', ability: 'Multiscale', moves: ['roost']}, {species: 'Lugia', ability: 'Multiscale', moves: ['roost']}],
 		]);
 
-		battle.commitDecisions();
+		battle.makeChoices();
 
 		let bpModifiers = new Map();
 		battle.onEvent('BasePower', battle.getFormat(), -100, function (bp, attacker, defender, move) {
 			bpModifiers.set(move.id, this.event.modifier);
 		});
-		battle.commitDecisions();
-		battle.p1.chooseMove('fusionflare', 2).chooseMove('instruct', -1).foe.chooseDefault();
+		battle.makeChoices('move fusionflare 2, move instruct -1');
 
 		assert.strictEqual(bpModifiers.get('fusionbolt'), 1);
 		assert.strictEqual(bpModifiers.get('fusionflare'), 2);

--- a/test/simulator/misc/fusion-combo.js
+++ b/test/simulator/misc/fusion-combo.js
@@ -22,7 +22,7 @@ describe('Fusion Bolt + Fusion Flare', function () {
 		battle.onEvent('BasePower', battle.getFormat(), -100, function (bp, attacker, defender, move) {
 			bpModifiers.set(move.id, this.event.modifier);
 		});
-		battle.makeChoices('move fusionbolt 1, move fusionflare 1');
+		battle.makeChoices('move fusionbolt 1, move fusionflare 1', 'default');
 
 		assert.strictEqual(bpModifiers.get('fusionbolt'), 1);
 		assert.strictEqual(bpModifiers.get('fusionflare'), 2);
@@ -40,7 +40,7 @@ describe('Fusion Bolt + Fusion Flare', function () {
 		battle.onEvent('BasePower', battle.getFormat(), -100, function (bp, attacker, defender, move) {
 			bpModifiers.set(move.id, this.event.modifier);
 		});
-		battle.makeChoices('move fusionflare 2, move instruct -1');
+		battle.makeChoices('move fusionflare 2, move instruct -1', 'default');
 
 		assert.strictEqual(bpModifiers.get('fusionbolt'), 1);
 		assert.strictEqual(bpModifiers.get('fusionflare'), 2);

--- a/test/simulator/moves/counter.js
+++ b/test/simulator/moves/counter.js
@@ -14,7 +14,7 @@ describe('Counter', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sawk', ability: 'sturdy', moves: ['seismictoss']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Throh', ability: 'guts', moves: ['counter']}]);
-		assert.hurtsBy(battle.p1.active[0], 200, () => battle.commitDecisions());
+		assert.hurtsBy(battle.p1.active[0], 200, () => battle.makeChoices());
 	});
 
 	it('should deal damage based on the last hit from the last Physical attack', function () {
@@ -28,7 +28,7 @@ describe('Counter', function () {
 			}
 		});
 
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.strictEqual(battle.p1.active[0].maxhp - battle.p1.active[0].hp, 2 * lastDamage);
 	});
 
@@ -36,7 +36,7 @@ describe('Counter', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Sawk', ability: 'sturdy', moves: ['aurasphere']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Throh', ability: 'guts', moves: ['counter']}]);
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 
 	it('should target the opposing Pokemon that hit the user with a Physical attack most recently that turn', function () {
@@ -82,7 +82,7 @@ describe('Mirror Coat', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Espeon', ability: 'synchronize', moves: ['sonicboom']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Umbreon', ability: 'synchronize', moves: ['mirrorcoat']}]);
-		assert.hurtsBy(battle.p1.active[0], 40, () => battle.commitDecisions());
+		assert.hurtsBy(battle.p1.active[0], 40, () => battle.makeChoices());
 	});
 
 	it('should deal damage based on the last hit from the last Special attack', function () {
@@ -96,7 +96,7 @@ describe('Mirror Coat', function () {
 			}
 		});
 
-		battle.commitDecisions();
+		battle.makeChoices();
 		assert.strictEqual(battle.p1.active[0].maxhp - battle.p1.active[0].hp, 2 * lastDamage);
 	});
 
@@ -104,7 +104,7 @@ describe('Mirror Coat', function () {
 		battle = common.createBattle();
 		battle.join('p1', 'Guest 1', 1, [{species: 'Espeon', ability: 'synchronize', moves: ['tackle']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: 'Umbreon', ability: 'synchronize', moves: ['mirrorcoat']}]);
-		assert.false.hurts(battle.p1.active[0], () => battle.commitDecisions());
+		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 
 	it('should target the opposing Pokemon that hit the user with a Special attack most recently that turn', function () {

--- a/test/simulator/moves/trumpcard.js
+++ b/test/simulator/moves/trumpcard.js
@@ -24,7 +24,7 @@ describe('Trump Card', function () {
 		});
 
 		for (let i = 0; i < 5; i++) {
-			battle.commitDecisions();
+			battle.makeChoices();
 		}
 
 		assert.deepStrictEqual(basePowers, [40, 50, 60, 80, 200]);
@@ -46,7 +46,7 @@ describe('Trump Card', function () {
 		battle.p1.active[0].moveSlots[0].pp = 2;
 
 		for (let i = 0; i < 2; i++) {
-			battle.commitDecisions();
+			battle.makeChoices();
 		}
 
 		assert.deepStrictEqual(basePowers, [80, 200]);


### PR DESCRIPTION
#2444 indicates that tests should be migrated to use `makeChoices`.

- 6aa40b1 performs a straightforward migration of the Prankster test.
- 03b5b2c migrates to the doubles syntax but also uses `makeChoices` with no args instead of `commitDecisions`, since it should amount to the same thing
- 05fd9b1 takes this further, replaying all `commitDecisions` which just select the default with `makeChoices` instead.

I'm not sure all of these are desirable: 6aa40b1 seems relatively obvious, but I'm not sure if the idea is to remove `commitDecisions` entirely in the long term (calling it indirectly through `makeChoices` like I do in 05fd9b1 seems like a kind of roundabout way of doing things) or just `chooseSwitch`/`chooseMove`, it isn't clear from #2444.

After this, only `test/simulator/misc/decisions.js` and `test/simulator/misc/choice-parser.js` should have the old calls, but it seems like they rely on some of the functionality lacking with the new `makeChoices` method.

Either way, I think the **Refactor old tests** bullet point in #2444 regarding this method should be updated after this PR is resolved/rejected to reflect the correct state of the `makeChoices` refactoring. :)


