### PR TITLE
Remove |callback| in favor of |error|

### DIFF
--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -680,7 +680,12 @@ Mean Look or something), you will receive a message starting with:
 
 `|error|[Invalid choice]`
 
-This will tell you to send a different decision.
+This will tell you to send a different decision. If your previous choice
+revealed additional information, the error will contain an updated `REQUEST`
+object (in the same format as `|request|`) to base your decisions off of:
+
+`|error|[Invalid choice] MESSAGE|REQUEST`
+
 
 ### Choice requests
 

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -680,7 +680,7 @@ revealed additional information (For example: a move disabled by Imprison
 or a trapping effect), the error will be followed with a `|request|` command
 to base your decision off of:
 
-`|error|[Unavailable choice] MESSAGE`
+`|error|[Unavailable choice] MESSAGE`  
 `|request|REQUEST`
 
 ### Choice requests

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -678,14 +678,15 @@ against race conditions involving `/undo` (the cancel button).
 If an invalid decision is sent (trying to switch when you're trapped by
 Mean Look or something), you will receive a message starting with:
 
-`|error|[Invalid choice]`
+`|error|[Invalid choice] MESSAGE`
 
 This will tell you to send a different decision. If your previous choice
-revealed additional information, the error will contain an updated `REQUEST`
-object (in the same format as `|request|`) to base your decisions off of:
+revealed additional information (For examplse: a move disabled by Imprison
+or a trapping effect), the error will be followed with a `|request|` command
+to base your decision off of:
 
-`|error|[Invalid choice] MESSAGE|REQUEST`
-
+`|error|[Unavailable choice] MESSAGE`
+`|request|REQUEST`
 
 ### Choice requests
 

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -676,7 +676,7 @@ Mean Look or something), you will receive a message starting with:
 `|error|[Invalid choice] MESSAGE`
 
 This will tell you to send a different decision. If your previous choice
