### PR TITLE
Add Empty Learnsets for Pokestar Pokemon

### DIFF
--- a/data/learnsets.js
+++ b/data/learnsets.js
@@ -64993,6 +64993,57 @@ let BattleLearnsets = {
 		wish: ["7L22"],
 		worryseed: ["7T"],
 	}},
+	pokestarsmeargle: {learnset: {
+
+	}},
+	pokestarufo: {learnset: {
+
+	}},
+	pokestarufo2: {learnset: {
+
+	}},
+	pokestarbrycenman: {learnset: {
+
+	}},
+	pokestarmt: {learnset: {
+
+	}},
+	pokestarmt2: {learnset: {
+
+	}},
+	pokestartransport: {learnset: {
+
+	}},
+	pokestargiant: {learnset: {
+
+	}},
+	pokestarhumanoid: {learnset: {
+
+	}},
+	pokestarmonster: {learnset: {
+
+	}},
+	pokestarf00: {learnset: {
+
+	}},
+	pokestarf002: {learnset: {
+
+	}},
+	pokestarspirit: {learnset: {
+
+	}},
+	pokestarblackdoor: {learnset: {
+
+	}},
+	pokestarwhitedoor: {learnset: {
+
+	}},
+	pokestarblackbelt: {learnset: {
+
+	}},
+	pokestarufopropu2: {learnset: {
+
+	}},
 };
 
 exports.BattleLearnsets = BattleLearnsets;

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -990,6 +990,7 @@ interface Template extends Readonly<BasicEffect & TemplateData & TemplateFormats
 	readonly formeLetter: string
 	readonly gender: GenderName
 	readonly genderRatio: {M: number, F: number}
+	readonly learnset: {[k: string]: MoveSource[]}
 	readonly maleOnlyHidden: boolean
 	readonly nfe: boolean
 	readonly prevo: string
@@ -999,7 +1000,6 @@ interface Template extends Readonly<BasicEffect & TemplateData & TemplateFormats
 	readonly addedType?: string
 	readonly isMega?: boolean
 	readonly isPrimal?: boolean
-	readonly learnset?: {[k: string]: MoveSource[]}
 }
 
 type GameType = 'singles' | 'doubles' | 'triples' | 'rotation' | 'multi' | 'free-for-all'


### PR DESCRIPTION
Discussed in the dev room. I think actually adding empty learnsets for the Pokestar Pokemon is a better design than having to check if `Template.learnset` exists. 

Since Pokestar pokemon were the only things I could find without a learnset defined, I also made `learnset` a required property on `Template` to avoid a bug like this in the future.

These changes make ff911e2 unnecessary. 