### PR TITLE
Don't share self-replacing abilities

### DIFF
--- a/data/mods/pic/scripts.js
+++ b/data/mods/pic/scripts.js
@@ -7,7 +7,7 @@ exports.BattleScripts = {
 			return name;
 		}
 		let id = toID(name);
-		if (id.startsWith('ability')) return Object.assign(Object.create(this.getAbility(id.slice(7))), {id});
+		if (id.startsWith('ability') && !['abilitypowerofalchemy', 'abilityreceiver', 'abilitytrace'].includes(id)) return Object.assign(Object.create(this.getAbility(id.slice(7))), {id});
 		return Object.getPrototypeOf(this).getEffect.call(this, name);
 	},
 	pokemon: {


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/8066699/) (and with a couple of followup posts).

When these abilities replace themselves with another Ability, that will then get shared as normal.

I've implemented this by not cloning the effects for those Abilities (resulting in dummy no-op effects instead) so that the code dealing with adding and removing shared abilities is unaffected.