### PR TITLE
Implement Chat.stripFormatting

### DIFF
--- a/server/chat-formatter.ts
+++ b/server/chat-formatter.ts
@@ -444,3 +444,14 @@ class TextFormatter {
 export function formatText(str: string, isTrusted = false) {
 	return new TextFormatter(str, isTrusted).get();
 }
+
+/**
+ * Takes a string and strips all standard chat formatting except greentext from it, the text of a link is kept.
+ */
+export function stripFormatting(str: string) {
+	// Doesn't match > meme arrows because the angle bracket appears in the chat still.
+	str = str.replace(/\*\*([^\s\*]+)\*\*|__([^\s_]+)__|~~([^\s~]+)~~|``([^\s`]+)``|\^\^([^\s\^]+)\^\^|\\([^\s\\]+)\\/g,
+		(match, $1, $2, $3, $4, $5, $6) => $1 || $2 || $3 || $4 || $5 || $6);
+	// Remove all of the link expect for the text in [[text<url>]]
+	return str.replace(/\[\[(?:([^<]*)\s*<[^>]+>|([^\]]+))\]\]/g, (match, $1, $2) => $1 || $2 || '');
+}

--- a/server/chat-plugins/daily-spotlight.js
+++ b/server/chat-plugins/daily-spotlight.js
@@ -130,7 +130,7 @@ const commands = {
 			if (ret.err) return this.errorReply(`Invalid image url: ${image}`);
 		}
 		description = rest.join(',');
-		if (description.length > 500) return this.errorReply("Descriptions can be at most 500 characters long.");
+		if (Chat.stripFormatting(description).length > 500) return this.errorReply("Descriptions can be at most 500 characters long.");
 		const obj = {image: image || null, description: description};
 		if (!spotlights[room.id]) spotlights[room.id] = {};
 		if (!spotlights[room.id][key]) spotlights[room.id][key] = [];

--- a/server/chat-plugins/room-faqs.js
+++ b/server/chat-plugins/room-faqs.js
@@ -47,9 +47,8 @@ const commands = {
 		topic = toID(topic);
 		if (!(topic && rest.length)) return this.parse('/help roomfaq');
 		let text = rest.join(',').trim();
-		let filteredText = text.replace(/\[\[(?:([^<]+)\s<[^>]+>|([^\]]+))\]\]/g, (match, $1, $2) => $1 || $2);
 		if (topic.length > 25) return this.errorReply("FAQ topics should not exceed 25 characters.");
-		if (filteredText.length > 500) return this.errorReply("FAQ entries should not exceed 500 characters.");
+		if (Chat.stripFormatting(text).length > 500) return this.errorReply("FAQ entries should not exceed 500 characters.");
 
 		text = text.replace(/^>/, '&gt;');
 

--- a/server/chat.js
+++ b/server/chat.js
@@ -1928,6 +1928,8 @@ Chat.stringify = function (value, depth = 0) {
 Chat.formatText = require(/** @type {any} */('../.server-dist/chat-formatter')).formatText;
 /** @type {typeof import('./chat-formatter').linkRegex} */
 Chat.linkRegex = require(/** @type {any} */('../.server-dist/chat-formatter')).linkRegex;
+/** @type {typeof import('./chat-formatter').stripFormatting} */
+Chat.stripFormatting = require(/** @type {any} */('../.server-dist/chat-formatter')).stripFormatting;
 Chat.updateServerLock = false;
 
 /**


### PR DESCRIPTION
The idea here is that formatting such as `**`, `__`, `~~`, ect and links (bar the "text" in `[[text<url>]]`) do not count to the 500 character limit for daily spotlights/rfaqs. This has been requested by UnleashOurPassion (and iirc other staff members).

This Pull Request closes #5659 (I asked UOP if I could merge their changes into this).