### PR TITLE
Display Elo in rated battles

### DIFF
--- a/server/ladders.js
+++ b/server/ladders.js
@@ -638,8 +638,10 @@ class Ladder extends LadderStore {
 		Rooms.createBattle(ready1.formatid, {
 			p1: user1,
 			p1team: ready1.team,
+			p1rating: ready1.rating,
 			p2: user2,
 			p2team: ready2.team,
+			p2rating: ready2.rating,
 			rated: Math.min(ready1.rating, ready2.rating),
 		});
 	}

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -505,11 +505,11 @@ class RoomBattle extends RoomGames.RoomGame {
 
 		this.listen();
 
-		this.addPlayer(options.p1, options.p1team || '');
-		this.addPlayer(options.p2, options.p2team || '');
+		this.addPlayer(options.p1, options.p1team || '', options.p1rating);
+		this.addPlayer(options.p2, options.p2team || '', options.p2rating);
 		if (this.playerCap > 2) {
-			this.addPlayer(options.p3, options.p3team || '');
-			this.addPlayer(options.p4, options.p4team || '');
+			this.addPlayer(options.p3, options.p3team || '', options.p3rating);
+			this.addPlayer(options.p4, options.p4team || '', options.p4rating);
 		}
 		this.timer = new RoomBattleTimer(this);
 		if (Config.forcetimer) this.timer.start();
@@ -960,8 +960,9 @@ class RoomBattle extends RoomGames.RoomGame {
 	 *
 	 * @param {User | null} user
 	 * @param {string?} team
+	 * @param {number} elo
 	 */
-	addPlayer(user, team) {
+	addPlayer(user, team, elo = 0) {
 		// TypeScript bug: no `T extends RoomGamePlayer`
 		const player = /** @type {RoomBattlePlayer} */ (super.addPlayer(user));
 		if (!player) return null;
@@ -973,14 +974,9 @@ class RoomBattle extends RoomGames.RoomGame {
 				name: player.name,
 				avatar: user ? '' + user.avatar : '',
 				team: team,
+				elo: elo,
 			};
 			this.stream.write(`>player ${slot} ${JSON.stringify(options)}`);
-			if (this.rated) {
-				new Ladders.LadderStore(this.format).getRating(player.userid).then(response => {
-					const elo = Math.round(response);
-					if (this.room) this.room.add(`|elo|${player.name}|${elo}`);
-				});
-			}
 		}
 
 		if (user) this.room.auth[user.userid] = Users.PLAYER_SYMBOL;

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -974,7 +974,7 @@ class RoomBattle extends RoomGames.RoomGame {
 				name: player.name,
 				avatar: user ? '' + user.avatar : '',
 				team: team,
-				rating: rating,
+				rating: Math.round(rating),
 			};
 			this.stream.write(`>player ${slot} ${JSON.stringify(options)}`);
 		}

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -960,9 +960,9 @@ class RoomBattle extends RoomGames.RoomGame {
 	 *
 	 * @param {User | null} user
 	 * @param {string?} team
-	 * @param {number} elo
+	 * @param {number} rating
 	 */
-	addPlayer(user, team, elo = 0) {
+	addPlayer(user, team, rating = 0) {
 		// TypeScript bug: no `T extends RoomGamePlayer`
 		const player = /** @type {RoomBattlePlayer} */ (super.addPlayer(user));
 		if (!player) return null;
@@ -974,7 +974,7 @@ class RoomBattle extends RoomGames.RoomGame {
 				name: player.name,
 				avatar: user ? '' + user.avatar : '',
 				team: team,
-				elo: elo,
+				rating: rating,
 			};
 			this.stream.write(`>player ${slot} ${JSON.stringify(options)}`);
 		}

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -974,7 +974,13 @@ class RoomBattle extends RoomGames.RoomGame {
 				avatar: user ? '' + user.avatar : '',
 				team: team,
 			};
-			this.stream.write(`>player ${slot} ` + JSON.stringify(options));
+			this.stream.write(`>player ${slot} ${JSON.stringify(options)}`);
+			if (this.rated) {
+				new Ladders.LadderStore(this.format).getRating(player.userid).then(response => {
+					const elo = Math.round(response);
+					if (this.room) this.room.add(`|elo|${player.name}|${elo}`);
+				});
+			}
 		}
 
 		if (user) this.room.auth[user.userid] = Users.PLAYER_SYMBOL;

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -11,10 +11,8 @@ Receiving messages
 
 The beginning of a battle will look something like this:
 
-    |elo|Anonycat|1200
-    |elo|Anonybird|1300
-    |player|p1|Anonycat|60
-    |player|p2|Anonybird|113
+    |player|p1|Anonycat|60|1200
+    |player|p2|Anonybird|113|1300
     |teamsize|p1|4
     |teamsize|p2|5
     |gametype|doubles
@@ -41,11 +39,7 @@ The beginning of a battle will look something like this:
     |
     |start
 
-`|elo|PLAYER|ELO`
-
-> - `ELO` is the player's elo in the format they're playing. This will not be sent in unrated battles
-
-`|player|PLAYER|USERNAME|AVATAR`
+`|player|PLAYER|USERNAME|AVATAR|ELO`
 
 > Player details.
 >
@@ -54,6 +48,7 @@ The beginning of a battle will look something like this:
 > - `USERNAME` is the username
 > - `AVATAR` is the player's avatar identifier (usually a number, but other
 >    values can be used for custom avatars)
+> - `ELO` is the player's elo in the format they're playing. This will be `0` in unrated battles
 
 `|teamsize|PLAYER|NUMBER`
 

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -11,6 +11,8 @@ Receiving messages
 
 The beginning of a battle will look something like this:
 
+    |elo|Anonycat|1200
+    |elo|Anonybird|1300
     |player|p1|Anonycat|60
     |player|p2|Anonybird|113
     |teamsize|p1|4
@@ -38,6 +40,10 @@ The beginning of a battle will look something like this:
     |teampreview
     |
     |start
+
+`|elo|PLAYER|ELO`
+
+> - `ELO` is the player's elo in the format they're playing. This will not be sent in unrated battles
 
 `|player|PLAYER|USERNAME|AVATAR`
 

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -39,7 +39,7 @@ The beginning of a battle will look something like this:
     |
     |start
 
-`|player|PLAYER|USERNAME|AVATAR|ELO`
+`|player|PLAYER|USERNAME|AVATAR|RATING`
 
 > Player details.
 >
@@ -48,7 +48,7 @@ The beginning of a battle will look something like this:
 > - `USERNAME` is the username
 > - `AVATAR` is the player's avatar identifier (usually a number, but other
 >    values can be used for custom avatars)
-> - `ELO` is the player's elo in the format they're playing. This will be `0` in unrated battles
+> - `RATING` is the player's Elo rating in the format they're playing. This will only be displayed in rated battles and when the player is first introduced otherwise it's blank
 
 `|teamsize|PLAYER|NUMBER`
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3005,7 +3005,7 @@ export class Battle extends Dex.ModdedDex {
 		}
 		if (!didSomething) return;
 		this.inputLog.push(`>player ${slot} ` + JSON.stringify(options));
-		this.add('player', side.id, side.name, side.avatar, options.rating || 0);
+		this.add('player', side.id, side.name, side.avatar, options.rating || '');
 		this.start();
 	}
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3005,7 +3005,7 @@ export class Battle extends Dex.ModdedDex {
 		}
 		if (!didSomething) return;
 		this.inputLog.push(`>player ${slot} ` + JSON.stringify(options));
