### PR TITLE
Notify users the first time a PM/challenge is blocked

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -552,10 +552,7 @@ const commands = {
 		if (!targetUser || !targetUser.connected) return this.errorReply(`User ${this.targetUsername} is not currently online.`);
 		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
 		if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) {
-			if (!targetUser.blockPMsNotified) {
-				targetUser.send(`The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms.`);
-				targetUser.blockPMsNotified = true;
-			}
+			Chat.maybeNotifyBlocked('pm', targetUser, user);
 			return this.errorReply("This user is currently blocking PMs.");
 		}
 		if (targetUser.locked && !user.can('lock')) return this.errorReply("This user is currently locked, so you cannot send them a pminfobox.");
@@ -584,10 +581,7 @@ const commands = {
 		if (!targetUser || !targetUser.connected) return this.errorReply(`User ${this.targetUsername} is not currently online.`);
 		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
 		if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) {
-			if (!targetUser.blockPMsNotified) {
-				targetUser.send(`The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms.`);
-				targetUser.blockPMsNotified = true;
-			}
+			Chat.maybeNotifyBlocked('pm', targetUser, user);
 			return this.errorReply("This user is currently blocking PMs.");
 		}
 		if (targetUser.locked && !user.can('lock')) return this.errorReply("This user is currently locked, so you cannot send them UHTML.");

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -551,7 +551,13 @@ const commands = {
 
 		if (!targetUser || !targetUser.connected) return this.errorReply(`User ${this.targetUsername} is not currently online.`);
 		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
-		if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) return this.errorReply("This user is currently blocking PMs.");
+		if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) {
+			if (!targetUser.blockPMsNotified) {
+				targetUser.send(`The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms.`);
+				targetUser.blockPMsNotified = true;
+			}
+			return this.errorReply("This user is currently blocking PMs.");
+		}
 		if (targetUser.locked && !user.can('lock')) return this.errorReply("This user is currently locked, so you cannot send them a pminfobox.");
 
 		// Apply the infobox to the message
@@ -577,7 +583,13 @@ const commands = {
 
 		if (!targetUser || !targetUser.connected) return this.errorReply(`User ${this.targetUsername} is not currently online.`);
 		if (!(targetUser in room.users) && !user.can('addhtml')) return this.errorReply("You do not have permission to use this command to users who are not in this room.");
-		if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) return this.errorReply("This user is currently blocking PMs.");
+		if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) {
+			if (!targetUser.blockPMsNotified) {
+				targetUser.send(`The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms.`);
+				targetUser.blockPMsNotified = true;
+			}
+			return this.errorReply("This user is currently blocking PMs.");
+		}
 		if (targetUser.locked && !user.can('lock')) return this.errorReply("This user is currently locked, so you cannot send them UHTML.");
 
 		let message = `|pm|${user.getIdentity()}|${targetUser.getIdentity()}|/uhtml${(cmd === 'pmuhtmlchange' ? 'change' : '')} ${target}`;

