### PR TITLE
Fixes for target resolution

### DIFF
--- a/data/mods/gen3/scripts.js
+++ b/data/mods/gen3/scripts.js
@@ -71,11 +71,11 @@ let BattleScripts = {
 			return false;
 		}
 
-		const targets = pokemon.getMoveTargets(move, target);
+		const {targets, pressureTargets} = pokemon.getMoveTargets(move, target);
 
 		if (!sourceEffect || sourceEffect.id === 'pursuit') {
 			let extraPP = 0;
-			for (const source of targets) {
+			for (const source of pressureTargets) {
 				const ppDrop = this.runEvent('DeductPP', source, pokemon, move);
 				if (ppDrop !== true) {
 					extraPP += ppDrop || 0;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -207,11 +207,11 @@ let BattleScripts = {
 			return false;
 		}
 
-		let targets = pokemon.getMoveTargets(move, target);
+		const {targets, pressureTargets} = pokemon.getMoveTargets(move, target);
 
 		if (!sourceEffect || sourceEffect.id === 'pursuit') {
 			let extraPP = 0;
-			for (const source of targets) {
+			for (const source of pressureTargets) {
 				let ppDrop = this.runEvent('DeductPP', source, pokemon, move);
 				if (ppDrop !== true) {
 					extraPP += ppDrop || 0;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2186,7 +2186,8 @@ export class Battle extends Dex.ModdedDex {
 				target = pokemon.side.active[-targetLoc - 1];
 			}
 			if (target && !(target.fainted && target.side !== pokemon.side)) {
-				// We aren't targetting a fainted foe.
+				// Target is unfainted: no need to retarget
+				// Or target is a fainted ally: attack shouldn't retarget
 				return target;
 			}
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2185,16 +2185,13 @@ export class Battle extends Dex.ModdedDex {
 			} else {
 				target = pokemon.side.active[-targetLoc - 1];
 			}
-			if (target) {
-				if (!target.fainted) {
-					// target exists and is not fainted
-					return target;
-				} else if (target.side === pokemon.side) {
-					// fainted allied targets don't retarget
-					return null;
-				}
+			if (target && !(target.fainted && target.side !== pokemon.side)) {
+				// We aren't targetting a fainted foe.
+				return target;
 			}
-			// chosen target not valid, retarget randomly with resolveTarget
+
+			// Chosen target not valid,
+			// retarget randomly with resolveTarget
 		}
 		return this.resolveTarget(pokemon, move);
 	}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -601,6 +601,9 @@ export class Pokemon {
 					target = this.battle.priorityEvent('RedirectTarget', this, this, this.battle.getActiveMove(move), target);
 				}
 			}
+			if (target.fainted) {
+				return [];
+			}
 			if (selectedTarget !== target) {
 				this.battle.retargetLastMove(target);
 			}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -560,8 +560,10 @@ export class Pokemon {
 		return this.foes().filter(foe => this.battle.isAdjacent(this, foe));
 	}
 
-	getMoveTargets(move: Move, target: Pokemon): Pokemon[] {
+	getMoveTargets(move: Move, target: Pokemon): {targets: Pokemon[], pressureTargets: Pokemon[]} {
 		const targets = [];
+		let pressureTargets;
+
 		switch (move.target) {
 		case 'all':
 		case 'foeSide':
@@ -591,7 +593,7 @@ export class Pokemon {
 			if (!target || (target.fainted && target.side !== this.side)) {
 				// If a targeted foe faints, the move is retargeted
 				const possibleTarget = this.battle.resolveTarget(this, move);
-				if (!possibleTarget) return [];
+				if (!possibleTarget) return {targets: [], pressureTargets: []};
 				target = possibleTarget;
 			}
 			if (target.side.active.length > 1) {
@@ -602,7 +604,7 @@ export class Pokemon {
 				}
 			}
 			if (target.fainted) {
-				return [];
+				return {targets: [], pressureTargets: []};
 			}
 			if (selectedTarget !== target) {
 				this.battle.retargetLastMove(target);
@@ -613,11 +615,12 @@ export class Pokemon {
 			if (move.pressureTarget) {
 				// At the moment, this is the only supported target.
 				if (move.pressureTarget === 'foeSide') {
-					targets.push(...this.foes());
+					pressureTargets = this.foes();
 				}
 			}
 		}
-		return targets;
+
+		return {targets, pressureTargets: pressureTargets || targets};
 	}
 
 	ignoringAbility() {

--- a/test/simulator/misc/target-resolution.js
+++ b/test/simulator/misc/target-resolution.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Target Resolution', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	describe(`Targetted Pokémon fainted in-turn`, function () {
+		it(`should redirect 'any' from a fainted foe to a targettable foe`, function () {
+			battle = common.createBattle({gameType: 'doubles'}, [[
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Metapod', ability: 'shedskin', moves: ['harden']},
+			], [
+				{species: 'Chansey', ability: 'naturalcure', moves: ['curse']},
+				{species: 'Latias', ability: 'levitate', moves: ['healingwish']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+			]]);
+			const defender = battle.p2.active[0];
+			assert.hurts(defender, () => battle.makeChoices('move waterpulse 2, auto', 'auto'));
+		});
+
+		it(`should not redirect 'any' from a fainted ally to another Pokémon by default`, function () {
+			battle = common.createBattle({gameType: 'doubles'}, [[
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Latias', ability: 'levitate', moves: ['healingwish']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+			], [
+				{species: 'Chansey', ability: 'naturalcure', moves: ['curse']},
+				{species: 'Metapod', ability: 'shedskin', moves: ['harden']},
+			]]);
+			const activePokemonList = [battle.p1.active[0], ...battle.p2.active];
+			const prevHps = activePokemonList.map(pokemon => pokemon.hp);
+			battle.makeChoices('move waterpulse -2, auto', 'auto');
+			const newHps = activePokemonList.map(pokemon => pokemon.hp);
+
+			assert.deepStrictEqual(prevHps, newHps);
+			assert(battle.log.includes('|move|p1a: Wailord|Water Pulse|null|[notarget]'));
+			assert(battle.log.includes('|-fail|p1a: Wailord'));
+		});
+
+		it(`should support RedirectTarget event for a fainted foe and type 'any' `, function () {
+			battle = common.createBattle({gameType: 'triples'}, [[
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+			], [
+				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
+				{species: 'Latias', ability: 'levitate', moves: ['healingwish']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+			]]);
+			let redirector = battle.p2.active[0];
+			battle.makeChoices('move waterpulse 2, auto', 'auto');
+			assert.statStage(redirector, 'spa', 1);
+
+			// Do it again with swapped positions
+			battle.destroy();
+			battle = common.createBattle({gameType: 'triples'}, [[
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+			], [
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+				{species: 'Latias', ability: 'levitate', moves: ['healingwish']},
+				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+			]]);
+			redirector = battle.p2.active[2];
+			battle.makeChoices('move waterpulse 2, auto', 'auto');
+			assert.statStage(redirector, 'spa', 1);
+		});
+
+		it(`should support RedirectTarget event for a fainted ally and type 'any'`, function () {
+			battle = common.createBattle({gameType: 'doubles'}, [[
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Latias', ability: 'levitate', moves: ['healingwish']},
+				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
+			], [
+				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
+				{species: 'Metapod', ability: 'shedskin', moves: ['harden']},
+			]]);
+			const redirector = battle.p2.active[0];
+			battle.makeChoices('move waterpulse -2, auto', 'auto');
+			assert.statStage(redirector, 'spa', 1);
+		});
+	});
+
+	describe(`Targetted slot is empty`, function () {
+		it(`should redirect 'any' from a fainted foe to a targettable foe`, function () {
+			battle = common.createBattle({gameType: 'doubles'}, [[
+				{species: 'Wailord', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Shedinja', item: 'flameorb', ability: 'wonderguard', moves: ['agility']},
+			], [
+				{species: 'Wailord', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Shedinja', item: 'flameorb', ability: 'wonderguard', moves: ['agility']},
+			]]);
+			const attackers = battle.sides.map(side => side.active[0]);
+
+			battle.makeChoices('auto', 'auto'); // Shedinjas burned
+			battle.makeChoices('auto', 'auto'); // Shedinjas faint
+
+			const prevHps = attackers.map(pokemon => pokemon.hp);
+			battle.makeChoices('move waterpulse 2, pass', 'move waterpulse 2, pass');
+			const newHps = attackers.map(pokemon => pokemon.hp);
+
+			assert(
+				newHps[0] < prevHps[0] && newHps[1] < prevHps[1],
+				`It should redirect the attacks from their original fainted targets to valid targets`
+			);
+		});
+
+		it(`should not redirect 'any' from a fainted ally to another Pokémon by default`, function () {
+			battle = common.createBattle({gameType: 'doubles'}, [[
+				{species: 'Wailord', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Shedinja', item: 'flameorb', ability: 'wonderguard', moves: ['agility']},
+			], [
+				{species: 'Wailord', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Shedinja', item: 'flameorb', ability: 'wonderguard', moves: ['agility']},
+			]]);
+
+			const attackers = battle.sides.map(side => side.active[0]);
+			const faintTargets = battle.sides.map(side => side.active[1]);
+
+			battle.makeChoices('auto', 'auto'); // Shedinjas burned
+			battle.makeChoices('auto', 'auto'); // Shedinjas faint
+			assert.fainted(faintTargets[0]);
+			assert.fainted(faintTargets[1]);
+
+			const prevHps = attackers.map(pokemon => pokemon.hp);
+			battle.makeChoices('move waterpulse -2, pass', 'move waterpulse -2, pass');
+			const newHps = attackers.map(pokemon => pokemon.hp);
+
+			assert.deepStrictEqual(prevHps, newHps);
+			assert(battle.log.includes('|move|p1a: Wailord|Water Pulse|null|[notarget]'));
+			assert(battle.log.includes('|-fail|p1a: Wailord'));
+			assert(battle.log.includes('|move|p2a: Wailord|Water Pulse|null|[notarget]'));
+			assert(battle.log.includes('|-fail|p2a: Wailord'));
+		});
+
+		it(`should support RedirectTarget event for a fainted foe and type 'any'`, function () {
+			battle = common.createBattle({gameType: 'doubles'}, [[
+				{species: 'Aurorus', ability: 'snowwarning', moves: ['waterpulse']},
+				{species: 'Shedinja', ability: 'wonderguard', moves: ['agility']},
+			], [
+				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
+				{species: 'Shedinja', ability: 'wonderguard', moves: ['agility']},
+			]]);
+			const redirector = battle.p2.active[0];
+
+			battle.makeChoices('auto', 'auto'); // Shedinjas faint
+			battle.makeChoices('move waterpulse 2, pass', 'auto');
+			assert.statStage(redirector, 'spa', 2);
+		});
+
+		it(`should support RedirectTarget event for a fainted ally and type 'any'`, function () {
+			battle = common.createBattle({gameType: 'doubles'}, [[
+				{species: 'Aurorus', ability: 'snowwarning', moves: ['waterpulse']},
+				{species: 'Shedinja', ability: 'wonderguard', moves: ['agility']},
+			], [
+				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
+				{species: 'Shedinja', ability: 'wonderguard', moves: ['agility']},
+			]]);
+			const redirector = battle.p2.active[0];
+
+			battle.makeChoices('auto', 'auto'); // Shedinjas faint
+			battle.makeChoices('move waterpulse -2, pass', 'auto');
+			assert.statStage(redirector, 'spa', 2);
+		});
+	});
+});

--- a/test/simulator/misc/target-resolution.js
+++ b/test/simulator/misc/target-resolution.js
@@ -39,7 +39,7 @@ describe('Target Resolution', function () {
 			const newHps = activePokemonList.map(pokemon => pokemon.hp);
 
 			assert.deepStrictEqual(prevHps, newHps);
-			assert(battle.log.includes('|move|p1a: Wailord|Water Pulse|null|[notarget]'));
+			assert(battle.log.includes('|move|p1a: Wailord|Water Pulse|p1: Latias|[notarget]'));
 			assert(battle.log.includes('|-fail|p1a: Wailord'));
 		});
 
@@ -136,9 +136,9 @@ describe('Target Resolution', function () {
 			const newHps = attackers.map(pokemon => pokemon.hp);
 
 			assert.deepStrictEqual(prevHps, newHps);
-			assert(battle.log.includes('|move|p1a: Wailord|Water Pulse|null|[notarget]'));
+			assert(battle.log.includes('|move|p1a: Wailord|Water Pulse|p1: Shedinja|[notarget]'));
 			assert(battle.log.includes('|-fail|p1a: Wailord'));
-			assert(battle.log.includes('|move|p2a: Wailord|Water Pulse|null|[notarget]'));
+			assert(battle.log.includes('|move|p2a: Wailord|Water Pulse|p2: Shedinja|[notarget]'));
 			assert(battle.log.includes('|-fail|p2a: Wailord'));
 		});
 

--- a/test/simulator/moves/imprison.js
+++ b/test/simulator/moves/imprison.js
@@ -10,7 +10,7 @@ describe('Imprison', function () {
 		battle.destroy();
 	});
 
-	it('should prevent foes from using moves that the user knows', function () {
+	it(`should prevent foes from using moves that the user knows`, function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [
 			{species: 'Abra', ability: 'prankster', moves: ['imprison', 'calmmind', 'batonpass']},
@@ -20,37 +20,55 @@ describe('Imprison', function () {
 			{species: 'Abra', ability: 'synchronize', moves: ['calmmind', 'gravity']},
 			{species: 'Kadabra', ability: 'prankster', moves: ['imprison', 'calmmind']},
 		]});
+
 		battle.makeChoices('move imprison', 'move calmmind');
-		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
-		assert.strictEqual(battle.p2.active[0].boosts['spd'], 0);
+		assert.statStage(battle.p2.active[0], 'spa', 0);
+		assert.statStage(battle.p2.active[0], 'spd', 0);
 		assert.cantMove(() => battle.choose('p2', 'move calmmind'), 'Abra', 'Calm Mind');
 
 		// Imprison doesn't end when the foe switches
 		battle.makeChoices('default', 'switch 2');
 		battle.makeChoices('move calmmind', 'move calmmind');
-		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
+		assert.statStage(battle.p2.active[0], 'spa', 0);
 
 		// Imprison is not passed by Baton Pass
 		battle.makeChoices('move batonpass', 'move calmmind');
-		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
+		assert.statStage(battle.p2.active[0], 'spa', 0);
 		battle.makeChoices('switch 2', '');
-		assert.strictEqual(battle.p2.active[0].boosts['spa'], 0);
+		assert.statStage(battle.p2.active[0], 'spa', 0);
 		battle.makeChoices('move calmmind', 'move calmmind');
-		assert.strictEqual(battle.p2.active[0].boosts['spa'], 1);
+		assert.statStage(battle.p2.active[0], 'spa', 1);
 
 		// Imprison ends after user switches
 		battle.makeChoices('switch 2', 'move calmmind');
-		assert.strictEqual(battle.p2.active[0].boosts['spa'], 2);
+		assert.statStage(battle.p2.active[0], 'spa', 2);
 		battle.makeChoices('move calmmind', 'move calmmind');
-		assert.strictEqual(battle.p2.active[0].boosts['spa'], 3);
+		assert.statStage(battle.p2.active[0], 'spa', 3);
 	});
 
-	it('should not prevent foes from using Z-Powered Status moves', function () {
+	it(`should not prevent foes from using Z-Powered Status moves`, function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [{species: 'Sableye', ability: 'prankster', moves: ['imprison', 'sunnyday']}]});
 		battle.setPlayer('p2', {team: [{species: 'Charmander', ability: 'blaze', item: 'firiumz', moves: ['sunnyday']}]});
+
 		battle.makeChoices('move imprison', 'move sunnyday zmove');
 		assert.statStage(battle.p2.active[0], 'spe', 1);
 		assert.ok(battle.field.isWeather('sunnyday'));
+	});
+
+	it(`should not prevent the user from using moves that a foe knows`, function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [
+			{species: 'Abra', ability: 'prankster', moves: ['imprison', 'calmmind', 'batonpass']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Abra', ability: 'synchronize', moves: ['calmmind', 'gravity']},
+		]});
+		const imprisonUser = battle.p1.active[0];
+
+		battle.makeChoices('move imprison', 'auto');
+		battle.makeChoices('move calmmind', 'auto');
+		assert.statStage(imprisonUser, 'spa', 1);
+		assert.statStage(imprisonUser, 'spd', 1);
 	});
 });


### PR DESCRIPTION
- Storm Drain and Lightningrod now redirect attacks originally targetted against an empty allied slot of the attacker.
- Imprison and Snatch no longer affect both ``self`` and ``foeSide``.

Fixes #5361 and fixes #5362.