### PR TITLE
Create Chat.statusfilter which also performs basic rank impersonation filtering

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -660,7 +660,7 @@ const commands = {
 		if (!target) return this.parse('/help status');
 
 		if (target.length > 32) return this.errorReply(`Your status is too long; it must be under 32 characters.`);
-		target = Chat.nicknamefilter(target, user, true);
+		target = Chat.statusfilter(target, user);
 		if (!target) return this.errorReply("Your status contains a banned word.");
 
 		user.setUserMessage(target);

--- a/server/chat.js
+++ b/server/chat.js
@@ -39,7 +39,8 @@ To reload chat commands:
  * 3. return undefined to send the original message through
  * @typedef {(this: CommandContext, message: string, user: User, room: ChatRoom | GameRoom?, connection: Connection, targetUser: User?, originalMessage: string) => (string | false | null | undefined)} ChatFilter
  */
-/** @typedef {(name: string, user: User, forStatus?: boolean) => (string)} NameFilter */
+/** @typedef {(name: string, user: User) => (string)} NameFilter */
+/** @typedef {(status: string, user: User) => (string)} StatusFilter */
 /** @typedef {(user: User, oldUser: User?, userType: string) => void} LoginFilter */
 
 const LINK_WHITELIST = ['*.pokemonshowdown.com', 'psim.us', 'smogtours.psim.us', '*.smogon.com', '*.pastebin.com', '*.hastebin.com'];
@@ -233,7 +234,7 @@ Chat.namefilter = function (name, user) {
 
 	name = Dex.getName(name);
 	for (const filter of Chat.namefilters) {
-		name = filter(name, user, false);
+		name = filter(name, user);
 		if (!name) return '';
 	}
 	return name;
@@ -269,16 +270,30 @@ Chat.nicknamefilters = [];
 /**
  * @param {string} nickname
  * @param {User} user
- * @param {boolean} [forStatus]
  */
-Chat.nicknamefilter = function (nickname, user, forStatus = false) {
-	if (forStatus) nickname = nickname.replace(/\|/g, '');
+Chat.nicknamefilter = function (nickname, user) {
 	for (const filter of Chat.nicknamefilters) {
-		nickname = filter(nickname, user, forStatus);
+		nickname = filter(nickname, user);
 		if (!nickname) return '';
 	}
 	return nickname;
 };
+
+/**@type {StatusFilter[]} */
+Chat.statusfilters = [];
+/**
+ * @param {string} status
+ * @param {User} user
+ */
+Chat.statusfilter = function (status, user) {
+	status = status.replace(/\|/g, '');
+	for (const filter of Chat.statusfilters) {
+		status = filter(status, user);
+		if (!status) return '';
+	}
+	return status;
+};
+
 
 /*********************************************************
  * Translations
@@ -1525,6 +1540,7 @@ Chat.loadPlugins = function () {
 	if (Config.hostfilter) Chat.hostfilters.push(Config.hostfilter);
 	if (Config.loginfilter) Chat.loginfilters.push(Config.loginfilter);
 	if (Config.nicknamefilter) Chat.nicknamefilters.push(Config.nicknamefilter);
+	if (Config.statusfilter) Chat.statusfilters.push(Config.statusfilter);
 
 	// Install plug-in commands and chat filters
 
@@ -1547,6 +1563,7 @@ Chat.loadPlugins = function () {
 		if (plugin.hostfilter) Chat.hostfilters.push(plugin.hostfilter);
 		if (plugin.loginfilter) Chat.loginfilters.push(plugin.loginfilter);
 		if (plugin.nicknamefilter) Chat.nicknamefilters.push(plugin.nicknamefilter);
+		if (plugin.statusfilter) Chat.statusfilters.push(plugin.statusfilter);
 	}
 };
 

--- a/server/globals.ts
+++ b/server/globals.ts
@@ -2,6 +2,7 @@ type PageTable = import('./chat').PageTable
 type ChatCommands = import('./chat').ChatCommands
 type ChatFilter = import('./chat').ChatFilter
 type NameFilter = import('./chat').NameFilter
+type StatusFilter = import('./chat').StatusFilter
 type LoginFilter = import('./chat').LoginFilter
 
 declare let Config: {[k: string]: any};


### PR DESCRIPTION
- separate `Chat.statusfilter` from `Chat.nicknamefilter` instead of just using `forStatus` for more flexibility going forward. Eliminating the duplicated code present in `namefilter`, `nicknamefilter` and `statusfilter` is out of scope, but would likely be beneficial as a followup
- do basic rank impersonation filtering, which when coupled with a UI which better differentiates rank in the user card (eg. Zarel/Pokemon-Showdown-Client#1319) should help with abuse