### PR TITLE
Improve Gen 4 Encore behavior

### DIFF
--- a/data/mods/gen4/moves.js
+++ b/data/mods/gen4/moves.js
@@ -523,9 +523,7 @@ let BattleMovedex = {
 			onStart(target, source) {
 				let noEncore = ['encore', 'mimic', 'mirrormove', 'sketch', 'struggle', 'transform'];
 				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
-				if (!target.lastMove || noEncore.includes(target.lastMove.id) ||
-					!target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0 ||
-					(!target.moveThisTurnResult && !target.moveLastTurnResult)) {
+				if (!target.lastMove || noEncore.includes(target.lastMove.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
 					this.add('-fail', source);
 					this.attrLastMove('[still]');

--- a/data/mods/gen4/moves.js
+++ b/data/mods/gen4/moves.js
@@ -523,7 +523,9 @@ let BattleMovedex = {
 			onStart(target, source) {
 				let noEncore = ['encore', 'mimic', 'mirrormove', 'sketch', 'struggle', 'transform'];
 				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
-				if (!target.lastMove || noEncore.includes(target.lastMove.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
+				if (!target.lastMove || noEncore.includes(target.lastMove.id) ||
+					!target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0 ||
+					(!target.moveThisTurnResult && !target.moveLastTurnResult)) {
 					// it failed
 					this.add('-fail', source);
 					this.attrLastMove('[still]');

--- a/data/mods/gen4/scripts.js
+++ b/data/mods/gen4/scripts.js
@@ -10,6 +10,14 @@ let BattleScripts = {
 		}
 	},
 
+	abortMove(move, pokemon, target, willTryMove) {
+		this.runEvent('MoveAborted', pokemon, target, move);
+		this.clearActiveMove(true);
+		pokemon.moveThisTurnResult = willTryMove;
+		// Reset lastMove
+		pokemon.moveUsed();
+	},
+
 	modifyDamage(baseDamage, pokemon, target, move, suppressMessages = false) {
 		// DPP divides modifiers into several mathematically important stages
 		// The modifiers run earlier than other generations are called with ModifyDamagePhase1 and ModifyDamagePhase2
@@ -89,6 +97,7 @@ let BattleScripts = {
 
 		return Math.floor(baseDamage);
 	},
+
 	tryMoveHit(target, pokemon, move) {
 		this.setActiveMove(move, pokemon, target);
 

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -44,12 +44,7 @@ let BattleScripts = {
 		} */
 		let willTryMove = this.runEvent('BeforeMove', pokemon, target, move);
 		if (!willTryMove) {
-			this.runEvent('MoveAborted', pokemon, target, move);
-			this.clearActiveMove(true);
-			// The event 'BeforeMove' could have returned false or null
-			// false indicates that this counts as a move failing for the purpose of calculating Stomping Tantrum's base power
-			// null indicates the opposite, as the Pokemon didn't have an option to choose anything
-			pokemon.moveThisTurnResult = willTryMove;
+			this.abortMove(move, pokemon, target, willTryMove);
 			return;
 		}
 		if (move.beforeMoveCallback) {
@@ -118,6 +113,14 @@ let BattleScripts = {
 			}
 		}
 		if (noLock && pokemon.volatiles.lockedmove) delete pokemon.volatiles.lockedmove;
+	},
+	abortMove(move, pokemon, target, willTryMove) {
+		this.runEvent('MoveAborted', pokemon, target, move);
+		this.clearActiveMove(true);
+		// The event 'BeforeMove' could have returned false or null
+		// false indicates that this counts as a move failing for the purpose of calculating Stomping Tantrum's base power
+		// null indicates the opposite, as the Pokemon didn't have an option to choose anything
+		pokemon.moveThisTurnResult = willTryMove;
 	},
 	/**
 	 * useMove is the "inside" move caller. It handles effects of the

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -751,6 +751,7 @@ interface BattleScriptsData {
 	runZPower?: (this: Battle, move: ActiveMove, pokemon: Pokemon) => void
 	targetTypeChoices?: (this: Battle, targetType: string) => boolean
 	tryMoveHit?: (this: Battle, target: Pokemon, pokemon: Pokemon, move: ActiveMove) => number | undefined | false | ''
+	abortMove?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon | null | undefined, willTryMove: boolean) => void
 	useMove?: (this: Battle, move: Move, pokemon: Pokemon, target?: Pokemon | null | undefined, sourceEffect?: Effect | null, zMove?: string) => boolean
 	useMoveInner?: (this: Battle, move: Move, pokemon: Pokemon, target?: Pokemon | null | undefined, sourceEffect?: Effect | null, zMove?: string) => boolean
 }

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3146,6 +3146,10 @@ export class Battle extends Dex.ModdedDex {
 		throw new Error(`The runMove function needs to be implemented in scripts.js or the battle format.`);
 	}
 
+	abortMove(move: ActiveMove, pokemon: Pokemon, target: Pokemon | null | undefined, willTryMove: boolean): void {
+		throw new Error(`The abortMove function needs to be implemented in scripts.js or the battle format.`);
+	}
+
 	useMove(move: string | Move, pokemon: Pokemon, target?: Pokemon | null, sourceEffect?: Effect | null, zMove?: string): boolean {
 		throw new Error(`The useMove function needs to be implemented in scripts.js or the battle format.`);
 	}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -643,10 +643,16 @@ export class Pokemon {
 		return amount;
 	}
 
-	moveUsed(move: Move, targetLoc?: number) {
-		this.lastMove = move;
-		this.lastMoveTargetLoc = targetLoc;
-		this.moveThisTurn = move.id;
+	moveUsed(move?: Move, targetLoc?: number) {
+		if (move) {
+			this.lastMove = move;
+			this.lastMoveTargetLoc = targetLoc;
+			this.moveThisTurn = move.id;
+		} else {
+			this.lastMove = null;
+			this.lastMoveTargetLoc = undefined;
+			this.moveThisTurn = '';
+		}
 	}
 
 	gotAttacked(move: string | Move, damage: number | false | undefined, source: Pokemon) {

--- a/test/simulator/moves/encore.js
+++ b/test/simulator/moves/encore.js
@@ -121,3 +121,24 @@ describe('Encore', function () {
 		assert.notStrictEqual(battle.p2.active[0].hp, hp);
 	});
 });
+
+describe('Encore [Gen 4]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should fail if the target did not make a move during its turn', function () {
+		battle = common.gen(4).createBattle({seed: [1, 2, 1, 2]}, [
+			[{species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['seismictoss', 'splash']}],
+			[{species: "Smeargle", ability: 'owntempo', moves: ['thunderwave', 'encore', 'splash']}],
+		]);
+
+		battle.resetRNG(); // Rigged to ensure P1 is fully paralyzed
+		battle.makeChoices('move seismictoss', 'move thunderwave');
+		// Should P2's encore should fail because P1's move failed, so P1 should be free to use Seismic Toss
+		battle.makeChoices('move splash', 'move encore');
+		battle.makeChoices('move seismictoss', 'move splash');
+
+		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp - 100);
+	});
+});


### PR DESCRIPTION
> ##### Gen IV
> * [x]  **Encore should fail if the target did not make a move during its turn**
  Due to flinch, full paralysis, etc.

_Originally posted by @Marty-D  in https://github.com/Zarel/Pokemon-Showdown/issues/2367#issue-125521536_

This PR adds a test for this behavior, which already seems to work. However, it also seems to work regardless of generation, which makes me a little worried about what the correct behavior should be/whether the test is correct (for reference, [this is the log ](https://gist.githubusercontent.com/scheibo/c9a2a78708420b53f93678a8370fd2a6/raw/gen4%2520encore)from the test)?

@Marty-D - can you confirm that this test is testing the scenario you wanted fixed? Should the behavior be Gen 4 specific (in which case, what is the correct behavior for other gens so I can fix it?) or is this universal (in which case, I should just make the test run against the latest generation instead of scoped to `gen(4)`)?