### PR TITLE
Add a shorter alias for /offlinewhois

### DIFF
--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -231,6 +231,7 @@ const commands = {
 
 	'!offlinewhois': true,
 	checkpunishment: 'offlinewhois',
+	cpm: 'offlinewhois',
 	offlinewhois(target, room, user) {
 		if (!user.trusted) {
 			return this.errorReply("/offlinewhois - Access denied.");


### PR DESCRIPTION
both /offlinewhois and /checkpunishment are rather inconvenient to type over and over - and I've been hearing this echoed a lot, so this couldn't hurt.