### PR TITLE
Helpticket: Use for-of instead of for-in in arrays

### DIFF
--- a/server/chat-plugins/helptickets.js
+++ b/server/chat-plugins/helptickets.js
@@ -1033,8 +1033,8 @@ let commands = {
 				this.privateModAction(displayMessage);
 			}
 
-			for (let i in affected) {
-				let userid = (typeof affected[i] !== 'string' ? affected[i].getLastId() : toId(affected[i]));
+			for (let user of affected) {
+				let userid = (typeof user !== 'string' ? user.getLastId() : toId(user));
 				let targetTicket = tickets[userid];
 				if (targetTicket && targetTicket.open) targetTicket.open = false;
 				if (Rooms(`help-${userid}`)) Rooms(`help-${userid}`).destroy();


### PR DESCRIPTION
It's more readable. Although it's a bit slower (https://jsperf.com/for-in-vs-for-of-in-arrays), I'd take 3% of less speed for readability in a place where speed isn't _that_ important