### PR TITLE
Don't add inactive rules as pseudoweathers

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -572,6 +572,7 @@ let Formats = [
 		mod: 'pokebilities',
 		ruleset: ['[Gen 7] OU'],
 		banlist: ['Bibarel', 'Bidoof', 'Diglett', 'Dugtrio', 'Excadrill', 'Glalie', 'Gothita', 'Gothitelle', 'Gothorita', 'Octillery', 'Porygon-Z', 'Remoraid', 'Smeargle', 'Snorunt', 'Trapinch', 'Wobbuffet', 'Wynaut'],
+		hasEventHandler: true, // should not be used as a ruleset
 		onBegin() {
 			let allPokemon = this.p1.pokemon.concat(this.p2.pokemon);
 			for (let pokemon of allPokemon) {
@@ -645,6 +646,7 @@ let Formats = [
 			'Kyurem-Black', 'Kyurem-White', 'Lugia', 'Lunala', 'Marshadow', 'Mewtwo', 'Naganadel', 'Necrozma-Dawn-Wings', 'Necrozma-Dusk-Mane',
 			'Palkia', 'Pheromosa', 'Rayquaza', 'Regigigas', 'Reshiram', 'Slaking', 'Solgaleo', 'Xerneas', 'Yveltal', 'Zekrom',
 		],
+		hasEventHandler: true, // should not be used as a ruleset
 		onValidateTeam(team) {
 			/**@type {{[k: string]: true}} */
 			let itemTable = {};
@@ -740,6 +742,7 @@ let Formats = [
 		searchShow: false,
 		ruleset: ['[Gen 7] OU'],
 		banlist: ['Kartana', 'Kyurem-Black', 'Shedinja'],
+		hasEventHandler: true, // should not be used as a ruleset
 		onModifyTemplate(template, target, source) {
 			if (!target) return; // Chat command
 			if (source && ['imposter', 'transform'].includes(source.id)) return;
@@ -768,6 +771,7 @@ let Formats = [
 			'Kangaskhanite', 'Mawilite', 'Medichamite',
 			'Huge Power', 'Imposter', 'Normalize', 'Pure Power', 'Wonder Guard', 'Mimic', 'Sketch', 'Sweet Scent', 'Transform',
 		],
+		hasEventHandler: true, // should not be used as a ruleset
 		onSwitchInPriority: 2,
 		onSwitchIn(pokemon) {
 			if (this.p1.active.every(ally => ally && !ally.fainted)) {
@@ -942,6 +946,7 @@ let Formats = [
 		mod: 'ssb',
 		team: 'randomStaffBros',
 		ruleset: ['HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod'],
+		hasEventHandler: true, // should not be used as a ruleset
 		onBegin() {
 			this.add('raw|SUPER STAFF BROS <b>BRAWL</b>!!');
 			this.add('message', 'GET READY FOR THE NEXT BATTLE!');

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -379,8 +379,7 @@ let BattleFormats = {
 	potd: {
 		effectType: 'Rule',
 		name: 'PotD',
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			if (global.Config && global.Config.potd) {
 				this.add('rule', "Pokemon of the Day: " + this.getTemplate(Config.potd).name);
 			}
@@ -391,8 +390,7 @@ let BattleFormats = {
 		name: 'Team Preview',
 		desc: "Allows each player to see the Pok&eacute;mon on their opponent's team before they choose their lead Pok&eacute;mon",
 		hasEventHandler: true,
-		onStartPriority: -10,
-		onStart() {
+		onBegin() {
 			this.add('clearpoke');
 			for (const side of this.sides) {
 				for (const pokemon of side.pokemon) {
@@ -423,8 +421,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Species Clause',
 		desc: "Prevents teams from having more than one Pok&eacute;mon from the same species",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Species Clause: Limit one of each Pokémon');
 		},
 		onValidateTeam(team, format) {
@@ -464,8 +461,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Item Clause',
 		desc: "Prevents teams from having more than one Pok&eacute;mon with the same item",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Item Clause: Limit one of each item');
 		},
 		onValidateTeam(team, format) {
@@ -485,8 +481,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Ability Clause',
 		desc: "Prevents teams from having more than two Pok&eacute;mon with the same ability",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Ability Clause: Limit two of each ability');
 		},
 		onValidateTeam(team, format) {
@@ -527,8 +522,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'OHKO Clause',
 		desc: "Bans all OHKO moves, such as Fissure",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'OHKO Clause: OHKO moves are banned');
 		},
 		onValidateSet(set) {
@@ -547,8 +541,7 @@ let BattleFormats = {
 		name: 'Evasion Abilities Clause',
 		desc: "Bans abilities that boost Evasion under certain weather conditions",
 		banlist: ['Sand Veil', 'Snow Cloak'],
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Evasion Abilities Clause: Evasion abilities are banned');
 		},
 	},
@@ -557,8 +550,7 @@ let BattleFormats = {
 		name: 'Evasion Moves Clause',
 		desc: "Bans moves that consistently raise the user's evasion when used",
 		banlist: ['Minimize', 'Double Team'],
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Evasion Moves Clause: Evasion moves are banned');
 		},
 	},
@@ -567,8 +559,7 @@ let BattleFormats = {
 		name: 'Accuracy Moves Clause',
 		desc: "Bans moves that have a chance to lower the target's accuracy when used",
 		banlist: ['Flash', 'Kinesis', 'Leaf Tornado', 'Mirror Shot', 'Mud Bomb', 'Mud-Slap', 'Muddy Water', 'Night Daze', 'Octazooka', 'Sand Attack', 'Smokescreen'],
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Accuracy Moves Clause: Accuracy-lowering moves are banned');
 		},
 	},
@@ -600,8 +591,7 @@ let BattleFormats = {
 		//   with one
 		// - OR it has eaten a Leppa berry it isn't holding
 
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Endless Battle Clause: Forcing endless battles is banned');
 		},
 	},
@@ -610,8 +600,7 @@ let BattleFormats = {
 		name: 'Moody Clause',
 		desc: "Bans the ability Moody",
 		banlist: ['Moody'],
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Moody Clause: Moody is banned');
 		},
 	},
@@ -620,8 +609,7 @@ let BattleFormats = {
 		name: 'Swagger Clause',
 		desc: "Bans the move Swagger",
 		banlist: ['Swagger'],
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Swagger Clause: Swagger is banned');
 		},
 	},
@@ -630,8 +618,7 @@ let BattleFormats = {
 		name: 'Baton Pass Clause',
 		desc: "Stops teams from having more than one Pok&eacute;mon with Baton Pass, and no Pok&eacute;mon may be capable of passing boosts to both Speed and another stat",
 		banlist: ["Baton Pass > 1"],
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Baton Pass Clause: Limit one Baton Passer, can\'t pass Spe and other stats simultaneously');
 		},
 		onValidateSet(set, format, setHas) {
@@ -685,8 +672,7 @@ let BattleFormats = {
 		name: 'CFZ Clause',
 		desc: "Bans the use of crystal-free Z-Moves",
 		banlist: ['10,000,000 Volt Thunderbolt', 'Acid Downpour', 'All-Out Pummeling', 'Black Hole Eclipse', 'Bloom Doom', 'Breakneck Blitz', 'Catastropika', 'Clangorous Soulblaze', 'Continental Crush', 'Corkscrew Crash', 'Devastating Drake', 'Extreme Evoboost', 'Genesis Supernova', 'Gigavolt Havoc', 'Guardian of Alola', 'Hydro Vortex', 'Inferno Overdrive', 'Let\'s Snuggle Forever', 'Light That Burns the Sky', 'Malicious Moonsault', 'Menacing Moonraze Maelstrom', 'Never-Ending Nightmare', 'Oceanic Operetta', 'Pulverizing Pancake', 'Savage Spin-Out', 'Searing Sunraze Smash', 'Shattered Psyche', 'Sinister Arrow Raid', 'Soul-Stealing 7-Star Strike', 'Splintered Stormshards', 'Stoked Sparksurfer', 'Subzero Slammer', 'Supersonic Skystrike', 'Tectonic Rage', 'Twinkle Tackle'],
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'CFZ Clause: Crystal-free Z-Moves are banned');
 		},
 	},
@@ -698,8 +684,7 @@ let BattleFormats = {
 			const item = this.getItem(set.item);
 			if (item.zMove) return [`${set.name || set.species}'s item ${item.name} is banned by Z-Move Clause.`];
 		},
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Z-Move Clause: Z-Moves are banned');
 		},
 	},
@@ -707,8 +692,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'HP Percentage Mod',
 		desc: "Shows the HP of Pok&eacute;mon in percentages",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'HP Percentage Mod: HP is shown in percentages');
 			this.reportPercentages = true;
 		},
@@ -717,8 +701,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Exact HP Mod',
 		desc: "Shows the exact HP of all Pok&eacute;mon",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Exact HP Mod: Exact HP is shown');
 			this.reportExactHP = true;
 		},
@@ -727,8 +710,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Cancel Mod',
 		desc: "Allows players to change their own choices before their opponents make one",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.supportCancel = true;
 		},
 	},
@@ -738,7 +720,7 @@ let BattleFormats = {
 		desc: "Prevents players from putting more than one of their opponent's Pok&eacute;mon to sleep at a time, and bans Mega Gengar from using Hypnosis",
 		banlist: ['Hypnosis + Gengarite'],
 		hasEventHandler: true,
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Sleep Clause Mod: Limit one foe put to sleep');
 		},
 		onSetStatus(status, target, source) {
@@ -761,8 +743,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Switch Priority Clause Mod',
 		desc: "Makes a faster Pokémon switch first when double-switching, unlike in Emerald link battles, where player 1's Pokémon would switch first",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Switch Priority Clause Mod: Faster Pokémon switch first');
 		},
 	},
