### PR TITLE
Scavengers: Add Recycled Hunts functionality

### DIFF
--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -253,21 +253,25 @@ class ScavengerHuntDatabase {
 		}
 
 		scavengersData.recycledHunts.push(huntSchema);
-		FS(DATABASE_FILE).writeUpdate(() => JSON.stringify(scavengersData));
+		this.updateDatabaseOnDisk();
 	}
 
 	static removeRecycledHuntFromDatabase(index) {
 		scavengersData.recycledHunts.splice(index - 1, 1);
-		FS(DATABASE_FILE).writeUpdate(() => JSON.stringify(scavengersData));
+		this.updateDatabaseOnDisk();
 	}
 
 	static addHintToRecycledHunt(huntNumber, questionNumber, hint) {
 		scavengersData.recycledHunts[huntNumber - 1].questions[questionNumber - 1].hints.push(hint);
-		FS(DATABASE_FILE).writeUpdate(() => JSON.stringify(scavengersData));
+		this.updateDatabaseOnDisk();
 	}
 
 	static removeHintToRecycledHunt(huntNumber, questionNumber, hintNumber) {
 		scavengersData.recycledHunts[huntNumber - 1].questions[questionNumber - 1].hints.splice(hintNumber - 1);
+		this.updateDatabaseOnDisk();
+	}
+
+	static updateDatabaseOnDisk() {
 		FS(DATABASE_FILE).writeUpdate(() => JSON.stringify(scavengersData));
 	}
 

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -485,6 +485,26 @@ class ScavengerHunt extends Rooms.RoomGame {
 			reset = true;
 		}
 
+		if (this.room.addRecycledHuntsToQueueAutomatically) {
+			if (!this.room.scavQueue) {
+				this.room.scavQueue = [];
+			}
+
+			const next = ScavengerHuntDatabase.getRecycledHuntFromDatabase();
+			const correctlyFormattedQuestions = next.questions.reduce((alreadyFormatted, questionObject) => {
+				alreadyFormatted.push(questionObject.text);
+				alreadyFormatted.push(questionObject.answers);
+				return alreadyFormatted;
+			}, []);
+			this.room.scavQueue.push({
+				hosts: next.hosts,
+				questions: correctlyFormattedQuestions,
+				staffHostId: 'scavengermanager',
+				staffHostName: 'Scavenger Manager',
+				gameType: 'unrated',
+			});
+		}
+
 		if (!reset) {
 			let sliceIndex = this.gameType === 'official' ? 5 : 3;
 

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -35,9 +35,7 @@ const HISTORY_PERIOD = 6; // months
 const ScavengerGames = require("./scavenger-games");
 
 let scavengersData = {recycledHunts: []};
-try {
-	scavengersData = JSON.parse(FS.readIfExistsSync(DATABASE_FILE));
-} catch (e) {}
+scavengersData = JSON.parse(FS(DATABASE_FILE).readIfExistsSync());
 
 // convert points stored in the old format
 const scavsRoom = Rooms('scavengers');

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -1651,6 +1651,49 @@ let commands = {
 	},
 };
 
