### PR TITLE
Fix Reflect Type interaction with typeless targets on client

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -13350,7 +13350,6 @@ let BattleMovedex = {
 		flags: {protect: 1, authentic: 1, mystery: 1},
 		onHit(target, source) {
 			if (source.template && (source.template.num === 493 || source.template.num === 773)) return false;
-			this.add('-start', source, 'typechange', '[from] move: Reflect Type', '[of] ' + target);
 			let newBaseTypes = target.getTypes(true).filter(type => type !== '???');
 			if (!newBaseTypes.length) {
 				if (target.addedType) {
@@ -13359,6 +13358,7 @@ let BattleMovedex = {
 					return false;
 				}
 			}
+			this.add('-start', source, 'typechange', '[from] move: Reflect Type', '[of] ' + target);
 			source.setType(newBaseTypes);
 			source.addedType = target.addedType;
 			source.knownType = target.side === source.side && target.knownType;


### PR DESCRIPTION
Issue demonstrated by this replay: http://replay.pokemonshowdown.com/gen7doublescustomgame-925407612
Reflect Type fails, but the client thinks it succeeded anyway, because the `-start` is sent before the fail condition is even checked. I didn't see a reason for it to be that way, so I've simply moved it after that check.