### PR TITLE
Migrate tests to Jest

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
 		"Config": false, "Monitor": false, "toId": false, "Dex": false, "LoginServer": false,
 		"Users": false, "Punishments": false, "Rooms": false, "Verifier": false, "Chat": false,
 		"Tournaments": false, "Dnsbl": false, "Sockets": false, "TeamValidator": false,
-		"TeamValidatorAsync": false, "Ladders": false
+		"TeamValidatorAsync": false, "Ladders": false, "beforeAll": false, "afterAll": false
 	},
 	"extends": "eslint:recommended",
 	"rules": {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	testEnvironment: 'node',
+	setupFilesAfterEnv: ['<rootDir>/test/main.js'],
+	testMatch: ['<rootDir>/test/simulator/**/*.js', '<rootDir>/test/application/*.js', '<rootDir>/test/chat-plugins/*.js', '<rootDir>/test/dev-tools/*.js'],
+};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The server for the Pokémon Showdown battle simulator",
   "version": "0.11.2",
   "dependencies": {
+    "jest": "^24.7.1",
     "probe-image-size": "^4.0.0",
     "sockjs": "0.3.19",
     "sucrase": "^3.10.1"
@@ -21,7 +22,7 @@
   "scripts": {
     "start": "node pokemon-showdown start",
     "build": "node build",
-    "test": "eslint --cache . && tslint --project . && node build && mocha && tsc",
+    "test": "eslint --cache . && tslint --project . && node build && jest && tsc",
     "tsc": "tsc",
     "lint": "eslint --cache ."
   },
@@ -63,7 +64,6 @@
     "@types/sockjs": "^0.3.31",
     "eslint": "^5.16.0",
     "husky": "^1.1.2",
-    "mocha": "^6.1.2",
     "tslint": "^5.15.0",
     "typescript": "^3.4.2"
   }

--- a/test/application/sockets.js
+++ b/test/application/sockets.js
@@ -12,7 +12,7 @@ describe.skip('Sockets', function () {
 		})
 	);
 
