### PR TITLE
Pull out non-sim code into RoomBattleStream

### DIFF
--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -50,42 +50,26 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 		this.battle = null;
 	}
 
-	_write(message: string) {
-		const startTime = Date.now();
+	_write(chunk: string) {
 		try {
-			for (const line of message.split('\n')) {
-				if (line.charAt(0) === '>') this._writeLine(line.slice(1));
-			}
+			this._writeLines(chunk);
 		} catch (err) {
-			if (typeof Monitor === 'undefined') {
-				this.pushError(err);
-				return;
-			}
-			const battle = this.battle;
-			Monitor.crashlog(err, 'A battle', {
-				message,
-				inputLog: battle ? '\n' + battle.inputLog.join('\n') : '',
-				log: battle ? '\n' + battle.getDebugLog() : '',
-			});
-
-			this.push(`update\n|html|<div class="broadcast-red"><b>The battle crashed</b><br />Don't worry, we're working on fixing it.</div>`);
-			if (battle) {
-				for (const side of battle.sides) {
-					if (side && side.requestState) {
-						this.push(`sideupdate\n${side.id}\n|error|[Invalid choice] The battle crashed`);
-					}
-				}
-			}
+			this.pushError(err);
+			return;
 		}
 		if (this.battle) this.battle.sendUpdates();
-		const deltaTime = Date.now() - startTime;
-		if (deltaTime > 1000) {
-			console.log(`[slow battle] ${deltaTime}ms - ${message}`);
+	}
+
+	_writeLines(chunk: string) {
+		for (const line of chunk.split('\n')) {
+			if (line.charAt(0) === '>') {
+				const [type, message] = splitFirst(line.slice(1), ' ');
+				this._writeLine(type, message);
+			}
 		}
 	}
 
-	_writeLine(line: string) {
-		let [type, message] = splitFirst(line, ' ');
+	_writeLine(type: string, message: string) {
 		switch (type) {
 		case 'start':
 			const options = JSON.parse(message);
@@ -118,48 +102,15 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 		case 'tiebreak':
 			this.battle!.tiebreak();
 			break;
-		case 'eval':
-			/* tslint:disable:no-eval */
-			const battle = this.battle!;
-			const p1 = battle && battle.sides[0];
-			const p2 = battle && battle.sides[1];
-			const p3 = battle && battle.sides[2];
-			const p4 = battle && battle.sides[3];
-			const p1active = p1 && p1.active[0];
-			const p2active = p2 && p2.active[0];
-			const p3active = p3 && p3.active[0];
-			const p4active = p4 && p4.active[0];
-			battle.inputLog.push(line);
-			message = message.replace(/\f/g, '\n');
-			battle.add('', '>>> ' + message.replace(/\n/g, '\n||'));
-			try {
-				let result = eval(message);
-				if (result && result.then) {
-					result.then((unwrappedResult: any) => {
-						unwrappedResult = Chat.stringify(unwrappedResult);
-						battle.add('', 'Promise -> ' + unwrappedResult);
-						battle.sendUpdates();
-					}, (error: Error) => {
-						battle.add('', '<<< error: ' + error.message);
-						battle.sendUpdates();
-					});
-				} else {
-					result = Chat.stringify(result);
-					result = result.replace(/\n/g, '\n||');
-					battle.add('', '<<< ' + result);
-				}
-			} catch (e) {
-				battle.add('', '<<< error: ' + e.message);
-			}
-			/* tslint:enable:no-eval */
-			break;
 		}
 	}
+
 	_end() {
 		// this is in theory synchronous...
 		this.push(null);
 		this._destroy();
 	}
+
 	_destroy() {
 		if (this.battle) this.battle.destroy();
 	}


### PR DESCRIPTION
`BattleStream` is the only part of `sim` which depends on `Monitor` and `Chat`. In order to get `sim` to function as a standalone package (design forthcoming, *'OP will surely deliver'*), we need to either pull out `Chat.stringify` and the `crashlogger` (*a la* [this gist](https://gist.github.com/scheibo/f399c7c3d02a857c36c0f8b6d5263a5a) that has probably rotted pretty hard by this point), or do what I've done in this PR which is to pull out the functionality which requires those dependencies into the `server` logic instead of `sim`. I think the approach taken here is preferable as general `sim` code isn't interested in slow battle logging etc.

The main motivation for doing this now as opposed to after I've sent out a more thorough design doc regarding modularization is because I'm looking to get (optional, for development) source map support working (I'm tired of clicking through to the `.sim-dist` files in VS Code and editing the compiled file by accident...). This PR, plus a change which splits the `sim` parts out of `globals.ts` and `globals.d.ts` (ie. into additional `sim.globals.ts` and `sim.d.ts`) means we can add a `tsconfig` which can optionally be used to actually emit code with a source map instead of only having the option of using the combination of `sucrase` for compilation and `tsc` for typechecking. I'm not proposing we actually *use* just `tsc` for production compilation (its slow), but I'd like to be able to do something like `node build --dev` or `node build --sourcemap` so that I can then run `node -r source-map-support/register foo.js` during testing to get a better debugging experience (and maybe prove that source maps are awesome and that we should be looking to use them in the client to allow for proper minification etc).

I've shared the motivation of this change as context, but **I think this change is desirable for its own merits** and hopefully we can not get sidetracked on talking about the motivation (modularization, possible source map support) at this point in time.