### PR TITLE
Send blockpms and blockchallenges status in |updateuser|

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -227,11 +227,12 @@ represented by a space), and the rest of the string being their username.
 > Finish logging in (or renaming) by sending: `/trn USERNAME,0,ASSERTION`
 > where `USERNAME` is your desired username and `ASSERTION` is `data.assertion`.
 
-`|updateuser|USERNAME|NAMED|AVATAR`
+`|updateuser|USERNAME|NAMED|AVATAR|BLOCKPMS|BLOCKCHALLENGES`
 
-> Your name or avatar was successfully changed. Your username is now `USERNAME`.
-> `NAMED` will be `0` if you are a guest or `1` otherwise. And your avatar is
-> now `AVATAR`.
+> Your name, avatar or blocking status was successfully changed. Your username is
+> now `USERNAME`. `NAMED` will be `0` if you are a guest or `1` otherwise. Your
+> avatar is now `AVATAR`. `BLOCKPMS` and `BLOCKCHALLENGES` will respectively be
+> `0` if true globally and `1` otherwise.
 
 `|formats|FORMATSLIST`
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -227,12 +227,12 @@ represented by a space), and the rest of the string being their username.
 > Finish logging in (or renaming) by sending: `/trn USERNAME,0,ASSERTION`
 > where `USERNAME` is your desired username and `ASSERTION` is `data.assertion`.
 
-`|updateuser|USERNAME|NAMED|AVATAR|BLOCKPMS|BLOCKCHALLENGES`
+`|updateuser|USERNAME|NAMED|AVATAR|BLOCKPMS|SETTINGS`
 
 > Your name, avatar or blocking status was successfully changed. Your username is
 > now `USERNAME`. `NAMED` will be `0` if you are a guest or `1` otherwise. Your
-> avatar is now `AVATAR`. `BLOCKPMS` and `BLOCKCHALLENGES` will respectively be
-> `0` if true globally and `1` otherwise.
+> avatar is now `AVATAR`. `SETTINGS` is a JSON object representing the current
+> state of various user settings.
 
 `|formats|FORMATSLIST`
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -229,7 +229,7 @@ represented by a space), and the rest of the string being their username.
 
 `|updateuser|USERNAME|NAMED|AVATAR|SETTINGS`
 
-> Your name, avatar or blocking status was successfully changed. Your username is
+> Your name, avatar or settings were successfully changed. Your username is
 > now `USERNAME`. `NAMED` will be `0` if you are a guest or `1` otherwise. Your
 > avatar is now `AVATAR`. `SETTINGS` is a JSON object representing the current
 > state of various user settings.

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -550,7 +550,7 @@ const commands = {
 
 		if (!targetUser || !targetUser.connected) return this.errorReply(`User ${this.targetUsername} is not currently online.`);
 		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
-		if (targetUser.ignorePMs && targetUser.ignorePMs !== user.group && !user.can('lock')) return this.errorReply("This user is currently ignoring PMs.");
+		if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) return this.errorReply("This user is currently blocking PMs.");
 		if (targetUser.locked && !user.can('lock')) return this.errorReply("This user is currently locked, so you cannot send them a pminfobox.");
 
 		// Apply the infobox to the message
@@ -576,7 +576,7 @@ const commands = {
 
 		if (!targetUser || !targetUser.connected) return this.errorReply(`User ${this.targetUsername} is not currently online.`);
 		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
-		if (targetUser.ignorePMs && targetUser.ignorePMs !== user.group && !user.can('lock')) return this.errorReply("This user is currently ignoring PMs.");
+		if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) return this.errorReply("This user is currently blocking PMs.");
 		if (targetUser.locked && !user.can('lock')) return this.errorReply("This user is currently locked, so you cannot send them UHTML.");
 
 		let message = `|pm|${user.getIdentity()}|${targetUser.getIdentity()}|/uhtml${(cmd === 'pmuhtmlchange' ? 'change' : '')} ${target}`;
