### PR TITLE
Introduce an ID type to sim

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1046,7 +1046,7 @@ let Formats = [
 				// that a pokemon is on a team through the onStart even triggering
 				// at the start of a match, users with pokemon names will need their
 				// statuse's to end in "user".
-				name += 'user';
+				name = /** @type {ID} */(name + 'user');
 			}
 			// Add the mon's status effect to it as a volatile.
 			let status = this.getEffect(name);

--- a/data/mods/gen2/moves.js
+++ b/data/mods/gen2/moves.js
@@ -107,7 +107,7 @@ let BattleMovedex = {
 					/** @type {ActiveMove} */
 					// @ts-ignore
 					let moveData = {
-						id: 'bide',
+						id: /** @type {ID} */('bide'),
 						name: "Bide",
 						accuracy: 100,
 						damage: this.effectData.totalDamage * 2,

--- a/data/mods/gen2/statuses.js
+++ b/data/mods/gen2/statuses.js
@@ -111,7 +111,7 @@ let BattleStatuses = {
 		},
 		onSwitchIn(pokemon) {
 			// Regular poison status and damage after a switchout -> switchin.
-			pokemon.status = 'psn';
+			pokemon.status = /** @type {ID} */('psn');
 		},
 		onAfterSwitchInSelf(pokemon) {
 			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));

--- a/data/mods/gen3/moves.js
+++ b/data/mods/gen3/moves.js
@@ -91,7 +91,7 @@ let BattleMovedex = {
 					/** @type {ActiveMove} */
 					// @ts-ignore
 					let moveData = {
-						id: 'bide',
+						id: /** @type {ID} */('bide'),
 						name: "Bide",
 						accuracy: 100,
 						damage: this.effectData.totalDamage * 2,

--- a/data/mods/gen4/abilities.js
+++ b/data/mods/gen4/abilities.js
@@ -378,7 +378,7 @@ let BattleAbilities = {
 			if (effect && effect.id === 'toxicspikes') return;
 			let id = status.id;
 			if (id === 'slp' || id === 'frz') return;
-			if (id === 'tox') id = 'psn';
+			if (id === 'tox') id = /** @type {ID} */('psn');
 			source.trySetStatus(id, target);
 		},
 	},

--- a/data/mods/gennext/statuses.js
+++ b/data/mods/gennext/statuses.js
@@ -136,8 +136,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'shadowtag';
-				pokemon.baseAbility = 'shadowtag';
+				pokemon.ability = /** @type {ID} */('shadowtag');
+				pokemon.baseAbility = /** @type {ID} */('shadowtag');
 			}
 			if (pokemon.transformed) return;
 			pokemon.setType(pokemon.hpType || 'Dark');
@@ -150,8 +150,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'heatproof';
-				pokemon.baseAbility = 'heatproof';
+				pokemon.ability = /** @type {ID} */('heatproof');
+				pokemon.baseAbility = /** @type {ID} */('heatproof');
 			}
 		},
 	},
@@ -162,8 +162,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'aftermath';
-				pokemon.baseAbility = 'aftermath';
+				pokemon.ability = /** @type {ID} */('aftermath');
+				pokemon.baseAbility = /** @type {ID} */('aftermath');
 			}
 		},
 	},
@@ -174,8 +174,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'compoundeyes';
-				pokemon.baseAbility = 'compoundeyes';
+				pokemon.ability = /** @type {ID} */('compoundeyes');
+				pokemon.baseAbility = /** @type {ID} */('compoundeyes');
 			}
 		},
 	},
@@ -186,8 +186,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'poisonheal';
-				pokemon.baseAbility = 'poisonheal';
+				pokemon.ability = /** @type {ID} */('poisonheal');
+				pokemon.baseAbility = /** @type {ID} */('poisonheal');
 			}
 		},
 	},
@@ -198,8 +198,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'filter';
-				pokemon.baseAbility = 'filter';
+				pokemon.ability = /** @type {ID} */('filter');
+				pokemon.baseAbility = /** @type {ID} */('filter');
 			}
 		},
 	},