-revealed additional information (For examplse: a move disabled by Imprison
+revealed additional information (For example: a move disabled by Imprison
 or a trapping effect), the error will be followed with a `|request|` command
 to base your decision off of:
 

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -274,18 +274,16 @@ export abstract class BattlePlayer {
 		if (cmd === 'request') {
 			return this.receiveRequest(JSON.parse(rest));
 		}
-		if (cmd === 'callback') {
-			return this.receiveCallback(rest.split('|'));
-		}
 		if (cmd === 'error') {
-			return this.receiveError(new Error(rest));
+			const [err, request] = splitFirst(rest, '|');
+			return this.receiveError(new Error(err), request && JSON.parse(request));
 		}
 		this.log.push(line);
 	}
 
 	abstract receiveRequest(request: AnyObject): void;
 
-	receiveError(error: Error) {
+	receiveError(error: Error, request?: AnyObject) {
 		throw error;
 	}
 

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -284,7 +284,6 @@ export abstract class BattlePlayer {
 	}
 
 	abstract receiveRequest(request: AnyObject): void;
-	abstract receiveCallback(callback: string[]): void;
 
 	receiveError(error: Error) {
 		throw error;

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -262,18 +262,7 @@ export abstract class BattlePlayer {
 	}
 
 	receive(chunk: string) {
-		const lines = chunk.split('\n');
-		if (lines.length >= 2 &&
-			lines[0].startsWith('|error|[Invalid Choice]') &&
-			lines[1].startsWith('|request|')) {
-			const err = lines[0].slice(7);
-			const request = lines[1].slice(9);
-			this.receiveError(new Error(err), JSON.parse(request));
-			const removed = lines.splice(0, 2);
-			if (this.debug) console.log(removed);
-		}
-
-		for (const line of lines) {
+		for (const line of chunk.split('\n')) {
 			this.receiveLine(line);
 		}
 	}
@@ -282,8 +271,13 @@ export abstract class BattlePlayer {
 		if (this.debug) console.log(line);
 		if (line.charAt(0) !== '|') return;
 		const [cmd, rest] = splitFirst(line.slice(1), '|');
-		if (cmd === 'request') return this.receiveRequest(JSON.parse(rest));
-		if (cmd === 'error') return this.receiveError(new Error(rest));
+		if (cmd === 'request') {
+			return this.receiveRequest(JSON.parse(rest));
+		}
+		if (cmd === 'error') {
+			const [err, request] = splitFirst(rest, '|');
+			return this.receiveError(new Error(err), request && JSON.parse(request));
+		}
 		this.log.push(line);
 	}
 

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -271,19 +271,14 @@ export abstract class BattlePlayer {
 		if (this.debug) console.log(line);
 		if (line.charAt(0) !== '|') return;
 		const [cmd, rest] = splitFirst(line.slice(1), '|');
-		if (cmd === 'request') {
-			return this.receiveRequest(JSON.parse(rest));
-		}
-		if (cmd === 'error') {
-			const [err, request] = splitFirst(rest, '|');
-			return this.receiveError(new Error(err), request && JSON.parse(request));
-		}
+		if (cmd === 'request') return this.receiveRequest(JSON.parse(rest));
+		if (cmd === 'error') return this.receiveError(new Error(rest));
 		this.log.push(line);
 	}
 
 	abstract receiveRequest(request: AnyObject): void;
 
-	receiveError(error: Error, request?: AnyObject) {
+	receiveError(error: Error) {
 		throw error;
 	}
 

--- a/sim/examples/random-player-ai.ts
+++ b/sim/examples/random-player-ai.ts
@@ -15,11 +15,6 @@ export class RandomPlayerAI extends BattlePlayer {
 	readonly mega: number;
 	readonly prng: PRNG;
 
-	trapped: Set<number>;
-	disabled: Map<number, Set<string>>;
-	lastRequest?: AnyObject;
-	retry: boolean;
-
 	constructor(
 		playerStream: ObjectReadWriteStream<string>,
 		options: {move?: number, mega?: number, seed?: PRNG | PRNGSeed | null } = {},
@@ -29,53 +24,9 @@ export class RandomPlayerAI extends BattlePlayer {
 		this.move = options.move || 1.0;
 		this.mega = options.mega || 0;
 		this.prng = options.seed && !Array.isArray(options.seed) ? options.seed : new PRNG(options.seed);
-
-		this.disabled = new Map();
-		this.trapped = new Set();
-		this.retry = false;
-	}
-
-	receiveError(error: Error) {
-		if (error.message.startsWith(`[Invalid choice]`) && this.retry) {
-			this.retry = false;
-			// If we get a choice error, we retry the choice using the last request provided
-			// we've got a '|callback' updating our state regarding what Pokemon are trapped
-			// or disabled.
-			this.makeChoice(this.lastRequest!);
-		} else {
-			throw error;
-		}
 	}
 
 	receiveRequest(request: AnyObject) {
-		this.disabled = new Map();
-		this.trapped = new Set();
-		this.retry = false;
-
-		this.lastRequest = request;
-		this.makeChoice(request);
-	}
-
-	receiveCallback(callback: string[]) {
-		const [type, ...args] = callback;
-		if (type === 'cant') {
-			this.retry = true;
-			const [pokemon, _, move] = args;
-			const position = pokemon[2].indexOf(`abcdef`);
-			let moves = this.disabled.get(position);
-			if (!moves) {
-				moves = new Set();
-				this.disabled.set(position, moves);
-			}
-			moves.add(move);
-		} else if (type === 'trapped') {
-			this.retry = true;
-			const position = Number(args);
-			this.trapped.add(position);
-		}
-	}
-
-	makeChoice(request: AnyObject) {
 		if (request.wait) {
 			// wait request
 			// do nothing
@@ -115,11 +66,9 @@ export class RandomPlayerAI extends BattlePlayer {
 				canUltraBurst = canUltraBurst && active.canUltraBurst;
 				canZMove = canZMove && !!active.canZMove;
 
-				const disabled = this.disabled.get(i);
 				let canMove = [1, 2, 3, 4].slice(0, active.moves.length).filter(j => (
 					// not disabled
-					!active.moves[j - 1].disabled &&
-					(!disabled || !disabled.has(toId(active.moves[j - 1].move)))
+					!active.moves[j - 1].disabled
 					// NOTE: we don't actually check for whether we have PP or not because the
 					// simulator will mark the move as disabled if there is zero PP and there are
 					// situations where we actually need to use a move with 0 PP (Gen 1 Wrap).
@@ -177,8 +126,7 @@ export class RandomPlayerAI extends BattlePlayer {
 					// not fainted
 					!pokemon[j - 1].condition.endsWith(` fnt`)
 				));
-				const trapped = active.trapped || (this.trapped && this.trapped.has(i));
-				const switches = trapped ? [] : canSwitch;
+				const switches = active.trapped ? [] : canSwitch;
 
 				if (switches.length && (!moves.length || this.prng.next() > this.move)) {
 					const target = this.prng.sample(switches);

--- a/sim/examples/random-player-ai.ts
+++ b/sim/examples/random-player-ai.ts
@@ -26,12 +26,10 @@ export class RandomPlayerAI extends BattlePlayer {
 		this.prng = options.seed && !Array.isArray(options.seed) ? options.seed : new PRNG(options.seed);
 	}
 
-	receiveError(error: Error, request?: AnyObject) {
-		if (request) {
-			this.receiveRequest(request);
-		} else {
-			throw error;
-		}
+	receiveError(error: Error) {
+		// If we made an unavailable choice we will receive a followup request to
+		// allow us the opportunity to correct our decision.
+		if (!error.message.startsWith('[Unavailable choice]')) throw error;
 	}
 
 	receiveRequest(request: AnyObject) {

--- a/sim/examples/random-player-ai.ts
+++ b/sim/examples/random-player-ai.ts
@@ -26,6 +26,14 @@ export class RandomPlayerAI extends BattlePlayer {
 		this.prng = options.seed && !Array.isArray(options.seed) ? options.seed : new PRNG(options.seed);
 	}
 
+	receiveError(error: Error, request?: AnyObject) {
+		if (request) {
+			this.receiveRequest(request);
+		} else {
+			throw error;
+		}
+	}
+
 	receiveRequest(request: AnyObject) {
 		if (request.wait) {
 			// wait request

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -321,9 +321,8 @@ export class Side {
 
 	emitChoiceError(message: string, includeRequest?: boolean) {
 		this.choice.error = message;
-		let sideupdate = `${this.id}\n|error|[Invalid choice] ${message}`;
-		if (includeRequest) sideupdate += `|${JSON.stringify(this.activeRequest)}`;
-		this.battle.send('sideupdate', sideupdate);
+		this.battle.send('sideupdate', `${this.id}\n|error|[Invalid choice] ${message}`);
+		if (includeRequest) this.emitRequest(this.activeRequest!);
 		if (this.battle.strictChoices) throw new Error(`[Invalid choice] ${message}`);
 		return false;
 	}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -404,14 +404,6 @@ export class Side {
 			return this.emitChoiceError(`Can't move: ${pokemon.name} can't use ${move.name} as a Z-move`);
 		}
 		if (zMove && this.choice.zMove) {
-			this.updateRequestForPokemon(pokemon, req => {
-				let updated = false;
-				if (req.canZMove) {
-					req.canZMove = false;
-					updated = true;
-				}
-				return updated;
-			});
 			return this.emitChoiceError(`Can't move: You can't Z-move more than once per battle`);
 		}
 
@@ -489,14 +481,6 @@ export class Side {
 			return this.emitChoiceError(`Can't move: ${pokemon.name} can't mega evolve`);
 		}
 		if (mega && this.choice.mega) {
-			this.updateRequestForPokemon(pokemon, req => {
-				let updated = false;
-				if (req.canMegaEvo) {
-					req.canMegaEvo = false;
-					updated = true;
-				}
-				return updated;
-			});
 			return this.emitChoiceError(`Can't move: You can only mega-evolve once per battle`);
 		}
 		const ultra = (megaOrZ === 'ultra');
@@ -504,14 +488,6 @@ export class Side {
 			return this.emitChoiceError(`Can't move: ${pokemon.name} can't mega evolve`);
 		}
 		if (ultra && this.choice.ultra) {
-			this.updateRequestForPokemon(pokemon, req => {
-				let updated = false;
-				if (req.canUltraBurst) {
-					req.canUltraBurst = false;
-					updated = true;
-				}
-				return updated;
-			});
 			return this.emitChoiceError(`Can't move: You can only ultra burst once per battle`);
 		}
 

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -321,8 +321,9 @@ export class Side {
 
 	emitChoiceError(message: string, includeRequest?: boolean) {
 		this.choice.error = message;
-		this.battle.send('sideupdate', `${this.id}\n|error|[Invalid choice] ${message}`);
-		if (includeRequest) this.emitRequest(this.activeRequest!);
+		let sideupdate = `${this.id}\n|error|[Invalid choice] ${message}`;
+		if (includeRequest) sideupdate += `|${JSON.stringify(this.activeRequest)}`;
+		this.battle.send('sideupdate', sideupdate);
 		if (this.battle.strictChoices) throw new Error(`[Invalid choice] ${message}`);
 		return false;
 	}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -462,9 +462,14 @@ export class Side {
 					let updated = false;
 					for (const m of req.moves) {
 						if (m.id === moveid) {
-							m.disabled = true;
-							if (disabledSource) m.disabledSource = disabledSource;
-							updated = true;
+							if (!m.disabled) {
+								m.disabled = true;
+								updated = true;
+							}
+							if (m.disabledSource !== disabledSource) {
+								m.disabledSource = disabledSource;
+								updated = true;
+							}
 							break;
 						}
 					}

--- a/test/assert.js
+++ b/test/assert.js
@@ -96,7 +96,7 @@ assert.cantUndo = function (fn, message) {
 };
 
 assert.cantTarget = function (fn, move, message) {
-	assert.cantMove(fn, 'target', move, message || `Expected not to be able to choose a target for ${move}.`);
+	assert.cantMove(fn, 'target', move, false, message || `Expected not to be able to choose a target for ${move}.`);
 };
 
 assert.statStage = function (pokemon, statName, stage, message) {

--- a/test/assert.js
+++ b/test/assert.js
@@ -74,17 +74,17 @@ assert.holdsItem = function (pokemon, message) {
 	});
 };
 
-assert.trapped = function (fn, message) {
+assert.trapped = function (fn, unavailable, message) {
 	assert.throws(
-		fn, /\[Invalid choice\] Can't switch: The active Pokémon is trapped/,
+		fn, new RegExp(`\\[${unavailable ? 'Unavailable' : 'Invalid'} choice\\] Can't switch: The active Pokémon is trapped`),
 		message || 'Expected active Pokemon to be trapped.');
 };
 
-assert.cantMove = function (fn, pokemon, move, message) {
+assert.cantMove = function (fn, pokemon, move, unavailable, message) {
 	message = message || `Expected ${pokemon} to not be able to use ${move}.`;
 	if (pokemon && move) {
 		assert.throws(
-			fn, new RegExp(`\\[Invalid choice\\] Can't move:.*${pokemon}.*${move}`, 'i'), message);
+			fn, new RegExp(`\\[${unavailable ? 'Unavailable' : 'Invalid'} choice\\] Can't move:.*${pokemon}.*${move}`, 'i'), message);
 	} else {
 		assert.throws(fn, /\[Invalid choice\] Can't move:/, message);
 	}

--- a/test/simulator/abilities/arenatrap.js
+++ b/test/simulator/abilities/arenatrap.js
@@ -31,7 +31,7 @@ describe('Arena Trap', function () {
 		assert.species(p2active[0], 'Dusknoir');
 		battle.makeChoices('move snore', 'switch 5');
 		assert.species(p2active[0], 'Magnezone');
-		assert.trapped(() => battle.makeChoices('', 'switch 6'));
+		assert.trapped(() => battle.makeChoices('', 'switch 6'), true);
 
 		assert.species(p2active[0], 'Magnezone'); // Magnezone is trapped
 
@@ -41,7 +41,7 @@ describe('Arena Trap', function () {
 		battle.makeChoices('move snore', 'switch 6');
 		assert.species(p2active[0], 'Vaporeon');
 
-		assert.trapped(() => battle.makeChoices('default', 'switch 2')); // Vaporeon is trapped
+		assert.trapped(() => battle.makeChoices('default', 'switch 2'), true); // Vaporeon is trapped
 		assert.species(p2active[0], 'Vaporeon');
 
 		battle.makeChoices('move telekinesis', 'default'); // Telekinesis
@@ -51,7 +51,7 @@ describe('Arena Trap', function () {
 
 		battle.makeChoices('move gravity', 'default'); // Gravity
 
-		assert.trapped(() => battle.makeChoices('', 'switch 4')); // Tornadus is trapped
+		assert.trapped(() => battle.makeChoices('', 'switch 4'), true); // Tornadus is trapped
 		assert.species(p2active[0], 'Tornadus');
 	});
 });

--- a/test/simulator/abilities/magnetpull.js
+++ b/test/simulator/abilities/magnetpull.js
@@ -18,13 +18,13 @@ describe('Magnet Pull', function () {
 			{species: "Starmie", ability: 'illuminate', moves: ['reflecttype']},
 		]});
 
-		assert.trapped(() => battle.makeChoices('', 'switch 2'));
+		assert.trapped(() => battle.makeChoices('', 'switch 2'), true);
 		battle.makeChoices('auto', 'auto');
 		assert.species(battle.p2.active[0], 'Heatran');
 		battle.makeChoices('auto', 'switch 2');
 		assert.species(battle.p2.active[0], 'Starmie');
 		battle.makeChoices('move charge', 'move reflecttype'); // Reflect Type makes Starmie part Steel
-		assert.trapped(() => battle.makeChoices('', 'switch 2'));
+		assert.trapped(() => battle.makeChoices('', 'switch 2'), true);
 		battle.makeChoices('auto', 'auto');
 		assert.species(battle.p2.active[0], 'Starmie');
 	});

--- a/test/simulator/abilities/shadowtag.js
+++ b/test/simulator/abilities/shadowtag.js
@@ -17,7 +17,7 @@ describe('Shadow Tag', function () {
 			{species: "Tornadus", ability: 'defiant', moves: ['tailwind']},
 			{species: "Heatran", ability: 'flashfire', moves: ['roar']},
 		]});
-		assert.trapped(() => battle.makeChoices('move counter', 'switch 2'));
+		assert.trapped(() => battle.makeChoices('move counter', 'switch 2'), true);
 	});
 
 	it('should not prevent Pokemon from switching out using moves', function () {

--- a/test/simulator/misc/decisions.js
+++ b/test/simulator/misc/decisions.js
@@ -300,9 +300,9 @@ describe('Choices', function () {
 		it('should not force Struggle usage on move attempt when choosing a disabled move', function () {
 			battle = common.createBattle();
 			battle.setPlayer('p1', {team: [{species: "Mew", item: 'assaultvest', ability: 'synchronize', moves: ['recover', 'icebeam']}]});
-			battle.setPlayer('p2', {team: [{species: "Rhydon", item: '', ability: 'prankster', moves: ['struggle', 'surf']}]});
+			battle.setPlayer('p2', {team: [{species: "Rhydon", item: '', ability: 'prankster', moves: ['surf']}]});
 			const failingAttacker = battle.p1.active[0];
-			battle.p2.chooseMove(2);
+			battle.p2.chooseMove(1);
 
 			assert.cantMove(() => battle.p1.chooseMove(1), 'Mew', 'Recover', true);
 			assert.strictEqual(battle.turn, 1);
@@ -314,7 +314,7 @@ describe('Choices', function () {
 		});
 
 		it('should send meaningful feedback to players if they try to use a disabled move', function () {
-			battle = common.createBattle();
+			battle = common.createBattle({strictChoices: false});
 			battle.setPlayer('p1', {team: [{species: "Skarmory", ability: 'sturdy', moves: ['spikes', 'roost']}]});
 			battle.setPlayer('p2', {team: [{species: "Smeargle", ability: 'owntempo', moves: ['imprison', 'spikes']}]});
 
@@ -324,15 +324,14 @@ describe('Choices', function () {
 			battle.send = (type, data) => {
 				if (type === 'sideupdate') buffer.push(Array.isArray(data) ? data.join('\n') : data);
 			};
-			assert.cantMove(() => battle.makeChoices('move 1', 'default'), 'Skarmory', 'Spikes', true);
-			assert(buffer.length >= 1);
-			assert(buffer.some(message => {
-				return message.startsWith('p1\n') && /\bcant\b/.test(message) && (/\|0\b/.test(message) || /\|p1a\b/.test(message));
-			}));
+			battle.p1.chooseMove(1);
+			assert(buffer.length >= 2);
+			assert(buffer.some(message => message.startsWith('p1\n|error|[Unavailable choice]')));
+			assert(buffer.some(message => message.startsWith('p1\n|request|') && JSON.parse(message.slice(12)).active[0].moves[0].disabled));
 		});
 
 		it('should send meaningful feedback to players if they try to switch a trapped Pokémon out', function () {
-			battle = common.createBattle();
+			battle = common.createBattle({strictChoices: false});
 			battle.setPlayer('p1', {team: [
 				{species: "Scizor", ability: 'swarm', moves: ['bulletpunch']},
 				{species: "Azumarill", ability: 'sapsipper', moves: ['aquajet']},
@@ -343,11 +342,10 @@ describe('Choices', function () {
 			battle.send = (type, data) => {
 				if (type === 'sideupdate') buffer.push(Array.isArray(data) ? data.join('\n') : data);
 			};
-			assert.trapped(() => battle.makeChoices('switch 2', 'default'), true);
-			assert(buffer.length >= 1);
-			assert(buffer.some(message => {
-				return message.startsWith('p1\n') && /\btrapped\b/.test(message) && (/\|0\b/.test(message) || /\|p1a\b/.test(message));
-			}));
+			battle.p1.chooseSwitch(2);
+			assert(buffer.length >= 2);
+			assert(buffer.some(message => message.startsWith('p1\n|error|[Unavailable choice]')));
+			assert(buffer.some(message => message.startsWith('p1\n|request|') && JSON.parse(message.slice(12)).active[0].trapped));
 		});
 	});
 

--- a/test/simulator/misc/decisions.js
+++ b/test/simulator/misc/decisions.js
@@ -304,7 +304,7 @@ describe('Choices', function () {
 			const failingAttacker = battle.p1.active[0];
 			battle.p2.chooseMove(2);
 
-			assert.cantMove(() => battle.p1.chooseMove(1), 'Mew', 'Recover');
+			assert.cantMove(() => battle.p1.chooseMove(1), 'Mew', 'Recover', true);
 			assert.strictEqual(battle.turn, 1);
 			assert.notStrictEqual(failingAttacker.lastMove && failingAttacker.lastMove.id, 'struggle');
 
@@ -324,7 +324,7 @@ describe('Choices', function () {
 			battle.send = (type, data) => {
 				if (type === 'sideupdate') buffer.push(Array.isArray(data) ? data.join('\n') : data);
 			};
-			assert.cantMove(() => battle.makeChoices('move 1', 'default'), 'Skarmory', 'Spikes');
+			assert.cantMove(() => battle.makeChoices('move 1', 'default'), 'Skarmory', 'Spikes', true);
 			assert(buffer.length >= 1);
 			assert(buffer.some(message => {
 				return message.startsWith('p1\n') && /\bcant\b/.test(message) && (/\|0\b/.test(message) || /\|p1a\b/.test(message));
@@ -343,7 +343,7 @@ describe('Choices', function () {
 			battle.send = (type, data) => {
 				if (type === 'sideupdate') buffer.push(Array.isArray(data) ? data.join('\n') : data);
 			};
-			assert.trapped(() => battle.makeChoices('switch 2', 'default'));
+			assert.trapped(() => battle.makeChoices('switch 2', 'default'), true);
 			assert(buffer.length >= 1);
 			assert(buffer.some(message => {
 				return message.startsWith('p1\n') && /\btrapped\b/.test(message) && (/\|0\b/.test(message) || /\|p1a\b/.test(message));

--- a/test/simulator/moves/imprison.js
+++ b/test/simulator/moves/imprison.js
@@ -24,7 +24,7 @@ describe('Imprison', function () {
 		battle.makeChoices('move imprison', 'move calmmind');
 		assert.statStage(battle.p2.active[0], 'spa', 0);
 		assert.statStage(battle.p2.active[0], 'spd', 0);
-		assert.cantMove(() => battle.choose('p2', 'move calmmind'), 'Abra', 'Calm Mind');
+		assert.cantMove(() => battle.choose('p2', 'move calmmind'), 'Abra', 'Calm Mind', true);
 
 		// Imprison doesn't end when the foe switches
 		battle.makeChoices('default', 'switch 2');


### PR DESCRIPTION
Fixes #5414.

---

Currently this won't work because the `RandomPlayerAI` will break as receiving the choice `|error|` will cause it to throw. The primary problem is that we don't know which choice error corresponds to the request - with this protocol the AI receives an updated request + an error, but it could issue an updated choice before it receives the error and then cant tell if the error corresponded to the first or second request. 

We could not issue a choice error if we reissue the request, but that seems wrong to me as the original choice was in fact erroneous. I think the best solution is going to be to that instead of emitting the request + error, we emit the request as *part* of the `|error|` (ie/ `|error|<MESSAGE>(|<REQUEST>)?`) provided an update occurred.

I'm also not sure of scenarios where we would ever need to update the request for zmove/mega/ultra burst. Isn't it always known whether you can do one of those? Why did we have `|callback|`'s for those?
