### PR TITLE
Make `build`s `replace` safer and easier to use

### DIFF
--- a/build
+++ b/build
@@ -19,7 +19,7 @@ function sucrase(src, out) {
 	shell(`npx sucrase -q ${src} -d ${out} --transforms typescript,imports --enable-legacy-typescript-module-interop`);
 }
 
-function replace(regex, replacement, file) {
+function replace(file, replacements) {
 	fs.lstat(file, function (err, stats) {
 		if (err) throw err;
 		if (stats.isSymbolicLink()) return;
@@ -27,9 +27,13 @@ function replace(regex, replacement, file) {
 			if (!file.endsWith('.js')) return;
 			fs.readFile(file, "utf-8", function (err, text) {
 					if (err) throw err;
-					var match = text.match(regex);
-					if (!match) return;
-					fs.writeFile(file, text.replace(regex, replacement), function (err) {
+					var anyMatch = false;
+					for (var i = 0; i < replacements.length; i++) {
+						anyMatch = anyMatch || text.match(replacements[i].regex);
+						if (anyMatch) text = text.replace(replacements[i].regex, replacements[i].replace);
+					}
+					if (!anyMatch) return;
+					fs.writeFile(file, text, function (err) {
 						if (err) throw err;
 					});
 				});
@@ -37,7 +41,7 @@ function replace(regex, replacement, file) {
 			fs.readdir(file, function (err, files) {
 				if (err) throw err;
 				for (var i = 0; i < files.length; i++) {
-					replace(regex, replacement, path.join(file, files[i]));
+					replace(path.join(file, files[i]), replacements);
 				}
 			});
 		}
@@ -57,7 +61,8 @@ try {
 
 sucrase('./sim', './.sim-dist');
 sucrase('./lib', './.lib-dist');
-rewrite('lib', '.lib-dist', '.sim-dist');
+// NOTE: replace is asynchronous - add additional replacements for the same path in one call instead of making multiple calls.
+replace(path.join(__dirname, '.sim-dist'), [{regex: new RegExp(`(require\\\(.*?)(lib)(.*?\\\))`), replace: `$1.lib-dist$3`}]);
 
 // Make sure config.js exists. If not, copy it over synchronously from
 // config-example.js, since it's needed before we can start the server

--- a/build
+++ b/build
@@ -62,7 +62,9 @@ try {
 sucrase('./sim', './.sim-dist');
 sucrase('./lib', './.lib-dist');
 // NOTE: replace is asynchronous - add additional replacements for the same path in one call instead of making multiple calls.
-replace(path.join(__dirname, '.sim-dist'), [{regex: new RegExp(`(require\\\(.*?)(lib)(.*?\\\))`), replace: `$1.lib-dist$3`}]);
+replace(path.join(__dirname, '.sim-dist'), [
+	{regex: new RegExp(`(require\\\(.*?)(lib)(.*?\\\))`), replace: `$1.lib-dist$3`},
+]);
 
 // Make sure config.js exists. If not, copy it over synchronously from
 // config-example.js, since it's needed before we can start the server


### PR DESCRIPTION
*Clearly, I really must likely rewriting this code...*

I'm worried that `replace` as it exists today has sharp edges and the next person to try to use it might run into issues. The main thing I'm worried about is someone adding a second `replace` call over the same path and getting into races due to to it writing the same files asynchronously. In addition to the potential correctness issue, it's also inefficient to open up the same files multiple times if you wanted to perform a second replace. 

This approach is the most minimal change, I also [tried an alternative approach](https://github.com/pkmn-cc/Pokemon-Showdown/commit/0d45de25b33c7bcd1528a8de98fbf576e8b15cb9) where I rewrote `replace` to use promises so that if you did want to run something over overlapping paths you could at least chain it properly with `await` or `then`, but that seems unnecessary at this point. 