### PR TITLE
Move Data.ActiveMove methods to Pokemon

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -131,7 +131,7 @@ let BattleAbilities = {
 		shortDesc: "If this Pokemon (not its substitute) takes a critical hit, its Attack is raised 12 stages.",
 		onHit(target, source, move) {
 			if (!target.hp) return;
-			if (move && move.effectType === 'Move' && move.getHitData(target).crit) {
+			if (move && move.effectType === 'Move' && target.getMoveHitData(move).crit) {
 				target.setBoost({atk: 6});
 				this.add('-setboost', target, 'atk', 12, '[from] ability: Anger Point');
 			}
@@ -892,7 +892,7 @@ let BattleAbilities = {
 	"filter": {
 		shortDesc: "This Pokemon receives 3/4 damage from supereffective attacks.",
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.getHitData(target).typeMod > 0) {
+			if (target.getMoveHitData(move).typeMod > 0) {
 				this.debug('Filter neutralize');
 				return this.chainModify(0.75);
 			}
@@ -2141,7 +2141,7 @@ let BattleAbilities = {
 	"neuroforce": {
 		shortDesc: "This Pokemon's attacks that are super effective against the target do 1.25x damage.",
 		onModifyDamage(damage, source, target, move) {
-			if (move && move.getHitData(target).typeMod > 0) {
+			if (move && target.getMoveHitData(move).typeMod > 0) {
 				return this.chainModify([0x1400, 0x1000]);
 			}
 		},
@@ -2523,7 +2523,7 @@ let BattleAbilities = {
 		desc: "This Pokemon receives 3/4 damage from supereffective attacks. Moongeist Beam, Sunsteel Strike, and the Mold Breaker, Teravolt, and Turboblaze Abilities cannot ignore this Ability.",
 		shortDesc: "This Pokemon receives 3/4 damage from supereffective attacks.",
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.getHitData(target).typeMod > 0) {
+			if (target.getMoveHitData(move).typeMod > 0) {
 				this.debug('Prism Armor neutralize');
 				return this.chainModify(0.75);
 			}
@@ -3111,7 +3111,7 @@ let BattleAbilities = {
 	"sniper": {
 		shortDesc: "If this Pokemon strikes with a critical hit, the damage is multiplied by 1.5.",
 		onModifyDamage(damage, source, target, move) {
-			if (move.getHitData(target).crit) {
+			if (target.getMoveHitData(move).crit) {
 				this.debug('Sniper boost');
 				return this.chainModify(1.5);
 			}
@@ -3171,7 +3171,7 @@ let BattleAbilities = {
 	"solidrock": {
 		shortDesc: "This Pokemon receives 3/4 damage from supereffective attacks.",
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.getHitData(target).typeMod > 0) {
+			if (target.getMoveHitData(move).typeMod > 0) {
 				this.debug('Solid Rock neutralize');
 				return this.chainModify(0.75);
 			}
@@ -3644,7 +3644,7 @@ let BattleAbilities = {
 	"tintedlens": {
 		shortDesc: "This Pokemon's attacks that are not very effective on a target deal double damage.",
 		onModifyDamage(damage, source, target, move) {
-			if (move.getHitData(target).typeMod < 0) {
+			if (target.getMoveHitData(move).typeMod < 0) {
 				this.debug('Tinted Lens boost');
 				return this.chainModify(2);
 			}

--- a/data/items.js
+++ b/data/items.js
@@ -324,7 +324,7 @@ let BattleItems = {
 			type: "Steel",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Steel' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Steel' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -738,7 +738,7 @@ let BattleItems = {
 			type: "Rock",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Rock' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Rock' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -928,7 +928,7 @@ let BattleItems = {
 			type: "Fighting",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Fighting' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Fighting' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -962,7 +962,7 @@ let BattleItems = {
 			type: "Flying",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Flying' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Flying' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -985,7 +985,7 @@ let BattleItems = {
 			type: "Dark",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Dark' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Dark' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -1563,7 +1563,7 @@ let BattleItems = {
 			type: "Bug",
 		},
 		onHit(target, source, move) {
-			if (move && move.getHitData(target).typeMod > 0) {
+			if (move && target.getMoveHitData(move).typeMod > 0) {
 				if (target.eatItem()) {
 					this.heal(target.maxhp / 4);
 				}
@@ -1608,7 +1608,7 @@ let BattleItems = {
 			basePower: 10,
 		},
 		onModifyDamage(damage, source, target, move) {
-			if (move && move.getHitData(target).typeMod > 0) {
+			if (move && target.getMoveHitData(move).typeMod > 0) {
 				return this.chainModify([0x1333, 0x1000]);
 			}
 		},
@@ -2336,7 +2336,7 @@ let BattleItems = {
 			type: "Dragon",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Dragon' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Dragon' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -2684,7 +2684,7 @@ let BattleItems = {
 			type: "Ghost",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Ghost' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Ghost' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -2707,7 +2707,7 @@ let BattleItems = {
 			type: "Poison",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Poison' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Poison' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -3811,7 +3811,7 @@ let BattleItems = {
 			type: "Fire",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Fire' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Fire' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -3920,7 +3920,7 @@ let BattleItems = {
 			type: "Water",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Water' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Water' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -3943,7 +3943,7 @@ let BattleItems = {
 			type: "Psychic",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Psychic' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Psychic' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -4706,7 +4706,7 @@ let BattleItems = {
 			type: "Grass",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Grass' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Grass' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -4851,7 +4851,7 @@ let BattleItems = {
 			type: "Fairy",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Fairy' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Fairy' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -5144,7 +5144,7 @@ let BattleItems = {
 			type: "Ground",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Ground' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Ground' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -5639,7 +5639,7 @@ let BattleItems = {
 			type: "Bug",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Bug' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Bug' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -5837,7 +5837,7 @@ let BattleItems = {
 			type: "Electric",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Electric' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Electric' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');
@@ -5951,7 +5951,7 @@ let BattleItems = {
 		},
 		onHitPriority: 1,
 		onHit(target, source, move) {
-			if (target.hp && move.category !== 'Status' && !move.damage && !move.damageCallback && move.getHitData(target).typeMod > 0 && target.useItem()) {
+			if (target.hp && move.category !== 'Status' && !move.damage && !move.damageCallback && target.getMoveHitData(move).typeMod > 0 && target.useItem()) {
 				this.boost({atk: 2, spa: 2});
 			}
 		},
@@ -6098,7 +6098,7 @@ let BattleItems = {
 			type: "Ice",
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.type === 'Ice' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
+			if (move.type === 'Ice' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'] || (move.infiltrates && this.gen >= 6))) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');

--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -784,7 +784,7 @@ let BattleScripts = {
 				isCrit = this.randomChance(critChance, 256);
 			}
 		}
-		if (isCrit) move.crit(target);
+		if (isCrit) target.setMoveCrit(move);
 
 		// Happens after crit calculation.
 		if (basePower) {

--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -546,7 +546,7 @@ let BattleScripts = {
 		}
 
 		if (isCrit && this.runEvent('CriticalHit', target, null, move)) {
-			move.crit(target);
+			target.setMoveCrit(move);
 		}
 
 		// Happens after crit calculation

--- a/data/mods/gen4/abilities.js
+++ b/data/mods/gen4/abilities.js
@@ -8,7 +8,7 @@ let BattleAbilities = {
 		shortDesc: "If this Pokemon or its substitute takes a critical hit, its Attack is raised 12 stages.",
 		onAfterSubDamage(damage, target, source, move) {
 			if (!target.hp) return;
-			if (move && move.effectType === 'Move' && move.getHitData(target).crit) {
+			if (move && move.effectType === 'Move' && target.getMoveHitData(move).crit) {
 				target.setBoost({atk: 6});
 				this.add('-setboost', target, 'atk', 12, '[from] ability: Anger Point');
 			}

--- a/data/mods/gen4/items.js
+++ b/data/mods/gen4/items.js
@@ -36,7 +36,7 @@ let BattleItems = {
 		inherit: true,
 		onSourceModifyDamage(damage, source, target, move) {
 			if (move.causedCrashDamage) return damage;
-			if (move.type === 'Fighting' && move.getHitData(target).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'])) {
+			if (move.type === 'Fighting' && target.getMoveHitData(move).typeMod > 0 && (!target.volatiles['substitute'] || move.flags['authentic'])) {
 				if (target.eatItem()) {
 					this.debug('-50% reduction');
 					this.add('-enditem', target, this.effect, '[weaken]');

--- a/data/mods/gen4/moves.js
+++ b/data/mods/gen4/moves.js
@@ -907,7 +907,7 @@ let BattleMovedex = {
 			},
 			onAnyModifyDamagePhase1(damage, source, target, move) {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
-					if (!move.getHitData(target).crit && !move.infiltrates) {
+					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
 						if (target.side.active.length > 1) return this.chainModify([0xAAC, 0x1000]);
 						return this.chainModify(0.5);
@@ -1267,7 +1267,7 @@ let BattleMovedex = {
 			},
 			onAnyModifyDamagePhase1(damage, source, target, move) {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
-					if (!move.getHitData(target).crit && !move.infiltrates) {
+					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
 						if (target.side.active.length > 1) return this.chainModify([0xAAC, 0x1000]);
 						return this.chainModify(0.5);

--- a/data/mods/gen4/scripts.js
+++ b/data/mods/gen4/scripts.js
@@ -41,7 +41,7 @@ let BattleScripts = {
 
 		baseDamage += 2;
 
-		const isCrit = move.getHitData(target).crit;
+		const isCrit = target.getMoveHitData(move).crit;
 		if (isCrit) {
 			baseDamage = this.modify(baseDamage, move.critModifier || 2);
 		}
@@ -63,7 +63,7 @@ let BattleScripts = {
 		// types
 		let typeMod = target.runEffectiveness(move);
 		typeMod = this.clampIntRange(typeMod, -6, 6);
-		move.setTypeModFor(target, typeMod);
+		target.setMoveTypeModFor(move, typeMod);
 		if (typeMod > 0) {
 			if (!suppressMessages) this.add('-supereffective', target);
 

--- a/data/mods/gen5/moves.js
+++ b/data/mods/gen5/moves.js
@@ -546,7 +546,7 @@ let BattleMovedex = {
 			},
 			onAnyModifyDamage(damage, source, target, move) {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
-					if (!move.getHitData(target).crit && !move.infiltrates) {
+					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
 						if (target.side.active.length > 1) return this.chainModify([0xA8F, 0x1000]);
 						return this.chainModify(0.5);
@@ -783,7 +783,7 @@ let BattleMovedex = {
 			},
 			onAnyModifyDamage(damage, source, target, move) {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
-					if (!move.getHitData(target).crit && !move.infiltrates) {
+					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
 						if (target.side.active.length > 1) return this.chainModify([0xA8F, 0x1000]);
 						return this.chainModify(0.5);

--- a/data/mods/gennext/abilities.js
+++ b/data/mods/gennext/abilities.js
@@ -258,7 +258,7 @@ let BattleAbilities = {
 		inherit: true,
 		shortDesc: "This Pokemon receives 1/2 damage from supereffective attacks.",
 		onSourceModifyDamage(damage, attacker, defender, move) {
-			if (move.getHitData(defender).typeMod > 0) {
+			if (defender.getMoveHitData(move).typeMod > 0) {
 				this.add('-message', "The attack was weakened by Solid Rock!");
 				return this.chainModify(0.5);
 			}
@@ -268,7 +268,7 @@ let BattleAbilities = {
 		inherit: true,
 		shortDesc: "This Pokemon receives 1/2 damage from supereffective attacks.",
 		onSourceModifyDamage(damage, attacker, defender, move) {
-			if (move.getHitData(defender).typeMod > 0) {
+			if (defender.getMoveHitData(move).typeMod > 0) {
 				this.add('-message', "The attack was weakened by Filter!");
 				return this.chainModify(0.5);
 			}

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -2873,7 +2873,7 @@ let BattleMovedex = {
 			onTryHitPriority: 3,
 			onTryHit(target, source, move) {
 				if (!move.flags['protect']) {
-					if (move.isZ) move.zBreakProtect(target);
+					if (move.isZ) target.setMoveZBreakProtect(move);
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');

--- a/data/mods/ssb/statuses.js
+++ b/data/mods/ssb/statuses.js
@@ -92,7 +92,7 @@ let BattleStatuses = {
 			this.add(`c|%Akir|too sleepy, c ya`);
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.getHitData(target).typeMod > 0 && !target.illusion) {
+			if (target.getMoveHitData(move).typeMod > 0 && !target.illusion) {
 				this.debug('Solid Rock neutralize');
 				return this.chainModify(0.75);
 			}
@@ -950,7 +950,7 @@ let BattleStatuses = {
 			this.add(`c|+Osiris|I'm getting too old for this x_x`);
 		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (move.getHitData(target).typeMod > 0 && !target.illusion) {
+			if (target.getMoveHitData(move).typeMod > 0 && !target.illusion) {
 				this.debug('Solid Rock neutralize');
 				return this.chainModify(0.75);
 			}

--- a/data/mods/stadium/scripts.js
+++ b/data/mods/stadium/scripts.js
@@ -532,7 +532,7 @@ let BattleScripts = {
 		}
 		// There is a critical hit.
 		if (isCrit && this.runEvent('CriticalHit', target, null, move)) {
-			move.crit(target);
+			target.setMoveCrit(move);
 		}
 
 		// Happens after crit calculation.

--- a/data/moves.js
+++ b/data/moves.js
@@ -852,7 +852,7 @@ let BattleMovedex = {
 							(target.side.getSideCondition('lightscreen') && this.getCategory(move) === 'Special')) {
 						return;
 					}
-					if (!move.getHitData(target).crit && !move.infiltrates) {
+					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Aurora Veil weaken');
 						if (target.side.active.length > 1) return this.chainModify([0xAAC, 0x1000]);
 						return this.chainModify(0.5);
@@ -1028,7 +1028,7 @@ let BattleMovedex = {
 			onTryHitPriority: 3,
 			onTryHit(target, source, move) {
 				if (!move.flags['protect']) {
-					if (move.isZ) move.zBreakProtect(target);
+					if (move.isZ) target.setMoveZBreakProtect(move);
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');
@@ -8972,7 +8972,7 @@ let BattleMovedex = {
 			onTryHitPriority: 3,
 			onTryHit(target, source, move) {
 				if (!move.flags['protect'] || move.category === 'Status') {
-					if (move.isZ) move.zBreakProtect(target);
+					if (move.isZ) target.setMoveZBreakProtect(move);
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');
@@ -9394,7 +9394,7 @@ let BattleMovedex = {
 			},
 			onAnyModifyDamage(damage, source, target, move) {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
-					if (!move.getHitData(target).crit && !move.infiltrates) {
+					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
 						if (target.side.active.length > 1) return this.chainModify([0xAAC, 0x1000]);
 						return this.chainModify(0.5);
@@ -10031,7 +10031,7 @@ let BattleMovedex = {
 			onTryHitPriority: 3,
 			onTryHit(target, source, move) {
 				if (!move.flags['protect']) {
-					if (move.isZ) move.zBreakProtect(target);
+					if (move.isZ) target.setMoveZBreakProtect(move);
 					return;
 				}
 				if (move && (move.target === 'self' || move.category === 'Status')) return;
@@ -12477,7 +12477,7 @@ let BattleMovedex = {
 			onTryHitPriority: 3,
 			onTryHit(target, source, move) {
 				if (!move.flags['protect']) {
-					if (move.isZ) move.zBreakProtect(target);
+					if (move.isZ) target.setMoveZBreakProtect(move);
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');
@@ -12999,7 +12999,7 @@ let BattleMovedex = {
 				// (e.g. it blocks 0 priority moves boosted by Prankster or Gale Wings; Quick Claw/Custap Berry do not count)
 				if (move.priority <= 0.1) return;
 				if (!move.flags['protect']) {
-					if (move.isZ) move.zBreakProtect(target);
+					if (move.isZ) target.setMoveZBreakProtect(move);
 					return;
 				}
 				this.add('-activate', target, 'move: Quick Guard');
@@ -13309,7 +13309,7 @@ let BattleMovedex = {
 			},
 			onAnyModifyDamage(damage, source, target, move) {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
-					if (!move.getHitData(target).crit && !move.infiltrates) {
+					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
 						if (target.side.active.length > 1) return this.chainModify([0xAAC, 0x1000]);
 						return this.chainModify(0.5);
@@ -15705,7 +15705,7 @@ let BattleMovedex = {
 			onTryHitPriority: 3,
 			onTryHit(target, source, move) {
 				if (!move.flags['protect']) {
-					if (move.isZ) move.zBreakProtect(target);
+					if (move.isZ) target.setMoveZBreakProtect(move);
 					return;
 				}
 				this.add('-activate', target, 'move: Protect');
@@ -18981,7 +18981,7 @@ let BattleMovedex = {
 					return;
 				}
 				if (move.isZ) {
-					move.zBreakProtect(target);
+					target.setMoveZBreakProtect(move);
 					return;
 				}
 				this.add('-activate', target, 'move: Wide Guard');

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -910,11 +910,6 @@ interface ActiveMove extends BasicEffect, MoveData {
 	 * truthy.
 	 */
 	isZPowered?: boolean
-	
-	getHitData(target: Pokemon): {crit: boolean, typeMod: number, zBrokeProtect: boolean}
-	crit(target: Pokemon): void
-	setTypeModFor(target: Pokemon, typeMod: number): void
-	zBreakProtect(target: Pokemon): void
 }
 
 type TemplateAbility = {0: string, 1?: string, H?: string, S?: string}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1980,7 +1980,7 @@ export class Battle extends Dex.ModdedDex {
 		if (move.willCrit || move.willCrit === undefined && critRatio && this.randomChance(1, critMult[critRatio])) {
 			if (this.runEvent('CriticalHit', target, null, move)) {
 				isCrit = true;
-				move.crit(target);
+				target.setMoveCrit(move);
 			}
 		}
 
@@ -2067,7 +2067,7 @@ export class Battle extends Dex.ModdedDex {
 		baseDamage = this.runEvent('WeatherModifyDamage', pokemon, target, move, baseDamage);
 
 		// crit - not a modifier
-		const isCrit = move.getHitData(target).crit;
+		const isCrit = target.getMoveHitData(move).crit;
 		if (isCrit) {
 			baseDamage = tr(baseDamage * (move.critModifier || (this.gen >= 6 ? 1.5 : 2)));
 		}
@@ -2086,7 +2086,7 @@ export class Battle extends Dex.ModdedDex {
 		// types
 		let typeMod = target.runEffectiveness(move);
 		typeMod = this.clampIntRange(typeMod, -6, 6);
-		move.setTypeModFor(target, typeMod);
+		target.setMoveTypeModFor(move, typeMod);
 		if (typeMod > 0) {
 			if (!suppressMessages) this.add('-supereffective', target);
 
@@ -2116,7 +2116,7 @@ export class Battle extends Dex.ModdedDex {
 		// Final modifier. Modifiers that modify damage after min damage check, such as Life Orb.
 		baseDamage = this.runEvent('ModifyDamage', pokemon, target, move, baseDamage);
 
-		if (move.isZPowered && move.getHitData(target).zBrokeProtect) {
+		if (move.isZPowered && target.getMoveHitData(move).zBrokeProtect) {
 			baseDamage = this.modify(baseDamage, 0.25);
 			this.add('-zbroken', target);
 		}

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -894,26 +894,6 @@ export class ActiveMove extends Move implements BasicEffect, MoveData {
 		this.hit = 0;
 		this.moveHitData = {crit: {}, typeMod: {}, zBrokeProtect: {}};
 	}
-
-	getHitData(target: Pokemon) {
-		return {
-			crit: this.moveHitData.crit[target.toString().slice(0, 3)] || false,
-			typeMod: this.moveHitData.typeMod[target.toString().slice(0, 3)] || 0,
-			zBrokeProtect: this.moveHitData.zBrokeProtect[target.toString().slice(0, 3)] || false,
-		};
-	}
-
-	crit(target: Pokemon) {
-		this.moveHitData.crit[target.toString().slice(0, 3)] = true;
-	}
-
-	setTypeModFor(target: Pokemon, typeMod: number) {
-		this.moveHitData.typeMod[target.toString().slice(0, 3)] = typeMod;
-	}
-
-	zBreakProtect(target: Pokemon) {
-		this.moveHitData.zBrokeProtect[target.toString().slice(0, 3)] = true;
-	}
 }
 
 type TypeInfoEffectType = 'Type' | 'EffectType';

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -525,6 +525,34 @@ export class Pokemon {
 		return null;
 	}
 
+	getMoveHitData(move: ActiveMove) {
+		move = Pokemon.ensureActiveMove(move);
+		return {
+			crit: move.moveHitData.crit[this.toString().slice(0, 3)] || false,
+			typeMod: move.moveHitData.typeMod[this.toString().slice(0, 3)] || 0,
+			zBrokeProtect: move.moveHitData.zBrokeProtect[this.toString().slice(0, 3)] || false,
+		};
+	}
+
+	setMoveCrit(move: ActiveMove) {
+		Pokemon.ensureActiveMove(move).moveHitData.crit[this.toString().slice(0, 3)] = true;
+	}
+
+	setMoveTypeModFor(move: ActiveMove, typeMod: number) {
+		Pokemon.ensureActiveMove(move).moveHitData.typeMod[this.toString().slice(0, 3)] = typeMod;
+	}
+
+	setMoveZBreakProtect(move: ActiveMove) {
+		Pokemon.ensureActiveMove(move).moveHitData.zBrokeProtect[this.toString().slice(0, 3)] = true;
+	}
+
+	// TODO(#5415): Revamp ActiveMove to fix this.
+	private static ensureActiveMove(obj: any): any {
+		obj.hit = obj.hit || 0;
+		obj.moveHitData = obj.moveHitData || {crit: {}, typeMod: {}, zBrokeProtect: {}};
+		return obj;
+	}
+
 	allies(): Pokemon[] {
 		let allies = this.side.active;
 		if (this.battle.gameType === 'multi') {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -527,10 +527,11 @@ export class Pokemon {
 
 	getMoveHitData(move: ActiveMove) {
 		move = Pokemon.ensureActiveMove(move);
+		const slotid = this.toString().slice(0, 3);
 		return {
-			crit: move.moveHitData.crit[this.toString().slice(0, 3)] || false,
-			typeMod: move.moveHitData.typeMod[this.toString().slice(0, 3)] || 0,
-			zBrokeProtect: move.moveHitData.zBrokeProtect[this.toString().slice(0, 3)] || false,
+			crit: move.moveHitData.crit[slotid] || false,
+			typeMod: move.moveHitData.typeMod[slotid] || 0,
+			zBrokeProtect: move.moveHitData.zBrokeProtect[slotid] || false,
 		};
 	}
 

--- a/test/simulator/abilities/battlearmor.js
+++ b/test/simulator/abilities/battlearmor.js
@@ -19,7 +19,7 @@ describe('Battle Armor', function () {
 		battle.onEvent('ModifyDamage', battle.getFormat(), function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
 				successfulEvent = true;
-				assert.ok(!move.getHitData(defender).crit);
+				assert.ok(!defender.getMoveHitData(move).crit);
 			}
 		});
 		battle.makeChoices('move quickattack', 'move frostbreath');
@@ -36,7 +36,7 @@ describe('Battle Armor', function () {
 		battle.onEvent('ModifyDamage', battle.getFormat(), function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
 				successfulEvent = true;
-				assert.ok(move.getHitData(defender).crit);
+				assert.ok(defender.getMoveHitData(move).crit);
 			}
 		});
 		battle.makeChoices('move quickattack', 'move frostbreath');

--- a/test/simulator/abilities/disguise.js
+++ b/test/simulator/abilities/disguise.js
@@ -83,7 +83,7 @@ describe('Disguise', function () {
 		battle.onEvent('Damage', battle.getFormat(), function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
 				successfulEvent = true;
-				assert.ok(!move.getHitData(defender).crit);
+				assert.ok(!defender.getMoveHitData(move).crit);
 			}
 		});
 		battle.makeChoices();

--- a/test/simulator/abilities/shellarmor.js
+++ b/test/simulator/abilities/shellarmor.js
@@ -19,7 +19,7 @@ describe('Shell Armor', function () {
 		battle.onEvent('ModifyDamage', battle.getFormat(), function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
 				successfulEvent = true;
-				assert.false(move.getHitData(defender).crit);
+				assert.false(defender.getMoveHitData(move).crit);
 			}
 		});
 		battle.makeChoices('move quickattack', 'move frostbreath');
@@ -35,7 +35,7 @@ describe('Shell Armor', function () {
 		battle.onEvent('ModifyDamage', battle.getFormat(), function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
 				successfulEvent = true;
-				assert.ok(move.getHitData(defender).crit);
+				assert.ok(defender.getMoveHitData(move).crit);
 			}
 		});
 		battle.makeChoices('move quickattack', 'move frostbreath');


### PR DESCRIPTION
See #5415 for context - having these methods is unsafe and leads
to crashes because not all `ActiveMove`s are created through the
`Data.ActiveMove` constructor. Instead of `Pokemon`, these could
alternatively be static methods on` ActiveMove` (or the `ActiveMove`
`class` could be completely abolished and reverted back to an
`interface`), but #5415 will deal with `ActiveMove` long term, this just
fixes the crashes.