--- a/server/chat.js
+++ b/server/chat.js
@@ -1144,6 +1144,10 @@ class CommandContext extends MessageContext {
 					return this.errorReply(`On this server, you must be of rank ${groupName} or higher to PM users.`);
 				}
 				if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) {
+					if (!targetUser.blockPMsNotified) {
+						targetUser.send(`The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms.`);
+						targetUser.blockPMsNotified = true;
+					}
 					if (!targetUser.can('lock')) {
 						return this.errorReply(`This user is blocking private messages right now.`);
 					} else {

--- a/server/chat.js
+++ b/server/chat.js
@@ -1941,15 +1941,16 @@ Chat.fitImage = async function (url, maxHeight = 300, maxWidth = 300) {
  * @param {User} user
  */
 Chat.maybeNotifyBlocked = function (blocked, targetUser, user) {
+	const prefix = `|pm|~|${targetUser.getIdentity()}|/nonotify `;
 	const options = 'or change it in the <button name="openOptions" class="subtle">Options</button> menu in the upper right.';
 	if (blocked === 'pm') {
 		if (!targetUser.blockPMsNotified) {
-			targetUser.send(`|html|The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms ${options}`);
+			targetUser.send(`${prefix}The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms ${options}`);
 			targetUser.blockPMsNotified = true;
 		}
 	} else if (blocked === 'challenge') {
 		if (!targetUser.blockChallengesNotified) {
-			targetUser.send(`|html|The user '${user.name}' attempted to challenge you to a battle but was blocked. To enable challenges, use /unblockchallenges ${options}`);
+			targetUser.send(`${prefix}The user '${user.name}' attempted to challenge you to a battle but was blocked. To enable challenges, use /unblockchallenges ${options}`);
 			targetUser.blockChallengesNotified = true;
 		}
 	}

--- a/server/chat.js
+++ b/server/chat.js
@@ -1144,10 +1144,7 @@ class CommandContext extends MessageContext {
 					return this.errorReply(`On this server, you must be of rank ${groupName} or higher to PM users.`);
 				}
 				if (targetUser.blockPMs && targetUser.blockPMs !== user.group && !user.can('lock')) {
-					if (!targetUser.blockPMsNotified) {
-						targetUser.send(`The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms.`);
-						targetUser.blockPMsNotified = true;
-					}
+					Chat.maybeNotifyBlocked('pm', targetUser, user);
 					if (!targetUser.can('lock')) {
 						return this.errorReply(`This user is blocking private messages right now.`);
 					} else {
@@ -1935,6 +1932,27 @@ Chat.fitImage = async function (url, maxHeight = 300, maxWidth = 300) {
 	}
 
 	return [Math.round(width * ratio), Math.round(height * ratio)];
+};
+
+/**
+ * Notifies a targetUser that a user was blocked from reaching them due to a setting they have enabled.
+ * @param {'pm'|'challenge'} blocked
+ * @param {User} targetUser
+ * @param {User} user
+ */
+Chat.maybeNotifyBlocked = function (blocked, targetUser, user) {
+	const options = 'or change it in the <button name="openOptions" class="subtle">Options</button> menu in the upper right.';
+	if (blocked === 'pm') {
+		if (!targetUser.blockPMsNotified) {
+			targetUser.send(`|html|The user '${user.name}' attempted to PM you but was blocked. To enable PMs, use /unblockpms ${options}`);
+			targetUser.blockPMsNotified = true;
+		}
+	} else if (blocked === 'challenge') {
+		if (!targetUser.blockChallengesNotified) {
+			targetUser.send(`|html|The user '${user.name}' attempted to challenge you to a battle but was blocked. To enable challenges, use /unblockchallenges ${options}`);
+			targetUser.blockChallengesNotified = true;
+		}
+	}
 };
 
 /**

--- a/server/ladders.js
+++ b/server/ladders.js
@@ -228,6 +228,10 @@ class Ladder extends LadderStore {
 		}
 		if (targetUser.blockChallenges && !user.can('bypassblocks', targetUser)) {
 			connection.popup(`The user '${targetUser.name}' is not accepting challenges right now.`);
+			if (!targetUser.blockChallengesNotified) {
+				targetUser.send(`The user '${user.name}' attempted to challenge you to a battle but was blocked. To enable challenges, use /unblockchallenges.`);
+				targetUser.blockChallengesNotified = true;
+			}
 			return false;
 		}
 		if (Date.now() < user.lastChallenge + 10 * SECONDS) {

--- a/server/ladders.js
+++ b/server/ladders.js
@@ -228,10 +228,7 @@ class Ladder extends LadderStore {
 		}
 		if (targetUser.blockChallenges && !user.can('bypassblocks', targetUser)) {
 			connection.popup(`The user '${targetUser.name}' is not accepting challenges right now.`);
-			if (!targetUser.blockChallengesNotified) {
-				targetUser.send(`The user '${user.name}' attempted to challenge you to a battle but was blocked. To enable challenges, use /unblockchallenges.`);
-				targetUser.blockChallengesNotified = true;
-			}
+			Chat.maybeNotifyBlocked('challenge', targetUser, user);
 			return false;
 		}
 		if (Date.now() < user.lastChallenge + 10 * SECONDS) {

--- a/server/users.js
+++ b/server/users.js
@@ -520,6 +520,8 @@ class User extends Chat.MessageContext {
 		/**@type {string} */
 		this.s3 = '';
 
+		this.blockChallengesNotified = false;
+		this.blockPMsNotified = false;
 		/** @type {boolean} */
 		this.punishmentNotified = false;
 		/** @type {boolean} */


### PR DESCRIPTION
> One solution would be to show a warning the first time a PM or challenge is blocked, every session.

_Originally posted by @Zarel in https://github.com/Zarel/Pokemon-Showdown-Client/issues/1271#issuecomment-488094948_

I'm not entirely sure this code does exactly what we want because it isn't completely clear to me what is meant by 'session' in this case (should the notifications be once-per-connection instead? Is there another way to handle sessions?). Also, not sure if the messages should just be plain or if we want `|error|` or something.