### PR TITLE
Implement /cmd roominfo

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4262,7 +4262,7 @@ const commands = {
 				roominfo.users.push(userinfo);
 			}
 
-			connection.send(`|queryresponse|roomroominfo|${JSON.stringify(roominfo)}`);
+			connection.send(`|queryresponse|roominfo|${JSON.stringify(roominfo)}`);
 		} else {
 			// default to sending null
 			connection.send(`|queryresponse|${cmd}|null`);

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4223,6 +4223,46 @@ const commands = {
 			Ladders(toId(target)).getTop().then(result => {
 				connection.send('|queryresponse|laddertop|' + JSON.stringify(result));
 			});
+		} else if (cmd === 'roominfo') {
+			if (!trustable) return false;
+
+			let targetRoom = Rooms.get(target);
+			if (!targetRoom) return false;
+			if (targetRoom.isPrivate && !user.inRooms.has(room.id) && !user.games.has(room.id)) {
+				return false;
+			}
+
+			let visibility;
+			if (targetRoom.isPrivate) {
+				visibility = (targetRoom.isPrivate === 'hidden') ? 'hidden' : 'private';
+			} else {
+				visibility = 'public';
+			}
+
+			let roominfo = {
+				title: targetRoom.title,
+				type: targetRoom.type,
+				visibility: visibility,
+				modjoin: targetRoom.modjoin || targetRoom.modchat,
+				auth: {},
+				users: [],
+			};
+
+			if (targetRoom.auth) {
+				for (let userid in targetRoom.auth) {
+					let rank = targetRoom.auth[userid];
+					if (!roominfo.auth[rank]) roominfo.auth[rank] = [];
+					roominfo.auth[rank].push(userid);
+				}
+			}
+
+			for (let userid in targetRoom.users) {
+				let user = targetRoom.users[userid];
+				let userinfo = user.getIdentity(room.id);
+				roominfo.users.push(userinfo);
+			}
+
+			connection.send(`|queryresponse|roomroominfo|${JSON.stringify(roominfo)}`);
 		} else {
 			// default to sending null
 			connection.send(`|queryresponse|${cmd}|null`);


### PR DESCRIPTION
At the moment, bots can't differentiate between hidden and private rooms, and while they can get the modjoin status and list of auth in rooms, it's very difficult to parse (I had to write a grammar to parse /roomauth's popup, but even then couldn't work out a way to get the room title while accounting for other servers that may have translated the command's output).

This allows bots to be able to get the room title, type, visibility, modjoin status, auth list, and userlist of a room easily.