### PR TITLE
Add forcedpublicprefixes for public OLT battles

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -402,6 +402,15 @@ exports.replsocketmode = 0o600;
 exports.disablehotpatchall = false;
 
 /**
+ * forcedpublicprefixes - user ID prefixes which will be forced to battle publicly.
+ * Battles involving user IDs which begin with one of the prefixes configured here
+ * will be unaffected by various battle privacy commands such as /modjoin, /hideroom
+ * or /ionext.
+ * @type {string[]}
+ */
+exports.forcedpublicprefixes = [];
+
+/**
  * permissions and groups:
  *   Each entry in `grouplist' is a seperate group. Some of the members are "special"
  *     while the rest is just a normal permission.

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4105,6 +4105,13 @@ const commands = {
 		}));
 	},
 
+	hidereplay: function (target, room, user, connection) {
+		if (!room || !room.battle || !this.can('joinbattle', null, room)) return;
+		if (room.hideReplay) return this.errorReply(`The replay for this battle is already set to hidden.`);
+		room.hideReplay = true;
+		this.addModAction(`${user.name} hid the replay of this battle.`);
+	},
+
 	addplayer(target, room, user) {
 		if (!target) return this.parse('/help addplayer');
 		if (!room.battle) return this.errorReply("You can only do this in battle rooms.");

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1008,8 +1008,8 @@ const commands = {
 			if (!this.can('editroom', null, room)) return;
 		} else if (room.battle) {
 			if (!this.can('editprivacy', null, room)) return;
-			const prefix = room.forcedPublic();
-			if (prefix) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
+			const prefix = room.battle.forcedPublic();
+			if (prefix && !user.can('lock')) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
 		} else {
 			// registered chatrooms show up on the room list and so require
 			// higher permissions to modify privacy settings

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1008,6 +1008,10 @@ const commands = {
 			if (!this.can('editroom', null, room)) return;
 		} else if (room.battle) {
 			if (!this.can('editprivacy', null, room)) return;
+			if (room.battle) {
+				const prefix = room.forcedPublic();
+				if (prefix) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
+			}
 		} else {
 			// registered chatrooms show up on the room list and so require
 			// higher permissions to modify privacy settings

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1008,10 +1008,8 @@ const commands = {
 			if (!this.can('editroom', null, room)) return;
 		} else if (room.battle) {
 			if (!this.can('editprivacy', null, room)) return;
-			if (room.battle) {
-				const prefix = room.forcedPublic();
-				if (prefix) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
-			}
+			const prefix = room.forcedPublic();
+			if (prefix) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
 		} else {
 			// registered chatrooms show up on the room list and so require
 			// higher permissions to modify privacy settings

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1009,7 +1009,7 @@ const commands = {
 		} else if (room.battle) {
 			if (!this.can('editprivacy', null, room)) return;
 			const prefix = room.battle.forcedPublic();
-			if (prefix && !user.can('lock')) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
+			if (prefix && !user.can('editprivacy')) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
 		} else {
 			// registered chatrooms show up on the room list and so require
 			// higher permissions to modify privacy settings
@@ -4105,7 +4105,7 @@ const commands = {
 		}));
 	},
 
-	hidereplay: function (target, room, user, connection) {
+	hidereplay(target, room, user, connection) {
 		if (!room || !room.battle || !this.can('joinbattle', null, room)) return;
 		if (room.hideReplay) return this.errorReply(`The replay for this battle is already set to hidden.`);
 		room.hideReplay = true;

--- a/server/chat-plugins/roomsettings.js
+++ b/server/chat-plugins/roomsettings.js
@@ -328,6 +328,10 @@ exports.commands = {
 			if (!this.can('editroom', null, room)) return;
 		} else if (room.battle) {
 			if (!this.can('editprivacy', null, room)) return;
+			if (room.battle) {
+				const prefix = room.forcedPublic();
+				if (prefix) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
+			}
 		} else {
 			if (!this.can('makeroom')) return;
 		}

--- a/server/chat-plugins/roomsettings.js
+++ b/server/chat-plugins/roomsettings.js
@@ -328,10 +328,8 @@ exports.commands = {
 			if (!this.can('editroom', null, room)) return;
 		} else if (room.battle) {
 			if (!this.can('editprivacy', null, room)) return;
-			if (room.battle) {
-				const prefix = room.forcedPublic();
-				if (prefix) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
-			}
+			const prefix = room.forcedPublic();
+			if (prefix) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
 		} else {
 			if (!this.can('makeroom')) return;
 		}

--- a/server/chat-plugins/roomsettings.js
+++ b/server/chat-plugins/roomsettings.js
@@ -330,7 +330,7 @@ exports.commands = {
 		} else if (room.battle) {
 			if (!this.can('editprivacy', null, room)) return;
 			const prefix = room.battle.forcedPublic();
-			if (prefix && !user.can('lock')) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
+			if (prefix && !user.can('editprivacy')) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
 		} else {
 			if (!this.can('makeroom')) return;
 		}

--- a/server/chat-plugins/roomsettings.js
+++ b/server/chat-plugins/roomsettings.js
@@ -296,6 +296,7 @@ exports.commands = {
 		} else {
 			user.inviteOnlyNextBattle = true;
 			user.update('inviteOnlyNextBattle');
+			if (user.forcedPublic) return this.errorReply(`Your next battle will be invite-only provided it is not rated, otherwise your '${user.forcedPublic}' prefix will force the battle to be public.`);
 			this.sendReply("Your next battle will be invite-only.");
 		}
 	},
@@ -328,8 +329,8 @@ exports.commands = {
 			if (!this.can('editroom', null, room)) return;
 		} else if (room.battle) {
 			if (!this.can('editprivacy', null, room)) return;
-			const prefix = room.forcedPublic();
-			if (prefix) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
+			const prefix = room.battle.forcedPublic();
+			if (prefix && !user.can('lock')) return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${prefix}'.`);
 		} else {
 			if (!this.can('makeroom')) return;
 		}

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -998,6 +998,7 @@ class RoomBattle extends RoomGames.RoomGame {
 	}
 
 	forcedPublic() {
+		if (!this.rated) return;
 		for (const userid in this.playerTable) {
 			const user = Users(userid);
 			if (user && user.forcedPublic) return user.forcedPublic;

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -997,6 +997,13 @@ class RoomBattle extends RoomGames.RoomGame {
 		return player;
 	}
 
+	forcedPublic() {
+		for (const userid in this.playerTable) {
+			const user = Users(userid);
+			if (user && user.forcedPublic) return user.forcedPublic;
+		}
+	}
+
 	makePlayer(/** @type {User} */ user) {
 		const num = this.players.length + 1;
 		return new RoomBattlePlayer(user, this, num);

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -999,8 +999,8 @@ class RoomBattle extends RoomGames.RoomGame {
 
 	forcedPublic() {
 		if (!this.rated) return;
-		for (const userid in this.playerTable) {
-			const user = Users(userid);
+		for (const player of this.players) {
+			const user = player.getUser();
 			if (user && user.forcedPublic) return user.forcedPublic;
 		}
 	}

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -1693,8 +1693,12 @@ let Rooms = Object.assign(getRoom, {
 				user.inviteOnlyNextBattle = false;
 			}
 		}
-		if (options.tour && !room.tour.modjoin) inviteOnly = [];
-		if (inviteOnly.length) {
+		const prefix = /** @type {RoomBattle} */(room.game).forcedPublic();
+		if (prefix && inviteOnly.length) {
+			room.isPrivate = false;
+			room.modjoin = null;
+			room.add(`|raw|<div class="broadcast-red"><strong>This battle is required to be public due to a player having a name prefixed by '${prefix}'.</div>`);
+		} else if (!options.tour || room.tour.modjoin) {
 			room.modjoin = '%';
 			room.isPrivate = 'hidden';
 			room.privacySetter = new Set(inviteOnly);

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -1696,7 +1696,7 @@ let Rooms = Object.assign(getRoom, {
 		}
 		if (inviteOnly.length) {
 			const prefix = battle.forcedPublic();
-			if (prefix && battle.rated) {
+			if (prefix) {
 				room.isPrivate = false;
 				room.modjoin = null;
 				room.add(`|raw|<div class="broadcast-red"><strong>This battle is required to be public due to a player having a name prefixed by '${prefix}'.</div>`);

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -1683,8 +1683,9 @@ let Rooms = Object.assign(getRoom, {
 			roomTitle = `${p1name} vs. ${p2name}`;
 		}
 		const room = Rooms.createGameRoom(roomid, roomTitle, options);
+		const battle = new Rooms.RoomBattle(room, formatid, options);
 		// @ts-ignore TODO: make RoomBattle a subclass of RoomGame
-		room.game = new Rooms.RoomBattle(room, formatid, options);
+		room.game = battle;
 
 		let inviteOnly = (options.inviteOnly || []);
 		for (const user of players) {
@@ -1693,16 +1694,18 @@ let Rooms = Object.assign(getRoom, {
 				user.inviteOnlyNextBattle = false;
 			}
 		}
-		const prefix = /** @type {RoomBattle} */(room.game).forcedPublic();
-		if (prefix && inviteOnly.length) {
-			room.isPrivate = false;
-			room.modjoin = null;
-			room.add(`|raw|<div class="broadcast-red"><strong>This battle is required to be public due to a player having a name prefixed by '${prefix}'.</div>`);
-		} else if (!options.tour || room.tour.modjoin) {
-			room.modjoin = '%';
-			room.isPrivate = 'hidden';
-			room.privacySetter = new Set(inviteOnly);
-			room.add(`|raw|<div class="broadcast-red"><strong>This battle is invite-only!</strong><br />Users must be invited with <code>/invite</code> (or be staff) to join</div>`);
+		if (inviteOnly.length) {
+			const prefix = battle.forcedPublic();
+			if (prefix && battle.rated) {
+				room.isPrivate = false;
+				room.modjoin = null;
+				room.add(`|raw|<div class="broadcast-red"><strong>This battle is required to be public due to a player having a name prefixed by '${prefix}'.</div>`);
+			} else if (!options.tour || room.tour.modjoin) {
+				room.modjoin = '%';
+				room.isPrivate = 'hidden';
+				room.privacySetter = new Set(inviteOnly);
+				room.add(`|raw|<div class="broadcast-red"><strong>This battle is invite-only!</strong><br />Users must be invited with <code>/invite</code> (or be staff) to join</div>`);
+			}
 		}
 
 		for (const p of players) {

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -1699,7 +1699,7 @@ let Rooms = Object.assign(getRoom, {
 			if (prefix) {
 				room.isPrivate = false;
 				room.modjoin = null;
-				room.add(`|raw|<div class="broadcast-red"><strong>This battle is required to be public due to a player having a name prefixed by '${prefix}'.</div>`);
+				room.add(`|raw|<div class="broadcast-blue"><strong>This battle is required to be public due to a player having a name prefixed by '${prefix}'.</div>`);
 			} else if (!options.tour || room.tour.modjoin) {
 				room.modjoin = '%';
 				room.isPrivate = 'hidden';

--- a/server/users.ts
+++ b/server/users.ts
@@ -71,6 +71,7 @@ function move(user: User, newUserid: ID) {
 	users.delete(user.userid);
 	user.userid = newUserid;
 	users.set(newUserid, user);
+	updateForcedPublic(user);
 
 	return true;
 }
@@ -84,6 +85,7 @@ function add(user: User) {
 
 	if (users.has(user.userid)) throw new Error(`userid taken: ${user.userid}`);
 	users.set(user.userid, user);
+	updateForcedPublic(user);
 }
 function deleteUser(user: User) {
 	prevUsers.delete('guest' + user.guestNum as ID);
@@ -93,7 +95,16 @@ function merge(user1: User, user2: User) {
 	prevUsers.delete(user2.userid);
 	prevUsers.set(user1.userid, user2.userid);
 }
-
+function updateForcedPublic(user: User) {
+	if (Config.forcedpublicprefixes) {
+		for (const prefix of Config.forcedpublicprefixes) {
+			if (user.userid.startsWith(toID(prefix))) {
+				user.forcedPublic = prefix;
+				break;
+			}
+		}
+	}
+}
 /**
  * Get a user.
  *
@@ -551,15 +562,6 @@ class User extends Chat.MessageContext {
 		this.statusType = 'online';
 		this.userMessage = '';
 		this.lastWarnedAt = 0;
-
-		if (Config.forcedpublicprefixes) {
-			for (const prefix of Config.forcedpublicprefixes) {
-				if (this.userid.startsWith(toID(prefix))) {
-					this.forcedPublic = prefix;
-					break;
-				}
-			}
-		}
 
 		// initialize
 		Users.add(this);

--- a/server/users.ts
+++ b/server/users.ts
@@ -526,6 +526,7 @@ class User extends Chat.MessageContext {
 		this.lastPM = '';
 		this.team = '';
 		this.lastMatch = '';
+		this.forcedPublic = null;
 
 		// settings
 		this.isSysop = false;

--- a/server/users.ts
+++ b/server/users.ts
@@ -71,7 +71,16 @@ function move(user: User, newUserid: ID) {
 	users.delete(user.userid);
 	user.userid = newUserid;
 	users.set(newUserid, user);
-	updateForcedPublic(user);
+
+	user.forcedPublic = undefined;
+	if (Config.forcedpublicprefixes) {
+		for (const prefix of Config.forcedpublicprefixes) {
+			if (user.userid.startsWith(toID(prefix))) {
+				user.forcedPublic = prefix;
+				break;
+			}
+		}
+	}
 
 	return true;
 }
@@ -85,7 +94,6 @@ function add(user: User) {
 
 	if (users.has(user.userid)) throw new Error(`userid taken: ${user.userid}`);
 	users.set(user.userid, user);
-	updateForcedPublic(user);
 }
 function deleteUser(user: User) {
 	prevUsers.delete('guest' + user.guestNum as ID);
@@ -95,16 +103,7 @@ function merge(user1: User, user2: User) {
 	prevUsers.delete(user2.userid);
 	prevUsers.set(user1.userid, user2.userid);
 }
-function updateForcedPublic(user: User) {
-	if (Config.forcedpublicprefixes) {
-		for (const prefix of Config.forcedpublicprefixes) {
-			if (user.userid.startsWith(toID(prefix))) {
-				user.forcedPublic = prefix;
-				break;
-			}
-		}
-	}
-}
+
 /**
  * Get a user.
  *

--- a/server/users.ts
+++ b/server/users.ts
@@ -72,7 +72,7 @@ function move(user: User, newUserid: ID) {
 	user.userid = newUserid;
 	users.set(newUserid, user);
 
-	user.forcedPublic = undefined;
+	user.forcedPublic = null;
 	if (Config.forcedpublicprefixes) {
 		for (const prefix of Config.forcedpublicprefixes) {
 			if (user.userid.startsWith(toID(prefix))) {
@@ -450,7 +450,7 @@ class User extends Chat.MessageContext {
 	lastPM: string;
 	team: string;
 	lastMatch: string;
-	forcedPublic?: string;
+	forcedPublic: string | null;
 
 	isSysop: boolean;
 	isStaff: boolean;

--- a/server/users.ts
+++ b/server/users.ts
@@ -440,6 +440,7 @@ class User extends Chat.MessageContext {
 	lastPM: string;
 	team: string;
 	lastMatch: string;
+	forcedPublic?: string;
 
 	isSysop: boolean;
 	isStaff: boolean;
@@ -550,6 +551,15 @@ class User extends Chat.MessageContext {
 		this.statusType = 'online';
 		this.userMessage = '';
 		this.lastWarnedAt = 0;
+
+		if (Config.forcedpublicprefixes) {
+			for (const prefix of Config.forcedpublicprefixes) {
+				if (this.userid.startsWith(toID(prefix))) {
+					this.forcedPublic = prefix;
+					break;
+				}
+			}
+		}
 
 		// initialize
 		Users.add(this);


### PR DESCRIPTION
Usernames prefixed by a special value decided ahead of time (eg. `'LT61RQ'`) will unable to hide their battles from spectators, as discussed in #5646. This is not a 'complete' OLT solution, we will probably want to followup with support for `/hidereplay`, as well as force unregistered accounts to only be able to ladder unrated to simplify coordination issues. However, simply coordinating  around updating `Config.forcedpublicprefixes` with the new prefix for the next qualifying periods is probably sufficient.