### PR TITLE
Remove unnecessary Array.prototype.values() calls

### DIFF
--- a/test/simulator/misc/choice-parser.js
+++ b/test/simulator/misc/choice-parser.js
@@ -32,7 +32,7 @@ describe('Choice parser', function () {
 				[{species: "Rhydon", ability: 'prankster', moves: ['splash']}],
 			]);
 
-			for (const side of battle.sides.values()) {
+			for (const side of battle.sides) {
 				assert.false(battle.choose(side.id, 'team Rhydon'));
 				assert.false(battle.choose(side.id, 'team Mew'));
 				assert.false(battle.choose(side.id, 'team first'));
@@ -134,7 +134,7 @@ describe('Choice parser', function () {
 				battle.join('p1', 'Guest 1', 1, [{species: "Mew", ability: 'synchronize', moves: ['recover']}]);
 				battle.join('p2', 'Guest 2', 1, [{species: "Rhydon", ability: 'prankster', moves: ['splash']}]);
 
-				for (const side of battle.sides.values()) {
+				for (const side of battle.sides) {
 					assert.false(battle.choose(side.id, 'pass'));
 				}
 			});

--- a/test/simulator/misc/decisions.js
+++ b/test/simulator/misc/decisions.js
@@ -401,7 +401,7 @@ describe('Choices', function () {
 			]]);
 
 			battle.makeChoices('move lunardance, move lunardance', 'move lunardance, move lunardance');
-			for (const side of battle.sides.values()) {
+			for (const side of battle.sides) {
 				for (const pokemon of side.active) {
 					assert.fainted(pokemon);
 				}
@@ -460,7 +460,7 @@ describe('Choices', function () {
 			]]);
 
 			battle.makeChoices('move lunardance, move lunardance', 'move lunardance, move lunardance');
-			for (const side of battle.sides.values()) {
+			for (const side of battle.sides) {
 				for (const pokemon of side.active) {
 					assert.fainted(pokemon);
 				}
@@ -473,7 +473,7 @@ describe('Choices', function () {
 				battle.p2.choosePass();
 			});
 
-			for (const side of battle.sides.values()) {
+			for (const side of battle.sides) {
 				for (const pokemon of side.active) {
 					assert.fainted(pokemon);
 				}


### PR DESCRIPTION
These break on [Node < v10.9.0](https://node.green/#ES2015-built-in-extensions-Array-prototype-methods-Array-prototype-values).