### PR TITLE
Update dependencies

### DIFF
--- a/lib/streams.ts
+++ b/lib/streams.ts
@@ -12,6 +12,8 @@
 
 const BUF_SIZE = 65536 * 4;
 
+type BufferEncoding = 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'latin1' | 'binary' | 'hex';
+
 export class ReadStream {
 	buf: Buffer;
 	bufStart: number;
@@ -20,7 +22,7 @@ export class ReadStream {
 	readSize: number;
 	atEOF: boolean;
 	errorBuf: Error[] | null;
-	encoding: string;
+	encoding: BufferEncoding;
 	isReadable: boolean;
 	isWritable: boolean;
 	nodeReadableStream: NodeJS.ReadableStream | null;
@@ -116,7 +118,7 @@ export class ReadStream {
 		this.expandBuf(newCapacity);
 	}
 
-	push(buf: Buffer | string | null, encoding: string = this.encoding) {
+	push(buf: Buffer | string | null, encoding: BufferEncoding = this.encoding) {
 		let size;
 		if (this.atEOF) return;
 		if (buf === null) {
@@ -209,11 +211,11 @@ export class ReadStream {
 		}
 	}
 
-	peek(byteCount?: number | null, encoding?: string): string | null | Promise<string | null>;
-	peek(encoding: string): string | null | Promise<string | null>;
-	peek(byteCount: number | string | null = null, encoding = this.encoding) {
+	peek(byteCount?: number | null, encoding?: BufferEncoding): string | null | Promise<string | null>;
+	peek(encoding: BufferEncoding): string | null | Promise<string | null>;
+	peek(byteCount: number | string | null = null, encoding: BufferEncoding = this.encoding) {
 		if (typeof byteCount === 'string') {
-			encoding = byteCount;
+			encoding = byteCount as BufferEncoding;
 			byteCount = null;
 		}
 		const maybeLoad = this.loadIntoBuffer(byteCount);
@@ -235,11 +237,11 @@ export class ReadStream {
 		return this.buf.slice(this.bufStart, this.bufStart + byteCount);
 	}
 
-	async read(byteCount?: number | null, encoding?: string): Promise<string | null>;
-	async read(encoding: string): Promise<string | null>;
-	async read(byteCount: number | string | null = null, encoding = this.encoding) {
+	async read(byteCount?: number | null, encoding?: BufferEncoding): Promise<string | null>;
+	async read(encoding: BufferEncoding): Promise<string | null>;
+	async read(byteCount: number | string | null = null, encoding: BufferEncoding = this.encoding) {
 		if (typeof byteCount === 'string') {
-			encoding = byteCount;
+			encoding = byteCount as BufferEncoding;
 			byteCount = null;
 		}
 		await this.loadIntoBuffer(byteCount, true);
@@ -265,7 +267,7 @@ export class ReadStream {
 		return out;
 	}
 
-	async indexOf(symbol: string, encoding: string = this.encoding) {
+	async indexOf(symbol: string, encoding: BufferEncoding = this.encoding) {
 		let idx = this.buf.indexOf(symbol, this.bufStart, encoding);
 		while (!this.atEOF && (idx >= this.bufEnd || idx < 0)) {
 			await this.loadIntoBuffer(true);
@@ -275,15 +277,15 @@ export class ReadStream {
 		return idx - this.bufStart;
 	}
 
-	async readAll(encoding = this.encoding) {
+	async readAll(encoding: BufferEncoding = this.encoding) {
 		return (await this.read(Infinity, encoding)) || '';
 	}
 
-	peekAll(encoding = this.encoding) {
+	peekAll(encoding: BufferEncoding = this.encoding) {
 		return this.peek(Infinity, encoding);
 	}
 
-	async readDelimitedBy(symbol: string, encoding: string = this.encoding) {
+	async readDelimitedBy(symbol: string, encoding: BufferEncoding = this.encoding) {
 		if (this.atEOF && !this.bufSize) return null;
 		const idx = await this.indexOf(symbol, encoding);
 		if (idx < 0) {
@@ -295,7 +297,7 @@ export class ReadStream {
 		}
 	}
 
-	async readLine(encoding = this.encoding) {
+	async readLine(encoding: BufferEncoding = this.encoding) {
 		if (!encoding) throw new Error(`readLine must have an encoding`);
 		let line = await this.readDelimitedBy('\n', encoding);
 		if (line && line.endsWith('\r')) line = line.slice(0, -1);
@@ -335,7 +337,7 @@ interface WriteStreamOptions {
 export class WriteStream {
 	isReadable: boolean;
 	isWritable: true;
-	encoding: string;
+	encoding: BufferEncoding;
 	nodeWritableStream: NodeJS.WritableStream | null;
 	drainListeners: (() => void)[];
 

--- a/package.json
+++ b/package.json
@@ -57,14 +57,14 @@
   "license": "MIT",
   "devDependencies": {
     "@types/cloud-env": "^0.2.0",
-    "@types/node": "^11.13.0",
+    "@types/node": "^11.13.2",
     "@types/node-static": "^0.7.3",
     "@types/nodemailer": "^4.6.7",
     "@types/sockjs": "^0.3.31",
-    "eslint": "^5.15.3",
+    "eslint": "^5.16.0",
     "husky": "^1.1.2",
-    "mocha": "^6.0.2",
+    "mocha": "^6.1.2",
     "tslint": "^5.15.0",
-    "typescript": "^3.3.4000"
+    "typescript": "^3.4.2"
   }
 }


### PR DESCRIPTION
Motivated by `--incremental` support on TS 3.4, only to try running it and notice no improvement. :( Turns out that since we use `noEmit` it doesnt work:  https://github.com/Microsoft/TypeScript/issues/30661. There are some [other features of 3.4](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html) which should prove useful though, but it looks like we'll need to continue to wait for faster typechecking.

Changes to `lib/streams.ts` are due to https://github.com/DefinitelyTyped/DefinitelyTyped/commit/ff1b97f5229632971c4f2927686fde76457bd5a5