### PR TITLE
Use Proxy wherever applicable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -85,7 +85,7 @@
 		"init-declarations": "off",
 		"no-shadow": "off",
 		"no-label-var": "error",
-		"no-restricted-globals": ["error", "Proxy", "Reflect", "Symbol", "WeakSet"],
+		"no-restricted-globals": ["error", "Reflect", "Symbol", "WeakSet"],
 		"no-shadow-restricted-names": "error",
 		"no-undef": ["error", {"typeof": true}],
 		"no-undefined": "off",

--- a/dev-tools/global.d.ts
+++ b/dev-tools/global.d.ts
@@ -11,7 +11,8 @@ import {PRNG as PRNGType, PRNGSeed as PRNGSeedType} from './../sim/prng';
 import {Side as SideType} from './../sim/side';
 import {TeamValidator as TeamValidatorType} from'./../sim/team-validator';
 
-import RoomsType = require('./../server/rooms');
+import __RoomsType__ = require('./../server/rooms');
+type RoomsType = Proxy<__RoomsType__>
 import RoomlogsType = require('./../server/roomlogs');
 import LadderStoreType = require('./../server/ladders-remote');
 import LaddersType = require('./../server/ladders');
@@ -70,10 +71,12 @@ declare global {
 	const BasicRoom: typeof RoomsType.BasicRoom
 	const BasicChatRoom: typeof RoomsType.ChatRoom
 	const RoomGame: typeof RoomsType.RoomGame
+	const RoomGamePlayer: typeof RoomsType.RoomGamePlayer
 	const RoomBattle: typeof RoomsType.RoomBattle
 	const Rooms: typeof RoomsType
 	const Roomlogs: typeof RoomlogsType
 	const Roomlog: typeof RoomlogsType.Roomlog
+	type Room = GlobalRoom | ChatRoom | GameRoom
 
 	// users
 	const Users: typeof UsersType

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -19,7 +19,20 @@ declare let Monitor: typeof import("../server/monitor");
 
 declare let LoginServer: typeof import('../server/loginserver');
 
-// type RoomBattle = AnyObject;
+let __RoomsType__: typeof import("../server/rooms")
+type RoomsType = Proxy<__RoomsType__>
+type GlobalRoom = typeof RoomsType.GlobalRoom
+type ChatRoom = typeof RoomsType.ChatRoomTypeForTS
+type GameRoom = typeof RoomsType.GameRoom
+type BasicRoom = typeof RoomsType.BasicRoom
+type BasicChatRoom = typeof RoomsType.ChatRoom
+type RoomGame = typeof RoomsType.RoomGame
+type RoomGamePlayer = typeof RoomsType.RoomGamePlayer
+type RoomBattle = typeof RoomsType.RoomBattle
+type Rooms = typeof RoomsType
+type Roomlogs = typeof RoomlogsType
+type Roomlog = typeof RoomlogsType.Roomlog
+type Room = GlobalRoom | GameRoom | ChatRoom;
 
 declare let Verifier: typeof import('../server/verifier');
 declare let Dnsbl: typeof import('../server/dnsbl');

--- a/server/chat.js
+++ b/server/chat.js
@@ -24,7 +24,6 @@ To reload chat commands:
 */
 
 'use strict';
-/** @typedef {GlobalRoom | GameRoom | ChatRoom} Room */
 
 /** @typedef {(this: PageContext, query: string[], user: User, connection: Connection) => (Promise<string | null | void> | string | null | void)} PageHandler */
 /** @typedef {{[k: string]: PageHandler | PageTable}} PageTable */

--- a/server/punishments.js
+++ b/server/punishments.js
@@ -1,5 +1,3 @@
-'use strict';
-/** @typedef {GlobalRoom | GameRoom | ChatRoom} Room */
 /**
  * Punishments
  * Pokemon Showdown - http://pokemonshowdown.com/
@@ -12,6 +10,8 @@
  *
  * @license MIT license
  */
+
+'use strict';
 
 let Punishments = module.exports;
 

--- a/server/users.js
+++ b/server/users.js
@@ -24,7 +24,6 @@
  */
 
 'use strict';
-/** @typedef {GlobalRoom | GameRoom | ChatRoom} Room */
 
 const PLAYER_SYMBOL = '\u2606';
 const HOST_SYMBOL = '\u2605';
@@ -411,7 +410,7 @@ class Connection {
 	}
 
 	/**
-	 * @param {GlobalRoom | GameRoom | ChatRoom} room
+	 * @param {Room} room
 	 */
 	joinRoom(room) {
 		if (this.inRooms.has(room.id)) return;
@@ -419,7 +418,7 @@ class Connection {
 		Sockets.roomAdd(this.worker, room.id, this.socketid);
 	}
 	/**
-	 * @param {GlobalRoom | GameRoom | ChatRoom} room
+	 * @param {Room} room
 	 */
 	leaveRoom(room) {
 		if (this.inRooms.has(room.id)) {
@@ -1280,7 +1279,7 @@ class User extends Chat.MessageContext {
 		return (prevNames.length ? prevNames[prevNames.length - 1] : this.userid);
 	}
 	/**
-	 * @param {string | GlobalRoom | GameRoom | ChatRoom} roomid
+	 * @param {string | Room} roomid
 	 * @param {Connection} connection
 	 */
 	async tryJoinRoom(roomid, connection) {
@@ -1353,7 +1352,7 @@ class User extends Chat.MessageContext {
 		}
 	}
 	/**
-	 * @param {GlobalRoom | GameRoom | ChatRoom | string} room
+	 * @param {Room | string} room
 	 * @param {Connection?} connection
 	 * @param {boolean} force
 	 */

--- a/test/application/rooms.js
+++ b/test/application/rooms.js
@@ -10,10 +10,6 @@ describe('Rooms features', function () {
 			it('should be a function', function () {
 				assert.strictEqual(typeof Rooms.get, 'function');
 			});
-
-			it('should be equal to `Rooms`', function () {
-				assert.strictEqual(Rooms.get, Rooms);
-			});
 		});
 		describe('Rooms.rooms', function () {
 			it('should be a Map', function () {


### PR DESCRIPTION
`server/rooms.js`, `server/users.js`, and `server/loginserver.js` are the modules to my knowledge that mutate functions and objects used for `module.exports` in ways I don't particularly like. This aims to remove those mutations by exporting a `Proxy` instead. A side effect of this is properties of `Rooms`, `Users`, and `LoginServer` will be immutable (unless that's unwanted).

This currently fails tslint because `RoomGame` and `RoomGamePlayer` don't get recognized as superclasses of various chat plugin classes. I have no clue why. Some help regarding that would be appreciated so I hopefully don't have to put `// @ts-ignore` before 234 lines of code.

This is just a draft PR since I'm not sure what @Zarel's thoughts are about this.