### PR TITLE
canZMove should not be set for disabled moves

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1103,7 +1103,7 @@ let BattleScripts = {
 		/**@type {AnyObject?[]} */
 		let zMoves = [];
 		for (const moveSlot of pokemon.moveSlots) {
-			if (moveSlot.pp <= 0) {
+			if (moveSlot.pp <= 0 || moveSlot.disabled) {
 				zMoves.push(null);
 				continue;
 			}


### PR DESCRIPTION
Fixes #5383.

I will add a unit test for this once #5348 lands, but I've confirmed this fixes the error which occurs on my branch.