### PR TITLE
Camouflage and Soak should fail if they don't change the type

### DIFF
--- a/data/mods/gen5/moves.js
+++ b/data/mods/gen5/moves.js
@@ -934,6 +934,16 @@ let BattleMovedex = {
 		basePower: 40,
 		flags: {protect: 1, mirror: 1, sound: 1},
 	},
+	soak: {
+		inherit: true,
+		onHit(target) {
+			if (!target.setType('Water')) {
+				this.add('-fail', target);
+				return null;
+			}
+			this.add('-start', target, 'typechange', 'Water');
+		},
+	},
 	solarbeam: {
 		inherit: true,
 		desc: "This attack charges on the first turn and executes on the second. Power is halved if the weather is Hail, Rain Dance, or Sandstorm. If the user is holding a Power Herb or the weather is Sunny Day, the move completes in one turn.",

--- a/data/mods/gen5/moves.js
+++ b/data/mods/gen5/moves.js
@@ -939,6 +939,8 @@ let BattleMovedex = {
 		desc: "Causes the target to become a Water type. Fails if the target is an Arceus.",
 		onHit(target) {
 			if (!target.setType('Water')) {
+				// Soak should animate even when it fails.
+				// Returning false would suppress the animation.
 				this.add('-fail', target);
 				return null;
 			}

--- a/data/mods/gen5/moves.js
+++ b/data/mods/gen5/moves.js
@@ -936,6 +936,7 @@ let BattleMovedex = {
 	},
 	soak: {
 		inherit: true,
+		desc: "Causes the target to become a Water type. Fails if the target is an Arceus.",
 		onHit(target) {
 			if (!target.setType('Water')) {
 				this.add('-fail', target);

--- a/data/mods/gen6/moves.js
+++ b/data/mods/gen6/moves.js
@@ -394,7 +394,7 @@ let BattleMovedex = {
 	},
 	soak: {
 		inherit: true,
-		desc: "Causes the target to become a Water type. Fails if the target is an Arceus.",
+		desc: "Causes the target to become a Water type. Fails if the target is an Arceus, or if the target is already purely Water type.",
 	},
 	spikyshield: {
 		inherit: true,

--- a/data/moves.js
+++ b/data/moves.js
@@ -15762,7 +15762,7 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 0,
 		category: "Status",
-		desc: "Causes the target to become a Water type. Fails if the target is an Arceus or a Silvally.",
+		desc: "Causes the target to become a Water type. Fails if the target is an Arceus or a Silvally, or if the target is already purely Water type.",
 		shortDesc: "Changes the target's type to Water.",
 		id: "soak",
 		name: "Soak",

--- a/data/moves.js
+++ b/data/moves.js
@@ -15771,6 +15771,8 @@ let BattleMovedex = {
 		flags: {protect: 1, reflectable: 1, mirror: 1, mystery: 1},
 		onHit(target) {
 			if (target.getTypes().join() === 'Water' || !target.setType('Water')) {
+				// Soak should animate even when it fails.
+				// Returning false would suppress the animation.
 				this.add('-fail', target);
 				return null;
 			}

--- a/data/moves.js
+++ b/data/moves.js
@@ -2104,7 +2104,7 @@ let BattleMovedex = {
 				newType = 'Psychic';
 			}
 
-			if (!target.setType(newType)) return false;
+			if (target.getTypes().join() === newType || !target.setType(newType)) return false;
 			this.add('-start', target, 'typechange', newType);
 		},
 		secondary: null,
@@ -15770,7 +15770,7 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1, mystery: 1},
 		onHit(target) {
-			if (!target.setType('Water')) {
+			if (target.getTypes().join() === 'Water' || !target.setType('Water')) {
 				this.add('-fail', target);
 				return null;
 			}


### PR DESCRIPTION
... in much the same way that Protean does nothing if the user is already the correct type.

Bulbapedia says that Soak doesn't fail for pure Water types in Gen 5.