### PR TITLE
Fix Focus Punch/Shell Trap behavior with Encore

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -5809,7 +5809,7 @@ let BattleMovedex = {
 				this.add('-singleturn', pokemon, 'move: Focus Punch');
 			},
 			onHit(pokemon, source, move) {
-				if (move.category !== 'Status') {
+				if (move.category !== 'Status' && !pokemon.volatiles['encore']) {
 					pokemon.volatiles['focuspunch'].lostFocus = true;
 				}
 			},
@@ -14769,7 +14769,7 @@ let BattleMovedex = {
 				this.add('-singleturn', pokemon, 'move: Shell Trap');
 			},
 			onHit(pokemon, source, move) {
-				if (pokemon.side !== source.side && move.category === 'Physical') {
+				if (pokemon.side !== source.side && move.category === 'Physical' && !pokemon.volatiles['encore']) {
 					pokemon.volatiles['shelltrap'].gotHit = true;
 				}
 			},

--- a/data/moves.js
+++ b/data/moves.js
@@ -5809,7 +5809,7 @@ let BattleMovedex = {
 				this.add('-singleturn', pokemon, 'move: Focus Punch');
 			},
 			onHit(pokemon, source, move) {
-				if (move.category !== 'Status' && !pokemon.volatiles['encore']) {
+				if (move.category !== 'Status') {
 					pokemon.volatiles['focuspunch'].lostFocus = true;
 				}
 			},
@@ -14769,7 +14769,7 @@ let BattleMovedex = {
 				this.add('-singleturn', pokemon, 'move: Shell Trap');
 			},
 			onHit(pokemon, source, move) {
-				if (pokemon.side !== source.side && move.category === 'Physical' && !pokemon.volatiles['encore']) {
+				if (pokemon.side !== source.side && move.category === 'Physical') {
 					pokemon.volatiles['shelltrap'].gotHit = true;
 				}
 			},

--- a/data/moves.js
+++ b/data/moves.js
@@ -14757,11 +14757,11 @@ let BattleMovedex = {
 		beforeTurnCallback(pokemon) {
 			pokemon.addVolatile('shelltrap');
 		},
-		onTry(pokemon) {
+		// TODO: Switch this to onTry after spread move over is reworked to fix PP usage.
+		beforeMoveCallback(pokemon) {
 			if (pokemon.volatiles['shelltrap'] && !pokemon.volatiles['shelltrap'].gotHit) {
-				this.attrLastMove('[still]');
 				this.add('cant', pokemon, 'Shell Trap', 'Shell Trap');
-				return false;
+				return true;
 			}
 		},
 		effect: {

--- a/data/moves.js
+++ b/data/moves.js
@@ -14760,7 +14760,7 @@ let BattleMovedex = {
 		// TODO: In order to correct PP usage, after spread move order has been reworked,
 		// switch this to `onTry` + add `this.attrLastMove('[still]');`.
 		beforeMoveCallback(pokemon) {
-			if (pokemon.volatiles['shelltrap'] && !pokemon.volatiles['shelltrap'].gotHit) {
+			if (!pokemon.volatiles['shelltrap'] || !pokemon.volatiles['shelltrap'].gotHit) {
 				this.add('cant', pokemon, 'Shell Trap', 'Shell Trap');
 				return true;
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -14757,10 +14757,11 @@ let BattleMovedex = {
 		beforeTurnCallback(pokemon) {
 			pokemon.addVolatile('shelltrap');
 		},
-		beforeMoveCallback(pokemon) {
+		onTry(pokemon) {
 			if (pokemon.volatiles['shelltrap'] && !pokemon.volatiles['shelltrap'].gotHit) {
+				this.attrLastMove('[still]');
 				this.add('cant', pokemon, 'Shell Trap', 'Shell Trap');
-				return true;
+				return false;
 			}
 		},
 		effect: {

--- a/data/moves.js
+++ b/data/moves.js
@@ -14757,7 +14757,8 @@ let BattleMovedex = {
 		beforeTurnCallback(pokemon) {
 			pokemon.addVolatile('shelltrap');
 		},
-		// TODO: Switch this to onTry after spread move over is reworked to fix PP usage.
+		// TODO: In order to correct PP usage, after spread move order has been reworked,
+		// switch this to `onTry` + add `this.attrLastMove('[still]');`.
 		beforeMoveCallback(pokemon) {
 			if (pokemon.volatiles['shelltrap'] && !pokemon.volatiles['shelltrap'].gotHit) {
 				this.add('cant', pokemon, 'Shell Trap', 'Shell Trap');

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -89,7 +89,7 @@ describe('Encore', function () {
 		hp = battle.p2.active[0].hp;
 
 		// During subequent turns the normal Shell Trap behavior applies.
-		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move teleport', 'move splash, move extremespeed 1');
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
 
@@ -117,7 +117,7 @@ describe('Encore', function () {
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 
 		// During subequent turns the normal Shell Trap behavior applies.
-		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move teleport', 'move splash, move extremespeed 1');
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
 });

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -86,7 +86,7 @@ describe('Encore', function () {
 		// If a user's previous move was Shell Trap and it is Encored into Shell Trap while attempting to
 		// execute the move, the regular "you must be hit" effect for Shell Trap will be enforced
 		battle.makeChoices('move shelltrap, move teleport', 'move encore 1, move extremespeed 1');
-		assert.notStrictEqual( battle.p2.active[0].hp, hp);
+		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 		hp = battle.p2.active[0].hp;
 
 		// During subequent turns the normal Shell Trap behavior applies.

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -32,7 +32,7 @@ describe('Encore', function () {
 		battle.makeChoices('move focuspunch 1, move teleport', 'move encore 1, move extremespeed 1');
 		assert.strictEqual(hp, battle.p2.active[0].hp);
 
-		// During subequent turns the normal Focus Punch behavior applies.
+		// During subsequent turns the normal Focus Punch behavior applies.
 		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
 		assert.strictEqual(hp, battle.p2.active[0].hp);
 	});
@@ -49,10 +49,10 @@ describe('Encore', function () {
 			],
 		]);
 
-		// If the Focus Punch user is not interrupted the attack is expected to be successful.
-		battle.makeChoices('move focuspunch 1, move knockoff', 'move splash, move extremespeed 2');
+		// If the Focus Punch user is interrupted the attack is not expected to be successful.
+		battle.makeChoices('move focuspunch 1, move knockoff', 'move splash, move extremespeed 1');
 		let hp = battle.p2.active[0].hp;
-		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
+		assert.strictEqual(hp, battle.p2.active[0].maxhp);
 
 		// The Pokemon Encored into Focus Punch is not subject to the negative effects of Focus Punch; that is,
 		// if it is hit at any time before or after the Encore, it still uses Focus Punch like normal. It doesn't matter
@@ -61,7 +61,7 @@ describe('Encore', function () {
 		assert.notStrictEqual(hp, battle.p2.active[0].hp);
 		hp = battle.p2.active[0].hp;
 
-		// During subequent turns the normal Focus Punch behavior applies.
+		// During subsequent turns the normal Focus Punch behavior applies.
 		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
 		assert.strictEqual(hp, battle.p2.active[0].hp);
 	});

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -41,7 +41,7 @@ describe('Encore', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [
 			[
 				{species: "Smeargle", level: 50, ability: 'owntempo', moves: ['splash', 'focuspunch']},
-				{species: "Abra", letvel: 1, ability: 'innerfocus', moves: ['knockoff', 'teleport']},
+				{species: "Abra", level: 1, ability: 'innerfocus', moves: ['knockoff', 'teleport']},
 			],
 			[
 				{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['encore', 'splash']},
@@ -49,10 +49,9 @@ describe('Encore', function () {
 			],
 		]);
 
-		// If the Focus Punch user is interrupted the attack is not expected to be successful.
-		battle.makeChoices('move focuspunch 1, move knockoff', 'move splash, move extremespeed 1');
+		battle.makeChoices('move focuspunch 1, move knockoff', 'move splash, move extremespeed 2');
 		let hp = battle.p2.active[0].hp;
-		assert.strictEqual(hp, battle.p2.active[0].maxhp);
+		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
 
 		// The Pokemon Encored into Focus Punch is not subject to the negative effects of Focus Punch; that is,
 		// if it is hit at any time before or after the Encore, it still uses Focus Punch like normal. It doesn't matter

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -88,7 +88,7 @@ describe('Encore', function () {
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 		hp = battle.p2.active[0].hp;
 
-		// During subequent turns the normal Shell Trap behavior applies.
+		// During subesquent turns the normal Shell Trap behavior applies.
 		battle.makeChoices('move shelltrap, move teleport', 'move splash, move extremespeed 1');
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
@@ -116,7 +116,7 @@ describe('Encore', function () {
 		battle.makeChoices('move splash, move teleport', 'move encore 1, move extremespeed 1');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 
-		// During subequent turns the normal Shell Trap behavior applies.
+		// During subsequent turns the normal Shell Trap behavior applies.
 		battle.makeChoices('move shelltrap, move teleport', 'move splash, move extremespeed 1');
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -10,11 +10,11 @@ describe('Encore', function () {
 		battle.destroy();
 	});
 
-	it('should make Focus Punch always work while active', function () {
+	it('should not affect Focus Punch if the the user\'s decision is not changed', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [
 			[
 				{species: "Smeargle", level: 50, ability: 'owntempo', moves: ['splash', 'focuspunch']},
-				{species: "Magikarp", ability: 'swiftswim', moves: ['splash']},
+				{species: "Abra", level: 1, ability: 'innerfocus', moves: ['knockoff', 'teleport']},
 			],
 			[
 				{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['encore', 'splash']},
@@ -23,27 +23,54 @@ describe('Encore', function () {
 		]);
 
 		// If the Focus Punch user is not interrupted the attack is expected to be successful.
-		battle.makeChoices('move focuspunch 1, move splash', 'move splash, move extremespeed 2');
+		battle.makeChoices('move focuspunch 1, move knockoff 1', 'move splash, move extremespeed 2');
 		const hp = battle.p2.active[0].hp;
 		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
 
 		// If a user's previous move was Focus Punch and it is Encored into Focus Punch while attempting to
 		// execute the move, the regular "you can't be hit" effect for Focus Punch will be enforced.
-		battle.makeChoices('move focuspunch 1, move splash', 'move encore, move extremespeed 1');
+		battle.makeChoices('move focuspunch 1, move teleport', 'move encore 1, move extremespeed 1');
 		assert.strictEqual(hp, battle.p2.active[0].hp);
+
+		// During subequent turns the normal Focus Punch behavior applies.
+		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
+		assert.strictEqual(hp, battle.p2.active[0].hp);
+	});
+
+	it('should make Focus Punch always succeed if it changes the user\'s decision', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [
+			[
+				{species: "Smeargle", level: 50, ability: 'owntempo', moves: ['splash', 'focuspunch']},
+				{species: "Abra", letvel: 1, ability: 'innerfocus', moves: ['knockoff', 'teleport']},
+			],
+			[
+				{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['encore', 'splash']},
+				{species: "Zigzagoon", level: 1, ability: 'pickup', moves: ['extremespeed']},
+			],
+		]);
+
+		// If the Focus Punch user is not interrupted the attack is expected to be successful.
+		battle.makeChoices('move focuspunch 1, move knockoff', 'move splash, move extremespeed 2');
+		let hp = battle.p2.active[0].hp;
+		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
 
 		// The Pokemon Encored into Focus Punch is not subject to the negative effects of Focus Punch; that is,
 		// if it is hit at any time before or after the Encore, it still uses Focus Punch like normal. It doesn't matter
 		// in the case of Focus Punch if the user was hit before or after the Encore; Focus Punch will still always work.
-		battle.makeChoices('move focuspunch 1, move splash', 'move splash, move extremespeed 1');
+		battle.makeChoices('move splash, move teleport', 'move encore 1, move extremespeed 1');
 		assert.notStrictEqual(hp, battle.p2.active[0].hp);
+		hp = battle.p2.active[0].hp;
+
+		// During subequent turns the normal Focus Punch behavior applies.
+		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
+		assert.strictEqual(hp, battle.p2.active[0].hp);
 	});
 
-	it('should make Shell Trap always fail while active', function () {
+	it('should not affect Shell Trap if the user\'s decision is not changed', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [
 			[
-				{species: "Smeargle", ability: 'owntempo', moves: ['shelltrap']},
-				{species: "Magikarp", ability: 'swiftswim', moves: ['splash']},
+				{species: "Smeargle", ability: 'owntempo', moves: ['shelltrap', 'splash']},
+				{species: "Abra", level: 1, ability: 'innerfocus', moves: ['knockoff', 'teleport']},
 			],
 			[
 				{species: "Smeargle", ability: 'owntempo', moves: ['encore', 'splash']},
@@ -52,20 +79,46 @@ describe('Encore', function () {
 		]);
 
 		// If the Shell Trap user is hit the attack is expected to be successful.
-		battle.makeChoices('move shelltrap, move splash', 'move splash, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move knockoff 1', 'move splash, move extremespeed 1');
 		let hp = battle.p2.active[0].hp;
 		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
 
 		// If a user's previous move was Shell Trap and it is Encored into Shell Trap while attempting to
 		// execute the move, the regular "you must be hit" effect for Shell Trap will be enforced
-		battle.makeChoices('move shelltrap, move splash', 'move encore 1, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move teleport', 'move encore 1, move extremespeed 1');
 		assert.notStrictEqual(hp, battle.p2.active[0].hp);
 		hp = battle.p2.active[0].hp;
+
+		// During subequent turns the normal Shell Trap behavior applies.
+		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
+		assert.notStrictEqual(hp, battle.p2.active[0].hp);
+	});
+
+	it('should make Shell Trap always fail if the user\'s decision is changed', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [
+			[
+				{species: "Smeargle", ability: 'owntempo', moves: ['splash', 'shelltrap']},
+				{species: "Abra", level: 1, ability: 'innerfocus', moves: ['knockoff', 'teleport']},
+			],
+			[
+				{species: "Smeargle", ability: 'owntempo', moves: ['encore', 'splash']},
+				{species: "Zigzagoon", ability: 'pickup', moves: ['extremespeed']},
+			],
+		]);
+
+		// If the Shell Trap user is hit the attack is expected to be successful.
+		battle.makeChoices('move shelltrap, move knockoff 1', 'move splash, move extremespeed 1');
+		let hp = battle.p2.active[0].hp;
+		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
 
 		// Shell Trap which has been encored will never be successful - even if it is hit with contact moves, it will never
 		// attack, and will always say "<Pokemon>'s shell trap didn't work. It doesn't matter in the case of Shell Trap if
 		// the user was hit before or after the Encore; Shell Trap will still always fail.
-		battle.makeChoices('move shelltrap, move splash', 'move splash, move extremespeed 1');
+		battle.makeChoices('move splash, move teleport', 'move encore 1, move extremespeed 1');
 		assert.strictEqual(hp, battle.p2.active[0].hp);
+
+		// During subequent turns the normal Shell Trap behavior applies.
+		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
+		assert.notStrictEqual(hp, battle.p2.active[0].hp);
 	});
 });

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -30,11 +30,11 @@ describe('Encore', function () {
 		// If a user's previous move was Focus Punch and it is Encored into Focus Punch while attempting to
 		// execute the move, the regular "you can't be hit" effect for Focus Punch will be enforced.
 		battle.makeChoices('move focuspunch 1, move teleport', 'move encore 1, move extremespeed 1');
-		assert.strictEqual(hp, battle.p2.active[0].hp);
+		assert.strictEqual(battle.p2.active[0].hp, hp);
 
 		// During subsequent turns the normal Focus Punch behavior applies.
 		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
-		assert.strictEqual(hp, battle.p2.active[0].hp);
+		assert.strictEqual(battle.p2.active[0].hp, hp);
 	});
 
 	it('should make Focus Punch always succeed if it changes the user\'s decision', function () {
@@ -58,12 +58,12 @@ describe('Encore', function () {
 		// if it is hit at any time before or after the Encore, it still uses Focus Punch like normal. It doesn't matter
 		// in the case of Focus Punch if the user was hit before or after the Encore; Focus Punch will still always work.
 		battle.makeChoices('move splash, move teleport', 'move encore 1, move extremespeed 1');
-		assert.notStrictEqual(hp, battle.p2.active[0].hp);
+		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 		hp = battle.p2.active[0].hp;
 
 		// During subsequent turns the normal Focus Punch behavior applies.
 		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
-		assert.strictEqual(hp, battle.p2.active[0].hp);
+		assert.strictEqual(battle.p2.active[0].hp, hp);
 	});
 
 	it('should not affect Shell Trap if the user\'s decision is not changed', function () {
@@ -86,12 +86,12 @@ describe('Encore', function () {
 		// If a user's previous move was Shell Trap and it is Encored into Shell Trap while attempting to
 		// execute the move, the regular "you must be hit" effect for Shell Trap will be enforced
 		battle.makeChoices('move shelltrap, move teleport', 'move encore 1, move extremespeed 1');
-		assert.notStrictEqual(hp, battle.p2.active[0].hp);
+		assert.notStrictEqual( battle.p2.active[0].hp, hp);
 		hp = battle.p2.active[0].hp;
 
 		// During subequent turns the normal Shell Trap behavior applies.
 		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
-		assert.notStrictEqual(hp, battle.p2.active[0].hp);
+		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
 
 	it('should make Shell Trap always fail if the user\'s decision is changed', function () {
@@ -115,10 +115,10 @@ describe('Encore', function () {
 		// attack, and will always say "<Pokemon>'s shell trap didn't work. It doesn't matter in the case of Shell Trap if
 		// the user was hit before or after the Encore; Shell Trap will still always fail.
 		battle.makeChoices('move splash, move teleport', 'move encore 1, move extremespeed 1');
-		assert.strictEqual(hp, battle.p2.active[0].hp);
+		assert.strictEqual(battle.p2.active[0].hp, hp);
 
 		// During subequent turns the normal Shell Trap behavior applies.
 		battle.makeChoices('move focuspunch 1, move teleport', 'move splash, move extremespeed 1');
-		assert.notStrictEqual(hp, battle.p2.active[0].hp);
+		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
 });

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -68,56 +68,56 @@ describe('Encore', function () {
 	it('should not affect Shell Trap if the user\'s decision is not changed', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [
 			[
-				{species: "Smeargle", ability: 'owntempo', moves: ['shelltrap', 'splash']},
+				{species: "Smeargle", level: 99, ability: 'owntempo', moves: ['shelltrap', 'splash']},
 				{species: "Abra", level: 1, ability: 'innerfocus', moves: ['knockoff', 'teleport']},
 			],
 			[
-				{species: "Smeargle", ability: 'owntempo', moves: ['encore', 'splash']},
-				{species: "Zigzagoon", ability: 'pickup', moves: ['extremespeed']},
+				{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['encore', 'splash']},
+				{species: "Zigzagoon", ability: 'pickup', item: 'assaultvest', moves: ['quickattack']},
 			],
 		]);
 
 		// If the Shell Trap user is hit the attack is expected to be successful.
-		battle.makeChoices('move shelltrap, move knockoff 1', 'move splash, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move knockoff 1', 'move splash, move quickattack 1');
 		let hp = battle.p2.active[0].hp;
 		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
 
 		// If a user's previous move was Shell Trap and it is Encored into Shell Trap while attempting to
 		// execute the move, the regular "you must be hit" effect for Shell Trap will be enforced
-		battle.makeChoices('move shelltrap, move teleport', 'move encore 1, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move teleport', 'move encore 1, move quickattack 1');
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 		hp = battle.p2.active[0].hp;
 
 		// During subesquent turns the normal Shell Trap behavior applies.
-		battle.makeChoices('move shelltrap, move teleport', 'move splash, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move teleport', 'move splash, move quickattack 1');
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
 
 	it('should make Shell Trap always fail if the user\'s decision is changed', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [
 			[
-				{species: "Smeargle", ability: 'owntempo', moves: ['splash', 'shelltrap']},
+				{species: "Smeargle", level: 99, ability: 'owntempo', moves: ['splash', 'shelltrap']},
 				{species: "Abra", level: 1, ability: 'innerfocus', moves: ['knockoff', 'teleport']},
 			],
 			[
-				{species: "Smeargle", ability: 'owntempo', moves: ['encore', 'splash']},
-				{species: "Zigzagoon", ability: 'pickup', moves: ['extremespeed']},
+				{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['encore', 'splash']},
+				{species: "Zigzagoon", ability: 'pickup', item: 'assaultvest', moves: ['quickattack']},
 			],
 		]);
 
 		// If the Shell Trap user is hit the attack is expected to be successful.
-		battle.makeChoices('move shelltrap, move knockoff 1', 'move splash, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move knockoff 1', 'move splash, move quickattack 1');
 		let hp = battle.p2.active[0].hp;
 		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
 
 		// Shell Trap which has been encored will never be successful - even if it is hit with contact moves, it will never
 		// attack, and will always say "<Pokemon>'s shell trap didn't work. It doesn't matter in the case of Shell Trap if
 		// the user was hit before or after the Encore; Shell Trap will still always fail.
-		battle.makeChoices('move splash, move teleport', 'move encore 1, move extremespeed 1');
+		battle.makeChoices('move splash, move teleport', 'move encore 1, move quickattack 1');
 		assert.strictEqual(battle.p2.active[0].hp, hp);
 
 		// During subsequent turns the normal Shell Trap behavior applies.
-		battle.makeChoices('move shelltrap, move teleport', 'move splash, move extremespeed 1');
+		battle.makeChoices('move shelltrap, move teleport', 'move splash, move quickattack 1');
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
 });

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Encore', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should make Focus Punch always work while active', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [
+			[
+				{species: "Smeargle", level: 50, ability: 'owntempo', moves: ['splash', 'focuspunch']},
+				{species: "Magikarp", ability: 'swiftswim', moves: ['splash']},
+			],
+			[
+				{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['encore', 'splash']},
+				{species: "Zigzagoon", level: 1, ability: 'pickup', moves: ['extremespeed']},
+			],
+		]);
+
+		// If the Focus Punch user is not interrupted the attack is expected to be successful.
+		battle.makeChoices('move focuspunch 1, move splash', 'move splash, move extremespeed 2');
+		const hp = battle.p2.active[0].hp;
+		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
+
+		// If a user's previous move was Focus Punch and it is Encored into Focus Punch while attempting to
+		// execute the move, the regular "you can't be hit" effect for Focus Punch will be enforced.
+		battle.makeChoices('move focuspunch 1, move splash', 'move encore, move extremespeed 1');
+		assert.strictEqual(hp, battle.p2.active[0].hp);
+
+		// The Pokemon Encored into Focus Punch is not subject to the negative effects of Focus Punch; that is,
+		// if it is hit at any time before or after the Encore, it still uses Focus Punch like normal. It doesn't matter
+		// in the case of Focus Punch if the user was hit before or after the Encore; Focus Punch will still always work.
+		battle.makeChoices('move focuspunch 1, move splash', 'move splash, move extremespeed 1');
+		assert.notStrictEqual(hp, battle.p2.active[0].hp);
+	});
+
+	it('should make Shell Trap always fail while active', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [
+			[
+				{species: "Smeargle", ability: 'owntempo', moves: ['shelltrap']},
+				{species: "Magikarp", ability: 'swiftswim', moves: ['splash']},
+			],
+			[
+				{species: "Smeargle", ability: 'owntempo', moves: ['encore', 'splash']},
+				{species: "Zigzagoon", ability: 'pickup', moves: ['extremespeed']},
+			],
+		]);
+
+		// If the Shell Trap user is hit the attack is expected to be successful.
+		battle.makeChoices('move shelltrap, move splash', 'move splash, move extremespeed 1');
+		let hp = battle.p2.active[0].hp;
+		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
+
+		// If a user's previous move was Shell Trap and it is Encored into Shell Trap while attempting to
+		// execute the move, the regular "you must be hit" effect for Shell Trap will be enforced
+		battle.makeChoices('move shelltrap, move splash', 'move encore 1, move extremespeed 1');
+		assert.notStrictEqual(hp, battle.p2.active[0].hp);
+		hp = battle.p2.active[0].hp;
+
+		// Shell Trap which has been encored will never be successful - even if it is hit with contact moves, it will never
+		// attack, and will always say "<Pokemon>'s shell trap didn't work. It doesn't matter in the case of Shell Trap if
+		// the user was hit before or after the Encore; Shell Trap will still always fail.
+		battle.makeChoices('move shelltrap, move splash', 'move splash, move extremespeed 1');
+		assert.strictEqual(hp, battle.p2.active[0].hp);
+	});
+});

--- a/test/simulator/moves/focuspunch.js
+++ b/test/simulator/moves/focuspunch.js
@@ -62,4 +62,28 @@ describe('Focus Punch', function () {
 		assert.strictEqual(battle.p1.active[0].status, 'tox');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
+
+	it('should not deduct PP if the user lost focus', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]);
+
+		const move = battle.p1.active[0].getMoveData(Dex.getMove('focuspunch'));
+		battle.makeChoices('move focuspunch', 'move magicalleaf');
+		assert.strictEqual(move.pp, move.maxpp);
+		battle.makeChoices('move focuspunch', 'move toxic');
+		assert.strictEqual(move.pp, move.maxpp - 1);
+	});
+
+	it('should deduct PP if the user lost focus before Gen 5', function () {
+		battle = common.gen(4).createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]);
+
+		const move = battle.p1.active[0].getMoveData(Dex.getMove('focuspunch'));
+		battle.makeChoices('move focuspunch', 'move magicalleaf');
+		assert.strictEqual(move.pp, move.maxpp - 1);
+		battle.makeChoices('move focuspunch', 'move toxic');
+		assert.strictEqual(move.pp, move.maxpp - 2);
+	});
 });

--- a/test/simulator/moves/shelltrap.js
+++ b/test/simulator/moves/shelltrap.js
@@ -10,7 +10,7 @@ describe('Shell Trap', function () {
 		battle.destroy();
 	});
 
-	it('should deduct PP regardless if it was successful', function () {
+	it.skip('should deduct PP regardless if it was successful', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [
 			[
 				{species: 'Turtonator', ability: 'shellarmor', moves: ['shelltrap']},
@@ -25,9 +25,11 @@ describe('Shell Trap', function () {
 		const move = battle.p1.active[0].getMoveData(Dex.getMove('shelltrap'));
 		battle.makeChoices('move shelltrap, move splash', 'move irondefense, move splash');
 		assert.strictEqual(move.pp, move.maxpp - 1);
+
+		const cant = '|cant|p1a: Turtonator|Shell Trap|Shell Trap';
+		assert.strictEqual(battle.log.filter(m => m === cant).length, 1);
+
 		battle.makeChoices('move shelltrap, move splash', 'move tackle, move splash');
 		assert.strictEqual(move.pp, move.maxpp - 2);
-
-		assert.bounded(battle.p2.active[0].maxhp - battle.p2.active[0].hp, [31, 37]);
 	});
 });

--- a/test/simulator/moves/shelltrap.js
+++ b/test/simulator/moves/shelltrap.js
@@ -11,14 +11,21 @@ describe('Shell Trap', function () {
 	});
 
 	it('should deduct PP regardless if it was successful', function () {
-		battle = common.createBattle();
-		battle.join('p1', 'Guest 1', 1, [{species: 'Turtonator', ability: 'shellarmor', moves: ['shelltrap']}]);
-		battle.join('p2', 'Guest 2', 1, [{species: 'Turtonator', ability: 'shellarmor', moves: ['tackle', 'irondefense']}]);
+		battle = common.createBattle({gameType: 'doubles'}, [
+			[
+				{species: 'Turtonator', ability: 'shellarmor', moves: ['shelltrap']},
+				{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']},
+			],
+			[
+				{species: 'Turtonator', ability: 'shellarmor', moves: ['tackle', 'irondefense']},
+				{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']},
+			],
+		]);
 
 		const move = battle.p1.active[0].getMoveData(Dex.getMove('shelltrap'));
-		battle.makeChoices('move shelltrap', 'move irondefense');
+		battle.makeChoices('move shelltrap, move splash', 'move irondefense, move splash');
 		assert.strictEqual(move.pp, move.maxpp - 1);
-		battle.makeChoices('move shelltrap', 'move tackle');
+		battle.makeChoices('move shelltrap, move splash', 'move tackle, move splash');
 		assert.strictEqual(move.pp, move.maxpp - 2);
 	});
 });

--- a/test/simulator/moves/shelltrap.js
+++ b/test/simulator/moves/shelltrap.js
@@ -27,5 +27,7 @@ describe('Shell Trap', function () {
 		assert.strictEqual(move.pp, move.maxpp - 1);
 		battle.makeChoices('move shelltrap, move splash', 'move tackle, move splash');
 		assert.strictEqual(move.pp, move.maxpp - 2);
+
+		assert.bounded(battle.p2.active[0].maxhp - battle.p2.active[0].hp, [31, 37]);
 	});
 });

--- a/test/simulator/moves/shelltrap.js
+++ b/test/simulator/moves/shelltrap.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Shell Trap', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should deduct PP regardless if it was successful', function () {
+		battle = common.createBattle();
+		battle.join('p1', 'Guest 1', 1, [{species: 'Turtonator', ability: 'shellarmor', moves: ['shelltrap']}]);
+		battle.join('p2', 'Guest 2', 1, [{species: 'Turtonator', ability: 'shellarmor', moves: ['tackle', 'irondefense']}]);
+
+		const move = battle.p1.active[0].getMoveData(Dex.getMove('shelltrap'));
+		battle.makeChoices('move shelltrap', 'move irondefense');
+		assert.strictEqual(move.pp, move.maxpp - 1);
+		battle.makeChoices('move shelltrap', 'move tackle');
+		assert.strictEqual(move.pp, move.maxpp - 2);
+	});
+});


### PR DESCRIPTION
> - [x] Encore should work successfully on Shell Trap, in a similar way to the Focus Punch behavior. EDIT: see [here ](https://www.smogon.com/forums/threads/bug-reports-v3-0-read-op-before-posting.3634749/post-7796738)for clarification.

_Originally posted by @DaWoblefet in https://github.com/Zarel/Pokemon-Showdown/issues/2367#issuecomment-390426966_

@Marty-D PTAL :)