### PR TITLE
Fix some Typescript related TODOs

### DIFF
--- a/server/chat-plugins/mafia.js
+++ b/server/chat-plugins/mafia.js
@@ -535,10 +535,10 @@ class MafiaTracker extends Rooms.RoomGame {
 		let roles = Dex.shuffle(this.roles.slice());
 		if (roles.length) {
 			for (let p in this.players) {
-				let role = roles.shift() || null;
+				let role = /** @type {MafiaRole} */(roles.shift());
 				this.players[p].role = role;
 				let u = Users(p);
-				if (u && u.connected) u.send(`>${this.room.id}\n|notify|Your role is ${/** @type {MafiaRole} */(role).safeName}. For more details of your role, check your Role PM.`);
+				if (u && u.connected) u.send(`>${this.room.id}\n|notify|Your role is ${role.safeName}. For more details of your role, check your Role PM.`);
 			}
 		}
 		this.dead = {};

--- a/server/chat-plugins/mafia.js
+++ b/server/chat-plugins/mafia.js
@@ -535,10 +535,10 @@ class MafiaTracker extends Rooms.RoomGame {
 		let roles = Dex.shuffle(this.roles.slice());
 		if (roles.length) {
 			for (let p in this.players) {
-				let role = roles.shift();
+				let role = roles.shift() || null;
 				this.players[p].role = role;
 				let u = Users(p);
-				if (u && u.connected) u.send(`>${this.room.id}\n|notify|Your role is ${role.safeName}. For more details of your role, check your Role PM.`);
+				if (u && u.connected) u.send(`>${this.room.id}\n|notify|Your role is ${/** @type {MafiaRole} */(role).safeName}. For more details of your role, check your Role PM.`);
 			}
 		}
 		this.dead = {};

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -2500,11 +2500,8 @@ class Battle extends Dex.ModdedDex {
 	/**
 	 * @param {Pokemon} pokemon
 	 * @param {string | Move} move
-	 * @return {Pokemon | null}
 	 */
 	resolveTarget(pokemon, move) {
-		// TODO: figure out why TypeScript thinks this is Pokemon | Pokemon
-
 		// A move was used without a chosen target
 
 		// For instance: Metronome chooses Ice Beam. Since the user didn't

--- a/sim/dex.js
+++ b/sim/dex.js
@@ -964,9 +964,9 @@ class ModdedDex {
 	}
 
 	/**
-	 * TODO: TypeScript generics
-	 * @param {Array} arr
-	 * @return {Array}
+	 * @param {T[]} arr
+	 * @return {T[]}
+	 * @template T
 	 */
 	shuffle(arr) {
 		// In-place shuffle by Fisher-Yates algorithm


### PR DESCRIPTION
The `Pokemon | Pokemon` TODO seems to be obsolete now - removing the `@return {Pokemon | null}` doesn't cause the compiler to complain.