### PR TITLE
Random Battle: Update Heliolisk

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -7174,7 +7174,7 @@ let BattleFormatsData = {
 		tier: "LC",
 	},
 	heliolisk: {
-		randomBattleMoves: ["raindance", "thunder", "hypervoice", "surf", "darkpulse", "hiddenpowerice", "voltswitch", "thunderbolt"],
+		randomBattleMoves: ["raindance", "hypervoice", "surf", "darkpulse", "hiddenpowerice", "voltswitch", "thunderbolt"],
 		randomDoubleBattleMoves: ["surf", "voltswitch", "hiddenpowerice", "raindance", "thunder", "darkpulse", "thunderbolt", "protect"],
 		tier: "NU",
 		doublesTier: "(DUU)",

--- a/data/mods/gen6/formats-data.js
+++ b/data/mods/gen6/formats-data.js
@@ -4577,7 +4577,7 @@ let BattleFormatsData = {
 		tier: "LC",
 	},
 	heliolisk: {
-		randomBattleMoves: ["raindance", "thunder", "hypervoice", "surf", "darkpulse", "hiddenpowerice", "voltswitch", "thunderbolt"],
+		randomBattleMoves: ["raindance", "hypervoice", "surf", "darkpulse", "hiddenpowerice", "voltswitch", "thunderbolt"],
 		randomDoubleBattleMoves: ["surf", "voltswitch", "hiddenpowerice", "raindance", "thunder", "darkpulse", "thunderbolt", "protect"],
 		tier: "UU",
 		doublesTier: "(DUU)",

--- a/data/mods/gen6/random-teams.js
+++ b/data/mods/gen6/random-teams.js
@@ -568,7 +568,6 @@ class RandomGen6Teams extends RandomTeams {
 		if (hasMove['autotomize'] && hasMove['heavyslam']) {
 			moves[moves.indexOf('autotomize')] = 'rockpolish';
 		}
-
 		if (hasMove['raindance'] && hasMove['thunderbolt']) {
 			moves[moves.indexOf('thunderbolt')] = 'thunder';
 		}

--- a/data/mods/gen6/random-teams.js
+++ b/data/mods/gen6/random-teams.js
@@ -280,11 +280,8 @@ class RandomGen6Teams extends RandomTeams {
 				case 'chargebeam':
 					if (hasMove['thunderbolt'] && counter.Special < 3) rejected = true;
 					break;
-				case 'thunder':
-					if (hasMove['thunderbolt'] && !hasMove['raindance']) rejected = true;
-					break;
 				case 'thunderbolt':
-					if (hasMove['discharge'] || (hasMove['raindance'] && hasMove['thunder']) || (hasMove['voltswitch'] && hasMove['wildcharge'])) rejected = true;
+					if (hasMove['discharge'] || (hasMove['voltswitch'] && hasMove['wildcharge'])) rejected = true;
 					break;
 				case 'dazzlinggleam':
 					if (hasMove['playrough'] && counter.setupType !== 'Special') rejected = true;
@@ -454,7 +451,7 @@ class RandomGen6Teams extends RandomTeams {
 					break;
 				case 'raindance':
 					if (counter.Physical + counter.Special < 2 || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					if (!hasType['Water'] && !hasMove['thunder']) rejected = true;
+					if (!hasType['Water'] && !counter['Water']) rejected = true;
 					break;
 				case 'sunnyday':
 					if (counter.Physical + counter.Special < 2 || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
@@ -570,6 +567,10 @@ class RandomGen6Teams extends RandomTeams {
 		// Moveset modifications
 		if (hasMove['autotomize'] && hasMove['heavyslam']) {
 			moves[moves.indexOf('autotomize')] = 'rockpolish';
+		}
+
+		if (hasMove['raindance'] && hasMove['thunderbolt']) {
+			moves[moves.indexOf('thunderbolt')] = 'thunder';
 		}
 
 		// If Hidden Power has been removed, reset the IVs

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -883,11 +883,8 @@ class RandomTeams extends Dex.ModdedDex {
 				case 'chargebeam':
 					if (hasMove['thunderbolt'] && counter.Special < 3) rejected = true;
 					break;
-				case 'thunder':
-					if (hasMove['thunderbolt'] && !hasMove['raindance']) rejected = true;
-					break;
 				case 'thunderbolt':
-					if (hasMove['discharge'] || (hasMove['raindance'] && hasMove['thunder']) || (hasMove['voltswitch'] && hasMove['wildcharge'])) rejected = true;
+					if (hasMove['discharge'] || (hasMove['voltswitch'] && hasMove['wildcharge'])) rejected = true;
 					break;
 				case 'thunderpunch':
 					if (hasAbility['Galvanize'] && !!counter['Normal']) rejected = true;
@@ -1081,7 +1078,7 @@ class RandomTeams extends Dex.ModdedDex {
 					break;
 				case 'raindance':
 					if (counter.Physical + counter.Special < 2 || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					if (!hasType['Water'] && !hasMove['thunder']) rejected = true;
+					if (!hasType['Water'] && !counter['Water']) rejected = true;
 					break;
 				case 'sunnyday':
 					if (counter.Physical + counter.Special < 2 || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
@@ -1198,6 +1195,10 @@ class RandomTeams extends Dex.ModdedDex {
 			} else {
 				moves[moves.indexOf('autotomize')] = 'rockpolish';
 			}
+		}
+
+		if (hasMove['raindance'] && hasMove['thunderbolt']) {
+			moves[moves.indexOf('thunderbolt')] = 'thunder';
 		}
 
 		/**@type {[string, string | undefined, string | undefined]} */

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1196,7 +1196,6 @@ class RandomTeams extends Dex.ModdedDex {
 				moves[moves.indexOf('autotomize')] = 'rockpolish';
 			}
 		}
-
 		if (hasMove['raindance'] && hasMove['thunderbolt']) {
 			moves[moves.indexOf('thunderbolt')] = 'thunder';
 		}


### PR DESCRIPTION
- Change the Thunder/Thunderbolt rejection condition to a moveset
modification to improve consistency.
- Change the Rain Dance rejection condition on non-Water mons to
have a Water move.
- Give Heliolisk Waterium Z if it has Rain Dance + Surf.