### PR TITLE
Tweak cases how/when base power is included in required

### DIFF
--- a/sim/side.ts
+++ b/sim/side.ts
@@ -182,13 +182,13 @@ export class Side {
 				},
 				moves: pokemon.moves.map(move => {
 					if (move === 'hiddenpower') {
-						return move + toID(pokemon.hpType) + (pokemon.hpPower === 70 ? '' : pokemon.hpPower);
+						return move + toID(pokemon.hpType) + (this.battle.gen < 6 ? '' : pokemon.hpPower);
 					}
 					if (move === 'frustration' || move === 'return') {
 						const m = this.battle.getMove(move)!;
 						// @ts-ignore - Frustration and Return only require the source Pokemon
 						const basePower = m.basePowerCallback(pokemon);
-						return `${m.name} ${basePower}`;
+						return `${move}${basePower}`;
 					}
 					return move;
 				}),


### PR DESCRIPTION
- include base power  in the `side` data for Hidden Power when `gen < 6` (like in `sim/pokemon.ts`) instead of when`power != 70`
   - alternatively, both places should probably only include base power if (`gen < 6 && pokemon.hpPower < 70`)
- send `frustrationN`/`returnN` as an ID instead of a name: `'Frustration N'`/`'Return N'`. `sim/pokemon.ts` sends the name in its logic, but `side` seems to send IDs

These both nits, but for consistency reasons they seem worth fixing.
