### PR TITLE
Document remaining message types in SIM-PROTOCOL

### DIFF
--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -136,7 +136,8 @@ The beginning of a battle will look something like this:
 
 `|upkeep`
 
-> Signals the upkeep phase of the turn.
+> Signals the upkeep phase of the turn where the number of turns left for field
+> conditions are updated.
 
 `|turn|NUMBER`
 
@@ -543,7 +544,8 @@ stat boosts are minor actions.
 
 `|-nothing`
 
-> A move did absolutely nothing. (For example: Splash).
+> **DEPRECATED**: A move did absolutely nothing. (For example: Splash). In the
+> future this will be of the form `|-activate||move:Splash`.
 
 `|-hitcount|POKEMON|NUM`
 

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -134,6 +134,10 @@ The beginning of a battle will look something like this:
 > `inactive` means that the timer is on at the time the message was sent,
 > while `inactiveoff` means that the timer is off.
 
+`|upkeep`
+
+> Signals the upkeep phase of the turn.
+
 `|turn|NUMBER`
 
 > It is now turn `NUMBER`.
@@ -283,10 +287,6 @@ message).
 `|faint|POKEMON`
 
 > The Pokémon `POKEMON` has fainted.
-
-`|upkeep`
-
-> TODO
 
 ### Minor actions
 

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -540,11 +540,13 @@ stat boosts are minor actions.
 
 `|-singlemove|POKEMON|MOVE`
 
-> TODO movestatus?
+> The Pokémon `POKEMON` used move `MOVE` which causes a temporary effect lasting
+> the duration of the move. (For example: Grudge, Destiny Bond).
 
 `|-singleturn|POKEMON|MOVE`
 
-> TODO turnstatus?
+> The Pokémon `POKEMON` used move `MOVE` which causes a temporary effect lasting
+> the duration of the turn. (For example: Protect, Focus Punch, Roost).
 
 `|-start|POKEMON|???`
 

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -416,6 +416,17 @@ stat boosts are minor actions.
 
 > Indicates that the side condition `CONDITION` ended for the given `SIDE`.
 
+`|-start|POKEMON|EFFECT`
+
+> A [*volatile* status](https://bulbapedia.bulbagarden.net/wiki/Status_condition#Volatile_status)
+> has been inflicted on the `POKEMON` Pokémon by `EFFECT`. (For example:
+> confusion, Taunt, Substitute).
+
+`|-end|POKEMON|EFFECT`
+
+> The volatile status from `EFFECT` inflicted on the `POKEMON` Pokémon has
+> ended.
+
 `|-crit|POKEMON`
 
 > A move has dealt a critical hit against the `POKEMON`.
@@ -547,14 +558,6 @@ stat boosts are minor actions.
 
 > The Pokémon `POKEMON` used move `MOVE` which causes a temporary effect lasting
 > the duration of the turn. (For example: Protect, Focus Punch, Roost).
-
-`|-start|POKEMON|???`
-
-> TODO
-
-`|-end|POKEMON|???`
-
-> TODO
 
 
 Sending decisions

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -284,6 +284,10 @@ message).
 
 > The Pokémon `POKEMON` has fainted.
 
+`|upkeep`
+
+> TODO
+
 ### Minor actions
 
 Minor actions are less important than major actions. In the official client,
@@ -299,6 +303,17 @@ stat boosts are minor actions.
 > ability like Hyper Cutter, in which case `ACTION` will be `unboost|STAT`,
 > where `STAT` indicates where the ability prevents stat drops. (For abilities
 > that block all stat drops, like Clear Body, `|STAT` does not appear.) 
+
+`|-notarget|POKEMON`
+
+> A move has failed due to their being no target Pokémon `POKEMON`. `POKEMON` is
+> not present in Generation 1. This action is specific to Generations 1-4 as in
+> later Generations a failed move will display using `-fail`.
+
+`|-miss|SOURCE|TARGET`
+
+> The move used by the `SOURCE` Pokémon missed (maybe absent) the `TARGET`
+> Pokémon.
 
 `|-damage|POKEMON|HP STATUS`
 
@@ -335,6 +350,44 @@ stat boosts are minor actions.
 `|-unboost|POKEMON|STAT|AMOUNT`
 
 > Same as `-boost`, but for negative stat changes instead.