@@ -770,8 +751,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Freeze Clause Mod',
 		desc: "Prevents players from freezing more than one of their opponent's Pok&eacute;mon at a time",
-		hasEventHandler: true,
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Freeze Clause Mod: Limit one foe frozen');
 		},
 		onSetStatus(status, target, source) {
@@ -792,8 +772,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Same Type Clause',
 		desc: "Forces all Pok&eacute;mon on a team to share a type with each other",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Same Type Clause: Pokémon in a team must share a type');
 		},
 		onValidateTeam(team) {
@@ -827,8 +806,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Mega Rayquaza Clause',
 		desc: "Prevents Rayquaza from mega evolving",
-		hasEventHandler: 'StartOnly',
-		onStart() {
+		onBegin() {
 			this.add('rule', 'Mega Rayquaza Clause: You cannot mega evolve Rayquaza');
 			for (const side of this.sides) {
 				for (const pokemon of side.pokemon) {

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -751,6 +751,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Freeze Clause Mod',
 		desc: "Prevents players from freezing more than one of their opponent's Pok&eacute;mon at a time",
+		hasEventHandler: true,
 		onBegin() {
 			this.add('rule', 'Freeze Clause Mod: Limit one foe frozen');
 		},

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -379,6 +379,7 @@ let BattleFormats = {
 	potd: {
 		effectType: 'Rule',
 		name: 'PotD',
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			if (global.Config && global.Config.potd) {
 				this.add('rule', "Pokemon of the Day: " + this.getTemplate(Config.potd).name);
@@ -389,6 +390,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Team Preview',
 		desc: "Allows each player to see the Pok&eacute;mon on their opponent's team before they choose their lead Pok&eacute;mon",
+		hasEventHandler: true,
 		onStartPriority: -10,
 		onStart() {
 			this.add('clearpoke');
@@ -421,6 +423,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Species Clause',
 		desc: "Prevents teams from having more than one Pok&eacute;mon from the same species",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Species Clause: Limit one of each Pokémon');
 		},
@@ -461,6 +464,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Item Clause',
 		desc: "Prevents teams from having more than one Pok&eacute;mon with the same item",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Item Clause: Limit one of each item');
 		},
@@ -481,6 +485,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Ability Clause',
 		desc: "Prevents teams from having more than two Pok&eacute;mon with the same ability",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Ability Clause: Limit two of each ability');
 		},
@@ -522,6 +527,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'OHKO Clause',
 		desc: "Bans all OHKO moves, such as Fissure",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'OHKO Clause: OHKO moves are banned');
 		},
@@ -541,6 +547,7 @@ let BattleFormats = {
 		name: 'Evasion Abilities Clause',
 		desc: "Bans abilities that boost Evasion under certain weather conditions",
 		banlist: ['Sand Veil', 'Snow Cloak'],
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Evasion Abilities Clause: Evasion abilities are banned');
 		},
@@ -550,6 +557,7 @@ let BattleFormats = {
 		name: 'Evasion Moves Clause',
 		desc: "Bans moves that consistently raise the user's evasion when used",
 		banlist: ['Minimize', 'Double Team'],
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Evasion Moves Clause: Evasion moves are banned');
 		},
@@ -559,6 +567,7 @@ let BattleFormats = {
 		name: 'Accuracy Moves Clause',
 		desc: "Bans moves that have a chance to lower the target's accuracy when used",
 		banlist: ['Flash', 'Kinesis', 'Leaf Tornado', 'Mirror Shot', 'Mud Bomb', 'Mud-Slap', 'Muddy Water', 'Night Daze', 'Octazooka', 'Sand Attack', 'Smokescreen'],
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Accuracy Moves Clause: Accuracy-lowering moves are banned');
 		},
@@ -591,6 +600,7 @@ let BattleFormats = {
 		//   with one
 		// - OR it has eaten a Leppa berry it isn't holding
 
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Endless Battle Clause: Forcing endless battles is banned');
 		},
@@ -600,6 +610,7 @@ let BattleFormats = {
 		name: 'Moody Clause',
 		desc: "Bans the ability Moody",
 		banlist: ['Moody'],
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Moody Clause: Moody is banned');
 		},
@@ -609,6 +620,7 @@ let BattleFormats = {
 		name: 'Swagger Clause',
 		desc: "Bans the move Swagger",
 		banlist: ['Swagger'],
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Swagger Clause: Swagger is banned');
 		},
@@ -618,6 +630,7 @@ let BattleFormats = {
 		name: 'Baton Pass Clause',
 		desc: "Stops teams from having more than one Pok&eacute;mon with Baton Pass, and no Pok&eacute;mon may be capable of passing boosts to both Speed and another stat",
 		banlist: ["Baton Pass > 1"],
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Baton Pass Clause: Limit one Baton Passer, can\'t pass Spe and other stats simultaneously');
 		},
@@ -672,6 +685,7 @@ let BattleFormats = {
 		name: 'CFZ Clause',
 		desc: "Bans the use of crystal-free Z-Moves",
 		banlist: ['10,000,000 Volt Thunderbolt', 'Acid Downpour', 'All-Out Pummeling', 'Black Hole Eclipse', 'Bloom Doom', 'Breakneck Blitz', 'Catastropika', 'Clangorous Soulblaze', 'Continental Crush', 'Corkscrew Crash', 'Devastating Drake', 'Extreme Evoboost', 'Genesis Supernova', 'Gigavolt Havoc', 'Guardian of Alola', 'Hydro Vortex', 'Inferno Overdrive', 'Let\'s Snuggle Forever', 'Light That Burns the Sky', 'Malicious Moonsault', 'Menacing Moonraze Maelstrom', 'Never-Ending Nightmare', 'Oceanic Operetta', 'Pulverizing Pancake', 'Savage Spin-Out', 'Searing Sunraze Smash', 'Shattered Psyche', 'Sinister Arrow Raid', 'Soul-Stealing 7-Star Strike', 'Splintered Stormshards', 'Stoked Sparksurfer', 'Subzero Slammer', 'Supersonic Skystrike', 'Tectonic Rage', 'Twinkle Tackle'],
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'CFZ Clause: Crystal-free Z-Moves are banned');
 		},
@@ -684,6 +698,7 @@ let BattleFormats = {
 			const item = this.getItem(set.item);
 			if (item.zMove) return [`${set.name || set.species}'s item ${item.name} is banned by Z-Move Clause.`];
 		},
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Z-Move Clause: Z-Moves are banned');
 		},
@@ -692,6 +707,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'HP Percentage Mod',
 		desc: "Shows the HP of Pok&eacute;mon in percentages",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'HP Percentage Mod: HP is shown in percentages');
 			this.reportPercentages = true;
