### PR TITLE
Make the 'substitute' volatile lower case

### DIFF
--- a/data/mods/gen1/moves.js
+++ b/data/mods/gen1/moves.js
@@ -911,7 +911,7 @@ let BattleMovedex = {
 		name: "Substitute",
 		pp: 10,
 		priority: 0,
-		volatileStatus: 'Substitute',
+		volatileStatus: 'substitute',
 		onTryHit(target) {
 			if (target.volatiles['substitute']) {
 				this.add('-fail', target, 'move: Substitute');

--- a/data/moves.js
+++ b/data/moves.js
@@ -16779,7 +16779,7 @@ let BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1, nonsky: 1},
-		volatileStatus: 'Substitute',
+		volatileStatus: 'substitute',
 		onTryHit(target) {
 			if (target.volatiles['substitute']) {
 				this.add('-fail', target, 'move: Substitute');


### PR DESCRIPTION
Small consistency nit with no functional different, but volatiles are IDs and all the rest are lowercase.