### PR TITLE
Fix Gen 1 bug involving last damage and Substitute (#2598)

### DIFF
--- a/data/mods/gen1/moves.js
+++ b/data/mods/gen1/moves.js
@@ -943,14 +943,15 @@ let BattleMovedex = {
 					return;
 				}
 				if (move.volatileStatus && target === source) return;
+				// NOTE: In future generations the damage is capped to the remaining HP of the
+				// Substitute, here we deliberately use the uncapped damage when tracking lastDamage etc.
 				let uncappedDamage = this.getDamage(source, target, move);
 				if (!uncappedDamage) return null;
-				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage); // TODO?
+				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
 				if (!uncappedDamage) return uncappedDamage;
-				let cappedDamage = uncappedDamage > target.volatiles['substitute'].hp ?
+				source.lastDamage = uncappedDamage;
+				target.volatiles['substitute'].hp -= uncappedDamage > target.volatiles['substitute'].hp ?
 					/** @type {number} */(target.volatiles['substitute'].hp) : uncappedDamage;
-				source.lastDamage = uncappedDamage; // TODO?
-				target.volatiles['substitute'].hp -= cappedDamage;
 				if (target.volatiles['substitute'].hp <= 0) {
 					target.removeVolatile('substitute');
 					target.subFainted = true;
@@ -960,13 +961,13 @@ let BattleMovedex = {
 				// Drain/recoil does not happen if the substitute breaks
 				if (target.volatiles['substitute']) {
 					if (move.recoil) {
-						this.damage(Math.round(uncappedDamage * move.recoil[0] / move.recoil[1]), source, target, 'recoil'); // TODO?
+						this.damage(Math.round(uncappedDamage * move.recoil[0] / move.recoil[1]), source, target, 'recoil');
 					}
 					if (move.drain) {
-						this.heal(Math.ceil(uncappedDamage * move.drain[0] / move.drain[1]), source, target, 'drain'); // TODO?
+						this.heal(Math.ceil(uncappedDamage * move.drain[0] / move.drain[1]), source, target, 'drain');
 					}
 				}
-				this.runEvent('AfterSubDamage', target, source, move, uncappedDamage); // TODO?
+				this.runEvent('AfterSubDamage', target, source, move, uncappedDamage);
 				// Add here counter damage
 				let lastAttackedBy = target.getLastAttackedBy();
 				if (!lastAttackedBy) {

--- a/data/mods/gen1/moves.js
+++ b/data/mods/gen1/moves.js
@@ -943,12 +943,14 @@ let BattleMovedex = {
 					return;
 				}
 				if (move.volatileStatus && target === source) return;
-				let damage = this.getDamage(source, target, move);
-				if (!damage) return null;
-				damage = this.runEvent('SubDamage', target, source, move, damage);
-				if (!damage) return damage;
-				target.volatiles['substitute'].hp -= damage;
-				source.lastDamage = damage;
+				let uncappedDamage = this.getDamage(source, target, move);
+				if (!uncappedDamage) return null;
+				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage); // TODO?
+				if (!uncappedDamage) return uncappedDamage;
+				let cappedDamage = uncappedDamage > target.volatiles['substitute'].hp ?
+					/** @type {number} */(target.volatiles['substitute'].hp) : uncappedDamage;
+				source.lastDamage = uncappedDamage; // TODO?
+				target.volatiles['substitute'].hp -= cappedDamage;
 				if (target.volatiles['substitute'].hp <= 0) {
 					target.removeVolatile('substitute');
 					target.subFainted = true;
@@ -958,20 +960,20 @@ let BattleMovedex = {
 				// Drain/recoil does not happen if the substitute breaks
 				if (target.volatiles['substitute']) {
 					if (move.recoil) {
-						this.damage(Math.round(damage * move.recoil[0] / move.recoil[1]), source, target, 'recoil');
+						this.damage(Math.round(uncappedDamage * move.recoil[0] / move.recoil[1]), source, target, 'recoil'); // TODO?
 					}
 					if (move.drain) {
-						this.heal(Math.ceil(damage * move.drain[0] / move.drain[1]), source, target, 'drain');
+						this.heal(Math.ceil(uncappedDamage * move.drain[0] / move.drain[1]), source, target, 'drain'); // TODO?
 					}
 				}
-				this.runEvent('AfterSubDamage', target, source, move, damage);
+				this.runEvent('AfterSubDamage', target, source, move, uncappedDamage); // TODO?
 				// Add here counter damage
 				let lastAttackedBy = target.getLastAttackedBy();
 				if (!lastAttackedBy) {
-					target.attackedBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
+					target.attackedBy.push({source: source, move: move.id, damage: uncappedDamage, thisTurn: true});
 				} else {
 					lastAttackedBy.move = move.id;
-					lastAttackedBy.damage = damage;
+					lastAttackedBy.damage = uncappedDamage;
 				}
 				return 0;
 			},

--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -369,8 +369,6 @@ let BattleScripts = {
 		}
 
 		if (move.category !== 'Status') {
-			// FIXME: The stored damage should be calculated ignoring Substitute.
-			// https://github.com/Zarel/Pokemon-Showdown/issues/2598
 			target.gotAttacked(move, damage, pokemon);
 		}
 
@@ -887,7 +885,6 @@ let BattleScripts = {
 			damage *= this.random(217, 256);
 			damage = Math.floor(damage / 255);
 			if (damage > target.hp && !target.volatiles['substitute']) damage = target.hp;
-			if (target.volatiles['substitute'] && damage > target.volatiles['substitute'].hp) damage = target.volatiles['substitute'].hp;
 		}
 
 		// And we are done.

--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -245,8 +245,6 @@ let BattleScripts = {
 			move.totalDamage = damage;
 		}
 		if (move.category !== 'Status') {
-			// FIXME: The stored damage should be calculated ignoring Substitute.
-			// https://github.com/Zarel/Pokemon-Showdown/issues/2598
 			target.gotAttacked(move, damage, pokemon);
 		}
 		if (move.ohko) this.add('-ohko');

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1946,8 +1946,6 @@ class Battle extends Dex.ModdedDex {
 		if (damage !== 0) damage = this.clampIntRange(damage, 1);
 
 		if (this.gen <= 1) {
-			// FIXME: The stored damage should be calculated ignoring Substitute.
-			// https://github.com/Zarel/Pokemon-Showdown/issues/2598
 			if (this.currentMod === 'stadium' ||
 				!['recoil', 'drain'].includes(effect.id) && effect.effectType !== 'Status') {
 				this.lastDamage = damage;

--- a/test/simulator/moves/substitute.js
+++ b/test/simulator/moves/substitute.js
@@ -86,4 +86,19 @@ describe('Substitute', function () {
 		battle.makeChoices('move roost', 'move dualchop');
 		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
+
+	it('should track what the actual damage would have been without the substitute in Gen 1', function () {
+		battle = common.gen(1).createBattle([
+			[{species: 'Ponyta', moves: ['substitute', 'growl'], evs: {hp: 252, spd: 252}}],
+			[{species: 'Cloyster', moves: ['clamp'], evs: {spa: 252}}],
+		]);
+
+		const pokemon = battle.p1.active[0];
+		battle.makeChoices('move substitute', 'move clamp');
+		assert.strictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
+
+		const hp = pokemon.hp;
+		battle.makeChoices('move growl', 'move clamp');
+		assert.bounded(hp - pokemon.hp, [91, 108]);
+	});
 });


### PR DESCRIPTION
First stab at a mechanics change and I'm sure there's a whole host of things I'm missing - I just wrote a test and got it to pass. For example, I'm not sure whether *everything* should be using `uncappedDamage` (all the locations I guessed at have `TODO`s that I'd want removed before I could commit). Assuming the developers never capped damage damage at all seems realistic, but I don't know. 