### PR TITLE
Skip getRelevantEffects for invalid callbackTypes

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -972,7 +972,7 @@ class Battle extends Dex.ModdedDex {
 	getRelevantEffectsInner(thing, callbackType, foeCallbackType, foeThing, bubbleUp, bubbleDown, getAll) {
 		if (!callbackType || !thing) return [];
 
-		let validCallbackType = !!getAll || CALLBACK_TYPES.has(callbackType);
+		let validCallbackType = !!getAll || this.callbackTypes.has(callbackType);
 		/**@type {AnyObject[]} */
 		let statuses = [];
 
@@ -1038,12 +1038,12 @@ class Battle extends Dex.ModdedDex {
 				}
 			}
 			if (foeCallbackType) {
-				if (!!getAll || CALLBACK_TYPES.has(foeCallbackType)) {
+				if (!!getAll || this.callbackTypes.has(foeCallbackType)) {
 					statuses = statuses.concat(this.getRelevantEffectsInner(thing.foe, foeCallbackType, null, null, false, false, getAll));
 				}
 				if (foeCallbackType.substr(0, 5) === 'onFoe') {
 					let onAnyCallbackType = `onAny${foeCallbackType.substr(5)}`;
-					if (!!getAll || CALLBACK_TYPES.has(onAnyCallbackType)) {
+					if (!!getAll || this.callbackTypes.has(onAnyCallbackType)) {
 						statuses = statuses.concat(this.getRelevantEffectsInner(thing.foe, onAnyCallbackType, null, null, false, false, getAll));
 						statuses = statuses.concat(this.getRelevantEffectsInner(thing, onAnyCallbackType, null, null, false, false, getAll));
 					}
@@ -1106,7 +1106,7 @@ class Battle extends Dex.ModdedDex {
 			}
 		}
 
-		let validFoeCallbackType = !!getAll || (!foeCallbackType ? false : CALLBACK_TYPES.has(foeCallbackType));
+		let validFoeCallbackType = !!getAll || (!foeCallbackType ? false : this.callbackTypes.has(foeCallbackType));
 		if (foeThing && foeCallbackType && foeCallbackType.substr(0, 8) !== 'onSource' && validFoeCallbackType) {
 			statuses = statuses.concat(this.getRelevantEffectsInner(foeThing, foeCallbackType, null, null, false, false, getAll));
 		} else if (foeCallbackType) {
@@ -1115,15 +1115,15 @@ class Battle extends Dex.ModdedDex {
 					statuses = statuses.concat(this.getRelevantEffectsInner(foeThing, foeCallbackType, null, null, false, false, getAll));
 				}
 				foeCallbackType = `onFoe${foeCallbackType.substr(8)}`;
-				validFoeCallbackType = !!getAll || CALLBACK_TYPES.has(foeCallbackType);
+				validFoeCallbackType = !!getAll || this.callbackTypes.has(foeCallbackType);
 				foeThing = null;
 			}
 			if (foeCallbackType.substr(0, 5) === 'onFoe') {
 				let eventName = foeCallbackType.substr(5);
 				let onAllyCallbackType = `onAlly${eventName}`;
 				let onAnyCallbackType = `onAny${eventName}`;
-				let validOnAllyCallbackType = !!getAll || CALLBACK_TYPES.has(onAllyCallbackType);
-				let validOnAnyCallbackType = !!getAll || CALLBACK_TYPES.has(onAnyCallbackType);
+				let validOnAllyCallbackType = !!getAll || this.callbackTypes.has(onAllyCallbackType);
+				let validOnAnyCallbackType = !!getAll || this.callbackTypes.has(onAnyCallbackType);
 
 				if (validOnAllyCallbackType || validOnAnyCallbackType) {
 					for (const allyActive of thing.side.active) {


### PR DESCRIPTION
Tests pass if the hardcoded `CALLBACK_TYPES` are used, and if I load data manually I think I get around the right counts of callbacks, but pretty much all the tests fail because they're not loading data (and do we want them to? seems like it would tank test performance?).

Figured I'd create a WIP PR for feedback:
- b531250: the `sim/battle.js` logic is what I think will be the end state for this branch. It definitely adds complexity to an already complex method, but given how important this method is with respect to performance it seems it would be justified (I'm anticipating on the order of a further 20% reduction). I think we might also want to consider breaking `getRelevantEffectInner` up, something like 5fbae3e seems like it would make things more readable compared to `HEAD`?
- 75f629a: `sim/dex.js` needs work. I'm not sure about a lot of things:
  - is `HAS_CALLBACKS` comprehensive/complete?
  - how should inheriting and `callbackTypes` work? Given that it's always OK to make `callbackTypes` larger than expected (we just get less performance benefit) I erred on the side of caution and just copied everything from the parent.
  - is looking for `startsWith('on')` actually the most robust way to do this? Thats the heuristic I used when going over `dev-tools/globals.ts` to come up with the hardcoded `CALLBACK_TYPES`, but I'm not sure if that's right. Also, that nested `for`-loop is ugh.
  - how do I deal with the loading/test issue in an acceptable way? The naive solution for speedy tests would be could use the hardcoded set of `CALLBACK_TYPES` during testing and the loaded `callbackTypes` in prod, but then we're not actually testing reality so there's cracks for bugs to slip in.
