### PR TITLE
Properly terminate BattleStream (fixes regression caused by #5210)

### DIFF
--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -88,7 +88,7 @@ export class BattleStream extends Streams.ObjectReadWriteStream {
 			options.send = (t: string, data: any) => {
 				if (Array.isArray(data)) data = data.join("\n");
 				this.push(`${t}\n${data}`);
-				if (type === 'end' && !this.keepAlive) {
+				if (t === 'end' && !this.keepAlive) {
 					this.push(null);
 					this._destroy();
 				}
@@ -290,7 +290,7 @@ export class BattleTextStream extends Streams.ReadWriteStream {
 		this.battleStream.end();
 	}
 	async _listen() {
-		let message: string;
+		let message;
 		// tslint:disable-next-line:no-conditional-assignment
 		while ((message = await this.battleStream.read())) {
 			if (!message.endsWith('\n')) message += '\n';

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3047,13 +3047,13 @@ export class Battle extends Dex.ModdedDex {
 		}
 	}
 
-// tslint:disable-next-line:ban-types
+	// tslint:disable-next-line:ban-types
 	addMove(...args: (string | number | Function | AnyObject)[]) {
 		this.lastMoveLine = this.log.length;
 		this.log.push(`|${args.join('|')}`);
 	}
 
-// tslint:disable-next-line:ban-types
+	// tslint:disable-next-line:ban-types
 	attrLastMove(...args: (string | number | Function | AnyObject)[]) {
 		if (this.lastMoveLine < 0) return;
 		if (this.log[this.lastMoveLine].startsWith('|-anim|')) {


### PR DESCRIPTION
*TFW you rename a variable because of the linter not liking shadowed variables and having it bite you in the end*

Also some miscellaneous nits I found when looking for the bug.