### PR TITLE
Push 'update' to p3 & p4 in `BattleStream`.

### DIFF
--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -172,7 +172,7 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 }
 
 /**
- * Splits a BattleStream into omniscient, spectator, p1, and p2
+ * Splits a BattleStream into omniscient, spectator, p1, p2, p3 and p4
  * streams, for ease of consumption.
  */
 export function getPlayerStreams(stream: BattleStream) {
@@ -220,6 +220,9 @@ export function getPlayerStreams(stream: BattleStream) {
 				streams.p1.push(p1Update);
 				const p2Update = data.replace(/\n\|split\n[^\n]*\n[^\n]*\n([^\n]*)\n[^\n]*/g, '\n$1').replace(/\n\n/g, '\n');
 				streams.p2.push(p2Update);
+				// p3 and p4 share update information with p1 and p2 respectively.
+				streams.p3.push(p1Update);
+				streams.p4.push(p2Update);
 				const specUpdate = data.replace(/\n\|split\n([^\n]*)\n[^\n]*\n[^\n]*\n[^\n]*/g, '\n$1').replace(/\n\n/g, '\n');
 				streams.spectator.push(specUpdate);
 				const omniUpdate = data.replace(/\n\|split\n[^\n]*\n[^\n]*\n[^\n]*/g, '');


### PR DESCRIPTION
> Yes, your teammate gets to see exact HP in 4 player battles, even when your teammate isn't really your teammate, because Zarel didn't think that mattered enough to use 6 channels. That said, I guess we probably should be pushing the updates like you suggested, though I'm not entirely sure what this function even gets used for.

_Originally posted by @MacChaeger in https://github.com/Zarel/Pokemon-Showdown/pull/5297_

---

I think this fix is required given the current design, but I'd also like to start a discussion around the design decisions regarding channels/streams and 4 player battles. 

- From a correctness POV, revealing information unnecessarily seems very undesirable. What is the difficultly with adding additional channels? I think in 2 player battles we should have 2 channels and in 4 player battles we should have 4?
- From an efficiency POV - I'm not sure we should be creating and updating `p3` and `p4` streams in every battle in this class, given I expect single and doubles to be substantially more popular and we should be optimizing for the common case. Similar to above - in multi battles we can create and maintain all 4 streams, but keep it with 2 streams in the common case?
