### PR TITLE
Move -mustrecharge message to onStart

### DIFF
--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -147,6 +147,7 @@ let BattleScripts = {
 		} else if (pokemon.hp) {
 			this.runEvent('AfterMoveSelf', pokemon, target, move);
 		}
+		if (pokemon.volatiles['mustrecharge']) this.add('-mustrecharge', pokemon);
 
 		// For partial trapping moves, we are saving the target
 		if (move.volatileStatus === 'partiallytrapped' && target && target.hp > 0) {

--- a/data/mods/gen1/statuses.js
+++ b/data/mods/gen1/statuses.js
@@ -235,6 +235,10 @@ let BattleStatuses = {
 			}
 		},
 	},
+	mustrecharge: {
+		inherit: true,
+		onStart() {},
+	},
 	lockedmove: {
 		// Outrage, Thrash, Petal Dance...
 		inherit: true,

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -362,10 +362,10 @@ let BattleStatuses = {
 			pokemon.removeVolatile('truant');
 			return null;
 		},
-		onLockMove(pokemon) {
+		onStart(pokemon) {
 			this.add('-mustrecharge', pokemon);
-			return 'recharge';
 		},
+		onLockMove: 'recharge',
 	},
 	futuremove: {
 		// this is a slot condition


### PR DESCRIPTION
```
|turn|21
|
|move|p1a: Venomoth|Stun Spore|p2a: Articuno
|-fail|p2a: Articuno|par
|move|p2a: Articuno|Hyper Beam|p1a: Venomoth
|-damage|p1a: Venomoth|156/256
|-mustrecharge|p2a: Articuno
|
|upkeep
|turn|22
|
|move|p1a: Venomoth|Psychic|p2a: Articuno
|-crit|p2a: Articuno
|-damage|p2a: Articuno|206/286 par
|-unboost|p2a: Articuno|spd|1
|-unboost|p2a: Articuno|spa|1
|cant|p2a: Articuno|recharge
|
|upkeep
```

This way it doesn't show up at the end of the turn or get added 3 separate times.

Fixes #5462.