### PR TITLE
Past Custom Game "canUseRandomTeam", Level 9999/24 Pokemon

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1854,7 +1854,11 @@ let Formats = [
 
 		mod: 'gen3',
 		searchShow: false,
+		canUseRandomTeam: true,
 		debug: true,
+		maxLevel: 9999,
+		trunc(n) { return Math.trunc(n); },
+		defaultLevel: 100,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
 	{
@@ -1900,7 +1904,11 @@ let Formats = [
 
 		mod: 'gen2',
 		searchShow: false,
+		canUseRandomTeam: true,
 		debug: true,
+		maxLevel: 9999,
+		trunc(n) { return Math.trunc(n); },
+		defaultLevel: 100,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
 	{
@@ -1957,7 +1965,11 @@ let Formats = [
 
 		mod: 'gen1',
 		searchShow: false,
+		canUseRandomTeam: true,
 		debug: true,
+		maxLevel: 9999,
+		trunc(n) { return Math.trunc(n); },
+		defaultLevel: 100,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
 ];


### PR DESCRIPTION
Using future stuff in past game custom game still doesn't work so copied the exact same ruleset (gen6's) for all CGs other than Gen7