### PR TITLE
Include a >version-origin hash if different from >version

### DIFF
--- a/server/global.d.ts
+++ b/server/global.d.ts
@@ -16,7 +16,7 @@ declare global {
 			IPTools: any
 			Config: any
 			Chat: any
-			__version: string
+			__version: {head: string, origin?: string}
 		}
 	}
 	// modules

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -1174,13 +1174,18 @@ if (!PM.isParentProcess) {
 			process.send(`THROW\n@!!@${repr}\n${error.stack}`);
 		},
 	};
-	global.__version = '';
+	global.__version = {head: ''};
 	try {
 		const execSync = require('child_process').execSync;
-		const out = execSync('git merge-base master HEAD', {
+		const head = execSync('git rev-parse HEAD', {
 			stdio: ['ignore', 'pipe', 'ignore'],
 		});
-		global.__version = ('' + out).trim();
+		const merge = execSync('git merge-base origin/master HEAD', {
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
+		global.__version.head = ('' + head).trim();
+		const origin = ('' + merge).trim();
+		if (origin !== global.__version.head) global.__version.origin = origin;
 	} catch (e) {}
 
 	if (Config.crashguard) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -189,7 +189,12 @@ export class Battle extends Dex.ModdedDex {
 		};
 		if (this.rated) inputOptions.rated = this.rated;
 		if (global.__version) {
-			this.inputLog.push(`>version ${global.__version}`);
+			if (global.__version.head) {
+				this.inputLog.push(`>version ${global.__version.head}`);
+			}
+			if (global.__version.origin) {
+				this.inputLog.push(`>version-origin ${global.__version.origin}`);
+			}
 		}
 		this.inputLog.push(`>start ` + JSON.stringify(inputOptions));
 

--- a/sim/global.d.ts
+++ b/sim/global.d.ts
@@ -15,7 +15,7 @@ declare global {
 			Dex: any
 			toID(input: any): string
 			TeamValidator: any
-			__version: string
+			__version: {head: string, origin?: string}
 		}
 	}
 	const Battle: BattleType


### PR DESCRIPTION
> I would say `>version` as before, and `>version-origin` only if they differ.

_Originally posted by @Zarel in https://github.com/Zarel/Pokemon-Showdown/pull/5417#issuecomment-483391024_

Fixes #5412, #5417.