### PR TITLE
 Prevent locked users from having Pokemon nicknames hidden in Cross Evolution

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -64,7 +64,11 @@ export class TeamValidator {
 			if (setProblems) {
 				problems = problems.concat(setProblems);
 			}
-			if (removeNicknames) set.name = dex.getTemplate(set.species).baseSpecies;
+			if (removeNicknames) {
+				if (format.name !== '[Gen 7] Cross Evolution' || !dex.getTemplate(set.name).exists) {
+					set.name = dex.getTemplate(set.species).baseSpecies;
+				}
+			}
 		}
 
 		for (const [rule, source, limit, bans] of ruleTable.complexTeamBans) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -65,7 +65,10 @@ export class TeamValidator {
 				problems = problems.concat(setProblems);
 			}
 			if (removeNicknames) {
-				if (format.name !== '[Gen 7] Cross Evolution' || !dex.getTemplate(set.name).exists) {
+				let crossTemplate: Template;
+				if (format.name === '[Gen 7] Cross Evolution' && (crossTemplate = dex.getTemplate(set.name)).exists) {
+					set.name = crossTemplate.species;
+				} else {
 					set.name = dex.getTemplate(set.species).baseSpecies;
 				}
 			}


### PR DESCRIPTION
This PR fixes #5668 by modifying the behavior of the `removeNicknames` flag for Cross Evolution: if a Pokemon's nickname represents the name of an actual Pokemon, it is not removed.