### PR TITLE
Prevent Idle state from propagating

### DIFF
--- a/server/users.ts
+++ b/server/users.ts
@@ -1058,7 +1058,7 @@ class User extends Chat.MessageContext {
 		this.latestHost = oldUser.latestHost;
 		this.latestHostType = oldUser.latestHostType;
 		this.userMessage = oldUser.userMessage || this.userMessage || '';
-		this.statusType = oldUser.statusType !== 'online' ? oldUser.statusType : this.statusType;
+		this.statusType = oldUser.statusType === 'busy' ? oldUser.statusType : this.statusType;
 
 		oldUser.markDisconnected();
 	}


### PR DESCRIPTION
Currently users are complaining about being `Idle` right from startup until they click a username/chat.

Merging users seems active enough to wipe the `Idle` state - do merges ever happen without activity on the user's end?

We may also want to clear `Idle` in `markDisconnected`? WDYT?