+const pages = {
+	recycledHunts(query, user, connection) {
+		this.title = 'Recycled Hunts';
+		let buf = "";
+		this.extractRoom();
+		if (!user.named) return Rooms.RETRY_AFTER_LOGIN;
+		if (!this.room.chatRoomData) return;
+		if (!this.can('mute', null, this.room)) return;
+		buf += `<div class="pad"><h2>List of recycled Scavenger hunts</h2>`;
+		buf += `<ol style="width: 90%;">`;
+		for (let i = 0; i < scavengersData.recycledHunts.length; ++i) {
+			buf += `<li>`;
+			buf += `<h4>By ${scavengersData.recycledHunts[i].hosts.map(host => host.name).join(', ')}</h4>`;
+			for (const question of scavengersData.recycledHunts[i].questions) {
+				buf += `<details>`;
+				buf += `<summary>${question.text}</summary>`;
+				buf += `<dl>`;
+				buf += `<dt>Answers:</dt>`;
+				for (const answer of question.answers) {
+					buf += `<dd>${answer}</dd>`;
+				}
+				buf += `</dl>`;
+
+				if (question.hints.length) {
+					buf += `<dl>`;
+					buf += `<dt>Hints:</dt>`;
+					for (const hint of question.hints) {
+						buf += `<dd>${hint}</dd>`;
+					}
+					buf += `</dl>`;
+				}
+				buf += `</details>`;
+			}
+			buf += `</li>`;
+		}
+		buf += `</ol>`;
+		buf += `</div>`;
+		return buf;
+	},
+};
+
+exports.pages = pages;
+
 exports.commands = {
 	// general
 	scav: 'scavengers',

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -34,12 +34,8 @@ const HISTORY_PERIOD = 6; // months
 
 const ScavengerGames = require("./scavenger-games");
 
-let scavengersData = {recycledHunts: []};
-try {
-	scavengersData = JSON.parse(FS(DATABASE_FILE).readIfExistsSync());
-} catch (err) {
-	console.log(err);
-}
+const databaseContentsJSON = FS(DATABASE_FILE).readIfExistsSync();
+const scavengersData = databaseContentsJSON ? JSON.parse(databaseContentsJSON) : {recycledHunts: []};
 
 // convert points stored in the old format
 const scavsRoom = Rooms('scavengers');

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -1675,7 +1675,7 @@ let commands = {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox([
 			"<b>Help for Recycled Hunts</b>",
-			"- addhunt &lt;Hunt Text[, hint for question 1 | another hint for question 1, ...]>: Adds a hunt to the database of recycled hunts.",
+			"- addhunt &lt;Hunt Text>: Adds a hunt to the database of recycled hunts.",
 			"- removehunt&lt;Hunt Number>: Removes a hunt form the database of recycled hunts.",
 			"- list: Shows a list of hunts in the database along with their questions and hints.",
 			"- addhint &lt;Hunt Number, Question Number, Hint Text>: Adds a hint to the specified question in the specified hunt.",

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -1693,6 +1693,9 @@ exports.commands = {
 	scavresetlb: 'scavengersresetlb',
 	scavengersresetlb: commands.resetladder,
 
+	recycledhunts: commands.recycledhunts,
+	recycledhuntshelp: commands.recycledhuntshelp,
+
 	scavrank: commands.rank,
 	scavladder: 'scavtop',
 	scavtop: commands.ladder,

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -1813,6 +1813,7 @@ exports.commands = {
 			"- /scav viewqueue - shows the list of queued scavenger hunts to be automatically started, as well as the option to remove hunts from the queue. (Requires: % @ * # & ~)",
 			"- /scav defaulttimer [value] - sets the default timer applied to automatically started hunts from the queue.",
 			"- /nexthunt - starts the next hunt in the queue.",
+			"- /recycledhunts - Modify the database of recycled hunts and enable/disable autoqueing them. More detailed help can be found in /recycledhuntshelp",
 		].join('<br />');
 
 		const gamesCommands = [

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -36,7 +36,7 @@ const ScavengerGames = require("./scavenger-games");
 
 let scavengersData = {};
 try {
-	scavengersData = require(`.././${DATABASE_FILE}`);
+	scavengersData = require(`../../${DATABASE_FILE}`);
 } catch (e) {}
 
 // convert points stored in the old format
@@ -224,7 +224,7 @@ function formatOrder(place) {
 
 class ScavengerHuntDatabase {
 	static getRecycledHuntFromDatabase() {
-		if (!scavengersData.recycledHunts || scavengersData.recycledHunts.length === 0) {
+		if (!scavengersData || !scavengersData.recycledHunts || scavengersData.recycledHunts.length === 0) {
 			return null;
 		}
 		// Return a random hunt from the database.
@@ -976,10 +976,12 @@ let commands = {
 		if (!cmd.includes('force') && ['regular', 'unrated', 'recycled'].includes(gameType) && room.scavQueue && room.scavQueue.length && !(room.game && room.game.scavParentGame)) return this.errorReply(`There are currently hunts in the queue! If you would like to start the hunt anyways, use /forcestart${gameType === 'regular' ? 'hunt' : gameType}.`);
 
 		if (gameType === 'recycled') {
-			target = ScavengerHunt.getRecycledHuntFromDatabase().fullText;
+			target = ScavengerHuntDatabase.getRecycledHuntFromDatabase();
 			if (!target) {
 				return this.errorReply("There are no hunts in the database.");
 			}
+
+			target = target.fullText;
 		}
 
 		let [hostsArray, ...params] = target.split('|');

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -35,7 +35,11 @@ const HISTORY_PERIOD = 6; // months
 const ScavengerGames = require("./scavenger-games");
 
 let scavengersData = {recycledHunts: []};
-scavengersData = JSON.parse(FS(DATABASE_FILE).readIfExistsSync());
+try {
+	scavengersData = JSON.parse(FS(DATABASE_FILE).readIfExistsSync());
+} catch (err) {
+	console.log(err);
+}
 
 // convert points stored in the old format
 const scavsRoom = Rooms('scavengers');


### PR DESCRIPTION
This adds a database of recycled hunts that Scavengers room staff can start and also auto-queue for times when the room is slow. This has been discussed with appropriate room staff.

The database itself is just JSON that is loaded and worked with in memory. Any changes that are made are immediately written back out to the JSON file.

The main way to interact with the database is through a new master command `/recycledhunts`. It is possible to add hunts, remove hunts, add hints, remove hints, and to enable/disable the auto-queue functionality through this command.

The existing queue and create commands were also updated to work with recycled hunts. Staff are able to queue and create either a random or specific recycled hunt from the database.

I think I updated and created all appropriate help text as well.

As always, let me know if anything needs changing and I'll take care of it.