### PR TITLE
Allow Room Owners to use addhtml

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -493,6 +493,7 @@ exports.grouplist = [
 		inherit: '@',
 		jurisdiction: 'u',
 		declare: true,
+		addhtml: true,
 		modchat: true,
 		roomonly: true,
 		gamemanagement: true,

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -482,6 +482,7 @@ exports.grouplist = [
 		roomdriver: true,
 		editroom: true,
 		declare: true,
+		addhtml: true,
 		modchatall: true,
 		roomonly: true,
 		gamemanagement: true,


### PR DESCRIPTION
While writing this I noticed addhtml is not included in the comment decribing all permissions. I'm bad at writing descriptions so I didn't fix it but I thought I'd mention it