@@ -210,8 +210,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'cursedbody';
-				pokemon.baseAbility = 'cursedbody';
+				pokemon.ability = /** @type {ID} */('cursedbody');
+				pokemon.baseAbility = /** @type {ID} */('cursedbody');
 			}
 		},
 	},
@@ -222,8 +222,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'cursedbody';
-				pokemon.baseAbility = 'cursedbody';
+				pokemon.ability = /** @type {ID} */('cursedbody');
+				pokemon.baseAbility = /** @type {ID} */('cursedbody');
 			}
 		},
 	},
@@ -234,8 +234,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'serenegrace';
-				pokemon.baseAbility = 'serenegrace';
+				pokemon.ability = /** @type {ID} */('serenegrace');
+				pokemon.baseAbility = /** @type {ID} */('serenegrace');
 			}
 		},
 	},
@@ -246,8 +246,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'synchronize';
-				pokemon.baseAbility = 'synchronize';
+				pokemon.ability = /** @type {ID} */('synchronize');
+				pokemon.baseAbility = /** @type {ID} */('synchronize');
 			}
 		},
 	},
@@ -258,8 +258,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'steadfast';
-				pokemon.baseAbility = 'steadfast';
+				pokemon.ability = /** @type {ID} */('steadfast');
+				pokemon.baseAbility = /** @type {ID} */('steadfast');
 			}
 		},
 	},
@@ -270,8 +270,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'sheerforce';
-				pokemon.baseAbility = 'sheerforce';
+				pokemon.ability = /** @type {ID} */('sheerforce');
+				pokemon.baseAbility = /** @type {ID} */('sheerforce');
 			}
 		},
 	},
@@ -282,8 +282,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'trace';
-				pokemon.baseAbility = 'trace';
+				pokemon.ability = /** @type {ID} */('trace');
+				pokemon.baseAbility = /** @type {ID} */('trace');
 			}
 		},
 	},
@@ -294,8 +294,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'trace';
-				pokemon.baseAbility = 'trace';
+				pokemon.ability = /** @type {ID} */('trace');
+				pokemon.baseAbility = /** @type {ID} */('trace');
 			}
 		},
 	},
@@ -306,8 +306,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'trace';
-				pokemon.baseAbility = 'trace';
+				pokemon.ability = /** @type {ID} */('trace');
+				pokemon.baseAbility = /** @type {ID} */('trace');
 			}
 		},
 	},
@@ -318,8 +318,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'trace';
-				pokemon.baseAbility = 'trace';
+				pokemon.ability = /** @type {ID} */('trace');
+				pokemon.baseAbility = /** @type {ID} */('trace');
 			}
 		},
 	},
@@ -330,8 +330,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'trace';
-				pokemon.baseAbility = 'trace';
+				pokemon.ability = /** @type {ID} */('trace');
+				pokemon.baseAbility = /** @type {ID} */('trace');
 			}
 		},
 	},
@@ -342,8 +342,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'trace';
-				pokemon.baseAbility = 'trace';
+				pokemon.ability = /** @type {ID} */('trace');
+				pokemon.baseAbility = /** @type {ID} */('trace');
 			}
 		},
 	},
@@ -367,8 +367,8 @@ let BattleStatuses = {
 		},
 		onStart(pokemon) {
 			if (pokemon.ability === 'levitate') {
-				pokemon.ability = 'icebody';
-				pokemon.baseAbility = 'icebody';
+				pokemon.ability = /** @type {ID} */('icebody');
+				pokemon.baseAbility = /** @type {ID} */('icebody');
 			}
 		},
 	},

