### PR TITLE
Fix crash in /crq

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4359,7 +4359,7 @@ const commands = {
 
 			for (let userid in targetRoom.users) {
 				let user = targetRoom.users[userid];
-				let userinfo = user.getIdentity(room.id);
+				let userinfo = user.getIdentity(targetRoom.id);
 				roominfo.users.push(userinfo);
 			}
 


### PR DESCRIPTION
5508b4662951bde6c5dd989f6ab515602bafe02b causes:

```
TypeError: Cannot read property 'id' of undefined
    at CommandContext.crq (/home/ps/showdown/server/chat-commands.js:4362:42)
    at CommandContext.run (/home/ps/showdown/server/chat.js:739:28)
    at CommandContext.parse (/home/ps/showdown/server/chat.js:564:19)
    at CommandContext.parse (/home/ps/showdown/server/chat.js:556:22)
    at CommandContext.msg (/home/ps/showdown/server/chat-commands.js:528:8)
    at CommandContext.run (/home/ps/showdown/server/chat.js:739:28)
    at CommandContext.parse (/home/ps/showdown/server/chat.js:564:19)
    at Object.Chat.parse (/home/ps/showdown/server/chat.js:1436:17)
    at User.chat (/home/ps/showdown/server/users.js:1473:9)
    at Function.socketReceive (/home/ps/showdown/server/users.js:1692:12)
```

Not positive this is the fix, but from the surrounding code it appears `targetRoom.id` (= `roominfo.id`) is probably what was intended?