### PR TITLE
Rework random teams to only perform 2 iterations

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1833,21 +1833,10 @@ class RandomTeams extends Dex.ModdedDex {
 
 				// Okay, the set passes, add it to our team
 				pokemon.push(set);
-
-				if (pokemon.length === 6) {
-					let illusion = teamDetails['illusion'];
-					if (illusion) {
-						// Make sure Zoroark isn't in the last slot
-						// (It can't use Illusion if it switches in from the last slot.)
-						if (illusion === 5) {
-							[pokemon[5], pokemon[4]] = [pokemon[4], pokemon[5]];
-							illusion = 4;
-						}
-						// Set Zoroark's level to be the same as the last Pokemon
-						pokemon[illusion - 1].level = pokemon[5].level;
-					}
-					break;
-				}
+				// For setting Zoroark's level and slot
+				if (set.ability === 'Illusion') teamDetails['illusion'] = pokemon.length;
+				// Don't bother performing accounting/tracking other teamDetails on the last Pokemon.
+				if (pokemon.length === 6) break;
 
 				// Now that our Pokemon has passed all checks, we can increment our counters
 				baseFormes[template.baseSpecies] = 1;
@@ -1877,12 +1866,21 @@ class RandomTeams extends Dex.ModdedDex {
 				if (set.moves.includes('stealthrock')) teamDetails['stealthRock'] = 1;
 				if (set.moves.includes('toxicspikes')) teamDetails['toxicSpikes'] = 1;
 				if (set.moves.includes('defog') || set.moves.includes('rapidspin')) teamDetails['hazardClear'] = 1;
-
-				// For setting Zoroark's level and slot
-				if (set.ability === 'Illusion') teamDetails['illusion'] = pokemon.length;
 			}
 		}
-		if (pokemon.length < 6) throw new Error(`Could not build a random team for ${this.format} (type=${type})`);
+
+		let illusion = teamDetails['illusion'];
+		if (illusion) {
+			// Make sure Zoroark isn't in the last slot
+			// (It can't use Illusion if it switches in from the last slot)
+			if (illusion === 5) {
+				[pokemon[5], pokemon[4]] = [pokemon[4], pokemon[5]];
+				illusion = 4;
+			}
+			// Set Zoroark's level to be the same as the last Pokemon
+			pokemon[illusion - 1].level = pokemon[5].level;
+		}
+
 		return pokemon;
 	}
 

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1837,7 +1837,8 @@ class RandomTeams extends Dex.ModdedDex {
 				if (pokemon.length === 6) {
 					let illusion = teamDetails['illusion'];
 					if (illusion) {
-						// Swap Zoroark's slot if it is the last Pokemon
+						// Make sure Zoroark isn't in the last slot
+						// (It can't use Illusion if it switches in from the last slot.)
 						if (illusion === 5) {
 							[pokemon[5], pokemon[4]] = [pokemon[4], pokemon[5]];
 							illusion = 4;

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1715,6 +1715,7 @@ class RandomTeams extends Dex.ModdedDex {
 	}
 
 	randomTeam() {
+		const seed = this.prng.seed;
 		let pokemon = [];
 
 		// For Monotype
@@ -1868,6 +1869,7 @@ class RandomTeams extends Dex.ModdedDex {
 				if (set.moves.includes('defog') || set.moves.includes('rapidspin')) teamDetails['hazardClear'] = 1;
 			}
 		}
+		if (pokemon.length < 6) throw new Error(`Could not build a random team for ${this.format} (seed=${seed})`);
 
 		let illusion = teamDetails['illusion'];
 		if (illusion) {

--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1810,9 +1810,6 @@ class RandomTeams extends Dex.ModdedDex {
 
 				let set = this.randomSet(template, pokemon.length, teamDetails, this.format.gameType !== 'singles');
 
-				// Illusion shouldn't be the last Pokemon of the team
-				if (set.ability === 'Illusion' && pokemon.length > 4) continue;
-
 				// Pokemon shouldn't have Physical and Special setup on the same set
 				let incompatibleMoves = ['bellydrum', 'swordsdance', 'calmmind', 'nastyplot'];
 				let intersectMoves = set.moves.filter(move => incompatibleMoves.includes(move));
@@ -1838,9 +1835,16 @@ class RandomTeams extends Dex.ModdedDex {
 				pokemon.push(set);
 
 				if (pokemon.length === 6) {
-					// Set Zoroark's level to be the same as the last Pokemon
 					let illusion = teamDetails['illusion'];
-					if (illusion) pokemon[illusion - 1].level = pokemon[5].level;
+					if (illusion) {
+						// Swap Zoroark's slot if it is the last Pokemon
+						if (illusion === 5) {
+							[pokemon[5], pokemon[4]] = [pokemon[4], pokemon[5]];
+							illusion = 4;
+						}
+						// Set Zoroark's level to be the same as the last Pokemon
+						pokemon[illusion - 1].level = pokemon[5].level;
+					}
 					break;
 				}
 
@@ -1873,7 +1877,7 @@ class RandomTeams extends Dex.ModdedDex {
 				if (set.moves.includes('toxicspikes')) teamDetails['toxicSpikes'] = 1;
 				if (set.moves.includes('defog') || set.moves.includes('rapidspin')) teamDetails['hazardClear'] = 1;
 
-				// For setting Zoroark's level
+				// For setting Zoroark's level and slot
 				if (set.ability === 'Illusion') teamDetails['illusion'] = pokemon.length;
 			}
 		}


### PR DESCRIPTION
After this, the only remaining restrictions on the second pass are:

1) Species clause
2) 6th slot Zoroak
3) bellydrum/swordsdance/calmmind/nastyplot sets
4) multiple zmoves

Not sure if we want to remove the restrictions from 2-4 as well, LMK.