### PR TITLE
Ensure random team generation always ends up with 6 Pokemon

### DIFF
--- a/test/sim/misc/random-teams.js
+++ b/test/sim/misc/random-teams.js
@@ -54,6 +54,25 @@ describe(`Random Team generator (slow)`, function () {
 			}
 		});
 	}
+
+	it(`should successfully create valid gen7monotyperandombattle teams`, function () {
+		this.timeout(0);
+		const generator = Dex.getTeamGenerator('gen7monotyperandombattle', [46, 41716, 23878, 52950]);
+
+		let teamCount = 1000;
+		while (teamCount--) {
+			let seed = generator.prng.seed;
+			try {
+				let team = generator.getTeam();
+				if (team.length < 6) throw new Error(`Team with less than 6 Pokemon: ${JSON.stringify(team)}`);
+				let invalidSet = team.find(set => !isValidSet(7, set));
+				if (invalidSet) throw new Error(`Invalid set: ${JSON.stringify(invalidSet)}`);
+			} catch (err) {
+				err.message += ` (seed ${seed})`;
+				throw err;
+			}
+		}
+	});
 });
 
 describe(`Challenge Cup Team generator`, function () {


### PR DESCRIPTION
Shoehorning monotype generation into normal team generation results in several issues, especially for mono-ice where there are only 28 possible Pokemon in the `pokemonPool` to begin with:

- Rotom-F, Ninetales-A and Sandslash-A are all going to be unfairly downsampled even though their alternate formes are not legal options on mono ice (Kyurem downsampling should be OK, because all are ice)
- We limit to 2 Pokemon per tier even though most Ice types are likely to be clustered in the lower tiers (or just Untiered) because theyre kind of trash
- We limit the number of type combinations even though a large fraction of Ice types are actually just pure Ice. We increase the 'allowable number of type combos' from 1 to 2 for monotype, but this is probably still too low for Ice.
- We only consider a single set for a Pokemon and dispose of the entire Pokemon if the set doesn't fit instead of rerolling the set

I'm merely documenting these issues here, but instead going with the simplest possible fix for having < 6 members on the team which is to just throw in another loop (with an `EXHAUSTION` constant to prevent infinite iteration). I'm also utilizing our `fulltest` tagging better - even with 1000 iterations it still only takes 3s on my notebook which is still substantially less than some of our slow tests which take 1 minute on our machine. I've also preseeded to make the first team generated one with only 5 mons before this change.