### PR TITLE
Improve README attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Staff
 
 - Bär Halberkamp [bumbadadabum] - Development
 - Chris Monsanto [chaos] - Sysadmin
-- Mathieu Dias-Martins [Marty-D] - Research (game mechanics), Development
 - Kirk Scheibelhut [pre] - Development
+- Mathieu Dias-Martins [Marty-D] - Research (game mechanics), Development
 - [The Immortal] - Development
 
 Retired Staff
@@ -168,14 +168,14 @@ Major Contributors
 
 - Andrew Werner [HoeenHero] - Development
 - Austin Couturier [Austin] - Development (damage calculator)
-- [peach] - Development
 - Kevin Lau [Ascriptmaster] - Development, Art (battle animations)
 - Konrad Borowski [xfix] - Development
 - Leonard Craft III [DaWoblefet] - Research (game mechanics)
-- Robin Vandenbrande [Quinella] - Development
 - Neil Rashbrook [urkerab] - Development
+- [peach] - Development
 - Quinton Lee [sirDonovan] - Development
 - [Ridaz] - Art (battle animations)
+- Robin Vandenbrande [Quinella] - Development
 - Tobias Mann [asgdf] - Development
 - William [MacChaeger] - Development
 
@@ -188,14 +188,14 @@ Contributors
 - Ben Frengley [TalkTakesTime] - Development
 - Cody Thompson [Rising_Dusk] - Development
 - [Honko] - Development (damage calculator)
-- Jacob McLemore [McLemore] - Development
-- Waleed Hassan [jetou] - Development
 - Ian Clail [Layell] - Art (battle graphics, sprites)
+- Jacob McLemore [McLemore] - Development
 - Jeremy Piemonte [panpawn] - Development
 - Kris Johnson [Kris] - Development
 - Luke Harmon-Vellotti [moo, CheeseMuffin] - Development
 - Russell Jones [SadisticMystic] - Research (game mechanics)
 - Spandan Punwatkar [spandan]- Development
+- Waleed Hassan [jetou] - Development
 
 Special thanks
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Staff
 - Bär Halberkamp [bumbadadabum] - Development
 - Chris Monsanto [chaos] - Sysadmin
 - Mathieu Dias-Martins [Marty-D] - Research (game mechanics), Development
-- Kirk Scheibelhut [pre, scheibo] - Development
+- Kirk Scheibelhut [pre] - Development
 - [The Immortal] - Development
 
 Retired Staff
@@ -168,7 +168,7 @@ Major Contributors
 
 - Andrew Werner [HoeenHero] - Development
 - Austin Couturier [Austin] - Development (damage calculator)
-- [jumbowhales] - Development
+- [peach] - Development
 - Kevin Lau [Ascriptmaster] - Development, Art (battle animations)
 - Konrad Borowski [xfix] - Development
 - Leonard Craft III [DaWoblefet] - Research (game mechanics)
@@ -177,25 +177,25 @@ Major Contributors
 - Quinton Lee [sirDonovan] - Development
 - [Ridaz] - Art (battle animations)
 - Tobias Mann [asgdf] - Development
-- William MacChaeger - Development
+- William [MacChaeger] - Development
 
 Contributors
 
 - Alexander B. [mathfreak231] - Development
 - Andrew Goodsell [Zracknel] - Art (battle weather backdrops)
 - Avery Zimmer [Lyren, SolarisFox] - Development
-- Ben Davies [Morfent, Kaiepi] - Development
+- Ben Davies [Morfent] - Development
 - Ben Frengley [TalkTakesTime] - Development
 - Cody Thompson [Rising_Dusk] - Development
 - [Honko] - Development (damage calculator)
-- Jacob McLemore - Development
-- Waleed Hassan [JetOU] - Development
+- Jacob McLemore [McLemore] - Development
+- Waleed Hassan [jetou] - Development
 - Ian Clail [Layell] - Art (battle graphics, sprites)
 - Jeremy Piemonte [panpawn] - Development
-- Kris Johnson - Development
+- Kris Johnson [Kris] - Development
 - Luke Harmon-Vellotti [moo, CheeseMuffin] - Development
 - Russell Jones [SadisticMystic] - Research (game mechanics)
-- Spandan Punwatkar - Development
+- Spandan Punwatkar [spandan]- Development
 
 Special thanks
 


### PR DESCRIPTION
Trying to standardize on `Real name [PS username]`.

Currently its inconsistent whether the username is included when its identical to one of a contributor's real name (Austin vs. Kris + McLemore + Spandan). Furthermore, GH username is only included in some cases (scheibo, Kaipei) and not in all (peach + whaelmer, McLemore + jmclemo6, jetou + TheJetOU, spandan + Spandanm etc).

I'm not sure which of `[moo, CheeseMuffin]` and `[Lyren, SolarisFox]` is the PS username (I assume the first?). If you're adamant on keeping GH username, I'd want us to include it for everyone where it differs, not just on a select few names.


