### PR TITLE
Reject `move` commands with multiple flags

### DIFF
--- a/sim/side.ts
+++ b/sim/side.ts
@@ -629,19 +629,25 @@ export class Side {
 
 			switch (choiceType) {
 			case 'move':
-				let targetLoc = 0;
+				const original = data;
+				const error = () => this.emitChoiceError(`Conflicting arguments for "move": ${original}`);
+				let targetLoc: number | undefined;
 				let megaOrZ = '';
 				while (true) {
 					if (/\s-?[1-3]$/.test(data)) {
+						if (targetLoc !== undefined) error();
 						targetLoc = parseInt(data.slice(-2), 10);
 						data = data.slice(0, -2).trim();
 					} else if (data.endsWith(' mega')) {
+						if (megaOrZ) error();
 						megaOrZ = 'mega';
 						data = data.slice(0, -5);
 					} else if (data.endsWith(' zmove')) {
+						if (megaOrZ) error();
 						megaOrZ = 'zmove';
 						data = data.slice(0, -6);
 					} else if (data.endsWith(' ultra')) {
+						if (megaOrZ) error();
 						megaOrZ = 'ultra';
 						data = data.slice(0, -6);
 					} else {
@@ -665,6 +671,7 @@ export class Side {
 				if (data) return this.emitChoiceError(`Unrecognized data after "pass": ${data}`);
 				this.choosePass();
 				break;
+			case 'auto':
 			case 'default':
 				this.autoChoose();
 				break;

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -635,19 +635,19 @@ export class Side {
 				let megaOrZ = '';
 				while (true) {
 					if (/\s-?[1-3]$/.test(data)) {
-						if (targetLoc !== undefined) error();
+						if (targetLoc !== undefined) return error();
 						targetLoc = parseInt(data.slice(-2), 10);
 						data = data.slice(0, -2).trim();
 					} else if (data.endsWith(' mega')) {
-						if (megaOrZ) error();
+						if (megaOrZ) return error();
 						megaOrZ = 'mega';
 						data = data.slice(0, -5);
 					} else if (data.endsWith(' zmove')) {
-						if (megaOrZ) error();
+						if (megaOrZ) return error();
 						megaOrZ = 'zmove';
 						data = data.slice(0, -6);
 					} else if (data.endsWith(' ultra')) {
-						if (megaOrZ) error();
+						if (megaOrZ) return error();
 						megaOrZ = 'ultra';
 						data = data.slice(0, -6);
 					} else {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -638,7 +638,7 @@ export class Side {
 					// We need to special case 'Conversion 2' so it doesn't get
 					// confused with 'Conversion' erroneously sent with the target
 					// '2' (since Conversion targets 'self', targetLoc can't be 2).
-					if (/\s-?[1-3]$/.test(data) && toId(data) !== 'conversion2') {
+					if (/\s(?:-|\+)?[1-3]$/.test(data) && toId(data) !== 'conversion2') {
 						if (targetLoc !== undefined) return error();
 						targetLoc = parseInt(data.slice(-2), 10);
 						data = data.slice(0, -2).trim();

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -634,7 +634,11 @@ export class Side {
 				let targetLoc: number | undefined;
 				let megaOrZ = '';
 				while (true) {
-					if (/\s-?[1-3]$/.test(data)) {
+					// If data ends with a number, treat it as a target location.
+					// We need to special case 'Conversion 2' so it doesn't get
+					// confused with 'Conversion' erroneously sent with the target
+					// '2' (since Conversion targets 'self', targetLoc can't be 2).
+					if (/\s-?[1-3]$/.test(data) && toId(data) !== 'conversion2') {
 						if (targetLoc !== undefined) return error();
 						targetLoc = parseInt(data.slice(-2), 10);
 						data = data.slice(0, -2).trim();

--- a/test/simulator/misc/choice-parser.js
+++ b/test/simulator/misc/choice-parser.js
@@ -57,27 +57,6 @@ describe('Choice parser', function () {
 			});
 		});
 
-		it('should allow mega evolving and targeting in the same move in either order', function () {
-			battle = common.createBattle({gameType: 'doubles'});
-			battle.join('p1', 'Guest 1', 1, [
-				{species: "Gengar", ability: 'cursedbody', item: 'gengarite', moves: ['shadowball']},
-				{species: "Koffing", ability: 'levitate', moves: ['smog']},
-			]);
-			battle.join('p2', 'Guest 2', 1, [
-				{species: "Blaziken", ability: 'speedboost', item: 'blazikenite', moves: ['blazekick']},
-				{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
-			]);
-
-			const badChoices = [`move 1 1 2`, `move 1 1 mega ultra`, `move 1 mega zmove 2`];
-			for (const badChoice of badChoices) {
-				const choice = `${badChoice}, move smog 1`;
-				assert.false(battle.choose('p1', choice), `Choice '${choice}' should be rejected`);
-			}
-
-			assert.ok(battle.choose('p1', `move 1 1 mega, move smog 1`));
-			assert.ok(battle.choose('p2', `move 1 mega 2, move irondefense`));
-		});
-
 		describe('Singles', function () {
 			it('should accept only `switch` choices', function () {
 				battle = common.createBattle();
@@ -159,6 +138,27 @@ describe('Choice parser', function () {
 					assert.false(battle.choose(side.id, 'pass'));
 				}
 			});
+		});
+
+		it('should allow mega evolving and targeting in the same move in either order', function () {
+			battle = common.createBattle({gameType: 'doubles'});
+			battle.join('p1', 'Guest 1', 1, [
+				{species: "Gengar", ability: 'cursedbody', item: 'gengarite', moves: ['shadowball']},
+				{species: "Koffing", ability: 'levitate', moves: ['smog']},
+			]);
+			battle.join('p2', 'Guest 2', 1, [
+				{species: "Blaziken", ability: 'speedboost', item: 'blazikenite', moves: ['blazekick']},
+				{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
+			]);
+
+			const badChoices = [`move 1 1 2`, `move 1 1 mega ultra`, `move 1 mega zmove 2`];
+			for (const badChoice of badChoices) {
+				const choice = `${badChoice}, move smog 1`;
+				assert.false(battle.choose('p1', choice), `Choice '${choice}' should be rejected`);
+			}
+
+			assert.ok(battle.choose('p1', `move 1 1 mega, move smog 1`));
+			assert.ok(battle.choose('p2', `move 1 mega 2, move irondefense`));
 		});
 
 		describe('Singles', function () {

--- a/test/simulator/misc/choice-parser.js
+++ b/test/simulator/misc/choice-parser.js
@@ -144,21 +144,21 @@ describe('Choice parser', function () {
 			battle = common.createBattle({gameType: 'doubles'});
 			battle.join('p1', 'Guest 1', 1, [
 				{species: "Gengar", ability: 'cursedbody', item: 'gengarite', moves: ['shadowball']},
-				{species: "Koffing", ability: 'levitate', moves: ['smog']},
+				{species: "Porygon", ability: 'download', moves: ['conversion2']},
 			]);
 			battle.join('p2', 'Guest 2', 1, [
-				{species: "Blaziken", ability: 'speedboost', item: 'blazikenite', moves: ['blazekick']},
+				{species: "Porygon-Z", ability: 'adaptability', item: 'normaliumz', moves: ['conversion2']},
 				{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
 			]);
 
 			const badChoices = [`move 1 1 2`, `move 1 1 mega ultra`, `move 1 mega zmove 2`];
 			for (const badChoice of badChoices) {
-				const choice = `${badChoice}, move smog 1`;
+				const choice = `${badChoice}, move Conversion 2`;
 				assert.false(battle.choose('p1', choice), `Choice '${choice}' should be rejected`);
 			}
 
-			assert.ok(battle.choose('p1', `move 1 1 mega, move smog 1`));
-			assert.ok(battle.choose('p2', `move 1 mega 2, move irondefense`));
+			assert.ok(battle.choose('p1', `move 1 1 mega, move Conversion 2 1`));
+			assert.ok(battle.choose('p2', `move Conversion 2 1 zmove, move irondefense`));
 		});
 
 		describe('Singles', function () {

--- a/test/simulator/misc/choice-parser.js
+++ b/test/simulator/misc/choice-parser.js
@@ -138,27 +138,27 @@ describe('Choice parser', function () {
 					assert.false(battle.choose(side.id, 'pass'));
 				}
 			});
-		});
 
-		it('should allow mega evolving and targeting in the same move in either order', function () {
-			battle = common.createBattle({gameType: 'doubles'});
-			battle.join('p1', 'Guest 1', 1, [
-				{species: "Gengar", ability: 'cursedbody', item: 'gengarite', moves: ['shadowball']},
-				{species: "Porygon", ability: 'download', moves: ['conversion2']},
-			]);
-			battle.join('p2', 'Guest 2', 1, [
-				{species: "Porygon-Z", ability: 'adaptability', item: 'normaliumz', moves: ['conversion2']},
-				{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
-			]);
+			it('should allow mega evolving and targeting in the same move in either order', function () {
+				battle = common.createBattle({gameType: 'doubles'});
+				battle.join('p1', 'Guest 1', 1, [
+					{species: "Gengar", ability: 'cursedbody', item: 'gengarite', moves: ['shadowball']},
+					{species: "Porygon", ability: 'download', moves: ['conversion2']},
+				]);
+				battle.join('p2', 'Guest 2', 1, [
+					{species: "Porygon-Z", ability: 'adaptability', item: 'normaliumz', moves: ['conversion2']},
+					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
+				]);
 
-			const badChoices = [`move 1 1 2`, `move 1 1 mega ultra`, `move 1 mega zmove 2`];
-			for (const badChoice of badChoices) {
-				const choice = `${badChoice}, move Conversion 2`;
-				assert.false(battle.choose('p1', choice), `Choice '${choice}' should be rejected`);
-			}
+				const badChoices = [`move 1 1 2`, `move 1 1 mega ultra`, `move 1 mega zmove 2`];
+				for (const badChoice of badChoices) {
+					const choice = `${badChoice}, move Conversion 2`;
+					assert.false(battle.choose('p1', choice), `Choice '${choice}' should be rejected`);
+				}
 
-			assert.ok(battle.choose('p1', `move 1 1 mega, move Conversion 2 1`));
-			assert.ok(battle.choose('p2', `move Conversion 2 1 zmove, move irondefense`));
+				assert.ok(battle.choose('p1', `move 1 1 mega, move Conversion 2 1`));
+				assert.ok(battle.choose('p2', `move Conversion 2 1 zmove, move irondefense`));
+			});
 		});
 
 		describe('Singles', function () {

--- a/test/simulator/misc/choice-parser.js
+++ b/test/simulator/misc/choice-parser.js
@@ -57,6 +57,27 @@ describe('Choice parser', function () {
 			});
 		});
 
+		it('should allow mega evolving and targeting in the same move in either order', function () {
+			battle = common.createBattle({gameType: 'doubles'});
+			battle.join('p1', 'Guest 1', 1, [
+				{species: "Gengar", ability: 'cursedbody', item: 'gengarite', moves: ['shadowball']},
+				{species: "Koffing", ability: 'levitate', moves: ['smog']},
+			]);
+			battle.join('p2', 'Guest 2', 1, [
+				{species: "Blaziken", ability: 'speedboost', item: 'blazikenite', moves: ['blazekick']},
+				{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
+			]);
+
+			const badChoices = [`move 1 1 2`, `move 1 1 mega ultra`, `move 1 mega zmove 2`];
+			for (const badChoice of badChoices) {
+				const choice = `${badChoice}, move smog 1`;
+				assert.false(battle.choose('p1', choice), `Choice '${choice}' should be rejected`);
+			}
+
+			assert.ok(battle.choose('p1', `move 1 1 mega, move smog 1`));
+			assert.ok(battle.choose('p2', `move 1 mega 2, move irondefense`));
+		});
+
 		describe('Singles', function () {
 			it('should accept only `switch` choices', function () {
 				battle = common.createBattle();
@@ -80,21 +101,6 @@ describe('Choice parser', function () {
 		});
 
 		describe('Doubles/Triples', function () {
-			it('should allow mega evolving and targeting in the same move in either order', function () {
-				battle = common.createBattle({gameType: 'doubles'});
-				battle.join('p1', 'Guest 1', 1, [
-					{species: "Gengar", ability: 'cursedbody', item: 'gengarite', moves: ['shadowball']},
-					{species: "Koffing", ability: 'levitate', moves: ['smog']},
-				]);
-				battle.join('p2', 'Guest 2', 1, [
-					{species: "Blaziken", ability: 'speedboost', item: 'blazikenite', moves: ['blazekick']},
-					{species: "Aggron", ability: 'sturdy', moves: ['irondefense']},
-				]);
-
-				assert.ok(battle.choose('p1', `move 1 1 mega, move smog 1`));
-				assert.ok(battle.choose('p2', `move 1 mega 2, move irondefense`));
-			});
-
 			it('should accept only `switch` and `pass` choices', function () {
 				battle = common.createBattle({gameType: 'doubles'});
 				battle.join('p1', 'Guest 1', 1, [


### PR DESCRIPTION
> This test was placed under ``Switch requests > Doubles/Triples``. It should be under ``Move requests > Generic``

_Originally posted by @Slayer95 in https://github.com/Zarel/Pokemon-Showdown/pull/5284_

> Where by "throw" I mean emit a choice error.

_Originally posted by @Zarel in https://github.com/Zarel/Pokemon-Showdown/pull/5284#issuecomment-471244025_

---

I also snuck in `'auto'` as an alias for `'default'`, as I've discovered many tests are using it during the cleanup I'm working on in #5286