### PR TITLE
Fix message order for locks

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1909,17 +1909,6 @@ const commands = {
 			affected = Punishments.lock(null, duration, userid, userReason);
 		}
 
-		let acAccount = (targetUser && targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
-		let displayMessage = '';
-		if (affected.length > 1) {
-			displayMessage = `(${name}'s ${(acAccount ? ` ac account: ${acAccount}, ` : "")} locked alts: ${affected.slice(1).map(user => user.getLastName()).join(", ")})`;
-			this.privateModAction(displayMessage);
-		} else if (acAccount) {
-			displayMessage = `(${name}'s ac account: ${acAccount})`;
-			this.privateModAction(displayMessage);
-		}
-		room.hideText([userid, toId(this.inputUsername)]);
-
 		const globalReason = (target ? `: ${userReason} ${proof}` : '');
 		this.globalModlog((week ? "WEEKLOCK" : "LOCK"), targetUser || userid, ` by ${user.userid}${globalReason}`);
 
@@ -1929,6 +1918,17 @@ const commands = {
 		// Notify staff room when a user is locked outside of it.
 		if (room.id !== 'staff' && Rooms('staff')) {
 			Rooms('staff').addByUser(user, `<<${room.id}>> ${lockMessage}`);
+		}
+
+		room.hideText([userid, toId(this.inputUsername)]);
+		let acAccount = (targetUser && targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
+		let displayMessage = '';
+		if (affected.length > 1) {
+			displayMessage = `(${name}'s ${(acAccount ? ` ac account: ${acAccount}, ` : "")} locked alts: ${affected.slice(1).map(user => user.getLastName()).join(", ")})`;
+			this.privateModAction(displayMessage);
+		} else if (acAccount) {
+			displayMessage = `(${name}'s ac account: ${acAccount})`;
+			this.privateModAction(displayMessage);
 		}
 
 		if (targetUser) {


### PR DESCRIPTION
I don't know what exactly changed, but a while ago, the order of messages got a bit messed up for locks: 
![grafik](https://user-images.githubusercontent.com/5814184/55680750-fcb2a300-591d-11e9-950b-6a856f8eab0e.png)
So I switched things around a bit to make it look like this 
![grafik](https://user-images.githubusercontent.com/5814184/55680755-0fc57300-591e-11e9-91fe-c8d4079f6600.png)
 which is how it used to look, and what is probably the most sensible.