@@ -701,6 +717,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Exact HP Mod',
 		desc: "Shows the exact HP of all Pok&eacute;mon",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Exact HP Mod: Exact HP is shown');
 			this.reportExactHP = true;
@@ -710,6 +727,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Cancel Mod',
 		desc: "Allows players to change their own choices before their opponents make one",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.supportCancel = true;
 		},
@@ -719,6 +737,7 @@ let BattleFormats = {
 		name: 'Sleep Clause Mod',
 		desc: "Prevents players from putting more than one of their opponent's Pok&eacute;mon to sleep at a time, and bans Mega Gengar from using Hypnosis",
 		banlist: ['Hypnosis + Gengarite'],
+		hasEventHandler: true,
 		onStart() {
 			this.add('rule', 'Sleep Clause Mod: Limit one foe put to sleep');
 		},
@@ -742,6 +761,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Switch Priority Clause Mod',
 		desc: "Makes a faster Pokémon switch first when double-switching, unlike in Emerald link battles, where player 1's Pokémon would switch first",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Switch Priority Clause Mod: Faster Pokémon switch first');
 		},
@@ -750,6 +770,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Freeze Clause Mod',
 		desc: "Prevents players from freezing more than one of their opponent's Pok&eacute;mon at a time",
+		hasEventHandler: true,
 		onStart() {
 			this.add('rule', 'Freeze Clause Mod: Limit one foe frozen');
 		},
