### PR TITLE
Fix regressions in team generators

### DIFF
--- a/data/mods/gen6/random-teams.js
+++ b/data/mods/gen6/random-teams.js
@@ -1029,10 +1029,11 @@ class RandomGen6Teams extends RandomTeams {
 	}
 
 	/**
+	 * @param {PlayerOptions} [side]
 	 * @param {number} [depth]
 	 * @return {RandomTeamsTypes["RandomFactorySet"][]}
 	 */
-	randomFactoryTeam(depth = 0) {
+	randomFactoryTeam(side, depth = 0) {
 		let forceResult = (depth >= 4);
 
 		// The teams generated depend on the tier choice in such a way that
@@ -1153,15 +1154,15 @@ class RandomGen6Teams extends RandomTeams {
 				}
 			}
 		}
-		if (pokemon.length < 6) return this.randomFactoryTeam(++depth);
+		if (pokemon.length < 6) return this.randomFactoryTeam(side, ++depth);
 
 		// Quality control
 		if (!teamData.forceResult) {
 			for (const requiredFamily of requiredMoveFamilies) {
-				if (!teamData.has[requiredFamily]) return this.randomFactoryTeam(++depth);
+				if (!teamData.has[requiredFamily]) return this.randomFactoryTeam(side, ++depth);
 			}
 			for (let type in teamData.weaknesses) {
-				if (teamData.weaknesses[type] >= 3) return this.randomFactoryTeam(++depth);
+				if (teamData.weaknesses[type] >= 3) return this.randomFactoryTeam(side, ++depth);
 			}
 		}
 

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -719,8 +719,7 @@ let BattleMovedex = {
 				}
 			}
 			// Generate a new team
