### PR TITLE
Use async `fs` APIs in `build`

### DIFF
--- a/build
+++ b/build
@@ -24,6 +24,7 @@ function replace(regex, replacement, file) {
 		if (err) throw err;
 		if (stats.isSymbolicLink()) return;
 		if (stats.isFile()) {
+			if (!file.endsWith('.js')) return;
 			fs.readFile(file, "utf-8", function (err, text) {
 					if (err) throw err;
 					var match = text.match(regex);

--- a/build
+++ b/build
@@ -19,21 +19,28 @@ function sucrase(src, out) {
 	shell(`npx sucrase -q ${src} -d ${out} --transforms typescript,imports --enable-legacy-typescript-module-interop`);
 }
 
-// TODO: switch to async approach with bounded number of open files.
 function replace(regex, replacement, file) {
-	var stats = fs.lstatSync(file);
-	if (stats.isSymbolicLink()) return;
-	if (stats.isFile()) {
-		var text = fs.readFileSync(file, "utf-8");
-		var match = text.match(regex);
-		if (!match) return;
-		fs.writeFileSync(file, text.replace(regex, replacement));
-	} else if (stats.isDirectory()) {
-		var files = fs.readdirSync(file);
-		for (var i = 0; i < files.length; i++) {
-			replace(regex, replacement, path.join(file, files[i]));
+	fs.lstat(file, function (err, stats) {
+		if (err) throw err;
+		if (stats.isSymbolicLink()) return;
+		if (stats.isFile()) {
+			fs.readFile(file, "utf-8", function (err, text) {
+					if (err) throw err;
+					var match = text.match(regex);
+					if (!match) return;
+					fs.writeFile(file, text.replace(regex, replacement), function (err) {
+						if (err) throw err;
+					});
+				});
+		} else if (stats.isDirectory()) {
+			fs.readdir(file, function (err, files) {
+				if (err) throw err;
+				for (var i = 0; i < files.length; i++) {
+					replace(regex, replacement, path.join(file, files[i]));
+				}
+			});
 		}
-	}
+	});
 }
 
 function rewrite(src, out, dist) {


### PR DESCRIPTION
PS supports ~200k open files, so running out of file descriptors
should not be an issue given we have substantially less than ~200k
source files. Also note - the `build` script will not terminate
until the async operations are complete, and while the `rewrite`
method will 'race' with the logic which creates a `config.js`, this
will have no consequences on correctness.