@@ -771,6 +792,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Same Type Clause',
 		desc: "Forces all Pok&eacute;mon on a team to share a type with each other",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Same Type Clause: Pokémon in a team must share a type');
 		},
@@ -805,6 +827,7 @@ let BattleFormats = {
 		effectType: 'Rule',
 		name: 'Mega Rayquaza Clause',
 		desc: "Prevents Rayquaza from mega evolving",
+		hasEventHandler: 'StartOnly',
 		onStart() {
 			this.add('rule', 'Mega Rayquaza Clause: You cannot mega evolve Rayquaza');
 			for (const side of this.sides) {
@@ -833,6 +856,7 @@ let BattleFormats = {
 		name: 'Inverse Mod',
 		desc: "The mod for Inverse Battle which inverts the type effectiveness chart, swapping resistances and weaknesses with each other",
 		onNegateImmunity: false,
+		hasEventHandler: true,
 		onEffectiveness(typeMod, target, type, move) {
 			// The effectiveness of Freeze Dry on Water isn't reverted
 			if (move && move.id === 'freezedry' && type === 'Water') return;

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -679,7 +679,6 @@ interface FormatsData extends EventMethods {
 	noChangeForme?: boolean
 	onBasePowerPriority?: number
 	onModifyMovePriority?: number
-	onStartPriority?: number
 	onSwitchInPriority?: number
 	rated?: boolean
 	requirePentagon?: boolean

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -670,6 +670,7 @@ interface FormatsData extends EventMethods {
 	desc?: string
 	effectType?: string
 	forcedLevel?: number
+	hasEventHandler?: true | 'StartOnly'
 	gameType?: GameType
 	maxForcedLevel?: number
 	maxLevel?: number

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1819,7 +1819,14 @@ class Battle extends Dex.ModdedDex {
 		}
 		for (const rule of this.getRuleTable(format).keys()) {
 			if (rule.startsWith('+') || rule.startsWith('-') || rule.startsWith('!')) continue;
-			if (this.getFormat(rule).exists) this.addPseudoWeather(rule);
+			let subFormat = this.getFormat(rule);
+			if (subFormat.exists && subFormat.hasEventHandler) {
+				if (subFormat.hasEventHandler === 'StartOnly') {
+					this.singleEvent('Start', subFormat, null, this);
+				} else {
+					this.addPseudoWeather(rule);
+				}
+			}
 		}
 
 		if (!this.p1.pokemon[0] || !this.p2.pokemon[0]) {

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1820,12 +1820,9 @@ class Battle extends Dex.ModdedDex {
 		for (const rule of this.getRuleTable(format).keys()) {
 			if (rule.startsWith('+') || rule.startsWith('-') || rule.startsWith('!')) continue;
 			let subFormat = this.getFormat(rule);
-			if (subFormat.exists && subFormat.hasEventHandler) {
-				if (subFormat.hasEventHandler === 'StartOnly') {
-					this.singleEvent('Start', subFormat, null, this);
-				} else {
-					this.addPseudoWeather(rule);
-				}
+			if (subFormat.exists) {
+				if (subFormat.onBegin) subFormat.onBegin.call(this);
+				if (subFormat.hasEventHandler) this.addPseudoWeather(rule);
 			}
 		}
 


### PR DESCRIPTION
Previously, every single rule in the rule table was being added as a pseudoweather, which created a bunch of effects that were uselessly being checked for event handlers, over 10 of them in a normal match. This prevents that from happening by explicitly marking rulesets (and formats, in the hopes of some future OM being compatible as a ruleset) as having or not having event handlers.

For the record, the following do not count as event handlers for the purposes of `hasEventHandler`: 

- onBegin() (not a real event)
- onValidateTeam() (not a real event)
- onChangeSet() (not a real event)
- onValidateSet() (not a real event)
- checkLearnset() (not a real event)
- onModifyTemplate() (this is only ever a `singleEvent`, so a global listener is unnecessary)

I know this isn't anywhere near the level of the improvements that @scheibo has been making, but it's something.