### PR TITLE
Have /hidereplay turn on modjoin % once the battle is over

### DIFF
--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -782,6 +782,8 @@ class RoomBattle extends RoomGames.RoomGame {
 		if (parentGame && parentGame.onBattleWin) {
 			parentGame.onBattleWin(this.room, winnerid);
 		}
+		// If the room's replay was hidden, disable users from joining after the game is over
+		if (this.room.hideReplay) this.room.modjoin = '%';
 		this.room.update();
 	}
 	/**

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -88,6 +88,7 @@ class BasicRoom {
 		this.chatRoomData = null;
 		/** @type {boolean | 'hidden' | 'voice'} */
 		this.isPrivate = false;
+		this.hideReplay = false;
 		this.isPersonal = false;
 		/** @type {string | boolean} */
 		this.isHelp = false;


### PR DESCRIPTION
The OLTBot provides links to highly rated games in the OLT room, but the existence of these links means that even if `/hidereplay` is used, players can still try to scout/counter team their opponents  by looking in the OLT room to see if any of their previous matches have been linked. Battle rooms eventually expire, but not if they're constantly being visited by spectators after the fact, so this can still be a problem hours after the match. 

Currently the OLTBot has switched to using links which decay after 10 minutes to avoid this issue, but these links are external to PS so get a `target="_blank"` attribute appended by the chat formatter, causing the links to open in new tabs which annoys spectators. One solution for players is to do `/modjoin sync` and `/hideroom` _once the battle is over_, which will work because the OLT-prefix logic doesn't prevent them from doing it at that point, but that requires they issue two commands and remember to do it at the end, after we've already advertised '`/hidereplay` is your one-stop shop for all of your privacy needs'. 