### PR TITLE
Record statistics for help tickets

### DIFF
--- a/logs/tickets/README.md
+++ b/logs/tickets/README.md
@@ -1,0 +1,1 @@
+Logs of ticket stats are stored in this directory.


### PR DESCRIPTION
This Pull Request adds support for logging statistics about help tickets. These statistics are stored in tsv files located in `logs/tickets/YYYY-MM.tsv`.

When a ticket is closed, a line is added to the current month's tsv file containing information about the ticket including its type, how long it was open, how long it took staff to claim it for the first time, how long it was waiting on staff in total, what staff members participated (to our best knowledge) in the ticket's resolution, if the ticket was resolved, and its result. The possible ticket resolutions are:

- "dead" - The ticket was never activated by the user and was closed by the user (staff were not contacted).
- "unresolved" - The ticket was activated and staff were contacted, but no staff member came before the ticket was closed by the user.
- "resolved" - The ticket was activated and claimed by staff before it was closed.

Ticket results are either positive or negative, and the result is determined by which close button a global staff member uses.

- Appeal-type tickets ask global staff to close the ticket as "Approved" or "Denied". 
- Report-type tickets ask global staff to close the ticket as "Valid" or "Invalid".
- Other tickets ask global staff to close the ticket as "Assisted" or "Unassisted".

This information is formatted into two different tables. The first one shows average stats for each ticket type. This shows the total number of tickets of each type, average wait times for each type of ticket, and the percentage of ticket that closed with a specific resolution/positively.
![Type Table](https://i.imgur.com/nGM3Rb7.png?1)

The second table shows stats for each staff member who has done at least one ticket in the month. The information shown is the number of tickets done, and the average time spent on a single ticket.
![Staff Table](https://i.imgur.com/anEjEH8.png?1)

Of course none of this is perfectly accurate, outliers in averages can cause the average to jump higher/lower than it should be, and sometimes staff may help with far more tickets than shown in stats since they do it through communication in the staff room. But considering what we have to work with I think its setup pretty well.

Something to consider, If you have any suggestions for compressing the information in the % Resolutions, and % Positive Result cols (including the headers) please let me know, even something as simple as a better header to shrink that row is appreciated.

@scheibo helped with the design of this, thanks pre!