### PR TITLE
Remove FIXME's in gen1/gen2 random-teams.js

### DIFF
--- a/data/mods/gen1/random-teams.js
+++ b/data/mods/gen1/random-teams.js
@@ -131,12 +131,12 @@ class RandomGen1Teams extends RandomGen2Teams {
 		let nuTiers = ['UU', 'UUBL', 'NFE', 'LC', 'NU'];
 		let uuTiers = ['NFE', 'UU', 'UUBL', 'NU'];
 
-		let n = 1;
 		let pokemonPool = [];
 		for (let id in this.data.FormatsData) {
-			// FIXME: Not ES-compliant
-			if (n++ > 151 || !this.data.FormatsData[id].randomBattleMoves) continue;
-			pokemonPool.push(id);
+			let template = this.getTemplate(id);
+			if (template.gen <= this.gen && template.randomBattleMoves) {
+				pokemonPool.push(id);
+			}
 		}
 
 		// Now let's store what we are getting.

--- a/data/mods/gen2/random-teams.js
+++ b/data/mods/gen2/random-teams.js
@@ -8,12 +8,12 @@ class RandomGen2Teams extends RandomGen3Teams {
 		let pokemonLeft = 6;
 		let pokemon = [];
 
-		let n = 1;
 		let pokemonPool = [];
 		for (let id in this.data.FormatsData) {
-			// FIXME: Not ES-compliant
-			if (n++ > 251 || !this.data.FormatsData[id].randomSet1) continue;
-			pokemonPool.push(id);
+			let template = this.getTemplate(id);
+			if (template.gen <= this.gen && this.data.FormatsData[id].randomSet1) {
+				pokemonPool.push(id);
+			}
 		}
 
 		// Setup storage.


### PR DESCRIPTION
Switching to the pattern used by the later generation random team generators makes things more uniform and avoids any key-ordering issues which were 'not ES-compliant'. Note, this pattern is expected to be slower (though not in a way which matters) given we now `getTemplate` for each id (though it should be noted the old pattern was **not** breaking early and still iterated through every generations Pokemon, it just did less work inside each loop). 