### PR TITLE
Make linked moves target properly in Linked

### DIFF
--- a/data/mods/linked/scripts.js
+++ b/data/mods/linked/scripts.js
@@ -286,7 +286,7 @@ exports.BattleScripts = {
 				// @ts-ignore
 				let linkedMoves = action.linked;
 				for (let i = linkedMoves.length - 1; i >= 0; i--) {
-					let pseudoAction = {choice: 'move', priority: action.priority, speed: action.speed, pokemon: action.pokemon, targetLoc: action.targetLoc, moveid: linkedMoves[i].id, move: linkedMoves[i], mega: action.mega};
+					let pseudoAction = {choice: 'move', priority: action.priority, speed: action.speed, pokemon: action.pokemon, targetLoc: this.getTargetLoc(linkedMoves[i].target, action.pokemon), moveid: linkedMoves[i].id, move: linkedMoves[i], mega: action.mega};
 					// @ts-ignore
 					this.queue.unshift(pseudoAction);
 				}


### PR DESCRIPTION
Selecting a linked move which targets the user causes the follow-up move to fail if it targets a different Pokemon. This PR fixes that by causing each move to target its intended target, instead of using the target of the selected linked move.