### PR TITLE
Make Pokemon.moves a read only array

### DIFF
--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -1405,7 +1405,6 @@ let BattleMovedex = {
 						used: false,
 						virtual: true,
 					});
-					pokemon.moves.push(move.id);
 				}
 			},
 			onModifySpAPriority: 1,
@@ -1439,7 +1438,6 @@ let BattleMovedex = {
 						used: false,
 						virtual: true,
 					});
-					pokemon.moves.push(move.id);
 				}
 			},
 		},
@@ -1660,7 +1658,6 @@ let BattleMovedex = {
 							used: false,
 							virtual: true,
 						});
-						pokemon.moves.push(move.id);
 					}
 				}
 			},

--- a/data/mods/ssb/statuses.js
+++ b/data/mods/ssb/statuses.js
@@ -461,7 +461,6 @@ let BattleStatuses = {
 					used: false,
 					virtual: true,
 				});
-				target.moves.push(move.id);
 			}
 		},
 		onBeforeSwitchOut(pokemon) {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -382,7 +382,7 @@ export class Pokemon {
 		this.m = {};
 	}
 
-	get moves() {
+	get moves(): readonly string[] {
 		return this.moveSlots.map(moveSlot => moveSlot.id);
 	}
 
@@ -923,7 +923,6 @@ export class Pokemon {
 				used: false,
 				virtual: true,
 			});
-			this.moves.push(toId(moveName));
 		}
 		let boostName: BoostName;
 		for (boostName in pokemon.boosts) {


### PR DESCRIPTION
We're still trying to `push` uselessly to it in a couple of places.

I don't know if you want the Typescript annotation or whether it's the best way of annotating the requirement.