### PR TITLE
Fix Stadium mod's stat modification logic

### DIFF
--- a/data/mods/stadium/scripts.js
+++ b/data/mods/stadium/scripts.js
@@ -9,6 +9,14 @@ let BattleScripts = {
 	gen: 1,
 	// BattlePokemon scripts. Stadium shares gen 1 code but it fixes some problems with it.
 	pokemon: {
+		getStat(statName, unmodified) {
+			statName = /** @type {StatNameExceptHP} */(toId(statName));
+			// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
+			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
+			if (unmodified) return this.storedStats[statName];
+			// @ts-ignore
+			return this.modifiedStats[statName];
+		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.
 		modifyStat(statName, modifier) {

--- a/data/mods/stadium/scripts.js
+++ b/data/mods/stadium/scripts.js
@@ -9,14 +9,7 @@ let BattleScripts = {
 	gen: 1,
 	// BattlePokemon scripts. Stadium shares gen 1 code but it fixes some problems with it.
 	pokemon: {
-		getStat(statName, unmodified) {
-			statName = /** @type {StatNameExceptHP} */(toId(statName));
-			// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
-			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
-			if (unmodified) return this.storedStats[statName];
-			// @ts-ignore
-			return this.modifiedStats[statName];
-		},
+		inherit: true,
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		// Modified stats are declared in the Pokemon object in sim/pokemon.js in about line 681.
 		modifyStat(statName, modifier) {

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -762,6 +762,7 @@ interface ModdedBattleSide {
 }
 
 interface ModdedBattlePokemon {
+	inherit?: boolean
 	boostBy?: (this: Pokemon, boost: SparseBoostsTable) => boolean
 	calculateStat?: (this: Pokemon, statName: StatNameExceptHP, boost: number, modifier?: number) => number
 	getActionSpeed?: (this: Pokemon) => number

--- a/test/simulator/misc/statuses.js
+++ b/test/simulator/misc/statuses.js
@@ -71,6 +71,16 @@ describe('Paralysis', function () {
 		assert.strictEqual(battle.p1.active[0].getStat('spe'), battle.modify(speed, 0.25));
 	});
 
+	it('should reduce speed to 25% of its original value in Stadium', function () {
+		battle = common.mod('stadium').createBattle([
+			[{species: 'Vaporeon', moves: ['growl']}],
+			[{species: 'Jolteon', moves: ['thunderwave']}],
+		]);
+		let speed = battle.p1.active[0].getStat('spe');
+		battle.makeChoices('move growl', 'move thunderwave');
+		assert.strictEqual(battle.p1.active[0].getStat('spe'), battle.modify(speed, 0.25));
+	});
+
 	it('should reapply its speed drop when an opponent uses a stat-altering move in Gen 1', function () {
 		battle = common.gen(1).createBattle([
 			[{species: 'Electrode', moves: ['rest']}],


### PR DESCRIPTION
> Could this have affected the attack and speed loss for burn and paralysis in Gen 1 Stadium?
>
> Here is a replay https://replay.pokemonshowdown.com/gen1stadiumou-874684443
See turn 3 for speed being unaffected by paralysis and turn 31 for attack being unaffected by burn.

_Originally posted by @SamanthaLola in https://github.com/Zarel/Pokemon-Showdown/pull/5274#issuecomment-471769625_

I purposefully deleted this (https://github.com/Zarel/Pokemon-Showdown/pull/5274/files#diff-19490bbe318ddb0e323a7bd29127f453L12) because its identical to `getStat` in `gen1` which this mod `inherits` from. What did I miss about inheritance, why do I need to add this back?