### PR TITLE
Send updateuser when changing status type

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -661,7 +661,7 @@ const commands = {
 			user.update('blockPMs');
 			return this.sendReply(`You are now blocking private messages, except from staff and ${target}.`);
 		}
-		user.update();
+		user.update('blockPMs');
 		return this.sendReply("You are now blocking private messages, except from staff.");
 	},
 	blockpmshelp: [`/blockpms - Blocks private messages. Unblock them with /unblockpms.`],

--- a/server/users.ts
+++ b/server/users.ts
@@ -1527,6 +1527,7 @@ class User extends Chat.MessageContext {
 		if (type === this.statusType) return;
 		this.statusType = type;
 		this.updateIdentity();
+		this.update('statusType');
 	}
 	setUserMessage(message: string) {
 		if (message === this.userMessage) return;


### PR DESCRIPTION
This lets the client not rely on seeing the `|n|peach@!|peach` message to know when it's afk or not, which makes afk states display properly if you aren't in any rooms and is (imo) the best fix for the bug described in #5674. It _does_ mean that `/busy` will send 3 updateuser messages, but it's all one way and technically still part of 3 actions, so I think it's an acceptable trade.