### PR TITLE
Add a 15 second timeout when warning individual users

### DIFF
--- a/server/users.js
+++ b/server/users.js
@@ -540,6 +540,9 @@ class User extends Chat.MessageContext {
 		this.trackRename = '';
 		/** @type {string} */
 		this.status = '';
+		/** @type {number} */
+		this.lastWarnedAt = 0;
+
 		// initialize
 		Users.add(this);
 	}


### PR DESCRIPTION
It's possible to spam /warn in groupchats, preventing users from being
able to close the warn modal. This mitigates that by limiting the rate
you can warn a user to once every 15 seconds, which is longer than the
amount of time it takes for the warn modal to allow you to close it.