### PR TITLE
Don't show boost failure when stockpile wears off after it didn't boost

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -16458,7 +16458,13 @@ let BattleMovedex = {
 				if (curSpD !== target.boosts.spd) this.effectData.spd--;
 			},
 			onEnd(target) {
-				this.boost({def: this.effectData.def, spd: this.effectData.spd}, target, target);
+				if (this.effectData.def || this.effectData.spd) {
+					/** @type {SparseBoostsTable} */
+					let boosts = {};
+					if (this.effectData.def) boosts.def = this.effectData.def;
+					if (this.effectData.spd) boosts.spd = this.effectData.spd;
+					this.boost(boosts, target, target);
+				}
 				this.add('-end', target, 'Stockpile');
 				if (this.effectData.def !== this.effectData.layers * -1 || this.effectData.spd !== this.effectData.layers * -1) {
 					this.hint("In Gen 7, Stockpile keeps track of how many times it successfully altered each stat individually.");


### PR DESCRIPTION
Just a hunch, but if you're at +6 before you stockpile and then the stockpiled effect wears off it probably shouldn't say that the stat couldn't go any higher.