### PR TITLE
Include diffs of all User settings in |updateuser|

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -598,7 +598,7 @@ const commands = {
 		user.blockPMs = true;
 		if (target in Config.groups) {
 			user.blockPMs = target;
-			user.update();
+			user.update('blockPMs');
 			return this.sendReply(`You are now blocking private messages, except from staff and ${target}.`);
 		}
 		user.update();
@@ -613,7 +613,7 @@ const commands = {
 	unblockpms(target, room, user) {
 		if (!user.blockPMs) return this.errorReply("You are not blocking private messages! To block, use /blockpms");
 		user.blockPMs = false;
-		user.update();
+		user.update('blockPMs');
 		return this.sendReply("You are no longer blocking private messages.");
 	},
 	unblockpmshelp: [`/unblockpms - Unblocks private messages. Block them with /blockpms.`],
@@ -4052,7 +4052,7 @@ const commands = {
 	blockchallenges(target, room, user) {
 		if (user.blockChallenges) return this.errorReply("You are already blocking challenges!");
 		user.blockChallenges = true;
-		user.update();
+		user.update('blockChallenges');
 		this.sendReply("You are now blocking all incoming challenge requests.");
 	},
 	blockchallengeshelp: [`/blockchallenges - Blocks challenges so no one can challenge you. Unblock them with /unblockchallenges.`],
@@ -4065,7 +4065,7 @@ const commands = {
 	allowchallenges(target, room, user) {
 		if (!user.blockChallenges) return this.errorReply("You are already available for challenges!");
 		user.blockChallenges = false;
-		user.update();
+		user.update('blockChallenges');
 		this.sendReply("You are available for challenges from now on.");
 	},
 	allowchallengeshelp: [`/unblockchallenges - Unblocks challenges so you can be challenged again. Block them with /blockchallenges.`],

--- a/server/chat-plugins/helptickets.js
+++ b/server/chat-plugins/helptickets.js
@@ -1082,6 +1082,7 @@ let commands = {
 			if (!this.can('lock')) return;
 			if (user.ignoreTickets) return this.errorReply(`You are already ignoring help ticket notifications. Use /helpticket unignore to receive notifications again.`);
 			user.ignoreTickets = true;
+			user.update('ignoreTickets');
 			this.sendReply(`You are now ignoring help ticket notifications.`);
 		},
 		ignorehelp: [`/helpticket ignore - Ignore notifications for unclaimed help tickets. Requires: % @ & ~`],
@@ -1090,6 +1091,7 @@ let commands = {
 			if (!this.can('lock')) return;
 			if (!user.ignoreTickets) return this.errorReply(`You are not ignoring help ticket notifications. Use /helpticket ignore to stop receiving notifications.`);
 			user.ignoreTickets = false;
+			user.update('ignoreTickets');
 			this.sendReply(`You will now receive help ticket notifications.`);
 		},
 		unignorehelp: [`/helpticket unignore - Stop ignoring notifications for help tickets. Requires: % @ & ~`],

--- a/server/chat-plugins/roomsettings.js
+++ b/server/chat-plugins/roomsettings.js
@@ -283,9 +283,11 @@ exports.commands = {
 		if (!(groupConfig && groupConfig.editprivacy)) return this.errorReply(`/ionext - Access denied.`);
 		if (this.meansNo(target)) {
 			user.inviteOnlyNextBattle = false;
+			user.update('inviteOnlyNextBattle');
 			this.sendReply("Your next battle will be publicly visible.");
 		} else {
 			user.inviteOnlyNextBattle = true;
+			user.update('inviteOnlyNextBattle');
 			this.sendReply("Your next battle will be invite-only.");
 		}
 	},

--- a/server/users.js
+++ b/server/users.js
@@ -1058,7 +1058,7 @@ class User extends Chat.MessageContext {
 		this.latestIp = oldUser.latestIp;
 		this.latestHost = oldUser.latestHost;
 
-		oldUser.markInactive();
+		oldUser.markDisconnected();
 	}
 	/**
 	 * @param {Connection} connection
@@ -1200,7 +1200,7 @@ class User extends Chat.MessageContext {
 		this.setGroup(Config.groupsranking[0]);
 		return removed;
 	}
-	markInactive() {
+	markDisconnected() {
 		this.connected = false;
 		this.lastConnected = Date.now();
 		if (!this.registered) {
@@ -1223,7 +1223,7 @@ class User extends Chat.MessageContext {
 			if (connected === connection) {
 				// console.log('DISCONNECT: ' + this.userid);
 				if (this.connections.length <= 1) {
-					this.markInactive();
+					this.markDisconnected();
 				}
 				for (const roomid of connection.inRooms) {
 					this.leaveRoom(Rooms(roomid), connection, true);
@@ -1255,7 +1255,7 @@ class User extends Chat.MessageContext {
 		// Disconnects a user from the server
 		this.clearChatQueue();
 		let connection = null;
-		this.markInactive();
+		this.markDisconnected();
 		for (let i = this.connections.length - 1; i >= 0; i--) {
 			// console.log('DESTROY: ' + this.userid);
 			connection = this.connections[i];


### PR DESCRIPTION
Fixes #5424. The client code is already able to handle diffs.

- in certain scenarios I think we want to continue to send all the values instead of just the diffs
- `User.lastConnected` gets updated in `User.markInactive()`, but we cant send an `|updateuser|` at that point
- `User.isStaff` and `User.isSysop` usually get updated right before we'd be sending all the values anyway, so I'm trying to avoid doing a double `update`
- WTF is going on with `specialNextBattle`? I only see it being read, not being written?

    ```
    server/rooms.js:1615:               /** @type {(User & {specialNextBattle: boolean})[]} */
    server/rooms.js:1638:               if (players.some(user => user.specialNextBattle)) {
    server/rooms.js:1639:                       const p1Special = players[0].specialNextBattle;
    server/rooms.js:1642:                               if (user.specialNextBattle !== p1Special) {
    server/rooms.js:1643:                                       mismatch += ` vs. "${user.specialNextBattle}"`;
    ```