### PR TITLE
Chat plugins: ignore links when determining room FAQ length

### DIFF
--- a/server/chat-plugins/room-faqs.js
+++ b/server/chat-plugins/room-faqs.js
@@ -47,8 +47,9 @@ const commands = {
 		topic = toId(topic);
 		if (!(topic && rest.length)) return this.parse('/help roomfaq');
 		let text = rest.join(',').trim();
+		let filteredText = text.replace(/\[\[(?:([^<]+)\s<[^>]+>|([^\]]+))\]\]/g, (match, $1, $2) => $1 || $2);
 		if (topic.length > 25) return this.errorReply("FAQ topics should not exceed 25 characters.");
-		if (text.length > 500) return this.errorReply("FAQ entries should not exceed 500 characters.");
+		if (filteredText.length > 500) return this.errorReply("FAQ entries should not exceed 500 characters.");
 
 		text = text.replace(/^>/, '&gt;');
 


### PR DESCRIPTION
The current limit's much too short for Bot Development's room FAQ on
bots' nicks and git repositories.