### PR TITLE
Random Battle: Update Toucannon

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -7344,7 +7344,7 @@ let BattleFormatsData = {
 		tier: "NFE",
 	},
 	toucannon: {
-		randomBattleMoves: ["substitute", "beakblast", "swordsdance", "roost", "brickbreak", "bulletseed", "rockblast"],
+		randomBattleMoves: ["substitute", "bravebird", "swordsdance", "roost", "brickbreak", "bulletseed", "rockblast"],
 		randomDoubleBattleMoves: ["bulletseed", "rockblast", "bravebird", "tailwind", "protect"],
 		encounters: [
 			{"generation": 7, "level": 26},


### PR DESCRIPTION
Although Beak Blast is the better move for its home tier, the reduced
priority makes it a liability in Random Battle.