### PR TITLE
Allow any user to ignore help tickets

### DIFF
--- a/server/chat-plugins/helptickets.js
+++ b/server/chat-plugins/helptickets.js
@@ -1080,12 +1080,11 @@ let commands = {
 		unbanhelp: [`/helpticket unban [user] - Ticket unbans a user. Requires: % @ & ~`],
 
 		ignore(target, room, user) {
-			if (!this.can('lock')) return;
 			if (user.ignoreTickets) return this.errorReply(`You are already ignoring help ticket notifications. Use /helpticket unignore to receive notifications again.`);
 			user.ignoreTickets = true;
 			this.sendReply(`You are now ignoring help ticket notifications.`);
 		},
-		ignorehelp: [`/helpticket ignore - Ignore notifications for unclaimed help tickets. Requires: % @ & ~`],
+		ignorehelp: [`/helpticket ignore - Ignore notifications for unclaimed help tickets.`],
 
 		unignore(target, room, user) {
 			if (!this.can('lock')) return;

--- a/server/users.js
+++ b/server/users.js
@@ -663,21 +663,18 @@ class User extends Chat.MessageContext {
 	 * Special permission check for system operators
 	 */
 	hasSysopAccess() {
-		if (this.isSysop && Config.backdoor) {
-			// This is the Pokemon Showdown system operator backdoor.
+		// This is the Pokemon Showdown system operator backdoor.
 
-			// Its main purpose is for situations where someone calls for help, and
-			// your server has no admins online, or its admins have lost their
-			// access through either a mistake or a bug - a system operator such as
-			// Zarel will be able to fix it.
+		// Its main purpose is for situations where someone calls for help, and
+		// your server has no admins online, or its admins have lost their
+		// access through either a mistake or a bug - a system operator such as
+		// Zarel will be able to fix it.
 
-			// This relies on trusting Pokemon Showdown. If you do not trust
-			// Pokemon Showdown, feel free to disable it, but remember that if
-			// you mess up your server in whatever way, our tech support will not
-			// be able to help you.
-			return true;
-		}
-		return false;
+		// This relies on trusting Pokemon Showdown. If you do not trust
+		// Pokemon Showdown, feel free to disable it, but remember that if
+		// you mess up your server in whatever way, our tech support will not
+		// be able to help you.
+		return this.isSysop && Config.backdoor;
 	}
 	/**
 	 * Permission check for using the dev console


### PR DESCRIPTION
Really, users below '%' should be ignoring help tickets completely by default - right now they show up in chat and more importantly, the preview hovertext leaks ticket information to unprivileged users who happen to be in the room. I would have thought https://github.com/Zarel/Pokemon-Showdown/blob/master/server/chat-plugins/helptickets.js#L375 would cover this, but apparently not? (maybe it should be `'lock'`? Why do we check auth for `'lock`' in some cases and `'mute'` in others?)