### PR TITLE
Avoid calling toId where possible with Dex.getEffectByID

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1866,7 +1866,7 @@ export class Battle extends Dex.ModdedDex {
 			if (!source) source = this.event.source;
 			if (!effect) effect = this.effect;
 		}
-		if (effect === 'drain') effect = this.getEffect(effect);
+		if (effect === 'drain') effect = this.getEffectByID(effect as ID);
 		if (damage && damage <= 1) damage = 1;
 		damage = this.trunc(damage);
 		// for things like Liquid Ooze, the Heal event still happens when nothing is healed.
@@ -2589,7 +2589,7 @@ export class Battle extends Dex.ModdedDex {
 				}
 			}
 			for (const pokemon of this.getAllPokemon()) {
-				this.singleEvent('Start', this.getEffect(pokemon.species), pokemon.speciesData, pokemon);
+				this.singleEvent('Start', this.getEffectByID(pokemon.speciesid), pokemon.speciesData, pokemon);
 			}
 			this.midTurn = true;
 			break;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -407,7 +407,7 @@ class ModdedDex {
 			if (!template.tier) template.tier = 'Illegal';
 			if (!template.doublesTier) template.doublesTier = template.tier;
 		} else {
-			template = new Data.Template({name, exists: false});
+			template = new Data.Template({id, name, exists: false});
 		}
 		if (template.exists) this.templateCache.set(id, template);
 		return template;
@@ -439,7 +439,7 @@ class ModdedDex {
 		if (id && this.data.Movedex.hasOwnProperty(id)) {
 			move = new Data.Move({name}, this.data.Movedex[id]);
 		} else {
-			move = new Data.Move({name, exists: false});
+			move = new Data.Move({id, name, exists: false});
 		}
 		if (move.exists) this.moveCache.set(id, move);
 		return move;
@@ -486,22 +486,30 @@ class ModdedDex {
 			// @ts-ignore
 			return effect;
 		}
+		return this.getEffectByID(id, effect);
+	}
+
+	getEffectByID(id: ID, effect?: Effect | Move): PureEffect {
+		if (!id) return nullEffect;
+
+		if (!effect) effect = this.effectCache.get(id);
+		if (effect) return effect as PureEffect;
 
 		let found;
 		if (this.data.Formats.hasOwnProperty(id)) {
-			effect = new Data.Format({name}, this.data.Formats[id]);
+			effect = new Data.Format({name: id}, this.data.Formats[id]);
 		} else if (this.data.Statuses.hasOwnProperty(id)) {
-			effect = new Data.PureEffect({name}, this.data.Statuses[id]);
+			effect = new Data.PureEffect({name: id}, this.data.Statuses[id]);
 		} else if ((this.data.Movedex.hasOwnProperty(id) && (found = this.data.Movedex[id]).effect) ||
 							 (this.data.Abilities.hasOwnProperty(id) && (found = this.data.Abilities[id]).effect) ||
 							 (this.data.Items.hasOwnProperty(id) && (found = this.data.Items[id]).effect)) {
-			effect = new Data.PureEffect({name: found.name || name}, found.effect!);
+			effect = new Data.PureEffect({name: found.name || id}, found.effect!);
 		} else if (id === 'recoil') {
-			effect = new Data.PureEffect({name: 'Recoil', effectType: 'Recoil'});
+			effect = new Data.PureEffect({id, name: 'Recoil', effectType: 'Recoil'});
 		} else if (id === 'drain') {
-			effect = new Data.PureEffect({name: 'Drain', effectType: 'Drain'});
+			effect = new Data.PureEffect({id, name: 'Drain', effectType: 'Drain'});
 		} else {
-			effect = new Data.PureEffect({name, exists: false});
+			effect = new Data.PureEffect({id, name: id, exists: false});
 		}
 
 		this.effectCache.set(id, effect);
@@ -563,7 +571,7 @@ class ModdedDex {
 		if (this.data.Formats.hasOwnProperty(id)) {
 			effect = new Data.Format({name}, this.data.Formats[id], supplementaryAttributes);
 		} else {
-			effect = new Data.Format({name, exists: false});
+			effect = new Data.Format({id, name, exists: false});
 		}
 		return effect;
 	}
@@ -590,7 +598,7 @@ class ModdedDex {
 		if (id && this.data.Items.hasOwnProperty(id)) {
 			item = new Data.Item({name}, this.data.Items[id]);
 		} else {
-			item = new Data.Item({name, exists: false});
+			item = new Data.Item({id, name, exists: false});
 		}
 
 		if (item.exists) this.itemCache.set(id, item);
@@ -613,7 +621,7 @@ class ModdedDex {
 		if (id && this.data.Abilities.hasOwnProperty(id)) {
 			ability = new Data.Ability({name}, this.data.Abilities[id]);
 		} else {
-			ability = new Data.Ability({name, exists: false});
+			ability = new Data.Ability({id, name, exists: false});
 		}
 
 		if (ability.exists) this.abilityCache.set(id, ability);
@@ -630,7 +638,7 @@ class ModdedDex {
 		if (typeName && this.data.TypeChart.hasOwnProperty(typeName)) {
 			type = new Data.TypeInfo({id}, this.data.TypeChart[typeName]);
 		} else {
-			type = new Data.TypeInfo({name, exists: false, effectType: 'EffectType'});
+			type = new Data.TypeInfo({id, name, exists: false, effectType: 'EffectType'});
 		}
 
 		if (type.exists) this.typeCache.set(id, type);

--- a/sim/field.ts
+++ b/sim/field.ts
@@ -117,7 +117,7 @@ export class Field {
 	}
 
 	getWeather() {
-		return this.battle.getEffect(this.weather);
+		return this.battle.getEffectByID(this.weather);
 	}
 
 	setTerrain(status: string | Effect, source: Pokemon | 'debug' | null = null, sourceEffect: Effect | null = null) {
@@ -172,7 +172,7 @@ export class Field {
 	}
 
 	getTerrain() {
-		return this.battle.getEffect(this.terrain);
+		return this.battle.getEffectByID(this.terrain);
 	}
 
 	addPseudoWeather(

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -876,7 +876,7 @@ export class Pokemon {
 		this.clearVolatile();
 		this.boosts = pokemon.boosts;
 		for (const i in pokemon.volatiles) {
-			if (this.battle.getEffect(i).noCopy) continue;
+			if (this.battle.getEffectByID(i as ID).noCopy) continue;
 			// shallow clones
 			this.volatiles[i] = Object.assign({}, pokemon.volatiles[i]);
 			if (this.volatiles[i].linkedPokemon) {
@@ -1306,7 +1306,7 @@ export class Pokemon {
 	}
 
 	getStatus() {
-		return this.battle.getEffect(this.status);
+		return this.battle.getEffectByID(this.status);
 	}
 
 	eatItem(source?: Pokemon, sourceEffect?: Effect) {


### PR DESCRIPTION
**This changes reduces `toID` calls by ~15.7% (from `10238733` -> `8628355` over 100 random battles).**

After #5468, we can now start to avoid unnecessary `toId` calls in critical places. This commit avoids `toId` in certain obvious places by introducing a `Dex.getEffectByID` method which can be used internally to skip both `toId` and unnecessary lookups. This commit also performs a minor optimization by passing `id` to `Data` constructors (which saves a call to `toId` in the `BasicEffect` constructor, and which we could have done before #5468 introduced an `ID` type, I only just noticed it now).