### PR TITLE
Fix Counter/Mirror Coat to respect redirection

### DIFF
--- a/sim/battle.js
+++ b/sim/battle.js
@@ -2443,6 +2443,7 @@ class Battle extends Dex.ModdedDex {
 			return isAdjacent && !isFoe || isSelf;
 		case 'adjacentFoe':
 			return isAdjacent && isFoe;
+		case 'scripted':
 		case 'any':
 			return !isSelf;
 		}

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -2435,6 +2435,7 @@ class Battle extends Dex.ModdedDex {
 
 		switch (targetType) {
 		case 'randomNormal':
+		case 'scripted':
 		case 'normal':
 			return isAdjacent;
 		case 'adjacentAlly':
@@ -2443,7 +2444,6 @@ class Battle extends Dex.ModdedDex {
 			return isAdjacent && !isFoe || isSelf;
 		case 'adjacentFoe':
 			return isAdjacent && isFoe;
-		case 'scripted':
 		case 'any':
 			return !isSelf;
 		}

--- a/test/simulator/moves/counter.js
+++ b/test/simulator/moves/counter.js
@@ -57,7 +57,7 @@ describe('Counter', function () {
 		assert.false.fullHP(battle.p2.active[1]);
 	});
 
-	it('should bypass Follow Me', function () {
+	it('should respect Follow Me', function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Bastiodon', ability: 'sturdy', moves: ['counter']},
@@ -68,8 +68,8 @@ describe('Counter', function () {
 			{species: 'Clefable', ability: 'unaware', moves: ['followme']},
 		]);
 		battle.makeChoices('move counter, move splash', 'move acrobatics 1, move followme');
-		assert.fullHP(battle.p2.active[1]);
-		assert.false.fullHP(battle.p2.active[0]);
+		assert.false.fullHP(battle.p2.active[1]);
+		assert.fullHP(battle.p2.active[0]);
 	});
 });
 
@@ -123,7 +123,7 @@ describe('Mirror Coat', function () {
 		assert.false.fullHP(battle.p2.active[1]);
 	});
 
-	it('should bypass Follow Me', function () {
+	it('should respect Follow Me', function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.join('p1', 'Guest 1', 1, [
 			{species: 'Mew', ability: 'synchronize', moves: ['mirrorcoat']},
@@ -134,7 +134,7 @@ describe('Mirror Coat', function () {
 			{species: 'Clefable', ability: 'unaware', moves: ['followme']},
 		]);
 		battle.makeChoices('move mirrorcoat, move splash', 'move venoshock 1, move followme');
-		assert.fullHP(battle.p2.active[1]);
-		assert.false.fullHP(battle.p2.active[0]);
+		assert.false.fullHP(battle.p2.active[1]);
+		assert.fullHP(battle.p2.active[0]);
 	});
 });


### PR DESCRIPTION
I believe this change should affect Metal Burst as well, because it is the other user of `"target": "scripted"`. From #2367:

> Counter / Mirror Coat currently ignore redirection; they should be affected by redirection as normal ([source](https://www.smogon.com/forums/threads/bug-reports-v3-0-read-op-before-posting.3634749/post-7909353))

_Originally posted by @DaWoblefet in https://github.com/Zarel/Pokemon-Showdown/issues/2367#issuecomment-421827399_

Which I need to be careful about referencing so that Github doesn't accidentally close it. ;)