### PR TITLE
Fix `./pokemon-showdown simulate-battle`

### DIFF
--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -132,7 +132,7 @@ if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
 			var battleStream = new BattleTextStream({
 				debug: process.argv[3] === '--debug'
 			});
-      battleStream.start();
+			battleStream.start();
 			stdin.pipeTo(battleStream);
 			battleStream.pipeTo(stdout);
 		}


### PR DESCRIPTION
`./pokemon-showdown simulate-battle` is broken - it hangs and then runs out of heap space. Preliminary debugging seems to show `pipeTo` loops infinitely with `value` being empty. I want to use it to reproduce an [error](https://gist.githubusercontent.com/scheibo/3dd85304cf80a3cbf156576a849526c4/raw/529193017da90dbea150dcae0110fd7050a0b547/error) I encountered which seems to be related to `battle.destroy` (possibly a race with my harness?) given the [input log](https://gist.githubusercontent.com/scheibo/3dd85304cf80a3cbf156576a849526c4/raw/529193017da90dbea150dcae0110fd7050a0b547/input%2520log), but I can't until `simulate-battle` is fixed.

This PR obviously doesn't fix anything currently other than indentation, but it seems like creating a PR is the same difference as filing a bug report on GitHub (and I plan to fix it once I have a chance, provided someone else doesn't get around to it first).