### PR TITLE
Fix self idle display on merging

### DIFF
--- a/server/users.ts
+++ b/server/users.ts
@@ -1042,6 +1042,11 @@ class User extends Chat.MessageContext {
 		if (oldUser.autoconfirmed) this.autoconfirmed = oldUser.autoconfirmed;
 
 		this.updateGroup(this.registered);
+		// We only propagate the 'busy' statusType through merging - merging is
+		// active enough that the user should no longer be in the 'idle' state.
+		// Doing this before merging connections ensures the updateuser message
+		// shows the correct idle state.
+		this.setStatusType((this.statusType === 'busy' || oldUser.statusType === 'busy') ? 'busy' : 'online');
 
 		for (const connection of oldUser.connections) {
 			this.mergeConnection(connection);
@@ -1079,9 +1084,6 @@ class User extends Chat.MessageContext {
 		this.latestHost = oldUser.latestHost;
 		this.latestHostType = oldUser.latestHostType;
 		this.userMessage = oldUser.userMessage || this.userMessage || '';
-		// We only propagate the 'busy' statusType through merging - merging is
-		// active enough that the user should no longer be in the 'idle' state.
-		this.setStatusType((this.statusType === 'busy' || oldUser.statusType === 'busy') ? 'busy' : 'online');
 
 		oldUser.markDisconnected();
 	}


### PR DESCRIPTION
.............this doesn't fix the issue entirely, because apparently there's a clientside bug with seeing the ``|n|peach@!|peach`` message in the room backlog and marking you as away off that, but at least the server is doing everything correctly now.