-			let generator = new RandomStaffBrosTeams(this.format, this.prng);
-			let team = generator.generateTeam();
+			let team = this.teamGenerator.getTeam({name: source.side.name});
 			// Overwrite un-fainted pokemon other than the user
 			for (let i = 0; i < currentTeam.length; i++) {
 				if (currentTeam[i].fainted || !currentTeam[i].hp || currentTeam[i].position === source.position) continue;

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -44,6 +44,13 @@ class RandomTeams extends Dex.ModdedDex {
 	}
 
 	/**
+	 * @param {?PRNG | [number, number, number, number]} [prng]
+	 */
+	setSeed(prng) {
+		this.prng = prng && !Array.isArray(prng) ? prng : new PRNG(prng);
+	}
+
+	/**
 	 * @return {PokemonSet[]}
 	 */
 	generateTeam() {

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -51,12 +51,13 @@ class RandomTeams extends Dex.ModdedDex {
 	}
 
 	/**
+	 * @param {PlayerOptions | null} [options]
 	 * @return {PokemonSet[]}
 	 */
-	generateTeam() {
+	getTeam(options) {
 		const generatorName = typeof this.format.team === 'string' && this.format.team.startsWith('random') ? this.format.team + 'Team' : '';
 		// @ts-ignore
-		return this[generatorName || 'randomTeam']();
+		return this[generatorName || 'randomTeam'](options);
 	}
 
 	/**
@@ -1956,10 +1957,11 @@ class RandomTeams extends Dex.ModdedDex {
 	}
 
 	/**
+	 * @param {PlayerOptions} [side]
 	 * @param {number} [depth]
 	 * @return {RandomTeamsTypes["RandomFactorySet"][]}
 	 */
-	randomFactoryTeam(depth = 0) {
+	randomFactoryTeam(side, depth = 0) {
 		let forceResult = (depth >= 4);
 
 		// The teams generated depend on the tier choice in such a way that
@@ -2119,15 +2121,15 @@ class RandomTeams extends Dex.ModdedDex {
 				}
 			}
 		}
-		if (pokemon.length < 6) return this.randomFactoryTeam(++depth);
+		if (pokemon.length < 6) return this.randomFactoryTeam(side, ++depth);
 
 		// Quality control
 		if (!teamData.forceResult) {
 			for (const requiredFamily of requiredMoveFamilies) {
-				if (!teamData.has[requiredFamily]) return this.randomFactoryTeam(++depth);
+				if (!teamData.has[requiredFamily]) return this.randomFactoryTeam(side, ++depth);
 			}
 			for (let type in teamData.weaknesses) {
-				if (teamData.weaknesses[type] >= 3) return this.randomFactoryTeam(++depth);
+				if (teamData.weaknesses[type] >= 3) return this.randomFactoryTeam(side, ++depth);
 			}
 		}
 
@@ -2224,10 +2226,11 @@ class RandomTeams extends Dex.ModdedDex {
 	}
 
 	/**
+	 * @param {PlayerOptions} [side]
 	 * @param {number} [depth]
 	 * @return {RandomTeamsTypes["RandomFactorySet"][]}
 	 */
-	randomBSSFactoryTeam(depth = 0) {
+	randomBSSFactoryTeam(side, depth = 0) {
 		let forceResult = (depth >= 4);
 
 		let pokemon = [];
@@ -2345,15 +2348,15 @@ class RandomTeams extends Dex.ModdedDex {
 				}
 			}
 		}
-		if (pokemon.length < 6) return this.randomBSSFactoryTeam(++depth);
+		if (pokemon.length < 6) return this.randomBSSFactoryTeam(side, ++depth);
 
 		// Quality control
 		if (!teamData.forceResult) {
 			for (const requiredFamily of requiredMoveFamilies) {
-				if (!teamData.has[requiredFamily]) return this.randomBSSFactoryTeam(++depth);
+				if (!teamData.has[requiredFamily]) return this.randomBSSFactoryTeam(side, ++depth);
 			}
 			for (let type in teamData.weaknesses) {
-				if (teamData.weaknesses[type] >= 3) return this.randomBSSFactoryTeam(++depth);
+				if (teamData.weaknesses[type] >= 3) return this.randomBSSFactoryTeam(side, ++depth);
 			}
 		}
 

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -820,6 +820,13 @@ interface TypeInfo extends Readonly<TypeData> {
 	readonly toString: () => string
 }
 
+interface PlayerOptions {
+	name?: string;
+	avatar?: string;
+	team?: PokemonSet[] | string | null;
+	seed?: PRNGSeed;
+}
+
 interface Actions {
 	/** A move action */
 	MoveAction: {

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -95,7 +95,7 @@ if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
 			var Dex = require('./.sim-dist/dex');
 			global.toId = Dex.getId;
 			var seed = process.argv[4] ? process.argv[4].split(',').map(Number) : undefined;
-			console.log(Dex.packTeam(Dex.generateTeam(process.argv[3], seed)));
+			console.log(Dex.packTeam(Dex.generateTeam(process.argv[3], {seed})));
 		}
 		break;
 	case 'validate-team':

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3106,7 +3106,7 @@ export class Battle extends Dex.ModdedDex {
 			this.teamGenerator.setSeed(options.seed);
 		}
 
-		team = this.teamGenerator.generateTeam();
+		team = this.teamGenerator.getTeam(options);
 
 		return team as PokemonSet[];
 	}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -18,12 +18,6 @@ interface FaintedPokemon {
 	effect: Effect | null;
 }
 
-interface PlayerOptions {
-	name?: string;
-	avatar?: string;
-	team?: PokemonSet[] | string | null;
-}
-
 interface BattleOptions {
 	formatid: string; // Format ID
 	send?: (type: string, data: string | string[]) => void; // Output callback
@@ -3094,16 +3088,24 @@ export class Battle extends Dex.ModdedDex {
 
 	// players
 
-	getTeam(team: PokemonSet[] | string | null): PokemonSet[] {
+	getTeam(options: PlayerOptions): PokemonSet[] {
 		const format = this.getFormat();
+		let team = options.team;
 		if (typeof team === 'string') team = Dex.fastUnpackTeam(team);
 		if (!format.team && team) {
 			return team;
 		}
 
-		if (!this.teamGenerator) {
-			this.teamGenerator = this.getTeamGenerator(format, this.prng);
+		if (!options.seed) {
+			options.seed = PRNG.generateSeed();
 		}
+
+		if (!this.teamGenerator) {
+			this.teamGenerator = this.getTeamGenerator(format, options.seed);
+		} else {
+			this.teamGenerator.setSeed(options.seed);
+		}
+
 		team = this.teamGenerator.generateTeam();
 
 		return team as PokemonSet[];
@@ -3115,7 +3117,7 @@ export class Battle extends Dex.ModdedDex {
 		if (!this[slot]) {
 			// create player
 			const slotNum = (slot === 'p2' ? 1 : 0);
-			const team = this.getTeam(options.team || null);
+			const team = this.getTeam(options);
 			side = new Side(options.name || `Player ${slotNum + 1}`, this, slotNum, team);
 			if (options.avatar) side.avatar = '' + options.avatar;
 			this[slot] = side;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -958,8 +958,8 @@ class ModdedDex {
 		return new TeamGenerator(format, seed);
 	}
 
-	generateTeam(format: Format | string, seed: PRNG | PRNGSeed | null = null): PokemonSet[] {
-		return this.getTeamGenerator(format, seed).generateTeam();
+	generateTeam(format: Format | string, options: PlayerOptions | null = null): PokemonSet[] {
+		return this.getTeamGenerator(format, options && options.seed).getTeam(options);
 	}
 
 	dataSearch(target: string, searchIn?: DataType[] | null, isInexact?: boolean): AnyObject[] | false {

--- a/test/simulator/misc/random-teams.js
+++ b/test/simulator/misc/random-teams.js
@@ -37,7 +37,7 @@ describe(`Random Team generator`, function () {
 			while (teamCount--) {
 				let seed = generator.prng.seed;
 				try {
-					let team = generator.generateTeam();
+					let team = generator.getTeam();
 					let invalidSet = team.find(set => !isValidSet(gen, set));
 					if (invalidSet) throw new Error(`Invalid set: ${JSON.stringify(invalidSet)}`);
 				} catch (err) {
@@ -60,7 +60,7 @@ describe(`Challenge Cup Team generator`, function () {
 			while (teamCount--) {
 				let seed = generator.prng.seed;
 				try {
-					let team = generator.generateTeam();
+					let team = generator.getTeam();
 					let invalidSet = team.find(set => !isValidSet(gen, set));
 					if (invalidSet) throw new Error(`Invalid set: ${JSON.stringify(invalidSet)}`);
 				} catch (err) {
@@ -83,7 +83,7 @@ describe(`Hackmons Cup Team generator`, function () {
 			while (teamCount--) {
 				let seed = generator.prng.seed;
 				try {
-					let team = generator.generateTeam();
+					let team = generator.getTeam();
 					let invalidSet = team.find(set => !isValidSet(gen, set));
 					if (invalidSet) throw new Error(`Invalid set: ${JSON.stringify(invalidSet)}`);
 				} catch (err) {


### PR DESCRIPTION
- Reimplements 23573646d.
- The `side` parameter is required for Seasonal School Schemes and Seasonal Strikes Back, as well as #5303.