### PR TITLE
Specify if the name was manually forcerenamed in NameMonitor message

### DIFF
--- a/server/chat-plugins/chat-monitor.js
+++ b/server/chat-plugins/chat-monitor.js
@@ -259,7 +259,8 @@ let namefilter = function (name, user) {
 	}
 
 	if (user.trackRename) {
-		Monitor.log(`[NameMonitor] Username used: ${name} (forcerenamed from ${user.trackRename})`);
+		const automatic = !Chat.forceRenames.has(user.trackRename);
+		Monitor.log(`[NameMonitor] Username used: ${name} (${automatic ? 'automatically ' : ''}forcerenamed from ${user.trackRename})`);
 		user.trackRename = '';
 	}
 	return name;
@@ -268,7 +269,7 @@ let namefilter = function (name, user) {
 let loginfilter = function (user) {
 	if (user.namelocked) return;
 	const forceRenamer = Chat.forceRenames.get(user.userid);
-	if (forceRenamer) Monitor.log(`[NameMonitor] Name being used: ${user.name} (forcerenamed by ${forceRenamer})`);
+	if (forceRenamer) Monitor.log(`[NameMonitor] Forcerenamed name being reused: ${user.name}`);
 };
 /** @type {NameFilter} */
 let nicknamefilter = function (name, user) {


### PR DESCRIPTION
Also reword the "name being used" message to make it more clear.