### PR TITLE
Fix Pickup/Recycle of Terrain Seed while terrain is up

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2317,10 +2317,10 @@ let BattleAbilities = {
 			}
 			if (!pickupTargets.length) return;
 			let randomTarget = this.sample(pickupTargets);
-			pokemon.setItem(randomTarget.lastItem);
+			let item = randomTarget.lastItem;
 			randomTarget.lastItem = '';
-			let item = pokemon.getItem();
-			this.add('-item', pokemon, item, '[from] ability: Pickup');
+			this.add('-item', pokemon, this.getItem(item), '[from] ability: Pickup');
+			pokemon.setItem(item);
 		},
 		id: "pickup",
 		name: "Pickup",

--- a/data/moves.js
+++ b/data/moves.js
@@ -13281,9 +13281,10 @@ let BattleMovedex = {
 		flags: {snatch: 1},
 		onHit(pokemon) {
 			if (pokemon.item || !pokemon.lastItem) return false;
-			pokemon.setItem(pokemon.lastItem);
+			let item = pokemon.lastItem;
 			pokemon.lastItem = '';
-			this.add('-item', pokemon, pokemon.getItem(), '[from] move: Recycle');
+			this.add('-item', pokemon, this.getItem(item), '[from] move: Recycle');
+			pokemon.setItem(item);
 		},
 		secondary: null,
 		target: "self",


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/8175821).

This saves the item about to be set and reports it before it actually sets it so that its `onStart` handler can activate in order.

I could do Harvest in the same way, but those are only Berries, which never have an `onStart` handler.

For other item-switching moves there are issues with items that can't be switched so I can't see how to avoid having the messages in the wrong order (think about seed holder having Klutz or affected by Embargo). I don't think the underlying mechanics are wrong in this case though, it's just a cosmetic error.