### PR TITLE
Fix forcerename tracking wrong username

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -2561,7 +2561,6 @@ const commands = {
 		Ladders.cancelSearches(targetUser);
 		targetUser.resetName(true);
 		targetUser.send(`|nametaken||${user.name} considers your name inappropriate${(reason ? `: ${reason}` : ".")}`);
-		targetUser.trackRename = targetUser.name;
 		return true;
 	},
 	forcerenamehelp: [`/forcerename OR /fr [username], [reason] - Forcibly change a user's name and shows them the [reason]. Requires: % @ & ~`],

--- a/server/users.js
+++ b/server/users.js
@@ -942,7 +942,7 @@ class User extends Chat.MessageContext {
 		if (users.has(userid) && users.get(userid) !== this) {
 			return false;
 		}
-		
+
 		let oldname = this.name;
 		let oldid = this.userid;
 		if (userid !== this.userid) {

--- a/server/users.js
+++ b/server/users.js
@@ -942,7 +942,8 @@ class User extends Chat.MessageContext {
 		if (users.has(userid) && users.get(userid) !== this) {
 			return false;
 		}
-
+		
+		let oldname = this.name;
 		let oldid = this.userid;
 		if (userid !== this.userid) {
 			this.cancelReady();
@@ -983,6 +984,7 @@ class User extends Chat.MessageContext {
 		for (const roomid of this.inRooms) {
 			Rooms(roomid).onRename(this, oldid, joining);
 		}
+		if (isForceRenamed) this.trackRename = oldname;
 		return true;
 	}
 	/**


### PR DESCRIPTION
Prior to this, the forcerename command would wrongfully display (forcerenamed from Guest [number])