### PR TITLE
Remove additional toID calls

### DIFF
--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -468,7 +468,7 @@ let BattleScripts = {
 			}
 		}
 		if (move.selfSwitch && pokemon.hp) {
-			pokemon.switchFlag = move.fullname;
+			pokemon.switchFlag = move.id;
 		}
 		return damage;
 	},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -963,7 +963,7 @@ let BattleScripts = {
 			}
 			this.debug('move failed because it did nothing');
 		} else if (move.selfSwitch && pokemon.hp) {
-			pokemon.switchFlag = move.fullname;
+			pokemon.switchFlag = move.id;
 		}
 
 		return damage;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1627,7 +1627,7 @@ export class Battle extends Dex.ModdedDex {
 	) {
 		if (!targetArray) return [0];
 		let retVals: (number | false | undefined)[] = [];
-		if (typeof effect === 'string' || !effect) effect = this.getEffect(effect);
+		if (typeof effect === 'string' || !effect) effect = this.getEffectByID((effect || '') as ID);
 		for (const [i, curDamage] of damage.entries()) {
 			const target = targetArray[i];
 			let targetDamage = curDamage;
@@ -1751,7 +1751,7 @@ export class Battle extends Dex.ModdedDex {
 		if (!damage) return 0;
 		damage = this.clampIntRange(damage, 1);
 
-		if (typeof effect === 'string' || !effect) effect = this.getEffect(effect);
+		if (typeof effect === 'string' || !effect) effect = this.getEffectByID((effect || '') as ID);
 
 		// In Gen 1 BUT NOT STADIUM, Substitute also takes confusion and HJK recoil damage
 		if (this.gen <= 1 && this.currentMod !== 'stadium' &&
@@ -2342,7 +2342,7 @@ export class Battle extends Dex.ModdedDex {
 				}
 			} else if (action.choice === 'switch' || action.choice === 'instaswitch') {
 				if (typeof action.pokemon.switchFlag === 'string') {
-					action.sourceEffect = this.getEffect(action.pokemon.switchFlag);
+					action.sourceEffect = (this.getMove(action.pokemon.switchFlag as ID) as unknown) as PureEffect;
 				}
 				action.pokemon.switchFlag = false;
 				if (!action.speed) action.speed = action.pokemon.getActionSpeed();

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2342,7 +2342,7 @@ export class Battle extends Dex.ModdedDex {
 				}
 			} else if (action.choice === 'switch' || action.choice === 'instaswitch') {
 				if (typeof action.pokemon.switchFlag === 'string') {
-					action.sourceEffect = (this.getMove(action.pokemon.switchFlag as ID) as unknown) as PureEffect;
+					action.sourceEffect = this.getMove(action.pokemon.switchFlag as ID) as any;
 				}
 				action.pokemon.switchFlag = false;
 				if (!action.speed) action.speed = action.pokemon.getActionSpeed();

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -769,7 +769,7 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 	readonly isZ: boolean | string;
 	readonly flags: MoveFlags;
 	/** Whether or not the user must switch after using this move. */
-	readonly selfSwitch?: string | true;
+	readonly selfSwitch?: ID | boolean;
 	/** Move target only used by Pressure. */
 	readonly pressureTarget: string;
 	/** Move target used if the user is not a Ghost type (for Curse). */
@@ -795,6 +795,8 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 	readonly noSketch: boolean;
 	/** STAB multiplier (can be modified by other effects) (default 1.5). */
 	readonly stab?: number;
+
+	readonly volatileStatus?: ID;
 
 	constructor(data: AnyObject, ...moreData: (AnyObject | null)[]) {
 		super(data, ...moreData);
@@ -824,7 +826,7 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 		this.noPPBoosts = !!data.noPPBoosts;
 		this.isZ = data.isZ || false;
 		this.flags = data.flags || {};
-		this.selfSwitch = data.selfSwitch || undefined;
+		this.selfSwitch = (typeof data.selfSwitch === 'string' ? (data.selfSwitch as ID) : data.selfSwitch) || undefined;
 		this.pressureTarget = data.pressureTarget || '';
 		this.nonGhostTarget = data.nonGhostTarget || '';
 		this.ignoreAbility = data.ignoreAbility || false;
@@ -833,6 +835,7 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 		this.forceSTAB = !!data.forceSTAB;
 		this.noSketch = !!data.noSketch;
 		this.stab = data.stab || undefined;
+		this.volatileStatus = typeof data.volatileStatus === 'string' ? (data.volatileStatus as ID) : undefined;
 
 		if (!this.gen) {
 			if (this.num >= 622) {

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -885,7 +885,7 @@ interface ActiveMove extends BasicEffect, MoveData {
 	allies?: Pokemon[]
 	auraBooster?: Pokemon
 	causedCrashDamage?: boolean
-	forceStatus?: string
+	forceStatus?: ID
 	galvanizeBoosted?: boolean
 	hasAuraBreak?: boolean
 	hasBounced?: boolean
@@ -899,6 +899,7 @@ interface ActiveMove extends BasicEffect, MoveData {
 	pranksterBoosted?: boolean
 	refrigerateBoosted?: boolean
 	selfDropped?: boolean
+	selfSwitch?: ID | boolean
 	spreadHit?: boolean
 	stab?: number
 	statusRoll?: string

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -113,10 +113,10 @@ export class Pokemon {
 
 	/**
 	 * If the switch is called by an effect with a special switch
-	 * message, like U-turn or Baton Pass, this will be the fullname of
+	 * message, like U-turn or Baton Pass, this will be the ID of
 	 * the calling effect.
 	 */
-	switchFlag: boolean | string;
+	switchFlag: ID | boolean;
 	forceSwitchFlag: boolean;
 	switchCopyFlag: boolean;
 	draggedIn: number | null;


### PR DESCRIPTION
The other `getEffect` calls all are going to require `data` to be Typescripted because we need to perform *beaucoup* casting.