### PR TITLE
Make moves called by Dancer target properly

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -114,7 +114,10 @@ let BattleScripts = {
 			for (const dancer of dancers) {
 				if (this.faintMessages()) break;
 				this.add('-activate', dancer, 'ability: Dancer');
-				this.runMove(move.id, dancer, 0, this.getAbility('dancer'), undefined, true);
+				// @ts-ignore - Fuzz testing shows that TypeScript is likely wrong here and it's impossible for target to be null
+				const dancersTarget = target.side !== dancer.side && pokemon.side === dancer.side ? target : pokemon;
+				// @ts-ignore - Fuzz testing shows that TypeScript is likely wrong here and it's impossible for target to be null
+				this.runMove(move.id, dancer, this.getTargetLoc(dancersTarget, dancer), this.getAbility('dancer'), undefined, true);
 				// Using a Dancer move is enough to spoil Fake Out etc.
 				dancer.activeTurns++;
 			}

--- a/test/sim/abilities/dancer.js
+++ b/test/sim/abilities/dancer.js
@@ -108,4 +108,32 @@ describe('Dancer', function () {
 		const dancer = battle.p1.active[0];
 		assert.hurts(dancer, () => battle.makeChoices('move fierydance', 'move meanlook'));
 	});
+
+	it('should target the user of a Dance move unless it was an ally attacking an opponent', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Oricorio', level: 98, ability: 'dancer', item: 'laggingtail', moves: ['sleeptalk', 'protect', 'teeterdance']},
+			{species: 'Oricorio', level: 99, ability: 'heatproof', moves: ['fierydance', 'sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Oricorio', ability: 'heatproof', moves: ['fierydance', 'sleeptalk']},
+			{species: 'Suicune', ability: 'heatproof', moves: ['sleeptalk']},
+		]});
+
+		const opponentTargetingAlly = battle.p2.active[0];
+		assert.hurts(opponentTargetingAlly, () => battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance 2, move sleeptalk'));
+
+		const opponentTargetingOpponent = battle.p2.active[0];
+		assert.hurts(opponentTargetingOpponent, () => battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance -2, move sleeptalk'));
+
+		const allyTargetingDancer = battle.p1.active[1];
+		assert.hurts(allyTargetingDancer, () => battle.makeChoices('move sleeptalk, move fierydance -1', 'move sleeptalk, move sleeptalk'));
+
+		const allyTargetingOpponent = battle.p1.active[1];
+		const opponentTargetedByAlly = battle.p2.active[1];
+		const opponentNotTargetedByAlly = battle.p2.active[0];
+		assert.hurts(opponentTargetedByAlly, () => battle.makeChoices('move sleeptalk, move fierydance 2', 'move sleeptalk, move sleeptalk'));
+		assert(!allyTargetingOpponent.hurtThisTurn);
+		assert(!opponentNotTargetedByAlly.hurtThisTurn);
+	});
 });


### PR DESCRIPTION
This fixes https://github.com/Zarel/Pokemon-Showdown/projects/3#card-23723922 based on the research conducted [here](https://www.smogon.com/forums/threads/pokemon-sun-moon-battle-mechanics-research.3586701/post-7965255/).

I don't think it's possible for this code path to be reached when `target === null`, so the `ts-ignore` directives hides those errors. If I'm incorrect in that regard, then let me know what the behavior should be and I can implement it.

Also now with unit tests. :)