### PR TITLE
Test: Implement `npm run fulltest` and flagging tests as slow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ cache:
 notifications:
   webhooks: https://www.travisbuddy.com/
   on_success: change
+script: npm run fulltest
 travisBuddy:
   insertMode: update

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "start": "node pokemon-showdown start",
     "build": "node build",
-    "test": "eslint --cache . && tslint --project . && node build && mocha && tsc",
+    "test": "eslint --cache . && tslint --project . && node build && mocha -i -g \"\\(slow\\)\" && tsc",
+    "fulltest": "eslint --cache . && tslint --project . && node build && mocha && tsc",
     "tsc": "tsc",
     "lint": "eslint --cache ."
   },

--- a/test/dev-tools/harness.js
+++ b/test/dev-tools/harness.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const {MultiRunner} = require('./../../dev-tools/harness');
 
-describe.skip('MultiRunner', async () => {
+describe('MultiRunner (slow)', async () => {
 	it('should run successfully', async () => {
 		const opts = {totalGames: 1, prng: [1, 2, 3, 4]};
 		assert.strictEqual(await (new MultiRunner(opts).run()), 0);

--- a/test/dev-tools/smoke.js
+++ b/test/dev-tools/smoke.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const {SmokeRunner} = require('./../../dev-tools/smoke');
 
-describe.skip('SmokeRunner', async () => {
+describe('SmokeRunner (slow)', async () => {
 	it('should run successfully', async () => {
 		const opts = {format: 'gen7doublescustomgame', maxGames: 1, prng: [1, 2, 3, 4]};
 		assert.strictEqual(await (new SmokeRunner(opts).run()), 0);


### PR DESCRIPTION
- Tests flagged with (slow) will no longer be run in `npm test`.
- Travis CI will now run `fulltest`.
- Unskip slow dev-tools tests and flag as such.