@@ -589,34 +589,34 @@ const commands = {
 	pmuhtmlhelp: [`/pmuhtml [user], [name], [html] - PMs [html] that can change to [user]. Requires * ~`],
 	pmuhtmlchangehelp: [`/pmuhtmlchange [user], [name], [html] - Changes html that was previously PMed to [user] to [html]. Requires * ~`],
 
-	'!ignorepms': true,
-	blockpm: 'ignorepms',
-	blockpms: 'ignorepms',
-	ignorepm: 'ignorepms',
-	ignorepms(target, room, user) {
-		if (user.ignorePMs === (target || true)) return this.errorReply("You are already blocking private messages! To unblock, use /unblockpms");
-		user.ignorePMs = true;
+	'!blockpms': true,
+	blockpm: 'blockpms',
+	ignorepms: 'blockpms',
+	ignorepm: 'blockpms',
+	blockpms(target, room, user) {
+		if (user.blockPMs === (target || true)) return this.errorReply("You are already blocking private messages! To unblock, use /unblockpms");
+		user.blockPMs = true;
 		if (target in Config.groups) {
-			user.ignorePMs = target;
+			user.blockPMs = target;
 			user.update();
 			return this.sendReply(`You are now blocking private messages, except from staff and ${target}.`);
 		}
 		user.update();
 		return this.sendReply("You are now blocking private messages, except from staff.");
 	},
-	ignorepmshelp: [`/blockpms - Blocks private messages. Unblock them with /unignorepms.`],
+	blockpmshelp: [`/blockpms - Blocks private messages. Unblock them with /unblockpms.`],
 
-	'!unignorepms': true,
-	unblockpm: 'unignorepms',
-	unblockpms: 'unignorepms',
-	unignorepm: 'unignorepms',
-	unignorepms(target, room, user) {
-		if (!user.ignorePMs) return this.errorReply("You are not blocking private messages! To block, use /blockpms");
-		user.ignorePMs = false;
+	'!unblockpms': true,
+	unblockpm: 'unblockpms',
+	unignorepms: 'unblockpms',
+	unignorepm: 'unblockpms',
+	unblockpms(target, room, user) {
+		if (!user.blockPMs) return this.errorReply("You are not blocking private messages! To block, use /blockpms");
+		user.blockPMs = false;
 		user.update();
 		return this.sendReply("You are no longer blocking private messages.");
 	},
-	unignorepmshelp: [`/unblockpms - Unblocks private messages. Block them with /blockpms.`],
+	unblockpmshelp: [`/unblockpms - Unblocks private messages. Block them with /blockpms.`],
 
 	'!away': true,
 	idle: 'away',

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -593,14 +593,15 @@ const commands = {
 	blockpm: 'ignorepms',
 	blockpms: 'ignorepms',
 	ignorepm: 'ignorepms',
-	ignorepms(target, room, user, connection) {
+	ignorepms(target, room, user) {
 		if (user.ignorePMs === (target || true)) return this.errorReply("You are already blocking private messages! To unblock, use /unblockpms");
 		user.ignorePMs = true;
 		if (target in Config.groups) {
 			user.ignorePMs = target;
+			user.update();
 			return this.sendReply(`You are now blocking private messages, except from staff and ${target}.`);
 		}
-		connection.send(user.getUpdateuserText());
+		user.update();
 		return this.sendReply("You are now blocking private messages, except from staff.");
 	},
 	ignorepmshelp: [`/blockpms - Blocks private messages. Unblock them with /unignorepms.`],
@@ -609,10 +610,10 @@ const commands = {
 	unblockpm: 'unignorepms',
 	unblockpms: 'unignorepms',
 	unignorepm: 'unignorepms',
-	unignorepms(target, room, user, connection) {
+	unignorepms(target, room, user) {
 		if (!user.ignorePMs) return this.errorReply("You are not blocking private messages! To block, use /blockpms");
 		user.ignorePMs = false;
-		connection.send(user.getUpdateuserText());
+		user.update();
 		return this.sendReply("You are no longer blocking private messages.");
 	},
 	unignorepmshelp: [`/unblockpms - Unblocks private messages. Block them with /blockpms.`],
@@ -4048,10 +4049,10 @@ const commands = {
 	bch: 'blockchallenges',
 	blockchall: 'blockchallenges',
 	blockchalls: 'blockchallenges',
-	blockchallenges(target, room, user, connection) {
+	blockchallenges(target, room, user) {
 		if (user.blockChallenges) return this.errorReply("You are already blocking challenges!");
 		user.blockChallenges = true;
-		connection.send(user.getUpdateuserText());
+		user.update();
 		this.sendReply("You are now blocking all incoming challenge requests.");
 	},
 	blockchallengeshelp: [`/blockchallenges - Blocks challenges so no one can challenge you. Unblock them with /unblockchallenges.`],
@@ -4061,10 +4062,10 @@ const commands = {
 	unblockchall: 'allowchallenges',
 	unblockchalls: 'allowchallenges',
 	unblockchallenges: 'allowchallenges',
-	allowchallenges(target, room, user, connection) {
+	allowchallenges(target, room, user) {
 		if (!user.blockChallenges) return this.errorReply("You are already available for challenges!");
 		user.blockChallenges = false;
-		connection.send(user.getUpdateuserText());
+		user.update();
 		this.sendReply("You are available for challenges from now on.");
 	},
 	allowchallengeshelp: [`/unblockchallenges - Unblocks challenges so you can be challenged again. Block them with /blockchallenges.`],

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -593,13 +593,14 @@ const commands = {
 	blockpm: 'ignorepms',
 	blockpms: 'ignorepms',
 	ignorepm: 'ignorepms',
-	ignorepms(target, room, user) {
+	ignorepms(target, room, user, connection) {
 		if (user.ignorePMs === (target || true)) return this.errorReply("You are already blocking private messages! To unblock, use /unblockpms");
 		user.ignorePMs = true;
 		if (target in Config.groups) {
 			user.ignorePMs = target;
 			return this.sendReply(`You are now blocking private messages, except from staff and ${target}.`);
 		}
+		connection.send(user.getUpdateuserText());
 		return this.sendReply("You are now blocking private messages, except from staff.");
 	},
 	ignorepmshelp: [`/blockpms - Blocks private messages. Unblock them with /unignorepms.`],
@@ -608,9 +609,10 @@ const commands = {
 	unblockpm: 'unignorepms',
 	unblockpms: 'unignorepms',
 	unignorepm: 'unignorepms',
-	unignorepms(target, room, user) {
+	unignorepms(target, room, user, connection) {
 		if (!user.ignorePMs) return this.errorReply("You are not blocking private messages! To block, use /blockpms");
 		user.ignorePMs = false;
+		connection.send(user.getUpdateuserText());
 		return this.sendReply("You are no longer blocking private messages.");
 	},
 	unignorepmshelp: [`/unblockpms - Unblocks private messages. Block them with /blockpms.`],
@@ -4046,9 +4048,10 @@ const commands = {
 	bch: 'blockchallenges',
 	blockchall: 'blockchallenges',
 	blockchalls: 'blockchallenges',
-	blockchallenges(target, room, user) {
+	blockchallenges(target, room, user, connection) {
 		if (user.blockChallenges) return this.errorReply("You are already blocking challenges!");
 		user.blockChallenges = true;
+		connection.send(user.getUpdateuserText());
 		this.sendReply("You are now blocking all incoming challenge requests.");
 	},
 	blockchallengeshelp: [`/blockchallenges - Blocks challenges so no one can challenge you. Unblock them with /unblockchallenges.`],
@@ -4058,9 +4061,10 @@ const commands = {
 	unblockchall: 'allowchallenges',
 	unblockchalls: 'allowchallenges',
 	unblockchallenges: 'allowchallenges',
-	allowchallenges(target, room, user) {
+	allowchallenges(target, room, user, connection) {
 		if (!user.blockChallenges) return this.errorReply("You are already available for challenges!");
 		user.blockChallenges = false;
+		connection.send(user.getUpdateuserText());
 		this.sendReply("You are available for challenges from now on.");
 	},
 	allowchallengeshelp: [`/unblockchallenges - Unblocks challenges so you can be challenged again. Block them with /blockchallenges.`],

--- a/server/chat.js
+++ b/server/chat.js
@@ -1127,7 +1127,7 @@ class CommandContext extends MessageContext {
 					let groupName = Config.groups[Config.pmmodchat] && Config.groups[Config.pmmodchat].name || Config.pmmodchat;
 					return this.errorReply(`On this server, you must be of rank ${groupName} or higher to PM users.`);
 				}
-				if (targetUser.ignorePMs && targetUser.ignorePMs !== user.group && !user.can('lock')) {
+				if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) {
 					if (!targetUser.can('lock')) {
 						return this.errorReply(`This user is blocking private messages right now.`);
 					} else {
@@ -1135,7 +1135,7 @@ class CommandContext extends MessageContext {
 						return this.sendReply(`|html|If you need help, try opening a <a href="view-help-request" class="button">help ticket</a>`);
 					}
 				}
-				if (user.ignorePMs && user.ignorePMs !== targetUser.group && !targetUser.can('lock')) {
+				if (user.blockPMs && user.blockPMs !== targetUser.group && !targetUser.can('lock')) {
 					return this.errorReply(`You are blocking private messages right now.`);
 				}
 			}

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -860,8 +860,7 @@ class GlobalRoom extends BasicRoom {
 	 * @param {Connection} connection
 	 */
 	onConnect(user, connection) {
-		let initdata = '|updateuser|' + user.name + '|' + (user.named ? '1' : '0') + '|' + user.avatar + '\n';
-		connection.send(initdata + this.configRankList + this.formatListText);
+		connection.send(user.getUpdateuserText() + '\n' + this.configRankList + this.formatListText);
 	}
 	/**
 	 * @param {User} user

--- a/server/users.js
+++ b/server/users.js
@@ -494,7 +494,7 @@ class User extends Chat.MessageContext {
 		this.isSysop = false;
 		this.isStaff = false;
 		this.blockChallenges = false;
-		this.ignorePMs = false;
+		this.blockPMs = false;
 		this.ignoreTickets = false;
 		this.lastConnected = 0;
 		this.inviteOnlyNextBattle = false;
@@ -988,7 +988,7 @@ class User extends Chat.MessageContext {
 	}
 	getUpdateuserText() {
 		const named = this.named ? 1 : 0;
-		const settings = {blockPMs: this.ignorePMs, blockChallenges: this.blockChallenges};
+		const settings = {blockPMs: this.blockPMs, blockChallenges: this.blockChallenges};
 		return `|updateuser|${this.name}|${named}|${this.avatar}|${JSON.stringify(settings)}`;
 	}
 	update() {
@@ -1136,7 +1136,7 @@ class User extends Chat.MessageContext {
 				this.semilocked = '#dnsbl.';
 			}
 		}
-		if (this.ignorePMs && this.can('lock') && !this.can('bypassall')) this.ignorePMs = false;
+		if (this.blockPMs && this.can('lock') && !this.can('bypassall')) this.blockPMs = false;
 	}
 	/**
 	 * Set a user's group. Pass (' ', true) to force trusted

--- a/server/users.js
+++ b/server/users.js
@@ -988,9 +988,11 @@ class User extends Chat.MessageContext {
 	}
 	getUpdateuserText() {
 		const named = this.named ? 1 : 0;
-		const blockPMs = this.ignorePMs ? 1 : 0;
-		const blockChallenges = this.blockChallenges ? 1 : 0;
-		return `|updateuser|${this.name}|${named}|${this.avatar}|${blockPMs}|${blockChallenges}`;
+		const settings = {blockPMs: this.ignorePMs, blockChallenges: this.blockChallenges};
+		return `|updateuser|${this.name}|${named}|${this.avatar}|${JSON.stringify(settings)}`;
+	}
+	update() {
+		this.send(this.getUpdateuserText());
 	}
 	/**
 	 * @param {User} oldUser

--- a/server/users.js
+++ b/server/users.js
@@ -968,8 +968,7 @@ class User extends Chat.MessageContext {
 
 		for (const connection of this.connections) {
 			//console.log('' + name + ' renaming: socket ' + i + ' of ' + this.connections.length);
-			let initdata = `|updateuser|${this.name}|${this.named ? 1 : 0}|${this.avatar}`;
-			connection.send(initdata);
+			connection.send(this.getUpdateuserText());
 		}
 		for (const roomid of this.games) {
 			const room = Rooms(roomid);
@@ -986,6 +985,12 @@ class User extends Chat.MessageContext {
 		}
 		if (isForceRenamed) this.trackRename = oldname;
 		return true;
+	}
+	getUpdateuserText() {
+		const named = this.named ? 1 : 0;
+		const blockPMs = this.ignorePMs ? 1 : 0;
+		const blockChallenges = this.blockChallenges ? 1 : 0;
+		return `|updateuser|${this.name}|${named}|${this.avatar}|${blockPMs}|${blockChallenges}`;
 	}
 	/**
 	 * @param {User} oldUser
@@ -1049,8 +1054,7 @@ class User extends Chat.MessageContext {
 		this.connected = true;
 		this.connections.push(connection);
 		//console.log('' + this.name + ' merging: connection ' + connection.socket.id);
-		let initdata = `|updateuser|${this.name}|1|${this.avatar}`;
-		connection.send(initdata);
+		connection.send(this.getUpdateuserText());
 		connection.user = this;
 		for (const roomid of connection.inRooms) {
 			let room = Rooms(roomid);


### PR DESCRIPTION
Required for Zarel/Pokemon-Showdown-Client#1263.

---

The client (+ Preact client) already seem resilient to having additional parts to `|updateuser|`. I think though it would be better to make a JSON field `SETTINGS` instead of tacking on additional user settings as needed?