--- a/data/mods/mixandmega/scripts.js
+++ b/data/mods/mixandmega/scripts.js
@@ -15,7 +15,7 @@ let BattleScripts = {
 		if (item.megaStone) {
 			if (item.megaStone === pokemon.species) return null;
 			return item.megaStone;
-		} else if (pokemon.baseMoves.includes('dragonascent')) {
+		} else if (pokemon.baseMoves.includes(/** @type {ID} */('dragonascent'))) {
 			return 'Rayquaza-Mega';
 		} else {
 			return null;

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -504,7 +504,7 @@ let BattleFormats = {
 			for (const set of team) {
 				let ability = toId(set.ability);
 				if (!ability) continue;
-				if (ability in base) ability = base[ability];
+				if (ability in base) ability = /** @type {ID} */(base[ability]);
 				if (ability in abilityTable) {
 					if (abilityTable[ability] >= 2) {
 						return ["You are limited to two of each ability by the Ability Clause.", `(You have more than two ${this.getAbility(ability).name} variants)`];

--- a/server/chat-plugins/helptickets.js
+++ b/server/chat-plugins/helptickets.js
@@ -127,7 +127,7 @@ class HelpTicket extends Rooms.RoomGame {
 			tickets[this.ticket.userid] = this.ticket;
 			writeTickets();
 		} else {
-			let index = this.claimQueue.map(toId).indexOf(user.userid);
+			let index = this.claimQueue.map(toId).indexOf(/** @type {ID} */(user.userid));
 			if (index > -1) this.claimQueue.splice(index, 1);
 		}
 	}

--- a/server/chat-plugins/mafia.js
+++ b/server/chat-plugins/mafia.js
@@ -1235,7 +1235,7 @@ class MafiaTracker extends Rooms.RoomGame {
 		// ['alignment', 'alien']
 		// ['selection', ''] deselects
 		if (selection[1]) {
-			const roleIndex = player.IDEA.choices.map(toId).indexOf(selection[1]);
+			const roleIndex = player.IDEA.choices.map(toId).indexOf(/** @type {ID} */(selection[1]));
 			if (roleIndex === -1) return user.sendTo(this.room, `|error|${selection[1]} is not an available role, perhaps it is already selected?`);
 			selection[1] = player.IDEA.choices.splice(roleIndex, 1)[0];
 		} else {

--- a/server/chat-plugins/room-faqs.js
+++ b/server/chat-plugins/room-faqs.js
@@ -94,6 +94,7 @@ const commands = {
 	rfaq: 'roomfaq',
 	roomfaq(target, room, user) {
 		if (!roomFaqs[room.id]) return this.errorReply("This room has no FAQ topics.");
+		/** @type {string} */
 		let topic = toId(target);
 		if (topic === 'constructor') return false;
 		if (!topic) return this.sendReplyBox(`List of topics in this room: ${Object.keys(roomFaqs[room.id]).filter(val => !getAlias(room.id, val)).sort((a, b) => a.localeCompare(b)).join(', ')}`);

--- a/server/punishments.js
+++ b/server/punishments.js
@@ -807,7 +807,7 @@ const Punishments = new (class {
 	 */
 	unlock(name) {
 		let user = Users(name);
-		let id = toId(name);
+		let id = /** @type {string} */(toId(name));
 		/** @type {string[]} */
 		let success = [];
 		if (user && user.locked && !user.namelocked) {
@@ -864,7 +864,7 @@ const Punishments = new (class {
 	 */
 	unnamelock(name) {
 		let user = Users(name);
-		let id = toId(name);
+		let id = /** @type {string} */(toId(name));
 		/** @type {string[]} */
 		let success = [];
 		// @ts-ignore

--- a/server/tournaments/index.js
+++ b/server/tournaments/index.js
@@ -50,8 +50,10 @@ class Tournament extends Rooms.RoomGame {
 		this.playerCount = 0;
 		this.playerCap = (playerCap ? parseInt(playerCap) : Config.tourdefaultplayercap) || 0;
 
+		/** @type {string} */
 		this.format = formatId;
 		this.originalFormat = formatId;
+		/** @type {string} */
 		this.teambuilderFormat = formatId;
 		/** @type {string[]} */
 		this.customRules = [];

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -82,7 +82,7 @@ export class Battle extends Dex.ModdedDex {
 	winner?: string;
 
 	effect: Effect;
-	effectData: AnyObjectWithID;
+	effectData: AnyObject;
 
 	event: AnyObject;
 	events: AnyObject | null;
@@ -372,7 +372,7 @@ export class Battle extends Dex.ModdedDex {
 
 	/** The entire event system revolves around this function and runEvent. */
 	singleEvent(
-		eventid: string, effect: Effect, effectData: AnyObjectWithID | null,
+		eventid: string, effect: Effect, effectData: AnyObject | null,
 		target: string | Pokemon | Side | Field | Battle | null, source?: string | Pokemon | Effect | false | null,
 		sourceEffect?: Effect | string | null, relayVar?: any) {
 		if (this.eventDepth >= 8) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -21,7 +21,7 @@ interface FaintedPokemon {
 }
 
 interface BattleOptions {
-	formatid: string; // Format ID
+	formatid: ID; // Format ID
 	send?: (type: string, data: string | string[]) => void; // Output callback
 	prng?: PRNG; // PRNG override (you usually don't need this, just pass a seed)
 	seed?: PRNGSeed; // PRNG seed
@@ -48,7 +48,7 @@ type Part = string | number | boolean | AnyObject | null | undefined;
 export type RequestState = 'teampreview' | 'move' | 'switch' | '';
 
 export class Battle extends Dex.ModdedDex {
-	readonly id: '';
+	readonly id: ID;
 	readonly debugMode: boolean;
 	readonly deserialized: boolean;
 	readonly strictChoices: boolean;
@@ -82,7 +82,7 @@ export class Battle extends Dex.ModdedDex {
 	winner?: string;
 
 	effect: Effect;
-	effectData: AnyObject;
+	effectData: AnyObjectWithID;
 
 	event: AnyObject;
 	events: AnyObject | null;
@@ -184,7 +184,7 @@ export class Battle extends Dex.ModdedDex {
 		// (so speedSort doesn't need to bind before use)
 		this.comparePriority = this.comparePriority.bind(this);
 
-		const inputOptions: {formatid: string, seed: PRNGSeed, rated?: string | true} = {
+		const inputOptions: {formatid: ID, seed: PRNGSeed, rated?: string | true} = {
 			formatid: options.formatid, seed: this.prng.seed,
 		};
 		if (this.rated) inputOptions.rated = this.rated;
@@ -372,7 +372,7 @@ export class Battle extends Dex.ModdedDex {
 
 	/** The entire event system revolves around this function and runEvent. */
 	singleEvent(
-		eventid: string, effect: Effect, effectData: AnyObject | null,
+		eventid: string, effect: Effect, effectData: AnyObjectWithID | null,
 		target: string | Pokemon | Side | Field | Battle | null, source?: string | Pokemon | Effect | false | null,
 		sourceEffect?: Effect | string | null, relayVar?: any) {
 		if (this.eventDepth >= 8) {
@@ -2285,7 +2285,7 @@ export class Battle extends Dex.ModdedDex {
 		for (const side of this.sides) {
 			for (const pokemon of side.active) {
 				if (pokemon.fainted) {
-					pokemon.status = 'fnt';
+					pokemon.status = 'fnt' as ID;
 					pokemon.switchFlag = true;
 				}
 			}

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -37,14 +37,14 @@ export class Tools {
 	 * Dex.getId is generally assigned to the global toId, because of how
 	 * commonly it's used.
 	 */
-	static getId(text: any): string {
+	static getId(text: any): ID {
 		if (text && text.id) {
 			text = text.id;
 		} else if (text && text.userid) {
 			text = text.userid;
 		}
 		if (typeof text !== 'string' && typeof text !== 'number') return '';
-		return ('' + text).toLowerCase().replace(/[^a-z0-9]+/g, '');
+		return ('' + text).toLowerCase().replace(/[^a-z0-9]+/g, '') as ID;
 	}
 }
 const toId = Tools.getId;
@@ -56,7 +56,7 @@ export class BasicEffect implements EffectData {
 	 * becomes "mrmime", and "Basculin-Blue-Striped" becomes
 	 * "basculinbluestriped".
 	 */
-	id: string;
+	id: ID;
 	/**
 	 * Name. Currently does not support Unicode letters, so "Flabébé"
 	 * is "Flabebe" and "Nidoran♀" is "Nidoran-F".
@@ -115,9 +115,9 @@ export class BasicEffect implements EffectData {
 	/** Whether or not the effect affects fainted Pokemon. */
 	affectsFainted: boolean;
 	/** The status that the effect may cause. */
-	status?: string;
+	status?: ID;
 	/** The weather that the effect may cause. */
-	weather?: string;
+	weather?: ID;
 	/** HP that the effect may drain. */
 	drain?: [number, number];
 	flags: AnyObject;
@@ -128,7 +128,7 @@ export class BasicEffect implements EffectData {
 		data = combine(this, data, ...moreData);
 
 		this.name = Tools.getString(data.name).trim();
-		this.id = data.id || toId(this.name); // Hidden Power hack
+		this.id = toId(data.id || this.name); // Hidden Power hack
 		this.fullname = Tools.getString(data.fullname) || this.name;
 		this.effectType = Tools.getString(data.effectType) as EffectType || 'Effect';
 		this.exists = !!(this.exists && this.id);
@@ -141,8 +141,8 @@ export class BasicEffect implements EffectData {
 		this.duration = data.duration;
 		this.noCopy = !!data.noCopy;
 		this.affectsFainted = !!data.affectsFainted;
-		this.status = data.status || undefined;
-		this.weather = data.weather || undefined;
+		this.status = toId(data.status) || undefined;
+		this.weather = toId(data.weather) || undefined;
 		this.drain = data.drain || undefined;
 		this.flags = data.flags || {};
 		this.sourceEffect = data.sourceEffect || '';
@@ -490,7 +490,7 @@ export class Template extends BasicEffect implements Readonly<BasicEffect & Temp
 	 * 'basculinbluestriped'. To get the base species ID, you need to
 	 * manually read toId(template.baseSpecies).
 	 */
-	readonly speciesid: string;
+	readonly speciesid: ID;
 	/**
 	 * Species. Identical to name. Note that this is the full name,
 	 * e.g. 'Basculin-Blue-Striped'. To get the base species name, see
@@ -609,7 +609,7 @@ export class Template extends BasicEffect implements Readonly<BasicEffect & Temp
 
 		this.fullname = `pokemon: ${data.name}`;
 		this.effectType = 'Pokemon';
-		this.speciesid = data.speciesid || this.id;
+		this.speciesid = toId(data.speciesid) || this.id;
 		this.species = data.species || data.name;
 		this.name = data.species;
 		this.baseSpecies = data.baseSpecies || this.name;
@@ -861,7 +861,7 @@ export class TypeInfo implements Readonly<TypeData> {
 	 * ID. This will be a lowercase version of the name with all the
 	 * non-alphanumeric characters removed. e.g. 'flying'
 	 */
-	readonly id: string;
+	readonly id: ID;
 	/** Name. e.g. 'Flying' */
 	readonly name: string;
 	/** Effect type. */

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -128,7 +128,7 @@ export class BasicEffect implements EffectData {
 		data = combine(this, data, ...moreData);
 
 		this.name = Tools.getString(data.name).trim();
-		this.id = toId(data.id || this.name); // Hidden Power hack
+		this.id = data.id as ID || toId(this.name); // Hidden Power hack
 		this.fullname = Tools.getString(data.fullname) || this.name;
 		this.effectType = Tools.getString(data.effectType) as EffectType || 'Effect';
 		this.exists = !!(this.exists && this.id);
@@ -141,8 +141,8 @@ export class BasicEffect implements EffectData {
 		this.duration = data.duration;
 		this.noCopy = !!data.noCopy;
 		this.affectsFainted = !!data.affectsFainted;
-		this.status = toId(data.status) || undefined;
-		this.weather = toId(data.weather) || undefined;
+		this.status = data.status as ID || undefined;
+		this.weather = data.weather as ID || undefined;
 		this.drain = data.drain || undefined;
 		this.flags = data.flags || {};
 		this.sourceEffect = data.sourceEffect || '';
@@ -609,7 +609,7 @@ export class Template extends BasicEffect implements Readonly<BasicEffect & Temp
 
 		this.fullname = `pokemon: ${data.name}`;
 		this.effectType = 'Pokemon';
-		this.speciesid = toId(data.speciesid) || this.id;
+		this.speciesid = data.speciesid as ID || this.id;
 		this.species = data.species || data.name;
 		this.name = data.species;
 		this.baseSpecies = data.baseSpecies || this.name;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -139,14 +139,14 @@ class ModdedDex {
 	readonly isBase: boolean;
 	readonly currentMod: string;
 
-	readonly getId: (text: any) => string;
+	readonly getId: (text: any) => ID;
 	readonly getString: (str: any) => string;
 
-	readonly abilityCache: Map<string, Ability>;
-	readonly effectCache: Map<string, Effect | Move>;
-	readonly itemCache: Map<string, Item>;
-	readonly moveCache: Map<string, Move>;
-	readonly templateCache: Map<string, Template>;
+	readonly abilityCache: Map<ID, Ability>;
+	readonly effectCache: Map<ID, Effect | Move>;
+	readonly itemCache: Map<ID, Item>;
+	readonly moveCache: Map<ID, Move>;
+	readonly templateCache: Map<ID, Template>;
 	readonly typeCache: Map<string, TypeInfo>;
 
 	gen: number;
@@ -340,9 +340,9 @@ class ModdedDex {
 		name = (name || '').trim();
 		let id = toId(name);
 		if (id === 'nidoran' && name.slice(-1) === '♀') {
-			id = 'nidoranf';
+			id = 'nidoranf' as ID;
 		} else if (id === 'nidoran' && name.slice(-1) === '♂') {
-			id = 'nidoranm';
+			id = 'nidoranm' as ID;
 		}
 		let template: any = this.templateCache.get(id);
 		if (template) return template;
@@ -434,7 +434,7 @@ class ModdedDex {
 			return move;
 		}
 		if (id.substr(0, 11) === 'hiddenpower') {
-			id = /([a-z]*)([0-9]*)/.exec(id)![1];
+			id = /([a-z]*)([0-9]*)/.exec(id)![1] as ID;
 		}
 		if (id && this.data.Movedex.hasOwnProperty(id)) {
 			move = new Data.Move({name}, this.data.Movedex[id]);
@@ -539,7 +539,7 @@ class ModdedDex {
 			id = toId(name);
 		}
 		if (this.data.Formats.hasOwnProperty('gen7' + id)) {
-			id = 'gen7' + id;
+			id = ('gen7' + id) as ID;
 		}
 		let supplementaryAttributes: AnyObject | null = null;
 		if (name.includes('@@@')) {
@@ -623,12 +623,12 @@ class ModdedDex {
 	getType(name: string | TypeInfo): TypeInfo {
 		if (name && typeof name !== 'string') return name;
 
-		let id = toId(name);
-		id = id.charAt(0).toUpperCase() + id.substr(1);
-		let type = this.typeCache.get(id);
+		const id = toId(name);
+		const typeName = id.charAt(0).toUpperCase() + id.substr(1);
+		let type = this.typeCache.get(typeName);
 		if (type) return type;
-		if (id && this.data.TypeChart.hasOwnProperty(id)) {
-			type = new Data.TypeInfo({id}, this.data.TypeChart[id]);
+		if (typeName && this.data.TypeChart.hasOwnProperty(typeName)) {
+			type = new Data.TypeInfo({id}, this.data.TypeChart[typeName]);
 		} else {
 			type = new Data.TypeInfo({name, exists: false, effectType: 'EffectType'});
 		}
@@ -861,7 +861,7 @@ class ModdedDex {
 		for (const matchType of matchTypes) {
 			if (rule.slice(0, 1 + matchType.length) === matchType + ':') {
 				matchTypes = [matchType];
-				id = id.slice(matchType.length);
+				id = id.slice(matchType.length) as ID;
 				break;
 			}
 		}
@@ -899,7 +899,7 @@ class ModdedDex {
 				}
 				matches.push(matchType + ':' + id);
 			} else if (matchType === 'pokemon' && id.slice(-4) === 'base') {
-				id = id.slice(0, -4);
+				id = id.slice(0, -4) as ID;
 				if (table.hasOwnProperty(id)) {
 					matches.push('pokemon:' + id);
 				}

--- a/sim/field.ts
+++ b/sim/field.ts
@@ -9,12 +9,12 @@ import {State} from './state';
 
 export class Field {
 	readonly battle: Battle;
-	readonly id: '';
+	readonly id: ID;
 
-	weather: string;
-	weatherData: AnyObject;
-	terrain: string;
-	terrainData: AnyObject;
+	weather: ID;
+	weatherData: AnyObjectWithID;
+	terrain: ID;
+	terrainData: AnyObjectWithID;
 	pseudoWeather: AnyObject;
 
 	constructor(battle: Battle) {

--- a/sim/field.ts
+++ b/sim/field.ts
@@ -12,9 +12,9 @@ export class Field {
 	readonly id: ID;
 
 	weather: ID;
-	weatherData: AnyObjectWithID;
+	weatherData: AnyObject;
 	terrain: ID;
-	terrainData: AnyObjectWithID;
+	terrainData: AnyObject;
 	pseudoWeather: AnyObject;
 
 	constructor(battle: Battle) {

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -6,7 +6,9 @@ type PRNGSeed = import('./prng').PRNGSeed;
 type Side = import('./side').Side
 type Validator = import('./team-validator').Validator
 
+type ID = '' | string & {__isID: true};
 interface AnyObject {[k: string]: any}
+interface AnyObjectWithID {id?: ID, [k: string]: any}
 type DexTable<T> = {[key: string]: T}
 
 type GenderName = 'M' | 'F' | 'N' | '';
@@ -714,6 +716,9 @@ interface ModdedEffectData extends Partial<EffectData> {
 type EffectType = 'Effect' | 'Pokemon' | 'Move' | 'Item' | 'Ability' | 'Format' | 'Ruleset' | 'Weather' | 'Status' | 'Rule' | 'ValidatorRule'
 
 interface BasicEffect extends EffectData {
+	id: ID
+	weather?: ID
+	status?: ID
 	effectType: EffectType
 	exists: boolean
 	flags: AnyObject
@@ -871,6 +876,9 @@ type MoveHitData = {[targetSlotid: string]: {
 
 interface ActiveMove extends BasicEffect, MoveData {
 	readonly effectType: 'Move'
+	id: ID
+	weather?: ID
+	status?: ID
 	hit: number
 	moveHitData?: MoveHitData
 	ability?: Ability
@@ -985,7 +993,7 @@ interface Template extends Readonly<BasicEffect & TemplateData & TemplateFormats
 	readonly maleOnlyHidden: boolean
 	readonly nfe: boolean
 	readonly prevo: string
-	readonly speciesid: string
+	readonly speciesid: ID
 	readonly spriteid: string
 	readonly tier: string
 	readonly addedType?: string
@@ -1136,7 +1144,7 @@ interface ModdedBattlePokemon {
 	boostBy?: (this: Pokemon, boost: SparseBoostsTable) => boolean | number
 	calculateStat?: (this: Pokemon, statName: StatNameExceptHP, boost: number, modifier?: number) => number
 	getActionSpeed?: (this: Pokemon) => number
-	getRequestData?: (this: Pokemon) => {moves: {move: string, id: string, target?: string, disabled?: boolean}[], maybeDisabled?: boolean, trapped?: boolean, maybeTrapped?: boolean, canMegaEvo?: boolean, canUltraBurst?: boolean, canZMove?: AnyObject | null}
+	getRequestData?: (this: Pokemon) => {moves: {move: string, id: ID, target?: string, disabled?: boolean}[], maybeDisabled?: boolean, trapped?: boolean, maybeTrapped?: boolean, canMegaEvo?: boolean, canUltraBurst?: boolean, canZMove?: AnyObject | null}
 	getStat?: (this: Pokemon, statName: StatNameExceptHP, unboosted?: boolean, unmodified?: boolean, fastReturn?: boolean) => number
 	getWeight?: (this: Pokemon) => number
 	hasAbility?: (this: Pokemon, ability: string | string[]) => boolean
@@ -1186,7 +1194,7 @@ interface TypeInfo extends Readonly<TypeData> {
 	readonly gen: number
 	readonly HPdvs: SparseStatsTable
 	readonly HPivs: SparseStatsTable
-	readonly id: string
+	readonly id: ID
 	readonly name: string
 	readonly toString: () => string
 }
@@ -1212,7 +1220,7 @@ namespace Actions {
 		/** location of the target, relative to pokemon's side */
 		targetLoc: number;
 		/** a move to use (move action only) */
-		moveid: string;
+		moveid: ID
 		/** a move to use (move action only) */
 		move: Move;
 		/** true if megaing or ultra bursting */

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -8,7 +8,6 @@ type Validator = import('./team-validator').Validator
 
 type ID = '' | string & {__isID: true};
 interface AnyObject {[k: string]: any}
-interface AnyObjectWithID {id?: ID, [k: string]: any}
 type DexTable<T> = {[key: string]: T}
 
 type GenderName = 'M' | 'F' | 'N' | '';

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -9,7 +9,7 @@ import {State} from './state';
 
  /** A Pokemon's move slot. */
 interface MoveSlot {
-	id: string;
+	id: ID;
 	move: string;
 	pp: number;
 	maxpp: number;
@@ -29,7 +29,7 @@ export class Pokemon {
 	readonly fullname: string;
 	readonly id: string; // shouldn't really be used anywhere
 	readonly species: string;
-	readonly speciesid: string;
+	readonly speciesid: ID;
 	readonly level: number;
 	readonly gender: GenderName;
 	readonly happiness: number;
@@ -50,10 +50,10 @@ export class Pokemon {
 
 	baseTemplate: Template;
 	template: Template;
-	speciesData: AnyObject;
+	speciesData: AnyObjectWithID;
 
-	status: string;
-	statusData: AnyObject;
+	status: ID;
+	statusData: AnyObjectWithID;
 	volatiles: AnyObject;
 	showCure?: boolean;
 
@@ -82,13 +82,13 @@ export class Pokemon {
 	storedStats: StatsExceptHPTable;
 	boosts: BoostsTable;
 
-	baseAbility: string;
-	ability: string;
-	abilityData: {[k: string]: string | Pokemon};
+	baseAbility: ID;
+	ability: ID;
+	abilityData: {[k: string]: string | Pokemon | ID};
 
-	item: string;
-	itemData: {[k: string]: string | Pokemon};
-	lastItem: string;
+	item: ID;
+	itemData: {[k: string]: string | Pokemon | ID};
+	lastItem: ID;
 	usedItemThisTurn: boolean;
 	ateBerry: boolean;
 
@@ -183,7 +183,7 @@ export class Pokemon {
 	/** used for Assurance check */
 	hurtThisTurn: boolean;
 	lastDamage: number;
-	attackedBy: {source: Pokemon, damage: number, thisTurn: boolean, move?: string}[];
+	attackedBy: {source: Pokemon, damage: number, thisTurn: boolean, move?: ID}[];
 
 	isActive: boolean;
 	activeTurns: number;
@@ -1074,8 +1074,8 @@ export class Pokemon {
 			evasion: 0,
 		};
 
-		if (this.battle.gen === 1 && this.baseMoves.includes('mimic') && !this.transformed) {
-			const moveslot = this.baseMoves.indexOf('mimic');
+		if (this.battle.gen === 1 && this.baseMoves.includes('mimic' as ID) && !this.transformed) {
+			const moveslot = this.baseMoves.indexOf('mimic' as ID);
 			const mimicPP = this.moveSlots[moveslot] ? this.moveSlots[moveslot].pp : 16;
 			this.moveSlots = this.baseMoveSlots.slice();
 			this.moveSlots[moveslot].pp = mimicPP;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -50,10 +50,10 @@ export class Pokemon {
 
 	baseTemplate: Template;
 	template: Template;
-	speciesData: AnyObjectWithID;
+	speciesData: AnyObject;
 
 	status: ID;
-	statusData: AnyObjectWithID;
+	statusData: AnyObject;
 	volatiles: AnyObject;
 	showCure?: boolean;
 
@@ -84,10 +84,10 @@ export class Pokemon {
 
 	baseAbility: ID;
 	ability: ID;
-	abilityData: {[k: string]: string | Pokemon | ID};
+	abilityData: {[k: string]: string | Pokemon};
 
 	item: ID;
-	itemData: {[k: string]: string | Pokemon | ID};
+	itemData: {[k: string]: string | Pokemon};
 	lastItem: ID;
 	usedItemThisTurn: boolean;
 	ateBerry: boolean;


### PR DESCRIPTION
Similar to `ID` in Pokemon-Showdown-Client, but also including `''` to avoid a bunch of casts. More places can likely to converted to `ID`, and eventually certain `toId` calls can be removed, but this commit just lays the groundwork.