### PR TITLE
Fix article link for Gen 1 Tradeback OU

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1972,7 +1972,7 @@ let Formats = [
 		name: "[Gen 1] OU (tradeback)",
 		desc: `RBY OU with movepool additions from the Time Capsule.`,
 		threads: [
-			`&bullet; <a href="https://www.smogon.com/articles/rby-tradebacks-ou/">Information</a>`,
+			`&bullet; <a href="https://www.smogon.com/articles/rby-tradebacks-ou">Information</a>`,
 		],
 
 		mod: 'gen1',


### PR DESCRIPTION
The link 404s when it has a slash at the end.