### PR TITLE
Fixes crash in gen3doubles due to missing target

### DIFF
--- a/data/mods/gen3/scripts.js
+++ b/data/mods/gen3/scripts.js
@@ -132,7 +132,7 @@ let BattleScripts = {
 			if (move.spreadHit) this.attrLastMove('[spread] ' + hitTargets.join(','));
 		} else {
 			target = targets[0];
-			let lacksTarget = target.fainted;
+			let lacksTarget = !target || target.fainted;
 			if (!lacksTarget) {
 				if (move.target === 'adjacentFoe' || move.target === 'adjacentAlly' || move.target === 'normal' || move.target === 'randomNormal') {
 					lacksTarget = !this.isAdjacent(target, pokemon);


### PR DESCRIPTION
Fixes #5464

Simple fix, but I didn't just commit it directly because I want someone confirm that `targets` being empty is actually expected and that there's not a deeper issue at play.