### PR TITLE
Refactor punishments

### DIFF
--- a/server/punishments.js
+++ b/server/punishments.js
@@ -1677,16 +1677,16 @@ const Punishments = new (class {
 			let [punishType, id, expireTime, reason] = punishment;
 			let expiresIn = new Date(expireTime).getTime() - Date.now();
 			if (expiresIn < 1000) continue;
-			let userids = [...data[0]].filter(user => user !== id);
+			let alts = [...data[0]].filter(user => user !== id);
 			let ips = [...data[1]];
-			output.push({"punishType": punishType, "id": id, "expiresIn": expiresIn, "reason": reason, "userids": userids, "ips": ips});
+			output.push({"punishType": punishType, "id": id, "expiresIn": expiresIn, "reason": reason, "alts": alts, "ips": ips});
 		}
 
 		if (room.muteQueue) {
 			for (const entry of room.muteQueue) {
 				let expiresIn = new Date(entry.time).getTime() - Date.now();
 				if (expiresIn < 1000) continue;
-				output.push({"punishType": 'MUTE', "id": entry.userid, "expiresIn": expiresIn, "reason": '', "userids": [], "ips": []});
+				output.push({"punishType": 'MUTE', "id": entry.userid, "expiresIn": expiresIn, "reason": '', "alts": [], "ips": []});
 			}
 		}
 		return output;

--- a/server/punishments.js
+++ b/server/punishments.js
@@ -470,15 +470,17 @@ const Punishments = new (class {
 	}
 
 	// sharedips.tsv is in the format:
-	// IP, note
+	// IP, type (in this case always SHARED), note
 
 	async loadSharedIps() {
 		const data = await FS(SHAREDIPS_FILE).readIfExists();
 		if (!data) return;
 		for (const row of data.split("\n")) {
 			if (!row || row === '\r') continue;
-			const [ip, note] = row.trim().split("\t");
+			const [ip, type, note] = row.trim().split("\t");
 			if (!ip.includes('.')) continue;
+			if (type !== 'SHARED') continue;
+
 			Punishments.sharedIps.set(ip, note);
 		}
 	}
@@ -488,14 +490,14 @@ const Punishments = new (class {
 	 * @param {string} note
 	 */
 	appendSharedIp(ip, note) {
-		let buf = `${ip}\t${note}\r\n`;
+		let buf = `${ip}\tSHARED\t${note}\r\n`;
 		FS(SHAREDIPS_FILE).append(buf);
 	}
 
 	saveSharedIps() {
-		let buf = 'IP\tNote\r\n';
+		let buf = 'IP\tType\tNote\r\n';
 		Punishments.sharedIps.forEach((note, ip) => {
-			buf += `${ip}\t${note}\r\n`;
+			buf += `${ip}\tSHARED\t${note}\r\n`;
 		});
 
 		FS(SHAREDIPS_FILE).write(buf);

--- a/server/punishments.js
+++ b/server/punishments.js
@@ -47,6 +47,7 @@ const AUTOLOCK_POINT_THRESHOLD = 8;
  * @property {string} punishType
  * @property {number} expireTime
  * @property {string} reason
+ * @property {any[]} rest
  */
 
 /**
@@ -286,7 +287,7 @@ const Punishments = new (class {
 			/** @type {Map<string, PunishmentEntry>} */
 			const saveTable = new Map();
 			Punishments.ips.forEach((punishment, ip) => {
-				const [punishType, id, expireTime, reason] = punishment;
+				const [punishType, id, expireTime, reason, ...rest] = punishment;
 				if (id.charAt(0) === '#') return;
 				let entry = saveTable.get(id);
 
@@ -301,11 +302,12 @@ const Punishments = new (class {
 					punishType: punishType,
 					expireTime: expireTime,
 					reason: reason,
+					rest: rest,
 				};
 				saveTable.set(id, entry);
 			});
 			Punishments.userids.forEach((punishment, userid) => {
-				const [punishType, id, expireTime, reason] = punishment;
+				const [punishType, id, expireTime, reason, ...rest] = punishment;
 				if (id.charAt(0) === '#') return;
 				let entry = saveTable.get(id);
 
@@ -316,6 +318,7 @@ const Punishments = new (class {
 						punishType: punishType,
 						expireTime: expireTime,
 						reason: reason,
+						rest: rest,
 					};
 					saveTable.set(id, entry);
 				}
@@ -336,7 +339,7 @@ const Punishments = new (class {
 			/** @type {Map<string, PunishmentEntry>} */
 			const saveTable = new Map();
 			Punishments.roomIps.nestedForEach((punishment, roomid, ip) => {
-				const [punishType, punishUserid, expireTime, reason] = punishment;
+				const [punishType, punishUserid, expireTime, reason, ...rest] = punishment;
 				const id = roomid + '\t' + punishUserid;
 				if (id.charAt(0) === '#') return;
 				let entry = saveTable.get(id);
@@ -352,11 +355,12 @@ const Punishments = new (class {
 					punishType: punishType,
 					expireTime: expireTime,
 					reason: reason,
+					rest: rest,
 				};
 				saveTable.set(id, entry);
 			});
 			Punishments.roomUserids.nestedForEach((punishment, roomid, userid) => {
-				const [punishType, punishUserid, expireTime, reason] = punishment;
+				const [punishType, punishUserid, expireTime, reason, ...rest] = punishment;
 				const id = roomid + '\t' + punishUserid;
 				let entry = saveTable.get(id);
 
@@ -367,6 +371,7 @@ const Punishments = new (class {
 						punishType: punishType,
 						expireTime: expireTime,
 						reason: reason,
+						rest: rest,
 					};
 					saveTable.set(id, entry);
 				}
@@ -389,7 +394,7 @@ const Punishments = new (class {
 		/** @type {PunishmentEntry | null} */
 		let entry = null;
 		Punishments.ips.forEach((punishment, ip) => {
-			const [punishType, id, expireTime, reason] = punishment;
+			const [punishType, id, expireTime, reason, ...rest] = punishment;
 			if (id !== entryId) return;
 			if (entry) {
 				entry.userids.push(ip);
@@ -402,10 +407,11 @@ const Punishments = new (class {
 				punishType: punishType,
 				expireTime: expireTime,
 				reason: reason,
+				rest: rest,
 			};
 		});
 		Punishments.userids.forEach((punishment, userid) => {
-			const [punishType, id, expireTime, reason] = punishment;
+			const [punishType, id, expireTime, reason, ...rest] = punishment;
 			if (id !== entryId) return;
 
 			if (!entry) {
@@ -415,6 +421,7 @@ const Punishments = new (class {
 					punishType: punishType,
 					expireTime: expireTime,
 					reason: reason,
+					rest: rest,
 				};
 			}
 
@@ -441,7 +448,7 @@ const Punishments = new (class {
 	 * @return {string}
 	 */
 	renderEntry(entry, id) {
-		let row = [entry.punishType, id, entry.ips.join(','), entry.userids.join(','), entry.expireTime, entry.reason];
+		let row = [entry.punishType, id, entry.ips.join(','), entry.userids.join(','), entry.expireTime, entry.reason, ...entry.rest];
 		return row.join('\t') + '\r\n';
 	}
 
@@ -514,7 +521,7 @@ const Punishments = new (class {
 			this.punishInner(alt, punishment, userids, ips);
 		}
 
-		const [punishType, id, expireTime, reason] = punishment;
+		const [punishType, id, expireTime, reason, ...rest] = punishment;
 		userids.delete(id);
 		Punishments.appendPunishment({
 			userids: [...userids],
@@ -522,6 +529,7 @@ const Punishments = new (class {
 			punishType: punishType,
 			expireTime: expireTime,
 			reason: reason,
+			rest: rest,
 		}, id, PUNISHMENT_FILE);
 		return affected;
 	}
@@ -591,7 +599,7 @@ const Punishments = new (class {
 		for (const ip of ips) {
 			Punishments.ips.set(ip, punishment);
 		}
-		const [punishType, id, expireTime, reason] = punishment;
+		const [punishType, id, expireTime, reason, ...rest] = punishment;
 		let affected = Users.findUsers([...userids], [...ips], {includeTrusted: PUNISH_TRUSTED, forPunishment: true});
 		userids.delete(id);
 		Punishments.appendPunishment({
@@ -600,6 +608,7 @@ const Punishments = new (class {
 			punishType: punishType,
 			expireTime: expireTime,
 			reason: reason,
+			rest: rest,
 		}, id, PUNISHMENT_FILE);
 
 		return affected;
@@ -656,7 +665,7 @@ const Punishments = new (class {
 			this.roomPunishInner(roomid, curUser, punishment, userids, ips);
 		}
 
-		const [punishType, id, expireTime, reason] = punishment;
+		const [punishType, id, expireTime, reason, ...rest] = punishment;
 		userids.delete(id);
 		Punishments.appendPunishment({
 			userids: [...userids],
@@ -664,6 +673,7 @@ const Punishments = new (class {
 			punishType: punishType,
 			expireTime: expireTime,
 			reason: reason,
+			rest: rest,
 		}, roomid + '\t' + id, ROOM_PUNISHMENT_FILE);
 
 		if (typeof room === 'string' || !(room.isPrivate === true || room.isPersonal || room.battle)) {
@@ -721,7 +731,7 @@ const Punishments = new (class {
 		for (const ip of ips) {
 			Punishments.roomIps.nestedSet(room.id, ip, punishment);
 		}
-		const [punishType, id, expireTime, reason] = punishment;
+		const [punishType, id, expireTime, reason, ...rest] = punishment;
 		let affected = Users.findUsers([...userids], [...ips], {includeTrusted: PUNISH_TRUSTED, forPunishment: true});
 		userids.delete(id);
 		Punishments.appendPunishment({
@@ -730,6 +740,7 @@ const Punishments = new (class {
 			punishType: punishType,
 			expireTime: expireTime,
 			reason: reason,
+			rest: rest,
 		}, room.id + '\t' + id, ROOM_PUNISHMENT_FILE);
 
 		if (!(room.isPrivate === true || room.isPersonal || room.battle)) Punishments.monitorRoomPunishments(userid);

--- a/server/punishments.js
+++ b/server/punishments.js
@@ -243,7 +243,7 @@ const Punishments = new (class {
 			if (punishType === "Punishment") continue;
 			const keys = altKeys.split(',').concat(id);
 
-			const punishment = /** @type {Punishment} */ ([punishType, id, expireTime, reason.join(`\t`)]);
+			const punishment = /** @type {Punishment} */ ([punishType, id, expireTime, ...reason]);
 			if (Date.now() >= expireTime) {
 				continue;
 			}
@@ -269,7 +269,7 @@ const Punishments = new (class {
 			if (!userid) continue; // invalid format
 			const keys = altKeys.split(',').concat(userid);
 
-			const punishment = /** @type {Punishment} */ ([punishType, userid, expireTime, reason.join(`\t`)]);
+			const punishment = /** @type {Punishment} */ ([punishType, userid, expireTime, ...reason]);
 			if (Date.now() >= expireTime) {
 				continue;
 			}

--- a/server/punishments.js
+++ b/server/punishments.js
@@ -449,7 +449,8 @@ const Punishments = new (class {
 	 * @return {string}
 	 */
 	renderEntry(entry, id) {
-		let row = [entry.punishType, id, [entry.ips.join(','), entry.userids.join(',')].filter(el => el), entry.expireTime, entry.reason, ...entry.rest];
+		const keys = entry.ips.concat(entry.userids).join(',');
+		const row = [entry.punishType, id, keys, entry.expireTime, entry.reason, ...entry.rest];
 		return row.join('\t') + '\r\n';
 	}
 


### PR DESCRIPTION
**Changes**:
- `PunishmentEntry` now has `ips` and `userids` instead of `keys`.
- `PunishmentEntry` now has `reason` and `expireTime` instead of `rest`.
- `rest` was still kept as Zarel noted it was used for extensibility. 
- `Punishments.renderEntry` converts `PunishmentEntry` into the old format for to not ruin the databases.
- ~Removed `type` from sharedIPs because it's _always_ the same.~ Turns out it's in case there are more types in the future, so I reverted that change.

This will make my life easier when I work on migrating punishments to SQLite3

It has also another advantage in making the code more explicit for future readers.