### PR TITLE
Past Gens: Fix confusion interaction with self-destructing moves in gen 2

### DIFF
--- a/data/mods/gen2/statuses.js
+++ b/data/mods/gen2/statuses.js
@@ -150,6 +150,7 @@ let BattleStatuses = {
 				isSelfHit: true,
 				noDamageVariance: true,
 				flags: {},
+				selfdestruct: move.selfdestruct,
 			});
 			let damage = this.getDamage(pokemon, pokemon, move);
 			if (typeof damage !== 'number') throw new Error("Confusion damage not dealt");


### PR DESCRIPTION
This should fix https://github.com/Zarel/Pokemon-Showdown/projects/3#card-18664063