### PR TITLE
Random Battle: Fix Malamar

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -920,7 +920,7 @@ class RandomTeams extends Dex.ModdedDex {
 					break;
 				case 'superpower':
 					if (counter['Fighting'] > 1 && counter.setupType) rejected = true;
-					if (!hasAbility['Contrary'] && hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['rest'] && hasMove['sleeptalk'] && !hasAbility['Contrary']) rejected = true;
 					if (hasAbility['Contrary']) isSetup = true;
 					break;
 				case 'vacuumwave':

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -920,7 +920,7 @@ class RandomTeams extends Dex.ModdedDex {
 					break;
 				case 'superpower':
 					if (counter['Fighting'] > 1 && counter.setupType) rejected = true;
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (!hasAbility['Contrary'] && hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
 					if (hasAbility['Contrary']) isSetup = true;
 					break;
 				case 'vacuumwave':


### PR DESCRIPTION
Currently, Superpower is being rejected with RestTalk, but it shouldn't
do that if it is a Malamar, because of Contrary.