+
+`|-setboost|POKEMON|STAT|AMOUNT`
+
+> Same as `-boost` and `-unboost`, but `STAT` is *set* to `AMOUNT` instead of
+> boosted *by* `AMOUNT`. (For example: Anger Point, Belly Drum)
+
+`|-swapboost|SOURCE|TARGET|STATS`
+
+> Swaps the boosts from `STATS` between the `SOURCE` Pokémon and `TARGET
+> Pokémon.`STATS`takes the form of a comma-separated list of`STAT`abbreviations
+> as described in`-boost`. (For example: Guard Swap, Heart Swap).
+
+`|-invertboost|POKEMON`
+
+> Invert the boosts of the target Pokémon `POKEMON`. (For example: Topsy-Turvy).
+
+`|-clearboost|POKEMON`
+
+> Clears all of the boosts of the target `POKEMON`. (For example: Clear Smog).
+
+`|-clearallboost`
+
+> Clears all boosts from all Pokémon on both sides. (For example: Haze).
+
+`|-clearpositiveboost|TARGET|POKEMON|EFFECT`
+
+> Clear the positive boosts from the `TARGET` Pokémon due to an `EFFECT` of the
+> `POKEMON` Pokémon. (For example: 'move: Spectral Thief').
+
+`|-clearnegativeboost|POKEMON`
+
+> Clear the negative boosts from the target Pokémon `POKEMON`. (For example:
+> usually as the result of a `[zeffect]`).
+
+`|-copyboost|SOURCE|TARGET`
+
+> Copy the boosts from `SOURCE` Pokémon to `TARGET` Pokémon (For example: Psych
+> Up).
 
 `|-weather|WEATHER`
 
@@ -419,6 +472,22 @@ stat boosts are minor actions.
 
 > The Pokémon `POKEMON` used `MEGASTONE` to Mega Evolve.
 
+`|-primal|POKEMON`
+
+> The Pokémon `POKEMON` has reverted to its primal forme.
+
+`|-burst|POKEMON|SPECIES|ITEM`
+
+> The Pokémon `POKEMON` has used `ITEM` to Ultra Burst into `SPECIES`.
+
+`|-zpower|POKEMON`
+
+> The Pokémon `POKEMON` has used the z-move version of its move.
+
+`|-zbroken|POKEMON`
+
+> A z-move has broken through protect and hit the `POKEMON`.
+
 `|-activate|EFFECT`
 
 > A miscellaneous effect has activated. This is triggered whenever an effect could 
@@ -443,10 +512,47 @@ stat boosts are minor actions.
 > for messages from game mods that aren't supported by the client, like rule clauses 
 > such as Sleep Clause, or other metagames with custom messages for specific scenarios. 
 
-I'll document all the message types eventually, but for now this should be
-enough to get you started. You can watch the data sent and received from
-the server on a regular connection, or look at the client source code
-for a full list of message types.
+`|-combine`
+
+> A move has been combined with another (For example: Fire Pledge).
+
+`|-waiting|SOURCE|TARGET`
+
+> The `SOURCE` Pokémon has used a move and is waiting for the `TARGET` Pokémon
+> (For example: Fire Pledge).
+
+`|-prepare|ATTACKER|MOVE|DEFENDER`
+
+> The `ATTACKER` Pokémon is preparing to use a charge `MOVE` on the `DEFENDER`
+> (For example: Dig, Fly).
+
+`|-mustrecharge|POKEMON`
+
+> The Pokémon `POKEMON` must spend the turn recharging from a previous move.
+
+`|-nothing`
+
+> A move did absolutely nothing. (For example: Splash).
+
+`|-hitcount|POKEMON|NUM`
+
+> A multi-hit move hit the `POKEMON` `NUM` times.
+
+`|-singlemove|POKEMON|MOVE`
+
+> TODO movestatus?
+
+`|-singleturn|POKEMON|MOVE`
+
+> TODO turnstatus?
+
+`|-start|POKEMON|???`
+
+> TODO
+
+`|-end|POKEMON|???`
+
+> TODO
 
 
 Sending decisions


### PR DESCRIPTION
Oh yeah, a sexy and glamorous documentation PR!

Think this is now exhaustive from grepping through the client/server source (well, maybe `-anim`, but that seems OM only?). The client seems to generate its own artificial events (`-block`, etc) which are obviously not covered here. Had trouble coming up with definitions for some of these, so this PR is WIP until I figure them out or someone chimes in with them. :)

- [x] not fully clear on why `upkeep` is required (does `turn` not suffice?)
- [x]  `-start` and `-end` seems a bit complex and I wanted some guidance on what to write?
- [x]  still need to document `-singlemove` and `singleturn`, maybe could use some wording help here