-		this.add('player', side.id, side.name, side.avatar);
+		this.add('player', side.id, side.name, side.avatar, options.elo || 0);
 		this.start();
 	}
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3005,7 +3005,7 @@ export class Battle extends Dex.ModdedDex {
 		}
 		if (!didSomething) return;
 		this.inputLog.push(`>player ${slot} ` + JSON.stringify(options));
-		this.add('player', side.id, side.name, side.avatar, options.elo || 0);
+		this.add('player', side.id, side.name, side.avatar, options.rating || 0);
 		this.start();
 	}
 

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -1208,7 +1208,7 @@ interface TypeInfo extends Readonly<TypeData> {
 interface PlayerOptions {
 	name?: string;
 	avatar?: string;
-	elo?: number;
+	rating?: number;
 	team?: PokemonSet[] | string | null;
 	seed?: PRNGSeed;
 }

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -1208,6 +1208,7 @@ interface TypeInfo extends Readonly<TypeData> {
 interface PlayerOptions {
 	name?: string;
 	avatar?: string;
+	elo?: number;
 	team?: PokemonSet[] | string | null;
 	seed?: PRNGSeed;
 }


### PR DESCRIPTION
Client Pull Request: Zarel/Pokemon-Showdown-Client#1318

Suggested and approved here: https://www.smogon.com/forums/threads/3651687/

I did not implement the "make `/rank` only display the tier of the battle you're playing in" suggestion because you can use `/rank [player], [format]` or with this change it's even easier because you can just scroll up.