### PR TITLE
Remove Object.assign(function) pattern from TeamValidator{Async}

### DIFF
--- a/dev-tools/global.d.ts
+++ b/dev-tools/global.d.ts
@@ -47,7 +47,6 @@ declare global {
 	const Side: SideType
 	const Sim: typeof SimType
 	const TeamValidator: typeof TeamValidatorType
-	const Validator: typeof TeamValidatorType.Validator
 	const BattleStream: BattleStreamType.BattleStream
 
 	// dex data

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -3,7 +3,7 @@ type Field = import('./../sim/field').Field
 type ModdedDex = typeof import('./../sim/dex')
 type Pokemon = import('./../sim/pokemon').Pokemon
 type Side = import('./../sim/side').Side
-type Validator = import('./../sim/team-validator').Validator
+type Validator = import('./../sim/team-validator').TeamValidator
 
 type PageTable = import('./../server/chat').PageTable
 type ChatCommands = import('./../server/chat').ChatCommands

--- a/dev-tools/globals.ts
+++ b/dev-tools/globals.ts
@@ -3,7 +3,7 @@ type Field = import('./../sim/field').Field
 type ModdedDex = typeof import('./../sim/dex')
 type Pokemon = import('./../sim/pokemon').Pokemon
 type Side = import('./../sim/side').Side
-type Validator = import('./../sim/team-validator').TeamValidator
+type TeamValidator = import('./../sim/team-validator').TeamValidator
 
 type PageTable = import('./../server/chat').PageTable
 type ChatCommands = import('./../server/chat').ChatCommands
@@ -24,7 +24,7 @@ declare let LoginServer: typeof import('../server/loginserver');
 declare let Verifier: typeof import('../server/verifier');
 declare let Dnsbl: typeof import('../server/dnsbl');
 declare let Sockets: typeof import('../server/sockets');
-// let TeamValidator: typeof import('../sim/team-validator');
+// let TeamValidator: typeof import('../sim/team-validator').TeamValidator;
 declare let TeamValidatorAsync: typeof import('../server/team-validator-async');
 
 type GenderName = 'M' | 'F' | 'N' | '';
@@ -1051,7 +1051,7 @@ interface FormatsData extends EventMethods {
 	timer?: Partial<GameTimerSettings>
 	tournamentShow?: boolean
 	unbanlist?: string[]
-	checkLearnset?: (this: Validator, move: Move, template: Template, lsetData: PokemonSources, set: PokemonSet) => {type: string, [any: string]: any} | null
+	checkLearnset?: (this: TeamValidator, move: Move, template: Template, lsetData: PokemonSources, set: PokemonSet) => {type: string, [any: string]: any} | null
 	onAfterMega?: (this: Battle, pokemon: Pokemon) => void
 	onBegin?: (this: Battle) => void
 	onChangeSet?: (this: ModdedDex, set: PokemonSet, format: Format, setHas?: AnyObject, teamHas?: AnyObject) => string[] | void
@@ -1059,8 +1059,8 @@ interface FormatsData extends EventMethods {
 	onTeamPreview?: (this: Battle) => void
 	onValidateSet?: (this: ModdedDex, set: PokemonSet, format: Format, setHas: AnyObject, teamHas: AnyObject) => string[] | void
 	onValidateTeam?: (this: ModdedDex, team: PokemonSet[], format: Format, teamHas: AnyObject) => string[] | void
-	validateSet?: (this: Validator, set: PokemonSet, teamHas: AnyObject) => string[] | void
-	validateTeam?: (this: Validator, team: PokemonSet[], removeNicknames: boolean) => string[] | void,
+	validateSet?: (this: TeamValidator, set: PokemonSet, teamHas: AnyObject) => string[] | void
+	validateTeam?: (this: TeamValidator, team: PokemonSet[], removeNicknames: boolean) => string[] | void,
 	section?: string,
 	column?: number
 }

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -101,8 +101,8 @@ if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
 	case 'validate-team':
 		{
 			var Dex = require('./.sim-dist/dex');
-			var TeamValidator = require('./.sim-dist/team-validator');
-			var validator = TeamValidator(process.argv[3]);
+			var TeamValidator = require('./.sim-dist/team-validator').TeamValidator;
+			var validator = new TeamValidator(process.argv[3]);
 			var Streams = require('./.lib-dist/streams');
 			var stdin = new Streams.ReadStream(process.stdin);
 

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -102,7 +102,7 @@ if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
 		{
 			var Dex = require('./.sim-dist/dex');
 			var TeamValidator = require('./.sim-dist/team-validator').TeamValidator;
-			var validator = new TeamValidator(process.argv[3]);
+			var validator = TeamValidator.get(process.argv[3]);
 			var Streams = require('./.lib-dist/streams');
 			var stdin = new Streams.ReadStream(process.stdin);
 

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4110,7 +4110,7 @@ const commands = {
 		let format = originalFormat.effectType === 'Format' ? originalFormat : Dex.getFormat('[Gen 7] Pokebank Anything Goes');
 		if (format.effectType !== 'Format') return this.popupReply("Please provide a valid format.");
 
-		TeamValidatorAsync(format.id).validateTeam(user.team).then(result => {
+		new TeamValidatorAsync.TeamValidatorAsync(format.id).validateTeam(user.team).then(result => {
 			let matchMessage = (originalFormat === format ? "" : `The format '${originalFormat.name}' was not found.`);
 			if (result.charAt(0) === '1') {
 				connection.popup(`${(matchMessage ? matchMessage + "\n\n" : "")}Your team is valid for ${format.name}.`);

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4110,7 +4110,7 @@ const commands = {
 		let format = originalFormat.effectType === 'Format' ? originalFormat : Dex.getFormat('[Gen 7] Pokebank Anything Goes');
 		if (format.effectType !== 'Format') return this.popupReply("Please provide a valid format.");
 
-		new TeamValidatorAsync.TeamValidatorAsync(format.id).validateTeam(user.team).then(result => {
+		TeamValidatorAsync.create(format.id).validateTeam(user.team).then(result => {
 			let matchMessage = (originalFormat === format ? "" : `The format '${originalFormat.name}' was not found.`);
 			if (result.charAt(0) === '1') {
 				connection.popup(`${(matchMessage ? matchMessage + "\n\n" : "")}Your team is valid for ${format.name}.`);

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4110,7 +4110,7 @@ const commands = {
 		let format = originalFormat.effectType === 'Format' ? originalFormat : Dex.getFormat('[Gen 7] Pokebank Anything Goes');
 		if (format.effectType !== 'Format') return this.popupReply("Please provide a valid format.");
 
-		TeamValidatorAsync.create(format.id).validateTeam(user.team).then(result => {
+		TeamValidatorAsync.get(format.id).validateTeam(user.team).then(result => {
 			let matchMessage = (originalFormat === format ? "" : `The format '${originalFormat.name}' was not found.`);
 			if (result.charAt(0) === '1') {
 				connection.popup(`${(matchMessage ? matchMessage + "\n\n" : "")}Your team is valid for ${format.name}.`);

--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -723,7 +723,7 @@ function runDexsearch(target, cmd, canAll, message) {
 
 			for (let move in alts.moves) {
 				if (!lsetData[mon]) lsetData[mon] = {fastCheck: true, sources: [], sourcesBefore: maxGen};
-				if (!new TeamValidator(`gen${maxGen}ou`).checkLearnset(move, mon, lsetData[mon]) === alts.moves[move]) {
+				if (!TeamValidator.get(`gen${maxGen}ou`).checkLearnset(move, mon, lsetData[mon]) === alts.moves[move]) {
 					matched = true;
 					break;
 				}
@@ -1537,7 +1537,7 @@ function runLearn(target, cmd) {
 	}
 	let lsetData = {set: {}, sources: [], sourcesBefore: gen};
 
-	const validator = new TeamValidator(format);
+	const validator = TeamValidator.get(format);
 	let template = validator.dex.getTemplate(targets.shift());
 	let move = {};
 	let all = (cmd === 'learnall');

--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -723,7 +723,7 @@ function runDexsearch(target, cmd, canAll, message) {
 
 			for (let move in alts.moves) {
 				if (!lsetData[mon]) lsetData[mon] = {fastCheck: true, sources: [], sourcesBefore: maxGen};
-				if (!TeamValidator(`gen${maxGen}ou`).checkLearnset(move, mon, lsetData[mon]) === alts.moves[move]) {
+				if (!new TeamValidator(`gen${maxGen}ou`).checkLearnset(move, mon, lsetData[mon]) === alts.moves[move]) {
 					matched = true;
 					break;
 				}
@@ -1537,7 +1537,7 @@ function runLearn(target, cmd) {
 	}
 	let lsetData = {set: {}, sources: [], sourcesBefore: gen};
 
-	const validator = TeamValidator(format);
+	const validator = new TeamValidator(format);
 	let template = validator.dex.getTemplate(targets.shift());
 	let move = {};
 	let all = (cmd === 'learnall');

--- a/server/ladders.js
+++ b/server/ladders.js
@@ -137,7 +137,7 @@ class Ladder extends LadderStore {
 		if (isRated && !Ladders.disabled) {
 			let userid = user.userid;
 			[valResult, rating] = await Promise.all([
-				TeamValidatorAsync(this.formatid).validateTeam(team, !!(user.locked || user.namelocked)),
+				new TeamValidatorAsync.TeamValidatorAsync(this.formatid).validateTeam(team, !!(user.locked || user.namelocked)),
 				this.getRating(userid),
 			]);
 			if (userid !== user.userid) {
@@ -150,7 +150,7 @@ class Ladder extends LadderStore {
 				connection.popup(`The ladder is temporarily disabled due to technical difficulties - you will not receive ladder rating for this game.`);
 				rating = 1;
 			}
-			valResult = await TeamValidatorAsync(this.formatid).validateTeam(team, !!(user.locked || user.namelocked));
+			valResult = await new TeamValidatorAsync.TeamValidatorAsync(this.formatid).validateTeam(team, !!(user.locked || user.namelocked));
 		}
 
 		if (valResult.charAt(0) !== '1') {

--- a/server/ladders.js
+++ b/server/ladders.js
@@ -137,7 +137,7 @@ class Ladder extends LadderStore {
 		if (isRated && !Ladders.disabled) {
 			let userid = user.userid;
 			[valResult, rating] = await Promise.all([
-				TeamValidatorAsync.create(this.formatid).validateTeam(team, !!(user.locked || user.namelocked)),
+				TeamValidatorAsync.get(this.formatid).validateTeam(team, !!(user.locked || user.namelocked)),
 				this.getRating(userid),
 			]);
 			if (userid !== user.userid) {
@@ -150,7 +150,7 @@ class Ladder extends LadderStore {
 				connection.popup(`The ladder is temporarily disabled due to technical difficulties - you will not receive ladder rating for this game.`);
 				rating = 1;
 			}
-			valResult = await TeamValidatorAsync.create(this.formatid).validateTeam(team, !!(user.locked || user.namelocked));
+			valResult = await TeamValidatorAsync.get(this.formatid).validateTeam(team, !!(user.locked || user.namelocked));
 		}
 
 		if (valResult.charAt(0) !== '1') {

--- a/server/ladders.js
+++ b/server/ladders.js
@@ -137,7 +137,7 @@ class Ladder extends LadderStore {
 		if (isRated && !Ladders.disabled) {
 			let userid = user.userid;
 			[valResult, rating] = await Promise.all([
-				new TeamValidatorAsync.TeamValidatorAsync(this.formatid).validateTeam(team, !!(user.locked || user.namelocked)),
+				TeamValidatorAsync.create(this.formatid).validateTeam(team, !!(user.locked || user.namelocked)),
 				this.getRating(userid),
 			]);
 			if (userid !== user.userid) {
@@ -150,7 +150,7 @@ class Ladder extends LadderStore {
 				connection.popup(`The ladder is temporarily disabled due to technical difficulties - you will not receive ladder rating for this game.`);
 				rating = 1;
 			}
-			valResult = await new TeamValidatorAsync.TeamValidatorAsync(this.formatid).validateTeam(team, !!(user.locked || user.namelocked));
+			valResult = await TeamValidatorAsync.create(this.formatid).validateTeam(team, !!(user.locked || user.namelocked));
 		}
 
 		if (valResult.charAt(0) !== '1') {

--- a/server/team-validator-async.js
+++ b/server/team-validator-async.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-class ValidatorAsync {
+class TeamValidatorAsync {
 	/**
 	 * @param {string} format
 	 */
@@ -43,7 +43,7 @@ const PM = new QueryProcessManager(module, async message => {
 
 	let problems;
 	try {
-		problems = TeamValidator(formatid).validateTeam(parsedTeam, removeNicknames);
+		problems = new TeamValidator(formatid).validateTeam(parsedTeam, removeNicknames);
 	} catch (err) {
 		require(/** @type {any} */('../.lib-dist/crashlogger'))(err, 'A team validation', {
 			formatid: formatid,
@@ -107,13 +107,4 @@ if (!PM.isParentProcess) {
  * Exports
  *********************************************************/
 
-function getAsyncValidator(/** @type {string} */ format) {
-	return new ValidatorAsync(format);
-}
-
-let TeamValidatorAsync = Object.assign(getAsyncValidator, {
-	ValidatorAsync,
-	PM,
-});
-
-module.exports = TeamValidatorAsync;
+module.exports = {TeamValidatorAsync, PM};

--- a/server/team-validator-async.js
+++ b/server/team-validator-async.js
@@ -30,7 +30,7 @@ class TeamValidatorAsync {
 	/**
 	 * @param {string} format
 	 */
-	static create(format) {
+	static get(format) {
 		return new TeamValidatorAsync(format);
 	}
 }
@@ -50,7 +50,7 @@ const PM = new QueryProcessManager(module, async message => {
 
 	let problems;
 	try {
-		problems = new TeamValidator(formatid).validateTeam(parsedTeam, removeNicknames);
+		problems = TeamValidator.get(formatid).validateTeam(parsedTeam, removeNicknames);
 	} catch (err) {
 		require(/** @type {any} */('../.lib-dist/crashlogger'))(err, 'A team validation', {
 			formatid: formatid,
@@ -114,4 +114,4 @@ if (!PM.isParentProcess) {
  * Exports
  *********************************************************/
 
-module.exports = {create: TeamValidatorAsync.create, TeamValidatorAsync, PM};
+module.exports = {get: TeamValidatorAsync.get, TeamValidatorAsync, PM};

--- a/server/team-validator-async.js
+++ b/server/team-validator-async.js
@@ -26,6 +26,13 @@ class TeamValidatorAsync {
 		if (this.format.customRules) formatid += '@@@' + this.format.customRules.join(',');
 		return PM.query({formatid, removeNicknames, team});
 	}
+
+	/**
+	 * @param {string} format
+	 */
+	static create(format) {
+		return new TeamValidatorAsync(format);
+	}
 }
 
 /*********************************************************
@@ -107,4 +114,4 @@ if (!PM.isParentProcess) {
  * Exports
  *********************************************************/
 
-module.exports = {TeamValidatorAsync, PM};
+module.exports = {create: TeamValidatorAsync.create, TeamValidatorAsync, PM};

--- a/server/tournaments/index.js
+++ b/server/tournaments/index.js
@@ -1179,7 +1179,7 @@ const commands = {
 			if (Monitor.countPrepBattle(connection.ip, connection)) {
 				return;
 			}
-			TeamValidatorAsync(tournament.teambuilderFormat).validateTeam(user.team).then(result => {
+			new TeamValidatorAsync.TeamValidatorAsync(tournament.teambuilderFormat).validateTeam(user.team).then(result => {
 				if (result.charAt(0) === '1') {
 					connection.popup("Your team is valid for this tournament.");
 				} else {

--- a/server/tournaments/index.js
+++ b/server/tournaments/index.js
@@ -1179,7 +1179,7 @@ const commands = {
 			if (Monitor.countPrepBattle(connection.ip, connection)) {
 				return;
 			}
-			new TeamValidatorAsync.TeamValidatorAsync(tournament.teambuilderFormat).validateTeam(user.team).then(result => {
+			TeamValidatorAsync.create(tournament.teambuilderFormat).validateTeam(user.team).then(result => {
 				if (result.charAt(0) === '1') {
 					connection.popup("Your team is valid for this tournament.");
 				} else {

--- a/server/tournaments/index.js
+++ b/server/tournaments/index.js
@@ -1179,7 +1179,7 @@ const commands = {
 			if (Monitor.countPrepBattle(connection.ip, connection)) {
 				return;
 			}
-			TeamValidatorAsync.create(tournament.teambuilderFormat).validateTeam(user.team).then(result => {
+			TeamValidatorAsync.get(tournament.teambuilderFormat).validateTeam(user.team).then(result => {
 				if (result.charAt(0) === '1') {
 					connection.popup("Your team is valid for this tournament.");
 				} else {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -9,7 +9,7 @@
 
 import Dex = require('./dex');
 
-export class Validator {
+export class TeamValidator {
 	readonly format: Format;
 	readonly dex: ModdedDex;
 	readonly ruleTable: RuleTable;
@@ -311,7 +311,7 @@ export class Validator {
 			return problems;
 		}
 
-		set.ivs = Validator.fillStats(set.ivs, 31);
+		set.ivs = TeamValidator.fillStats(set.ivs, 31);
 		let ivs: StatsTable = set.ivs;
 		const maxedIVs = Object.values(ivs).every(stat => stat === 31);
 
@@ -358,7 +358,7 @@ export class Validator {
 				}
 				ivs.hp = -1;
 			} else if (!canBottleCap) {
-				ivs = set.ivs = Validator.fillStats(dex.getType(set.hpType).HPivs, 31);
+				ivs = set.ivs = TeamValidator.fillStats(dex.getType(set.hpType).HPivs, 31);
 			}
 		}
 		if (set.hpType === 'Fighting' && ruleTable.has('pokemon')) {
@@ -415,7 +415,7 @@ export class Validator {
 			}
 		}
 		if (dex.gen <= 2 || dex.gen !== 6 && (format.id.endsWith('hackmons') || format.name.includes('BH'))) {
-			if (!set.evs) set.evs = Validator.fillStats(null, 252);
+			if (!set.evs) set.evs = TeamValidator.fillStats(null, 252);
 			const evTotal = (set.evs.hp || 0) + (set.evs.atk || 0) + (set.evs.def || 0) +
 				(set.evs.spa || 0) + (set.evs.spd || 0) + (set.evs.spe || 0);
 			if (evTotal === 508 || evTotal === 510) {
@@ -676,7 +676,7 @@ export class Validator {
 			}
 		} else {
 			requiredIVs = eventData.perfectIVs || 0;
-			if (eventData.generation >= 6 && eventData.perfectIVs === undefined && Validator.hasLegendaryIVs(template)) {
+			if (eventData.generation >= 6 && eventData.perfectIVs === undefined && TeamValidator.hasLegendaryIVs(template)) {
 				requiredIVs = 3;
 			}
 		}
@@ -1297,11 +1297,3 @@ export class Validator {
 		return filledStats;
 	}
 }
-
-function getValidator(format: string | Format) {
-	return new Validator(format);
-}
-
-export const TeamValidator = Object.assign(getValidator, {
-	Validator,
-});

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1296,4 +1296,8 @@ export class TeamValidator {
 		}
 		return filledStats;
 	}
+
+	static get(format: string | Format) {
+		return new TeamValidator(format);
+	}
 }

--- a/test/application/team-validator.js
+++ b/test/application/team-validator.js
@@ -19,7 +19,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'nonexistentPokemon', moves: ['thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -27,7 +27,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', moves: ['thunderbolt'], ability: 'static', item: 'nonexistentItem', evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -35,7 +35,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', moves: ['thunderbolt'], ability: 'nonexistentAbility', evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -43,21 +43,21 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['nonexistentMove'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
 	it('should validate Gen 2 IVs', function () {
 		let team = Dex.fastUnpackTeam('|raikou|||hiddenpowerwater||||14,28,26,,,|||');
-		let illegal = TeamValidator('gen2ou').validateTeam(team);
+		let illegal = new TeamValidator('gen2ou').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = Dex.fastUnpackTeam('|raikou|||hiddenpowerfire||||14,28,26,,,|||');
-		illegal = TeamValidator('gen2ou').validateTeam(team);
+		illegal = new TeamValidator('gen2ou').validateTeam(team);
 		assert(illegal);
 
 		team = Dex.fastUnpackTeam('|raikou|||hiddenpowerwater||||16,28,26,,,|||');
-		illegal = TeamValidator('gen2ou').validateTeam(team);
+		illegal = new TeamValidator('gen2ou').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -65,7 +65,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['thunderbolt'], nature: 'nonexistentNature', evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -73,7 +73,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['thunderbolt'], happiness: 'invalidHappinessValue', evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -81,13 +81,13 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = [
 			{species: 'meowstic', ability: 'prankster', moves: ['trick', 'magiccoat'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 	});
 
@@ -95,7 +95,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['blastburn', 'frenzyplant', 'hydrocannon', 'dragonascent'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -103,7 +103,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'arceus', ability: 'multitype', item: 'dragoniumz', moves: ['judgment'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen71v1').validateTeam(team);
+		let illegal = new TeamValidator('gen71v1').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -111,49 +111,49 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'azumarill', ability: 'hugepower', moves: ['bellydrum', 'aquajet'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen5ou').validateTeam(team);
+		let illegal = new TeamValidator('gen5ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'cloyster', moves: ['rapidspin', 'explosion']},
 		];
-		illegal = TeamValidator('gen2ou').validateTeam(team);
+		illegal = new TeamValidator('gen2ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'blissey', moves: ['present', 'healbell']},
 		];
-		illegal = TeamValidator('gen2ou').validateTeam(team);
+		illegal = new TeamValidator('gen2ou').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = [
 			{species: 'marowak', moves: ['swordsdance', 'rockslide', 'bodyslam']},
 		];
-		illegal = TeamValidator('gen2ou').validateTeam(team);
+		illegal = new TeamValidator('gen2ou').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = [
 			{species: 'skarmory', ability: 'keeneye', moves: ['curse', 'drillpeck'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen3ou').validateTeam(team);
+		illegal = new TeamValidator('gen3ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'skarmory', ability: 'keeneye', moves: ['whirlwind', 'drillpeck'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen3ou').validateTeam(team);
+		illegal = new TeamValidator('gen3ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'armaldo', ability: 'battlearmor', moves: ['knockoff', 'rapidspin'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen3ou').validateTeam(team);
+		illegal = new TeamValidator('gen3ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'snorlax', ability: 'immunity', moves: ['curse', 'pursuit'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen4ou').validateTeam(team);
+		illegal = new TeamValidator('gen4ou').validateTeam(team);
 		assert.strictEqual(illegal, null);
 	});
 
@@ -161,28 +161,28 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'machamp', ability: 'steadfast', moves: ['fissure'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'tauros', ability: 'sheerforce', moves: ['bodyslam'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'tauros', ability: 'intimidate', ivs: {hp: 31, atk: 31, def: 30, spa: 30, spd: 30, spe: 30}, moves: ['bodyslam'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = [
 			{species: 'machamp', ability: 'noguard', moves: ['fissure'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 		team = [
 			{species: 'tauros', ability: 'sheerforce', ivs: {hp: 31, atk: 31, def: 30, spa: 30, spd: 30, spe: 30}, moves: ['bodyslam'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -190,33 +190,33 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'rockruff', ability: 'owntempo', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'rockruff', level: 9, ability: 'owntempo', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 		team = [
 			{species: 'rockruff', level: 9, ability: 'owntempo', moves: ['tackle'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'rockruff', level: 9, ability: 'steadfast', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'lycanrocdusk', ability: 'toughclaws', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'lycanroc', ability: 'steadfast', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -225,14 +225,14 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'gyaradosmega', item: 'gyaradosite', ability: 'intimidate', moves: ['dragondance', 'crunch', 'waterfall', 'icefang'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		// mega forme ability
 		team = [
 			{species: 'gyaradosmega', item: 'gyaradosite', ability: 'moldbreaker', moves: ['dragondance', 'crunch', 'waterfall', 'icefang'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 	});
 
@@ -240,7 +240,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pichu', ability: 'static', moves: ['thunderbolt']},
 		];
-		let illegal = TeamValidator('gen1ou').validateTeam(team);
+		let illegal = new TeamValidator('gen1ou').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -251,7 +251,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes@@@-Pikachu').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes@@@-Pikachu').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -259,7 +259,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'blaziken', ability: 'blaze', moves: ['skyuppercut'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7ou@@@+Blaziken').validateTeam(team);
+		let illegal = new TeamValidator('gen7ou@@@+Blaziken').validateTeam(team);
 		assert(!illegal);
 	});
 
@@ -267,7 +267,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes@@@-Agility').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes@@@-Agility').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -275,7 +275,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'absol', ability: 'pressure', moves: ['batonpass'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7ou@@@+Baton Pass').validateTeam(team);
+		let illegal = new TeamValidator('gen7ou@@@+Baton Pass').validateTeam(team);
 		assert(!illegal);
 	});
 
@@ -283,7 +283,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], item: 'lightball', evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes@@@-Light Ball').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes@@@-Light Ball').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -291,7 +291,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'eevee', ability: 'runaway', moves: ['tackle'], item: 'eeviumz', evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7lc@@@+Eevium Z').validateTeam(team);
+		let illegal = new TeamValidator('gen7lc@@@+Eevium Z').validateTeam(team);
 		assert(!illegal);
 	});
 
@@ -299,7 +299,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes@@@-Static').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes@@@-Static').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -307,7 +307,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'wobbuffet', ability: 'shadowtag', moves: ['counter'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7ou@@@+Shadow Tag').validateTeam(team);
+		let illegal = new TeamValidator('gen7ou@@@+Shadow Tag').validateTeam(team);
 		assert(!illegal);
 	});
 
@@ -315,14 +315,14 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7anythinggoes@@@-Pikachu + Agility').validateTeam(team);
+		let illegal = new TeamValidator('gen7anythinggoes@@@-Pikachu + Agility').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'smeargle', ability: 'owntempo', moves: ['gravity'], evs: {hp: 1}},
 			{species: 'pikachu', ability: 'static', moves: ['thunderbolt'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7doublesou@@@-Gravity ++ Thunderbolt').validateTeam(team);
+		illegal = new TeamValidator('gen7doublesou@@@-Gravity ++ Thunderbolt').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -331,7 +331,7 @@ describe('Team Validator', function () {
 			{species: 'smeargle', ability: 'owntempo', moves: ['gravity'], evs: {hp: 1}},
 			{species: 'abomasnow', ability: 'snowwarning', moves: ['grasswhistle'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7doublesou@@@-Gravity ++ Grass Whistle > 2').validateTeam(team);
+		let illegal = new TeamValidator('gen7doublesou@@@-Gravity ++ Grass Whistle > 2').validateTeam(team);
 		assert(!illegal);
 
 		team = [
@@ -339,7 +339,7 @@ describe('Team Validator', function () {
 			{species: 'abomasnow', ability: 'snowwarning', moves: ['grasswhistle'], evs: {hp: 1}},
 			{species: 'cacturne', ability: 'sandveil', moves: ['grasswhistle'], evs: {hp: 1}},
 		];
-		illegal = TeamValidator('gen7doublesou@@@-Gravity ++ Grass Whistle > 2').validateTeam(team);
+		illegal = new TeamValidator('gen7doublesou@@@-Gravity ++ Grass Whistle > 2').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -348,7 +348,7 @@ describe('Team Validator', function () {
 			{species: 'smeargle', ability: 'owntempo', moves: ['gravity'], evs: {hp: 1}},
 			{species: 'abomasnow', ability: 'snowwarning', moves: ['grasswhistle'], evs: {hp: 1}},
 		];
-		let illegal = TeamValidator('gen7doublesou@@@+Gravity ++ Grass Whistle').validateTeam(team);
+		let illegal = new TeamValidator('gen7doublesou@@@+Gravity ++ Grass Whistle').validateTeam(team);
 		assert(!illegal);
 	});
 });

--- a/test/application/team-validator.js
+++ b/test/application/team-validator.js
@@ -19,7 +19,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'nonexistentPokemon', moves: ['thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = TeamValidator.get('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -27,7 +27,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', moves: ['thunderbolt'], ability: 'static', item: 'nonexistentItem', evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = TeamValidator.get('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -35,7 +35,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', moves: ['thunderbolt'], ability: 'nonexistentAbility', evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = TeamValidator.get('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -43,21 +43,21 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['nonexistentMove'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = TeamValidator.get('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
 	it('should validate Gen 2 IVs', function () {
 		let team = Dex.fastUnpackTeam('|raikou|||hiddenpowerwater||||14,28,26,,,|||');
-		let illegal = new TeamValidator('gen2ou').validateTeam(team);
+		let illegal = TeamValidator.get('gen2ou').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = Dex.fastUnpackTeam('|raikou|||hiddenpowerfire||||14,28,26,,,|||');
-		illegal = new TeamValidator('gen2ou').validateTeam(team);
+		illegal = TeamValidator.get('gen2ou').validateTeam(team);
 		assert(illegal);
 
 		team = Dex.fastUnpackTeam('|raikou|||hiddenpowerwater||||16,28,26,,,|||');
-		illegal = new TeamValidator('gen2ou').validateTeam(team);
+		illegal = TeamValidator.get('gen2ou').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -65,7 +65,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['thunderbolt'], nature: 'nonexistentNature', evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = TeamValidator.get('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -73,7 +73,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['thunderbolt'], happiness: 'invalidHappinessValue', evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7customgame').validateTeam(team);
+		let illegal = TeamValidator.get('gen7customgame').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -81,13 +81,13 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = [
 			{species: 'meowstic', ability: 'prankster', moves: ['trick', 'magiccoat'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 	});
 
@@ -95,7 +95,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['blastburn', 'frenzyplant', 'hydrocannon', 'dragonascent'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -103,7 +103,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'arceus', ability: 'multitype', item: 'dragoniumz', moves: ['judgment'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen71v1').validateTeam(team);
+		let illegal = TeamValidator.get('gen71v1').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -111,49 +111,49 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'azumarill', ability: 'hugepower', moves: ['bellydrum', 'aquajet'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen5ou').validateTeam(team);
+		let illegal = TeamValidator.get('gen5ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'cloyster', moves: ['rapidspin', 'explosion']},
 		];
-		illegal = new TeamValidator('gen2ou').validateTeam(team);
+		illegal = TeamValidator.get('gen2ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'blissey', moves: ['present', 'healbell']},
 		];
-		illegal = new TeamValidator('gen2ou').validateTeam(team);
+		illegal = TeamValidator.get('gen2ou').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = [
 			{species: 'marowak', moves: ['swordsdance', 'rockslide', 'bodyslam']},
 		];
-		illegal = new TeamValidator('gen2ou').validateTeam(team);
+		illegal = TeamValidator.get('gen2ou').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = [
 			{species: 'skarmory', ability: 'keeneye', moves: ['curse', 'drillpeck'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen3ou').validateTeam(team);
+		illegal = TeamValidator.get('gen3ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'skarmory', ability: 'keeneye', moves: ['whirlwind', 'drillpeck'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen3ou').validateTeam(team);
+		illegal = TeamValidator.get('gen3ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'armaldo', ability: 'battlearmor', moves: ['knockoff', 'rapidspin'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen3ou').validateTeam(team);
+		illegal = TeamValidator.get('gen3ou').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'snorlax', ability: 'immunity', moves: ['curse', 'pursuit'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen4ou').validateTeam(team);
+		illegal = TeamValidator.get('gen4ou').validateTeam(team);
 		assert.strictEqual(illegal, null);
 	});
 
@@ -161,28 +161,28 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'machamp', ability: 'steadfast', moves: ['fissure'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'tauros', ability: 'sheerforce', moves: ['bodyslam'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'tauros', ability: 'intimidate', ivs: {hp: 31, atk: 31, def: 30, spa: 30, spd: 30, spe: 30}, moves: ['bodyslam'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		team = [
 			{species: 'machamp', ability: 'noguard', moves: ['fissure'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 		team = [
 			{species: 'tauros', ability: 'sheerforce', ivs: {hp: 31, atk: 31, def: 30, spa: 30, spd: 30, spe: 30}, moves: ['bodyslam'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -190,33 +190,33 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'rockruff', ability: 'owntempo', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'rockruff', level: 9, ability: 'owntempo', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 		team = [
 			{species: 'rockruff', level: 9, ability: 'owntempo', moves: ['tackle'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'rockruff', level: 9, ability: 'steadfast', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'lycanrocdusk', ability: 'toughclaws', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 		team = [
 			{species: 'lycanroc', ability: 'steadfast', moves: ['happyhour'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -225,14 +225,14 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'gyaradosmega', item: 'gyaradosite', ability: 'intimidate', moves: ['dragondance', 'crunch', 'waterfall', 'icefang'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 
 		// mega forme ability
 		team = [
 			{species: 'gyaradosmega', item: 'gyaradosite', ability: 'moldbreaker', moves: ['dragondance', 'crunch', 'waterfall', 'icefang'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7anythinggoes').validateTeam(team);
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
 		assert.strictEqual(illegal, null);
 	});
 
@@ -240,7 +240,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pichu', ability: 'static', moves: ['thunderbolt']},
 		];
-		let illegal = new TeamValidator('gen1ou').validateTeam(team);
+		let illegal = TeamValidator.get('gen1ou').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -251,7 +251,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes@@@-Pikachu').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes@@@-Pikachu').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -259,7 +259,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'blaziken', ability: 'blaze', moves: ['skyuppercut'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7ou@@@+Blaziken').validateTeam(team);
+		let illegal = TeamValidator.get('gen7ou@@@+Blaziken').validateTeam(team);
 		assert(!illegal);
 	});
 
@@ -267,7 +267,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes@@@-Agility').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes@@@-Agility').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -275,7 +275,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'absol', ability: 'pressure', moves: ['batonpass'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7ou@@@+Baton Pass').validateTeam(team);
+		let illegal = TeamValidator.get('gen7ou@@@+Baton Pass').validateTeam(team);
 		assert(!illegal);
 	});
 
@@ -283,7 +283,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], item: 'lightball', evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes@@@-Light Ball').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes@@@-Light Ball').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -291,7 +291,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'eevee', ability: 'runaway', moves: ['tackle'], item: 'eeviumz', evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7lc@@@+Eevium Z').validateTeam(team);
+		let illegal = TeamValidator.get('gen7lc@@@+Eevium Z').validateTeam(team);
 		assert(!illegal);
 	});
 
@@ -299,7 +299,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes@@@-Static').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes@@@-Static').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -307,7 +307,7 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'wobbuffet', ability: 'shadowtag', moves: ['counter'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7ou@@@+Shadow Tag').validateTeam(team);
+		let illegal = TeamValidator.get('gen7ou@@@+Shadow Tag').validateTeam(team);
 		assert(!illegal);
 	});
 
@@ -315,14 +315,14 @@ describe('Team Validator', function () {
 		let team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7anythinggoes@@@-Pikachu + Agility').validateTeam(team);
+		let illegal = TeamValidator.get('gen7anythinggoes@@@-Pikachu + Agility').validateTeam(team);
 		assert(illegal);
 
 		team = [
 			{species: 'smeargle', ability: 'owntempo', moves: ['gravity'], evs: {hp: 1}},
 			{species: 'pikachu', ability: 'static', moves: ['thunderbolt'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7doublesou@@@-Gravity ++ Thunderbolt').validateTeam(team);
+		illegal = TeamValidator.get('gen7doublesou@@@-Gravity ++ Thunderbolt').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -331,7 +331,7 @@ describe('Team Validator', function () {
 			{species: 'smeargle', ability: 'owntempo', moves: ['gravity'], evs: {hp: 1}},
 			{species: 'abomasnow', ability: 'snowwarning', moves: ['grasswhistle'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7doublesou@@@-Gravity ++ Grass Whistle > 2').validateTeam(team);
+		let illegal = TeamValidator.get('gen7doublesou@@@-Gravity ++ Grass Whistle > 2').validateTeam(team);
 		assert(!illegal);
 
 		team = [
@@ -339,7 +339,7 @@ describe('Team Validator', function () {
 			{species: 'abomasnow', ability: 'snowwarning', moves: ['grasswhistle'], evs: {hp: 1}},
 			{species: 'cacturne', ability: 'sandveil', moves: ['grasswhistle'], evs: {hp: 1}},
 		];
-		illegal = new TeamValidator('gen7doublesou@@@-Gravity ++ Grass Whistle > 2').validateTeam(team);
+		illegal = TeamValidator.get('gen7doublesou@@@-Gravity ++ Grass Whistle > 2').validateTeam(team);
 		assert(illegal);
 	});
 
@@ -348,7 +348,7 @@ describe('Team Validator', function () {
 			{species: 'smeargle', ability: 'owntempo', moves: ['gravity'], evs: {hp: 1}},
 			{species: 'abomasnow', ability: 'snowwarning', moves: ['grasswhistle'], evs: {hp: 1}},
 		];
-		let illegal = new TeamValidator('gen7doublesou@@@+Gravity ++ Grass Whistle').validateTeam(team);
+		let illegal = TeamValidator.get('gen7doublesou@@@+Gravity ++ Grass Whistle').validateTeam(team);
 		assert(!illegal);
 	});
 });


### PR DESCRIPTION
> It's just sugar because @Zarel believes that ``Users(id)`` and ``Rooms(id)`` is a nicer API than ``Users.get(id)`` / ``Rooms.get(id)``.
>
> Thumbs up if you *don't* think so.

_Originally posted by @Slayer95 in https://github.com/Zarel/Pokemon-Showdown/pull/5429#issuecomment-481463245_

This is my counter argument. I even added some sugar back in 111f26b because in that case `new TeamValidatorAsync.TeamValidatorAsync(...)` looks worse than `TeamValidatorAsync.create(...)` IMO. I don't think its necessary for `TeamValidator` and `new TeamValidator(...)` is shorter than `TeamValidator.create(...)` anyway, but I can maybe see adding a factory method there as well for consistency. Either way, I believe this pattern is more straightforward than the previous one, and having to type `.create` or `new ` doesn't seem like such a large imposition as to merit adding the confusing `Object.assign(function)` pattern.

I'm happy to migrate `Rooms`/`Users` in a separate PR, I just wanted to throw something concrete out there. (I only really planned to change `TeamValidator` as a strawman, but `TeamValidatorAsync` is such a close analog that it seems wrong to have them both have different APIs. Which is why I'd also be OK with a `create` method on `TeamValidator`, FWIW)