### PR TITLE
Fix crash in multi elim tours

### DIFF
--- a/server/tournaments/generator-elimination.js
+++ b/server/tournaments/generator-elimination.js
@@ -450,7 +450,8 @@ class Elimination {
 		let currentNode = this.treeRoot;
 		for (let n = 0; n < this.maxSubtrees; ++n) {
 			results.push([currentNode.user]);
-			// @ts-ignore
+
+			if (!currentNode.children) break;
 			currentNode = currentNode.children[currentNode.result === 'loss' ? 0 : 1];
 			if (!currentNode) break;
 		}


### PR DESCRIPTION
With the old api, node.getChildAt would return null if the node had no children