### PR TITLE
Always inflict external staleness from Heal Pulse.

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -5605,7 +5605,7 @@ let BattleMovedex = {
 			} else {
 				success = !!this.heal(Math.ceil(target.maxhp * 0.5));
 			}
-			if (success && target.side.id !== source.side.id) {
+			if (target.side.id !== source.side.id) {
 				target.staleness = 'external';
 			}
 			return success;
@@ -7355,7 +7355,7 @@ let BattleMovedex = {
 			} else {
 				success = !!this.heal(Math.ceil(target.maxhp * 0.5));
 			}
-			if (success && target.side.id !== source.side.id) {
+			if (target.side.id !== source.side.id) {
 				target.staleness = 'external';
 			}
 			return success;

--- a/test/sim/misc/endlessbattleclause.js
+++ b/test/sim/misc/endlessbattleclause.js
@@ -31,6 +31,28 @@ describe('Endless Battle Clause (slow)', () => {
 		assert.fail("The battle did not end despite Endless Battle Clause");
 	});
 
+	it('should trigger even if Heal Pulse does not heal', () => {
+		battle = common.createBattle({endlessBattleClause: true});
+		battle.setPlayer('p1', {team: [
+			{species: "Slowbro", item: 'leppaberry', moves: ['block', 'healpulse', 'recycle']},
+			{species: "Magikarp", moves: ['splash']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: "Slowbro", item: 'leppaberry', moves: ['block', 'healpulse', 'recycle']},
+			{species: "Magikarp", moves: ['splash']},
+		]});
+		battle.makeChoices('move block', 'move block');
+		for (let i = 0; i < 16; i++) {
+			battle.makeChoices('move recycle', 'move recycle');
+		}
+		assert.false(battle.ended);
+		battle.makeChoices('move healpulse', 'move recycle');
+		assert.false(battle.ended);
+		battle.makeChoices('move recycle', 'move healpulse');
+		assert(battle.ended);
+		assert.false(battle.winner);
+	});
+
 	it('should not trigger by both Pokemon eating a Leppa Berry they started with', () => {
 		battle = common.createBattle({endlessBattleClause: true});
 		battle.setPlayer('p1', {team: [{species: "Sunkern", item: 'leppaberry', moves: ['synthesis']}]});


### PR DESCRIPTION
Currently the specification claims this to be the case, when the code actually only sets external staleness if HP is healed.

Context: https://replay.pokemonshowdown.com/gen7ou-931202355

It's not entirely clear whether we want this fix as opposed to simply changing the spec to specify that HP must be healed. The troll Funbro vs. Funbro battle exhibited in the replay only ends before 1000 turns if they both use Heal Pulse.