### PR TITLE
Run effectiveness events even for string type

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1598,15 +1598,17 @@ export class Pokemon {
 
 	runEffectiveness(moveOrType: ActiveMove | string) {
 		let totalTypeMod = 0;
-		const move = (typeof moveOrType !== 'string' ? moveOrType : null);
+		let move;
+		if (typeof moveOrType === 'string') {
+			move = this.battle.getActiveMove('Judgment');
+			move.type = moveOrType;
+		} else {
+			move = moveOrType;
+		}
 		for (const type of this.getTypes()) {
 			let typeMod = this.battle.getEffectiveness(moveOrType, type);
-			if (move) {
-				typeMod = this.battle.singleEvent('Effectiveness', move, null, this, type, move, typeMod);
-				totalTypeMod += this.battle.runEvent('Effectiveness', this, type, move, typeMod);
-			} else {
-				totalTypeMod += typeMod;
-			}
+			typeMod = this.battle.singleEvent('Effectiveness', move, null, this, type, move, typeMod);
+			totalTypeMod += this.battle.runEvent('Effectiveness', this, type, move, typeMod);
 		}
 		return totalTypeMod;
 	}

--- a/test/simulator/misc/inversebattle.js
+++ b/test/simulator/misc/inversebattle.js
@@ -35,6 +35,27 @@ describe('Inverse Battle', function () {
 		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
+	it('should affect Stealth Rock damage', function () {
+		battle.join('p1', 'Guest 1', 1, [{species: "Smeargle", moves: ['splash', 'stealthrock']}]);
+		battle.join('p2', 'Guest 2', 1, [
+			{species: "Ninjask", moves: ['protect']},
+			{species: "Steelix", moves: ['rest']},
+			{species: "Hitmonchan", moves: ['rest']},
+			{species: "Chansey", moves: ['wish']},
+			{species: "Staraptor", moves: ['roost']},
+			{species: "Volcarona", moves: ['roost']},
+		]);
+		battle.makeChoices('move stealthrock', 'move protect');
+		let pokemon;
+		for (let i = 2; i <= 6; i++) {
+			battle.makeChoices('move splash', 'switch ' + i);
+			pokemon = battle.p2.active[0];
+			const expectedPercent = Math.pow(0.5, i - 1);
+			const expectedDamage = Math.floor(pokemon.maxhp * expectedPercent);
+			assert.strictEqual(pokemon.maxhp - pokemon.hp, expectedDamage, `${pokemon.name} should take ${expectedPercent * 100}%`);
+		}
+	});
+
 	it('should not affect ability-based immunities', function () {
 		battle.join('p1', 'Guest 1', 1, [{species: "Hariyama", ability: 'guts', moves: ['earthquake']}]);
 		battle.join('p2', 'Guest 2', 1, [{species: "Mismagius", ability: 'levitate', moves: ['shadowsneak']}]);


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/8066734/).

This is a regression from commit 13614b9 which among other things stopped `onEffectiveness` events from being sent when running type effectiveness for a string rather than an `ActiveMove`, so to handle these I picked an innocuous move and manually set its type.