### PR TITLE
Trademarked: Make legality-expanding custom rules effective

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -613,10 +613,10 @@ let Formats = [
 			const restrictedMoves = this.format.restrictedMoves || [];
 			let move = this.dex.getMove(set.ability);
 			if (move.category !== 'Status' || move.status === 'slp' || restrictedMoves.includes(move.name) || set.moves.map(toID).includes(move.id)) return this.validateSet(set, teamHas);
-            let customRules = this.format.customRules || [];
-            if (!customRules.includes('ignoreillegalabilities')) customRules.push('ignoreillegalabilities');
+			let customRules = this.format.customRules || [];
+			if (!customRules.includes('ignoreillegalabilities')) customRules.push('ignoreillegalabilities');
 			let TeamValidator = /** @type {new(format: string | Format) => Validator} */ (this.constructor);
-            let validator = new TeamValidator(Dex.getFormat(this.format.id + '@@@' + customRules.join(',')));
+			let validator = new TeamValidator(Dex.getFormat(this.format.id + '@@@' + customRules.join(',')));
 			let moves = set.moves;
 			set.moves = [set.ability];
 			set.ability = '';

--- a/config/formats.js
+++ b/config/formats.js
@@ -613,8 +613,10 @@ let Formats = [
 			const restrictedMoves = this.format.restrictedMoves || [];
 			let move = this.dex.getMove(set.ability);
 			if (move.category !== 'Status' || move.status === 'slp' || restrictedMoves.includes(move.name) || set.moves.map(toID).includes(move.id)) return this.validateSet(set, teamHas);
+            let customRules = this.format.customRules || [];
+            if (!customRules.includes('ignoreillegalabilities')) customRules.push('ignoreillegalabilities');
 			let TeamValidator = /** @type {new(format: string | Format) => Validator} */ (this.constructor);
-			let validator = new TeamValidator(Dex.getFormat(this.format.id + '@@@ignoreillegalabilities'));
+            let validator = new TeamValidator(Dex.getFormat(this.format.id + '@@@' + customRules.join(',')));
 			let moves = set.moves;
 			set.moves = [set.ability];
 			set.ability = '';


### PR DESCRIPTION
* (First pull request) I agree to make this code available under the MIT license.
* Discussed this change with Urkerab in PM, final code is substantially due to him.
* Tested in Trademarked Ubers and Trademarked STABmons public tours.
* Known issue with STABmons: some stabmons moves will still be illegal due to stabmonsmovelegality expecting the format's restrictedMoves to be stabmons restricted moves, not restricted trademarks.