### PR TITLE
Cleanup stat naming and types (storedStats, StatNameExceptHP)

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -280,15 +280,17 @@ let BattleAbilities = {
 		shortDesc: "This Pokemon's highest stat is raised by 1 if it attacks and KOes another Pokemon.",
 		onSourceFaint(target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
-				let stat = 'atk';
+				let statName = 'atk';
 				let bestStat = 0;
-				for (let i in source.storedStats) {
-					if (source.storedStats[i] > bestStat) {
-						stat = i;
-						bestStat = source.storedStats[i];
+				/** @type {StatNameExceptHP} */
+				let s;
+				for (s in source.storedStats) {
+					if (source.storedStats[s] > bestStat) {
+						statName = s;
+						bestStat = source.storedStats[s];
 					}
 				}
-				this.boost({[stat]: 1}, source);
+				this.boost({[statName]: 1}, source);
 			}
 		},
 		id: "beastboost",

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -282,10 +282,10 @@ let BattleAbilities = {
 			if (effect && effect.effectType === 'Move') {
 				let stat = 'atk';
 				let bestStat = 0;
-				for (let i in source.stats) {
-					if (source.stats[i] > bestStat) {
+				for (let i in source.storedStats) {
+					if (source.storedStats[i] > bestStat) {
 						stat = i;
-						bestStat = source.stats[i];
+						bestStat = source.storedStats[i];
 					}
 				}
 				this.boost({[stat]: 1}, source);

--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -28,19 +28,18 @@ let BattleScripts = {
 	// BattlePokemon scripts.
 	pokemon: {
 		getStat(statName, unmodified) {
-			statName = toId(statName);
-			if (statName === 'hp') return this.maxhp;
-			const s = /** @type {StatNameExceptHP} */(statName);
-			if (unmodified) return this.storedStats[s];
+			statName = /** @type {StatNameExceptHP} */(toId(statName));
+			// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
+			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
+			if (unmodified) return this.storedStats[statName];
 			// @ts-ignore
-			return this.modifiedStats[s];
+			return this.modifiedStats[statName];
 		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
-		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.
-		modifyStat(stat, modifier) {
-			if (!(stat in this.storedStats)) return;
+		modifyStat(statName, modifier) {
+			if (!(statName in this.storedStats)) throw new Error("Invalid `statName` passed to `modifyStat`");
 			// @ts-ignore
-			this.modifiedStats[stat] = this.battle.clampIntRange(Math.floor(this.modifiedStats[stat] * modifier), 1, 999);
+			this.modifiedStats[statName] = this.battle.clampIntRange(Math.floor(this.modifiedStats[statName] * modifier), 1, 999);
 		},
 		// In generation 1, boosting function increases the stored modified stat and checks for opponent's status.
 		boostBy(boost) {
@@ -802,7 +801,9 @@ let BattleScripts = {
 		let defender = target;
 		if (move.useTargetOffensive) attacker = target;
 		if (move.useSourceDefensive) defender = pokemon;
+		/** @type {StatNameExceptHP} */
 		let atkType = (move.category === 'Physical') ? 'atk' : 'spa';
+		/** @type {StatNameExceptHP} */
 		let defType = (move.defensiveCategory === 'Physical') ? 'def' : 'spd';
 		let attack = attacker.getStat(atkType);
 		let defense = defender.getStat(defType);

--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -30,14 +30,14 @@ let BattleScripts = {
 		getStat(statName, unmodified) {
 			statName = toId(statName);
 			if (statName === 'hp') return this.maxhp;
-			if (unmodified) return this.stats[statName];
+			if (unmodified) return this.storedStats[statName];
 			// @ts-ignore
 			return this.modifiedStats[statName];
 		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.
 		modifyStat(stat, modifier) {
-			if (!(stat in this.stats)) return;
+			if (!(stat in this.storedStats)) return;
 			// @ts-ignore
 			this.modifiedStats[stat] = this.battle.clampIntRange(Math.floor(this.modifiedStats[stat] * modifier), 1, 999);
 		},
@@ -71,7 +71,7 @@ let BattleScripts = {
 				// @ts-ignore
 				stat = Math.floor(Math.floor(2 * stat + this.set.ivs[i] + Math.floor(this.set.evs[i] / 4)) * this.level / 100 + 5);
 				// @ts-ignore
-				this.modifiedStats[i] = this.stats[i] = Math.floor(stat);
+				this.modifiedStats[i] = this.storedStats[i] = Math.floor(stat);
 				// @ts-ignore
 				if (this.boosts[i] >= 0) {
 					// @ts-ignore

--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -30,9 +30,10 @@ let BattleScripts = {
 		getStat(statName, unmodified) {
 			statName = toId(statName);
 			if (statName === 'hp') return this.maxhp;
-			if (unmodified) return this.storedStats[statName];
+			const s = /** @type {StatNameExceptHP} */(statName);
+			if (unmodified) return this.storedStats[s];
 			// @ts-ignore
-			return this.modifiedStats[statName];
+			return this.modifiedStats[s];
 		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.

--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -15,7 +15,7 @@ let BattleScripts = {
 			if (statName === 'hp') return this.maxhp;
 
 			// base stat
-			let stat = this.storedStats[statName];
+			let stat = this.storedStats[/** @type {StatNameExceptHP} */(statName)];
 
 			// Stat boosts.
 			if (!unboosted) {

--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -15,7 +15,7 @@ let BattleScripts = {
 			if (statName === 'hp') return this.maxhp;
 
 			// base stat
-			let stat = this.stats[statName];
+			let stat = this.storedStats[statName];
 
 			// Stat boosts.
 			if (!unboosted) {

--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -11,11 +11,12 @@ let BattleScripts = {
 	// BattlePokemon scripts.
 	pokemon: {
 		getStat(statName, unboosted, unmodified) {
-			statName = toId(statName);
-			if (statName === 'hp') return this.maxhp;
+			statName = /** @type {StatNameExceptHP} */(toId(statName));
+			// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
+			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
 
 			// base stat
-			let stat = this.storedStats[/** @type {StatNameExceptHP} */(statName)];
+			let stat = this.storedStats[statName];
 
 			// Stat boosts.
 			if (!unboosted) {
@@ -549,7 +550,9 @@ let BattleScripts = {
 		let defender = target;
 		if (move.useTargetOffensive) attacker = target;
 		if (move.useSourceDefensive) defender = pokemon;
+		/** @type {StatNameExceptHP} */
 		let atkType = (move.category === 'Physical') ? 'atk' : 'spa';
+		/** @type {StatNameExceptHP} */
 		let defType = (move.defensiveCategory === 'Physical') ? 'def' : 'spd';
 		let unboosted = false;
 		let noburndrop = false;

--- a/data/mods/gennext/abilities.js
+++ b/data/mods/gennext/abilities.js
@@ -339,8 +339,8 @@ let BattleAbilities = {
 			let totalspd = 0;
 			for (const foe of pokemon.side.foe.active) {
 				if (!foe || foe.fainted) continue;
-				totaldef += foe.stats.def;
-				totalspd += foe.stats.spd;
+				totaldef += foe.storedStats.def;
+				totalspd += foe.storedStats.spd;
 			}
 			if (totaldef && totaldef >= totalspd) {
 				this.boost({spa: 1});

--- a/data/mods/ssb/abilities.js
+++ b/data/mods/ssb/abilities.js
@@ -503,8 +503,8 @@ let BattleAbilities = {
 		isNonstandard: true,
 		onSourceFaint(target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
-				let statOrder = Object.keys(source.storedStats)
-				    .sort((stat1, stat2) => source.storedStats[stat2] - source.storedStats[stat1]);
+				// @ts-ignore
+				let statOrder = Object.keys(source.storedStats).sort((stat1, stat2) => source.storedStats[stat2] - source.storedStats[stat1]);
 				this.boost({[statOrder[0]]: 1, [statOrder[1]]: 1}, source);
 			}
 		},

--- a/data/mods/ssb/abilities.js
+++ b/data/mods/ssb/abilities.js
@@ -503,8 +503,8 @@ let BattleAbilities = {
 		isNonstandard: true,
 		onSourceFaint(target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
-				let statOrder = Object.keys(source.stats)
-				    .sort((stat1, stat2) => source.stats[stat2] - source.stats[stat1]);
+				let statOrder = Object.keys(source.storedStats)
+				    .sort((stat1, stat2) => source.storedStats[stat2] - source.storedStats[stat1]);
 				this.boost({[statOrder[0]]: 1, [statOrder[1]]: 1}, source);
 			}
 		},

--- a/data/mods/ssb/scripts.js
+++ b/data/mods/ssb/scripts.js
@@ -97,7 +97,7 @@ let BattleScripts = {
 			}
 			// Dancer activates in order of lowest speed stat to highest
 			// Ties go to whichever Pokemon has had the ability for the least amount of time
-			dancers.sort(function (a, b) { return -(b.stats['spe'] - a.stats['spe']) || b.abilityOrder - a.abilityOrder; });
+			dancers.sort(function (a, b) { return -(b.storedStats['spe'] - a.storedStats['spe']) || b.abilityOrder - a.abilityOrder; });
 			for (const dancer of dancers) {
 				if (this.faintMessages()) break;
 				this.add('-activate', dancer, 'ability: Dancer');

--- a/data/mods/stadium/scripts.js
+++ b/data/mods/stadium/scripts.js
@@ -13,9 +13,10 @@ let BattleScripts = {
 		getStat(statName, unmodified) {
 			statName = toId(statName);
 			if (statName === 'hp') return this.maxhp;
-			if (unmodified) return this.storedStats[statName];
+			const s = /** @type {StatNameExceptHP} */(statName);
+			if (unmodified) return this.storedStats[s];
 			// @ts-ignore
-			return this.modifiedStats[statName];
+			return this.modifiedStats[s];
 		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.

--- a/data/mods/stadium/scripts.js
+++ b/data/mods/stadium/scripts.js
@@ -13,27 +13,27 @@ let BattleScripts = {
 		getStat(statName, unmodified) {
 			statName = toId(statName);
 			if (statName === 'hp') return this.maxhp;
-			if (unmodified) return this.stats[statName];
+			if (unmodified) return this.storedStats[statName];
 			// @ts-ignore
 			return this.modifiedStats[statName];
 		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.
 		modifyStat(stat, modifier) {
-			if (!(stat in this.stats)) return;
+			if (!(stat in this.storedStats)) return;
 			// @ts-ignore
 			this.modifiedStats[stat] = this.battle.clampIntRange(Math.floor(this.modifiedStats[stat] * modifier), 1);
 		},
 		// This is run on Stadium after boosts and status changes.
 		recalculateStats() {
-			for (let statName in this.stats) {
+			for (let statName in this.storedStats) {
 				/**@type {number} */
 				// @ts-ignore
 				let stat = this.template.baseStats[statName];
 				// @ts-ignore
 				stat = Math.floor(Math.floor(2 * stat + this.set.ivs[statName] + Math.floor(this.set.evs[statName] / 4)) * this.level / 100 + 5);
 				// @ts-ignore
-				this.baseStats[statName] = this.stats[statName] = Math.floor(stat);
+				this.baseStoredStats[statName] = this.storedStats[statName] = Math.floor(stat);
 				// @ts-ignore
 				this.modifiedStats[statName] = Math.floor(stat);
 				// Re-apply drops, if necessary.

--- a/data/mods/stadium/scripts.js
+++ b/data/mods/stadium/scripts.js
@@ -7,23 +7,14 @@
 let BattleScripts = {
 	inherit: 'gen1',
 	gen: 1,
-	// BattlePokemon scripts.
+	// BattlePokemon scripts. Stadium shares gen 1 code but it fixes some problems with it.
 	pokemon: {
-		// Stadium shares gen 1 code but it fixes some problems with it.
-		getStat(statName, unmodified) {
-			statName = toId(statName);
-			if (statName === 'hp') return this.maxhp;
-			const s = /** @type {StatNameExceptHP} */(statName);
-			if (unmodified) return this.storedStats[s];
-			// @ts-ignore
-			return this.modifiedStats[s];
-		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.
-		modifyStat(stat, modifier) {
-			if (!(stat in this.storedStats)) return;
+		modifyStat(statName, modifier) {
+			if (!(statName in this.storedStats)) throw new Error("Invalid `statName` passed to `modifyStat`");
 			// @ts-ignore
-			this.modifiedStats[stat] = this.battle.clampIntRange(Math.floor(this.modifiedStats[stat] * modifier), 1);
+			this.modifiedStats[statName] = this.battle.clampIntRange(Math.floor(this.modifiedStats[statName] * modifier), 1);
 		},
 		// This is run on Stadium after boosts and status changes.
 		recalculateStats() {
@@ -559,7 +550,9 @@ let BattleScripts = {
 		let defender = target;
 		if (move.useTargetOffensive) attacker = target;
 		if (move.useSourceDefensive) defender = pokemon;
+		/** @type {StatNameExceptHP} */
 		let atkType = (move.category === 'Physical') ? 'atk' : 'spa';
+		/** @type {StatNameExceptHP} */
 		let defType = (move.defensiveCategory === 'Physical') ? 'def' : 'spd';
 		let attack = attacker.getStat(atkType);
 		let defense = defender.getStat(defType);

--- a/data/moves.js
+++ b/data/moves.js
@@ -6925,12 +6925,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, mystery: 1},
 		onHit(target, source) {
-			let newdef = Math.floor((target.stats.def + source.stats.def) / 2);
-			target.stats.def = newdef;
-			source.stats.def = newdef;
-			let newspd = Math.floor((target.stats.spd + source.stats.spd) / 2);
-			target.stats.spd = newspd;
-			source.stats.spd = newspd;
+			let newdef = Math.floor((target.storedStats.def + source.storedStats.def) / 2);
+			target.storedStats.def = newdef;
+			source.storedStats.def = newdef;
+			let newspd = Math.floor((target.storedStats.spd + source.storedStats.spd) / 2);
+			target.storedStats.spd = newspd;
+			source.storedStats.spd = newspd;
 			this.add('-activate', source, 'move: Guard Split', '[of] ' + target);
 		},
 		secondary: null,
@@ -12261,12 +12261,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, mystery: 1},
 		onHit(target, source) {
-			let newatk = Math.floor((target.stats.atk + source.stats.atk) / 2);
-			target.stats.atk = newatk;
-			source.stats.atk = newatk;
-			let newspa = Math.floor((target.stats.spa + source.stats.spa) / 2);
-			target.stats.spa = newspa;
-			source.stats.spa = newspa;
+			let newatk = Math.floor((target.storedStats.atk + source.storedStats.atk) / 2);
+			target.storedStats.atk = newatk;
+			source.storedStats.atk = newatk;
+			let newspa = Math.floor((target.storedStats.spa + source.storedStats.spa) / 2);
+			target.storedStats.spa = newspa;
+			source.storedStats.spa = newspa;
 			this.add('-activate', source, 'move: Power Split', '[of] ' + target);
 		},
 		secondary: null,
@@ -12325,23 +12325,23 @@ let BattleMovedex = {
 		effect: {
 			onStart(pokemon) {
 				this.add('-start', pokemon, 'Power Trick');
-				let newatk = pokemon.stats.def;
-				let newdef = pokemon.stats.atk;
-				pokemon.stats.atk = newatk;
-				pokemon.stats.def = newdef;
+				let newatk = pokemon.storedStats.def;
+				let newdef = pokemon.storedStats.atk;
+				pokemon.storedStats.atk = newatk;
+				pokemon.storedStats.def = newdef;
 			},
 			onCopy(pokemon) {
-				let newatk = pokemon.stats.def;
-				let newdef = pokemon.stats.atk;
-				pokemon.stats.atk = newatk;
-				pokemon.stats.def = newdef;
+				let newatk = pokemon.storedStats.def;
+				let newdef = pokemon.storedStats.atk;
+				pokemon.storedStats.atk = newatk;
+				pokemon.storedStats.def = newdef;
 			},
 			onEnd(pokemon) {
 				this.add('-end', pokemon, 'Power Trick');
-				let newatk = pokemon.stats.def;
-				let newdef = pokemon.stats.atk;
-				pokemon.stats.atk = newatk;
-				pokemon.stats.def = newdef;
+				let newatk = pokemon.storedStats.def;
+				let newdef = pokemon.storedStats.atk;
+				pokemon.storedStats.atk = newatk;
+				pokemon.storedStats.def = newdef;
 			},
 			onRestart(pokemon) {
 				pokemon.removeVolatile('Power Trick');
@@ -15707,9 +15707,9 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, authentic: 1, mystery: 1},
 		onHit(target, source) {
-			const targetSpe = target.stats.spe;
-			target.stats.spe = source.stats.spe;
-			source.stats.spe = targetSpe;
+			const targetSpe = target.storedStats.spe;
+			target.storedStats.spe = source.storedStats.spe;
+			source.storedStats.spe = targetSpe;
 			this.add('-activate', source, 'move: Speed Swap', '[of] ' + target);
 		},
 		secondary: null,

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -107,6 +107,8 @@ let BattleScripts = {
 				}
 			}
 			// Dancer activates in order of lowest speed stat to highest
+			// Note that the speed stat used is after any volatile replacements like Speed Swap,
+			// but before any multipliers like Agility or Choice Scarf
 			// Ties go to whichever Pokemon has had the ability for the least amount of time
 			dancers.sort(function (a, b) { return -(b.storedStats['spe'] - a.storedStats['spe']) || b.abilityOrder - a.abilityOrder; });
 			for (const dancer of dancers) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -110,7 +110,9 @@ let BattleScripts = {
 			// Note that the speed stat used is after any volatile replacements like Speed Swap,
 			// but before any multipliers like Agility or Choice Scarf
 			// Ties go to whichever Pokemon has had the ability for the least amount of time
-			dancers.sort(function (a, b) { return -(b.storedStats['spe'] - a.storedStats['spe']) || b.abilityOrder - a.abilityOrder; });
+			dancers.sort((a, b) =>
+				-(b.storedStats['spe'] - a.storedStats['spe']) || b.abilityOrder - a.abilityOrder
+			);
 			for (const dancer of dancers) {
 				if (this.faintMessages()) break;
 				this.add('-activate', dancer, 'ability: Dancer');

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -108,7 +108,7 @@ let BattleScripts = {
 			}
 			// Dancer activates in order of lowest speed stat to highest
 			// Ties go to whichever Pokemon has had the ability for the least amount of time
-			dancers.sort(function (a, b) { return -(b.stats['spe'] - a.stats['spe']) || b.abilityOrder - a.abilityOrder; });
+			dancers.sort(function (a, b) { return -(b.storedStats['spe'] - a.storedStats['spe']) || b.abilityOrder - a.abilityOrder; });
 			for (const dancer of dancers) {
 				if (this.faintMessages()) break;
 				this.add('-activate', dancer, 'ability: Dancer');

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -27,10 +27,13 @@ declare let Sockets: typeof import('../server/sockets');
 declare let TeamValidatorAsync: typeof import('../server/team-validator-async');
 
 type GenderName = 'M' | 'F' | 'N' | '';
-type StatName = 'hp' | 'atk' | 'def' | 'spa' | 'spd' | 'spe';
-type StatsTable = {hp: number, atk: number, def: number, spa: number, spd: number, spe: number};
+type StatNameExceptHP = 'atk' | 'def' | 'spa' | 'spd' | 'spe';
+type StatName = 'hp' | StatNameExceptHP;
+type StatsExceptHPTable = {[stat in StatNameExceptHP]: number};
+type StatsTable = {[stat in StatName]: number };
 type SparseStatsTable = Partial<StatsTable>;
-type BoostsTable = {atk: number, def: number, spa: number, spd: number, spe: number, accuracy: number, evasion: number};
+type BoostName = StatNameExceptHP | 'accuracy' | 'evasion';
+type BoostsTable = {[boost in BoostName]: number };
 type SparseBoostsTable = Partial<BoostsTable>;
 type PokemonSet = {
 	name: string,

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -763,14 +763,14 @@ interface ModdedBattleSide {
 
 interface ModdedBattlePokemon {
 	boostBy?: (this: Pokemon, boost: SparseBoostsTable) => boolean
-	calculateStat?: (this: Pokemon, statName: string, boost: number, modifier?: number) => number
+	calculateStat?: (this: Pokemon, statName: StatNameExceptHP, boost: number, modifier?: number) => number
 	getActionSpeed?: (this: Pokemon) => number
 	getRequestData?: (this: Pokemon) => {moves: {move: string, id: string, target?: string, disabled?: boolean}[], maybeDisabled?: boolean, trapped?: boolean, maybeTrapped?: boolean, canMegaEvo?: boolean, canUltraBurst?: boolean, canZMove?: AnyObject | null}
-	getStat?: (this: Pokemon, statName: string, unboosted?: boolean, unmodified?: boolean) => number
+	getStat?: (this: Pokemon, statName: StatNameExceptHP, unboosted?: boolean, unmodified?: boolean) => number
 	getWeight?: (this: Pokemon) => number
 	hasAbility?: (this: Pokemon, ability: string | string[]) => boolean
 	isGrounded?: (this: Pokemon, negateImmunity: boolean | undefined) => boolean | null
-	modifyStat?: (this: Pokemon, statName: string, modifier: number) => void
+	modifyStat?: (this: Pokemon, statName: StatNameExceptHP, modifier: number) => void
 	moveUsed?: (this: Pokemon, move: Move, targetLoc?: number) => void
 	recalculateStats?: (this: Pokemon) => void
 	setAbility?: (this: Pokemon, ability: string | Ability, source: Pokemon | null, isFromFormeChange: boolean) => string | false

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2096,8 +2096,8 @@ export class Battle extends Dex.ModdedDex {
 
 		let attacker = pokemon;
 		let defender = target;
-		let attackStat = category === 'Physical' ? 'atk' : 'spa';
-		let defenseStat = defensiveCategory === 'Physical' ? 'def' : 'spd';
+		let attackStat: StatNameExceptHP = category === 'Physical' ? 'atk' : 'spa';
+		let defenseStat: StatNameExceptHP = defensiveCategory === 'Physical' ? 'def' : 'spd';
 		let statTable = {atk: 'Atk', def: 'Def', spa: 'SpA', spd: 'SpD', spe: 'Spe'};
 		let attack;
 		let defense;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -208,7 +208,7 @@ export class Pokemon {
 
 	// Gen 1 only
 	modifiedStats?: StatsExceptHPTable;
-	modifyStat?: (this: Pokemon, statName: string, modifier: number) => void;
+	modifyStat?: (this: Pokemon, statName: StatNameExceptHP, modifier: number) => void;
 
 	// OMs
 	innate?: string;
@@ -419,12 +419,13 @@ export class Pokemon {
 		this.speed = this.getActionSpeed();
 	}
 
-	calculateStat(statName: string, boost: number, modifier?: number) {
-		statName = toId(statName);
-		if (statName === 'hp') return this.maxhp; // please just read .maxhp directly
+	calculateStat(statName: StatNameExceptHP, boost: number, modifier?: number) {
+		statName = toId(statName) as StatNameExceptHP;
+		// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
+		if (statName === 'hp') throw new Error("Please read `maxhp` directly");
 
 		// base stat
-		let stat = this.storedStats[statName as StatNameExceptHP];
+		let stat = this.storedStats[statName];
 
 		// Wonder Room swaps defenses before calculating anything else
 		if ('wonderroom' in this.battle.pseudoWeather) {
@@ -454,12 +455,13 @@ export class Pokemon {
 		return this.battle.modify(stat, (modifier || 1));
 	}
 
-	getStat(statName: string, unboosted?: boolean, unmodified?: boolean) {
-		statName = toId(statName);
-		if (statName === 'hp') return this.maxhp; // please just read .maxhp directly
+	getStat(statName: StatNameExceptHP, unboosted?: boolean, unmodified?: boolean) {
+		statName = toId(statName) as StatNameExceptHP;
+		// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
+		if (statName === 'hp') throw new Error("Please read `maxhp` directly");
 
 		// base stat
-		let stat = this.storedStats[statName as StatNameExceptHP];
+		let stat = this.storedStats[statName];
 
 		// Download ignores Wonder Room's effect, but this results in
 		// stat stages being calculated on the opposite defensive stat

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -64,24 +64,24 @@ export class Pokemon {
 	 * calculated purely from the species base stats, level, IVs, EVs,
 	 * and Nature, before modifications from item, ability, etc.
 	 *
-	 * `stats` are reset to `baseStats` on switch-out.
+	 * `storedStats` are reset to `baseStoredStats` on switch-out.
 	 */
-	baseStats: StatsTable;
+	baseStoredStats: StatsTable;
 	/**
 	 * These are pre-modification stored stats in-battle. At switch-in,
-	 * they're identical to `baseStats`, but can be temporarily changed
+	 * they're identical to `baseStoredStats`, but can be temporarily changed
 	 * until switch-out by effects such as Power Trick and Transform.
 	 *
 	 * Stat multipliers from abilities, items, and volatiles, such as
 	 * Solar Power, Choice Band, or Swords Dance, are not stored in
-	 * `stats`, but applied on top and accessed by `pokemon.getStat`.
+	 * `storedStats`, but applied on top and accessed by `pokemon.getStat`.
 	 *
 	 * (Except in Gen 1, where stat multipliers are stored, leading
 	 * to several famous glitches.)
 	 *
-	 * `stats` are reset to `baseStats` on switch-out.
+	 * `storedStats` are reset to `baseStoredStats` on switch-out.
 	 */
-	stats: {[k: string]: number};
+	storedStats: {[k: string]: number};
 	boosts: BoostsTable;
 
 	baseAbility: string;
@@ -318,8 +318,8 @@ export class Pokemon {
 		this.baseHpPower = this.hpPower;
 
 		// initialized in this.setTemplate(this.baseTemplate)
-		this.baseStats = null!;
-		this.stats = {atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
+		this.baseStoredStats = null!;
+		this.storedStats = {atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
 		this.boosts = {atk: 0, def: 0, spa: 0, spd: 0, spe: 0, accuracy: 0, evasion: 0};
 
 		this.baseAbility = toId(set.ability);
@@ -377,7 +377,7 @@ export class Pokemon {
 		if (this.battle.gen === 1) this.modifiedStats = {atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
 
 		this.clearVolatile();
-		this.maxhp = this.template.maxHP || this.baseStats.hp;
+		this.maxhp = this.template.maxHP || this.baseStoredStats.hp;
 		this.hp = this.maxhp;
 
 		this.isStale = 0;
@@ -424,14 +424,14 @@ export class Pokemon {
 		if (statName === 'hp') return this.maxhp; // please just read .maxhp directly
 
 		// base stat
-		let stat = this.stats[statName];
+		let stat = this.storedStats[statName];
 
 		// Wonder Room swaps defenses before calculating anything else
 		if ('wonderroom' in this.battle.pseudoWeather) {
 			if (statName === 'def') {
-				stat = this.stats['spd'];
+				stat = this.storedStats['spd'];
 			} else if (statName === 'spd') {
-				stat = this.stats['def'];
+				stat = this.storedStats['def'];
 			}
 		}
 
@@ -459,7 +459,7 @@ export class Pokemon {
 		if (statName === 'hp') return this.maxhp; // please just read .maxhp directly
 
 		// base stat
-		let stat = this.stats[statName];
+		let stat = this.storedStats[statName];
 
 		// Download ignores Wonder Room's effect, but this results in
 		// stat stages being calculated on the opposite defensive stat
@@ -872,8 +872,8 @@ export class Pokemon {
 		this.knownType = this.side === pokemon.side && pokemon.knownType;
 		this.apparentType = pokemon.apparentType;
 
-		for (const statName in this.stats) {
-			this.stats[statName] = pokemon.stats[statName];
+		for (const statName in this.storedStats) {
+			this.storedStats[statName] = pokemon.storedStats[statName];
 		}
 		this.moveSlots = [];
 		this.set.ivs = (this.battle.gen >= 5 ? this.set.ivs : pokemon.set.ivs);
@@ -950,11 +950,11 @@ export class Pokemon {
 		if (this.battle.gen >= 7) this.removeVolatile('autotomize');
 
 		const stats = this.battle.spreadModify(this.template.baseStats, this.set);
-		if (!this.baseStats) this.baseStats = stats;
-		for (const statName in this.stats) {
+		if (!this.baseStoredStats) this.baseStoredStats = stats;
+		for (const statName in this.storedStats) {
 			const s = statName as keyof StatsTable;
-			this.stats[s] = stats[s];
-			this.baseStats[s] = stats[s];
+			this.storedStats[s] = stats[s];
+			this.baseStoredStats[s] = stats[s];
 			if (this.modifiedStats) this.modifiedStats[s] = stats[s]; // Gen 1: Reset modified stats.
 		}
 		if (this.battle.gen <= 1) {
@@ -962,7 +962,7 @@ export class Pokemon {
 			if (this.status === 'par') this.modifyStat!('spe', 0.25);
 			if (this.status === 'brn') this.modifyStat!('atk', 0.5);
 		}
-		this.speed = this.stats.spe;
+		this.speed = this.storedStats.spe;
 		return template;
 	}
 

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -169,11 +169,11 @@ export class Side {
 				condition: pokemon.getHealth(pokemon.side),
 				active: (pokemon.position < pokemon.side.active.length),
 				stats: {
-					atk: pokemon.baseStats['atk'],
-					def: pokemon.baseStats['def'],
-					spa: pokemon.baseStats['spa'],
-					spd: pokemon.baseStats['spd'],
-					spe: pokemon.baseStats['spe'],
+					atk: pokemon.baseStoredStats['atk'],
+					def: pokemon.baseStoredStats['def'],
+					spa: pokemon.baseStoredStats['spa'],
+					spd: pokemon.baseStoredStats['spd'],
+					spe: pokemon.baseStoredStats['spe'],
 				},
 				moves: pokemon.moves.map(move => {
 					if (move === 'hiddenpower') {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -349,9 +349,9 @@ export class Validator {
 			if (dex.gen <= 2) {
 				let HPdvs = dex.getType(set.hpType).HPdvs;
 				ivs = set.ivs = {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30};
-				let stat: keyof StatsTable;
-				for (stat in HPdvs) {
-					ivs[stat] = HPdvs[stat]! * 2;
+				let statName: StatName;
+				for (statName in HPdvs) {
+					ivs[statName] = HPdvs[statName]! * 2;
 				}
 				ivs.hp = -1;
 			} else if (!canBottleCap) {
@@ -641,12 +641,12 @@ export class Validator {
 
 			if (!set.ivs) set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 			let statTable = {hp: 'HP', atk: 'Attack', def: 'Defense', spa: 'Special Attack', spd: 'Special Defense', spe: 'Speed'};
-			let statId: keyof StatsTable;
-			for (statId in eventData.ivs) {
-				if (canBottleCap && set.ivs[statId] === 31) continue;
-				if (set.ivs[statId] !== eventData.ivs[statId]) {
+			let statName: StatName;
+			for (statName in eventData.ivs) {
+				if (canBottleCap && set.ivs[statName] === 31) continue;
+				if (set.ivs[statName] !== eventData.ivs[statName]) {
 					if (fastReturn) return true;
-					problems.push(`${name} must have ${eventData.ivs[statId]} ${statTable[statId]} IVs${etc}.`);
+					problems.push(`${name} must have ${eventData.ivs[statName]} ${statTable[statName]} IVs${etc}.`);
 				}
 			}
 
@@ -671,9 +671,9 @@ export class Validator {
 			// Legendary Pokemon must have at least 3 perfect IVs in gen 6
 			// Events can also have a certain amount of guaranteed perfect IVs
 			let perfectIVs = 0;
-			let stat: keyof StatsTable;
-			for (stat in set.ivs) {
-				if (set.ivs[stat] >= 31) perfectIVs++;
+			let statName: StatName;
+			for (statName in set.ivs) {
+				if (set.ivs[statName] >= 31) perfectIVs++;
 			}
 			if (perfectIVs < requiredIVs) {
 				if (fastReturn) return true;
@@ -1269,10 +1269,10 @@ export class Validator {
 	static fillStats(stats: SparseStatsTable | null, fillNum: number = 0): StatsTable {
 		let filledStats: StatsTable = {hp: fillNum, atk: fillNum, def: fillNum, spa: fillNum, spd: fillNum, spe: fillNum};
 		if (stats) {
-			let stat: keyof StatsTable;
-			for (stat in filledStats) {
-				let val = stats[stat];
-				if (typeof val === 'number') filledStats[stat] = val;
+			let statName: StatName;
+			for (statName in filledStats) {
+				const stat = stats[statName];
+				if (typeof stat === 'number') filledStats[statName] = stat;
 			}
 		}
 		return filledStats;

--- a/test/simulator/abilities/desolateland.js
+++ b/test/simulator/abilities/desolateland.js
@@ -86,7 +86,7 @@ describe('Desolate Land', function () {
 		battle.makeChoices('move helpinghand', 'switch 3');
 		assert.false.fullHP(p2.active[0], "Charizard should be hurt by Solar Power");
 		battle.makeChoices('move solarbeam', 'switch 4');
-		assert.strictEqual(p2.active[0].getStat('spe'), 2 * p2.active[0].stats['spe'], "Venusaur's speed should be doubled by Chlorophyll");
+		assert.strictEqual(p2.active[0].getStat('spe'), 2 * p2.active[0].storedStats['spe'], "Venusaur's speed should be doubled by Chlorophyll");
 		assert.false.fullHP(p2.active[0], "Solar Beam should skip its charge turn");
 		battle.makeChoices('move helpinghand', 'switch 5');
 		assert.false.fullHP(p2.active[0], "Toxicroak should be hurt by Dry Skin");

--- a/test/simulator/abilities/primordialsea.js
+++ b/test/simulator/abilities/primordialsea.js
@@ -81,7 +81,7 @@ describe('Primordial Sea', function () {
 		battle.makeChoices('move sonicboom', 'move weatherball');
 		assert.species(p2.active[0], 'Castform-Rainy');
 		battle.makeChoices('move sonicboom', 'switch 2');
-		assert.strictEqual(battle.p2.active[0].getStat('spe'), 2 * battle.p2.active[0].stats['spe'], "Kingdra's Speed should be doubled by Swift Swim");
+		assert.strictEqual(battle.p2.active[0].getStat('spe'), 2 * battle.p2.active[0].storedStats['spe'], "Kingdra's Speed should be doubled by Swift Swim");
 		battle.makeChoices('move sonicboom', 'switch 3');
 		assert.notStrictEqual(battle.p2.active[0].maxhp - battle.p2.active[0].hp, 20);
 		battle.makeChoices('move sonicboom', 'switch 4');


### PR DESCRIPTION
> I would probably rename these to `storedStats` and `baseStoredStats`; to make it clearer that they aren't the Pokémon's "actual" stats.

_Originally posted by @Zarel in https://github.com/Zarel/Pokemon-Showdown/pull/5267_