### PR TITLE
Fix double [still] in Gen 1

### DIFF
--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -205,10 +205,6 @@ let BattleScripts = {
 			return false;
 		}
 
-		if (move.flags['charge'] && !pokemon.volatiles[move.id]) {
-			attrs = '|[still]'; // Suppress the default move animation
-		}
-
 		if (sourceEffect) attrs += '|[from]' + this.getEffect(sourceEffect);
 		this.addMove('move', pokemon, move.name, target + attrs);
 


### PR DESCRIPTION
Moves with the `'charge'` flag add the `'twoturnmove'` volatile which already handles adding `[still]`.

Fixes #5487