### PR TITLE
Add xfix as a maintainer for Scavengers and Trivia chat plugins

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+server/chat-plugins/scavenger*.js @xfix
+server/chat-plugins/trivia.js @xfix


### PR DESCRIPTION
This allows me to be notified if any of those files changes and automatically assigns me to pull requests involving those.

Other additions to this file are welcome, obviously, if you are maintaining some chat plugin or something (for instance @TheImmortal may want to be added to `random-teams.js`), you are welcome to add yourself after this change gets merged. Also @sparkychildcharlie and @whalemer are welcome to add themselves to this file as well if they want to be in Scavengers section. The syntax is similar to `.gitignore`.