### PR TITLE
Data: Make Template constructor autofill Pokestar learnsets

### DIFF
--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -644,6 +644,9 @@ export class Template extends BasicEffect implements Readonly<BasicEffect & Temp
 		this.maleOnlyHidden = !!data.maleOnlyHidden;
 		this.maxHP = data.maxHP || undefined;
 		this.learnset = data.learnset || undefined;
+		if (this.isNonstandard === 'Pokestar') {
+			this.learnset = {};
+		}
 		this.eventOnly = !!data.eventOnly;
 		this.eventPokemon = data.eventPokemon || undefined;
 		this.isMega = !!(this.forme && ['Mega', 'Mega-X', 'Mega-Y'].includes(this.forme)) || undefined;


### PR DESCRIPTION
Changes as discussed in #5579. Makes ff911e2 unnecessary.

Couldn't just make `this.learnset` default to `{}` because so much existing code checks `!template.learnset` or `template.learnset` directly, so went with a check for the template being of a Pokestar mon and then setting the learnset based on that.