### PR TITLE
Rework mocha fulltest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   "scripts": {
     "start": "node pokemon-showdown start",
     "build": "node build",
-    "test": "eslint --cache . && tslint --project . && node build && mocha -i -g \"\\(slow\\)\" && tsc",
-    "fulltest": "eslint --cache . && tslint --project . && node build && mocha && tsc",
     "tsc": "tsc",
-    "lint": "eslint --cache ."
+    "lint": "eslint --cache . && tslint --project .",
+    "pretest": "npm run lint && npm run build",
+    "test": "mocha",
+    "posttest": "npm run tsc",
+    "fulltest": "npm run pretest && mocha -g '$^' && npm run posttest"
   },
   "husky": {
     "hooks": {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 test/main.js test/dev-tools/**/*.js test/server/**/*.js test/sim/**/*.js
+-i -g "\(slow\)"
 -R dot
 -u bdd
 --exit


### PR DESCRIPTION
_#justbikesheddingthings_

Optional follow up to #5437, maybe you guys are interested in some or none of the following:

- leverage [mocha's merging order](https://mochajs.org/#merging) with an impossible regex and `test/mocha.opts` to make `npx mocha` be the default which skips slow tests
- put `eslint` and `tslint` together under the `lint` script
- use standard [`posttest` and `pretest` hooks](https://docs.npmjs.com/misc/scripts)

In other news, @KrisXV's test is damn slow. How long do we think is OK for Travis? Can I run a full cycle of smokes tests instead of just the one canary one?

