### PR TITLE
Make the `switch` command more flexible

### DIFF
--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -648,9 +648,9 @@ To be exact, `CHOICE` is one of:
 
 `SWITCHSPEC` is:
 
-- a pokemon nickname or 1-based slot number
-  - Note that if you have multiple Pokémon with the same nickname, using the
-    nickname will select the first unfainted one. If you want another Pokémon,
+- a Pokémon nickname/species or 1-based slot number
+  - Note that if you have multiple Pokémon with the same nickname/species, using the
+    nickname/species will select the first unfainted one. If you want another Pokémon,
     you'll need to specify it by slot number.
 
 Once a choice has been set for all players who need to make a choice, the

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -456,10 +456,10 @@ export class Side {
 			slot = parseInt(slotText!, 10) - 1;
 		}
 		if (isNaN(slot) || slot < 0) {
-			// maybe it's a name!
+			// maybe it's a name/species id!
 			slot = -1;
 			for (const [i, mon] of this.pokemon.entries()) {
-				if (slotText === mon.name) {
+				if (slotText!.toLowerCase() === mon.name.toLowerCase() || toId(slotText) === mon.speciesid) {
 					slot = i;
 					break;
 				}


### PR DESCRIPTION
Make it take a case-insensitive nickname or species id,
something several of our test cases already rely upon.