-	before(function () {
+	beforeAll(function () {
 		cluster.settings.silent = true;
 		cluster.removeAllListeners('disconnect');
 	});

--- a/test/application/users.js
+++ b/test/application/users.js
@@ -6,6 +6,8 @@ let userUtils = require('./../../dev-tools/users-utils');
 let Connection = userUtils.Connection;
 let User = userUtils.User;
 
+let connection;
+
 describe('Users features', function () {
 	describe('Users', function () {
 		describe('get', function () {
@@ -30,17 +32,17 @@ describe('Users features', function () {
 		describe('Connection', function () {
 			describe('#onDisconnect', function () {
 				beforeEach(function () {
-					this.connection = new Connection('127.0.0.1');
+					connection = new Connection('127.0.0.1');
 				});
 
 				it('should remove the connection from Users.connections', function () {
-					let connectionid = this.connection.id;
-					this.connection.destroy();
+					let connectionid = connection.id;
+					connection.destroy();
 					assert.strictEqual(Users.connections.has(connectionid), false);
 				});
 
 				it('should destroy any user on the connection as well', function () {
-					let user = new User(this.connection);
+					let user = new User(connection);
 					let {userid} = user;
 					user.disconnectAll();
 					user.destroy();
@@ -50,25 +52,25 @@ describe('Users features', function () {
 
 			describe('#joinRoom', function () {
 				beforeEach(function () {
-					this.connection = new Connection('127.0.0.1');
+					connection = new Connection('127.0.0.1');
 				});
 
 				afterEach(function () {
-					this.connection.destroy();
+					connection.destroy();
 				});
 
 				it('should join a room if not already present', function () {
-					this.connection.joinRoom(Rooms.lobby);
-					assert.ok(this.connection.inRooms.has('lobby'));
+					connection.joinRoom(Rooms.lobby);
+					assert.ok(connection.inRooms.has('lobby'));
 				});
 			});
 
 			describe('#leaveRoom', function () {
 				it('should leave a room that is present', function () {
-					this.connection = new Connection('127.0.0.1');
-					this.connection.joinRoom(Rooms.lobby);
-					this.connection.leaveRoom(Rooms.lobby);
-					assert.ok(!this.connection.inRooms.has('lobby'));
+					connection = new Connection('127.0.0.1');
+					connection.joinRoom(Rooms.lobby);
+					connection.leaveRoom(Rooms.lobby);
+					assert.ok(!connection.inRooms.has('lobby'));
 				});
 			});
 		});

--- a/test/main.js
+++ b/test/main.js
@@ -5,8 +5,7 @@ const fs = require('fs');
 
 const noop = () => {};
 
-before('initialization', function () {
-	this.timeout(0); // Remove timeout limitation
+beforeAll(function () {
 	process.on('unhandledRejection', err => {
 		// I'd throw the err, but we have a heisenbug on our hands and I'd
 		// rather not have it screw with Travis in the interim
@@ -48,4 +47,4 @@ before('initialization', function () {
 	LoginServer.disabled = true;
 
 	Ladders.disabled = true;
-});
+}, 0);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
-test/main.js test/simulator/**/*.js test/application/*.js test/chat-plugins/*.js test/dev-tools/*.js
--R dot
--u bdd
---exit

--- a/test/simulator/abilities/arenatrap.js
+++ b/test/simulator/abilities/arenatrap.js
@@ -11,7 +11,6 @@ describe('Arena Trap', function () {
 	});
 
 	it('should prevent grounded Pokemon that are not immune to trapping from switching out normally', function () {
-		this.timeout(0);
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [{species: "Dugtrio", ability: 'arenatrap', moves: ['snore', 'telekinesis', 'gravity']}]});
 		battle.setPlayer('p2', {team: [
@@ -53,5 +52,5 @@ describe('Arena Trap', function () {
 
 		assert.trapped(() => battle.makeChoices('', 'switch 4'), true); // Tornadus is trapped
 		assert.species(p2active[0], 'Tornadus');
-	});
+	}, 0);
 });

--- a/test/simulator/abilities/contrary.js
+++ b/test/simulator/abilities/contrary.js
@@ -11,7 +11,6 @@ describe('Contrary', function () {
 	});
 
 	it('should invert relative stat changes', function () {
-		this.timeout(0);
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [{species: "Spinda", ability: 'contrary', moves: ['superpower']}]});
 		battle.setPlayer('p2', {team: [{species: "Dragonite", ability: 'multiscale', moves: ['dragondance']}]});
@@ -19,7 +18,7 @@ describe('Contrary', function () {
 		battle.makeChoices('move superpower', 'move dragondance');
 		assert.statStage(contraryMon, 'atk', 1);
 		assert.statStage(contraryMon, 'def', 1);
-	});
+	}, 0);
 
 	it('should not invert absolute stat changes', function () {
 		battle = common.createBattle();

--- a/test/simulator/abilities/lightningrod.js
+++ b/test/simulator/abilities/lightningrod.js
@@ -37,7 +37,6 @@ describe('Lightning Rod', function () {
 	});
 
 	it('should redirect single-target Electric-type attacks to the user if it is a valid target', function () {
-		this.timeout(3000);
 		battle = common.createBattle({gameType: 'triples'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Manectric', ability: 'lightningrod', moves: ['sleeptalk']},
@@ -53,7 +52,7 @@ describe('Lightning Rod', function () {
 		assert.statStage(battle.p1.active[0], 'spa', 3);
 		assert.false.fullHP(battle.p1.active[2]);
 		assert.false.fullHP(battle.p2.active[0]);
-	});
+	}, 3000);
 
 	it('should redirect to the fastest Pokemon with the ability', function () {
 		battle = common.createBattle({gameType: 'doubles'});

--- a/test/simulator/abilities/pressure.js
+++ b/test/simulator/abilities/pressure.js
@@ -47,7 +47,6 @@ describe('Pressure', function () {
 	});
 
 	it('should deduct PP for each Pressure Pokemon targetted', function () {
-		this.timeout(3000);
 		battle = common.createBattle({gameType: 'triples'});
 		battle.setPlayer('p1', {team: [
 			{species: "Giratina", ability: 'pressure', moves: ['rest']},
@@ -63,10 +62,9 @@ describe('Pressure', function () {
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('hail')).pp, 12);
 		assert.strictEqual(battle.p2.active[1].getMoveData(Dex.getMove('spikes')).pp, 28);
 		assert.strictEqual(battle.p2.active[2].getMoveData(Dex.getMove('rockslide')).pp, 13);
-	});
+	}, 3000);
 
 	it('should deduct PP for each opposing Pressure Pokemon when Snatch of Imprison are used', function () {
-		this.timeout(3000);
 		battle = common.createBattle({gameType: 'triples'});
 		battle.setPlayer('p1', {team: [
 			{species: "Giratina", ability: 'pressure', moves: ['rest']},
@@ -81,7 +79,7 @@ describe('Pressure', function () {
 		battle.makeChoices('move rest, move rest, move rest', 'move snatch, move imprison, move rest');
 		assert.strictEqual(battle.p2.active[0].getMoveData(Dex.getMove('snatch')).pp, 12);
 		assert.strictEqual(battle.p2.active[1].getMoveData(Dex.getMove('imprison')).pp, 12);
-	});
+	}, 3000);
 });
 
 describe('Pressure [Gen 4]', function () {

--- a/test/simulator/misc/random-teams.js
+++ b/test/simulator/misc/random-teams.js
@@ -29,7 +29,6 @@ function isValidSet(gen, set) {
 describe(`Random Team generator`, function () {
 	for (const gen of ALL_GENS) {
 		it(`should successfully create valid Gen ${gen} teams`, function () {
-			this.timeout(0);
 			const generator = Dex.getTeamGenerator(`gen${gen}randombattle`);
 			if (generator.gen !== gen) return; // format doesn't exist for this gen
 
@@ -45,14 +44,13 @@ describe(`Random Team generator`, function () {
 					throw err;
 				}
 			}
-		});
+		}, 0);
 	}
 });
 
 describe(`Challenge Cup Team generator`, function () {
 	for (const gen of ALL_GENS) {
 		it(`should successfully create valid Gen ${gen} teams`, function () {
-			this.timeout(0);
 			const generator = Dex.getTeamGenerator(`gen${gen}challengecup`);
 			if (generator.gen !== gen) return; // format doesn't exist for this gen
 
@@ -68,14 +66,13 @@ describe(`Challenge Cup Team generator`, function () {
 					throw err;
 				}
 			}
-		});
+		}, 0);
 	}
 });
 
 describe(`Hackmons Cup Team generator`, function () {
 	for (const gen of ALL_GENS) {
 		it(`should successfully create valid Gen ${gen} teams`, function () {
-			this.timeout(0);
 			const generator = Dex.getTeamGenerator(`gen${gen}hackmonscup`);
 			if (generator.gen !== gen) return; // format doesn't exist for this gen
 
@@ -91,14 +88,13 @@ describe(`Hackmons Cup Team generator`, function () {
 					throw err;
 				}
 			}
-		});
+		}, 5000);
 	}
 });
 
 describe(`Factory sets`, function () {
 	for (const filename of ['bss-factory-sets', 'factory-sets']) {
 		it(`should have valid sets in ${filename}.json`, function () {
-			this.timeout(5000);
 			const setsJSON = require(`../../../data/${filename}.json`);
 
 			for (const type in setsJSON) {

--- a/test/simulator/misc/statusmoves.js
+++ b/test/simulator/misc/statusmoves.js
@@ -33,8 +33,6 @@ describe('Most status moves', function () {
 	});
 
 	it('should fail when the opposing Pokemon is immune to the status effect it sets', function () {
-		this.timeout(0);
-
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [{species: "Smeargle", ability: 'noguard', item: 'laggingtail', moves: ['thunderwave', 'willowisp', 'poisongas', 'toxic']}]});
 		battle.setPlayer('p2', {team: [
@@ -67,7 +65,7 @@ describe('Most status moves', function () {
 		battle.makeChoices('move toxic', 'move magnetrise');
 		assert.strictEqual(battle.p2.active[0].status, '');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
-	});
+	}, 0);
 });
 
 describe('Poison-inflicting status moves [Gen 2]', function () {

--- a/test/simulator/moves/followme.js
+++ b/test/simulator/moves/followme.js
@@ -11,8 +11,6 @@ describe('Follow Me', function () {
 	});
 
 	it('should redirect single-target moves towards it if it is a valid target', function () {
-		this.timeout(5000);
-
 		battle = common.createBattle({gameType: 'triples'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Clefable', ability: 'unaware', moves: ['followme']},
@@ -32,7 +30,7 @@ describe('Follow Me', function () {
 		});
 		battle.makeChoices('move followme, move calmmind, move calmmind', 'move lowkick 2, move lowkick 2, move lowkick 2');
 		assert.strictEqual(hitCount, 2);
-	});
+	}, 5000);
 
 	it('should not redirect self-targetting moves', function () {
 		battle = common.createBattle({gameType: 'doubles'});

--- a/test/simulator/moves/ragepowder.js
+++ b/test/simulator/moves/ragepowder.js
@@ -12,8 +12,6 @@ describe('Rage Powder', function () {
 	});
 
 	it('should redirect single-target moves towards it if it is a valid target', function () {
-		this.timeout(5000);
-
 		battle = common.createBattle({gameType: 'triples'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Amoonguss', ability: 'overcoat', item: 'safetygoggles', moves: ['ragepowder']},
@@ -42,7 +40,7 @@ describe('Rage Powder', function () {
 		assert.strictEqual(hitCount[0], 2);
 		assert.strictEqual(hitCount[1], 1);
 		assert.strictEqual(hitCount[2], 0);
-	});
+	}, 5000);
 
 	it('should not affect Pokemon with Powder immunities', function () {
 		battle = common.createBattle({gameType: 'triples'});


### PR DESCRIPTION
> * **Migrate tests to Jest** – Jest (https://jestjs.io/) supports parallel test-running, which would be nice to have over Mocha. Most of its API surface is similar, so this shouldn't take too long.

_Originally posted by @Zarel in https://github.com/Zarel/Pokemon-Showdown/issues/2444_

Did some investigation here. Have some failing tests still, but I figured I'd dump what I've figured out so far:

1) Jest has a pretty similar API, but since it doesn't use `this` we could switch `function () { ... }` to `() => { ... }` which is the preferred style. I didn't bother with this.
2) A lot of our tests do weird things with timeouts, possibly due to them getting hit by `Dex` loading? Why do half of these fiddle with timeouts? I can see why team generator might, but basic tests for abilities or moves? Smells like a bug to me.
3) Jest's test runner is much noisier by default, and we'd probably need to write our own/depend on a new one. The biggest difference is that its logging even on success (which I'm OK with), but this means we get tons of:

   ```
   PASS  test/simulator/abilities/roughskin.js
   ● Console
 
     console.log server/monitor.js:135
       NEW GLOBAL: global
     console.log server/monitor.js:135
       NEW CHATROOM: lobby
     console.log server/monitor.js:135
       NEW CHATROOM staff
   ```


    for each test. Maybe we could stub out `Monitor.notice` etc in the `beforeAll`?

4) Hot take: Jest will be slower. ![jest](https://i.imgur.com/pGyNank.png) Is what my computer looks like running Jest, and I'm pretty sure most PS! developers don't have that kind of hardware sitting under their desk. To make matters worse - even on my box, its slower (13-14s instead of 10-12s)! I'm guess this is possibly due to the verbosity of the logging (writing that much to the console is slow), but I'd bet even on my computer its not going to be much faster than Mocha due to `Dex` loading. `Dex` loading is super slow, and if we're naively running tests in parallel processes the way Jest does, we're paying the price multiple times. The optimal way of running PS is to spin up a number of processes roughly equal to the number of cores (maybe NUM_CORES-1, to allow for the GC thread), and then run `Dex` loading once in each one, and then run multiple battles in a loop (incidently, the PS server does this :P)

5) Jest doesn't like `Dex` loading, it seems to cause failures when a test is `skip`ped:


```
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.

      at ModdedDex.includeFormats (.sim-dist/dex.js:1643:17)
      at ModdedDex.get formats [as formats] (.sim-dist/dex.js:246:10)
      at ModdedDex.loadData (.sim-dist/dex.js:1584:80)
      at ModdedDex.includeData (.sim-dist/dex.js:1550:10)
      at Object.<anonymous>.process.nextTick (server/chat-plugins/info.js:2549:7)
.sim-dist/dex.js:1651
      throw new TypeError(`Exported property 'Formats' from "./config/formats.js" must be an array`);
      ^

TypeError: Exported property 'Formats' from "./config/formats.js" must be an array
    at ModdedDex.includeFormats (.sim-dist/dex.js:1651:13)
    at ModdedDex.get formats [as formats] (.sim-dist/dex.js:246:10)
    at ModdedDex.loadData (.sim-dist/dex.js:1584:80)
    at ModdedDex.includeData (.sim-dist/dex.js:1550:10)
    at Object.<anonymous>.process.nextTick (server/chat-plugins/info.js:2549:7)
    at processTicksAndRejections (internal/process/task_queues.js:79:9)
```


All in all, useful exercise, but not super sure about how much we want to invest in Jest?