### PR TITLE
Make sure BattleStream only calls _destroy once

### DIFF
--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -39,8 +39,8 @@ function splitFirst(str: string, delimiter: string, limit: number = 1) {
 }
 
 export class BattleStream extends Streams.ObjectReadWriteStream<string> {
-	readonly debug: boolean;
-	readonly keepAlive: boolean;
+	debug: boolean;
+	keepAlive: boolean;
 	battle: Battle | null;
 
 	constructor(options: {debug?: boolean, keepAlive?: boolean} = {}) {
@@ -92,10 +92,7 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 			options.send = (t: string, data: any) => {
 				if (Array.isArray(data)) data = data.join("\n");
 				this.push(`${t}\n${data}`);
-				if (t === 'end' && !this.keepAlive) {
-					this.push(null);
-					this._destroy();
-				}
+				if (t === 'end' && !this.keepAlive) this.push(null);
 			};
 			if (this.debug) options.debug = true;
 			this.battle = new Battle(options);
@@ -164,10 +161,7 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 		this._destroy();
 	}
 	_destroy() {
-		if (this.battle) {
-			this.battle.destroy();
-		}
-		this.battle = null;
+		if (this.battle) this.battle.destroy();
 	}
 }
 


### PR DESCRIPTION
Fixes `Error: Push after end of read stream` from https://github.com/Zarel/Pokemon-Showdown/pull/5370#issuecomment-478203045.

`this.push(null)` triggers `this._end()` which calls `this._destroy()` already.

This was fine before (though redundant), but no longer `null`-ing out `this.battle` (either by default or through `{retainBattle: true}`) causes the double `_destroy` to become a problem because the `if (this.battle) this.battle.destroy()` check no longer works, and `Battle#destroy()` is not meant to be called more than once.