### PR TITLE
Properly ignore links when determining RFAQ length

### DIFF
--- a/server/chat-plugins/room-faqs.js
+++ b/server/chat-plugins/room-faqs.js
@@ -47,7 +47,7 @@ const commands = {
 		topic = toID(topic);
 		if (!(topic && rest.length)) return this.parse('/help roomfaq');
 		let text = rest.join(',').trim();
-		let filteredText = text.replace(/\[\[(?:([^<]+)\s<[^>]+>|([^\]]+))\]\]/g, (match, $1, $2) => $1 || $2);
+		let filteredText = text.replace(/\[\[(?:([^<]+)\s*<[^>]+>|([^\]]+))\]\]/gm, (match, $1, $2) => $1 || $2);
 		if (topic.length > 25) return this.errorReply("FAQ topics should not exceed 25 characters.");
 		if (filteredText.length > 500) return this.errorReply("FAQ entries should not exceed 500 characters.");
 


### PR DESCRIPTION
- Use a multi-line regular expression for a multi-line command
- Add a `*` after the `\s` because the space in the middle of `[[foo <bar>]` is not mandatory for link formatting