### PR TITLE
Improve Follow the Leader validation

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -656,16 +656,15 @@ let Formats = [
 			}
 			const setIds = [set.name, set.species];
 			[set.name, set.species] = teamHas.leaderIds;
-			let problems = this.validateSet(set, teamHas) || [];
-			problems = problems.map(problem => problem.replace(teamHas.leaderIds[0], setIds[0]));
+			const problems = new Set((this.validateSet(set, teamHas) || []).map(problem => problem.replace(teamHas.leaderIds[0], setIds[0])));
 			[set.name, set.species] = setIds;
 			// @ts-ignore
 			set.follower = true;
 			set.ability = this.dex.getTemplate(set.species || set.name).abilities['0'];
 			for (const problem of this.validateSet(set, teamHas) || []) {
-				problems.push(problem);
+				problems.add(problem);
 			}
-			return problems || null;
+			return [...problems] || null;
 		},
 	},
 	{

--- a/config/formats.js
+++ b/config/formats.js
@@ -650,13 +650,12 @@ let Formats = [
 			return set.follower ? null : this.checkLearnset(move, template, lsetData, set);
 		},
 		validateSet(set, teamHas) {
-			if (!teamHas.leader) {
-				let problems = this.validateSet(set, teamHas);
-				teamHas.leader = set.species;
-				return problems;
+			if (!teamHas.leaderSpecies) {
+				teamHas.leaderSpecies = set.species;
+				return this.validateSet(set, teamHas);
 			}
-			let leader = this.dex.deepClone(set);
-			leader.species = teamHas.leader;
+			const leader = this.dex.deepClone(set);
+			leader.species = teamHas.leaderSpecies;
 			leader.follower = true;
 			return this.validateSet(leader, teamHas);
 		},

--- a/config/formats.js
+++ b/config/formats.js
@@ -647,7 +647,12 @@ let Formats = [
 		banlist: ['Regigigas', 'Shedinja', 'Slaking', 'Smeargle', 'Imposter', 'Huge Power', 'Pure Power'],
 		checkLearnset(move, template, lsetData, set) {
 			// @ts-ignore
-			return set.follower ? null : this.checkLearnset(move, template, lsetData, set);
+			if (set.follower) {
+				// @ts-ignore
+				delete set.follower;
+				return null;
+			}
+			return this.checkLearnset(move, template, lsetData, set);
 		},
 		validateSet(set, teamHas) {
 			if (!teamHas.leaderSpecies) {

--- a/config/formats.js
+++ b/config/formats.js
@@ -655,16 +655,19 @@ let Formats = [
 			return this.checkLearnset(move, template, lsetData, set);
 		},
 		validateSet(set, teamHas) {
-			if (!teamHas.leaderSpecies) {
-				teamHas.leaderSpecies = set.species;
+			if (!teamHas.leaderIds) {
+				teamHas.leaderIds = [set.name, set.species];
 				return this.validateSet(set, teamHas);
 			}
-			const setSpecies = set.species;
-			set.species = teamHas.leaderSpecies;
+			const setIds = [set.name, set.species];
+			[set.name, set.species] = teamHas.leaderIds;
 			// @ts-ignore
 			set.follower = true;
-			const problems = this.validateSet(set, teamHas);
-			set.species = setSpecies;
+			let problems = this.validateSet(set, teamHas);
+			if (problems) {
+				problems = problems.map(problem => problem.replace(teamHas.leaderIds[0], setIds[0]));
+			}
+			[set.name, set.species] = setIds;
 			return problems;
 		},
 	},

--- a/config/formats.js
+++ b/config/formats.js
@@ -661,6 +661,10 @@ let Formats = [
 			[set.name, set.species] = setIds;
 			// @ts-ignore
 			set.follower = true;
+			set.ability = this.dex.getTemplate(set.species || set.name).abilities['0'];
+			for (const problem of this.validateSet(set, teamHas) || []) {
+				problems.push(problem);
+			}
 			return problems || null;
 		},
 	},

--- a/config/formats.js
+++ b/config/formats.js
@@ -656,13 +656,13 @@ let Formats = [
 			}
 			const setIds = [set.name, set.species];
 			[set.name, set.species] = teamHas.leaderIds;
-			// @ts-ignore
-			set.follower = true;
 			let problems = this.validateSet(set, teamHas);
 			if (problems) {
 				problems = problems.map(problem => problem.replace(teamHas.leaderIds[0], setIds[0]));
 			}
 			[set.name, set.species] = setIds;
+			// @ts-ignore
+			set.follower = true;
 			return problems;
 		},
 	},

--- a/config/formats.js
+++ b/config/formats.js
@@ -654,10 +654,13 @@ let Formats = [
 				teamHas.leaderSpecies = set.species;
 				return this.validateSet(set, teamHas);
 			}
-			const leader = this.dex.deepClone(set);
-			leader.species = teamHas.leaderSpecies;
-			leader.follower = true;
-			return this.validateSet(leader, teamHas);
+			const setSpecies = set.species;
+			set.species = teamHas.leaderSpecies;
+			// @ts-ignore
+			set.follower = true;
+			const problems = this.validateSet(set, teamHas);
+			set.species = setSpecies;
+			return problems;
 		},
 	},
 	{

--- a/config/formats.js
+++ b/config/formats.js
@@ -657,14 +657,8 @@ let Formats = [
 			}
 			let leader = this.dex.deepClone(set);
 			leader.species = teamHas.leader;
-			let problems = this.validateSet(leader, teamHas);
-			if (problems) return problems;
-			set.ability = this.dex.getTemplate(set.species || set.name).abilities['0'];
-			// @ts-ignore
-			set.follower = true;
-			problems = this.validateSet(set, teamHas);
-			set.ability = leader.ability;
-			return problems;
+			leader.follower = true;
+			return this.validateSet(leader, teamHas);
 		},
 	},
 	{

--- a/config/formats.js
+++ b/config/formats.js
@@ -647,12 +647,7 @@ let Formats = [
 		banlist: ['Regigigas', 'Shedinja', 'Slaking', 'Smeargle', 'Imposter', 'Huge Power', 'Pure Power'],
 		checkLearnset(move, template, lsetData, set) {
 			// @ts-ignore
-			if (set.follower) {
-				// @ts-ignore
-				delete set.follower;
-				return null;
-			}
-			return this.checkLearnset(move, template, lsetData, set);
+			return set.follower ? null : this.checkLearnset(move, template, lsetData, set);
 		},
 		validateSet(set, teamHas) {
 			if (!teamHas.leaderIds) {

--- a/config/formats.js
+++ b/config/formats.js
@@ -656,14 +656,12 @@ let Formats = [
 			}
 			const setIds = [set.name, set.species];
 			[set.name, set.species] = teamHas.leaderIds;
-			let problems = this.validateSet(set, teamHas);
-			if (problems) {
-				problems = problems.map(problem => problem.replace(teamHas.leaderIds[0], setIds[0]));
-			}
+			let problems = this.validateSet(set, teamHas) || [];
+			problems = problems.map(problem => problem.replace(teamHas.leaderIds[0], setIds[0]));
 			[set.name, set.species] = setIds;
 			// @ts-ignore
 			set.follower = true;
-			return problems;
+			return problems || null;
 		},
 	},
 	{


### PR DESCRIPTION
Among fixing #5628, this PR removes a second team validation which I believe to be redundant—relevant lines are lines [638](https://github.com/Zarel/Pokemon-Showdown/commit/d7cc1dfec5d7dc8987f9efd9dab15bf043220a25#diff-51750d8b764d10b745cbaea560131ce8R638) and [641](https://github.com/Zarel/Pokemon-Showdown/commit/d7cc1dfec5d7dc8987f9efd9dab15bf043220a25#diff-51750d8b764d10b745cbaea560131ce8R641) of a previous commit.

@urkerab, maybe you can confirm.