### PR TITLE
Improve /hidereplay privacy

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4095,6 +4095,7 @@ const commands = {
 			hidden: room.isPrivate || room.hideReplay ? '1' : '',
 			inputlog: battle.inputLog ? battle.inputLog.join('\n') : null,
 		});
+		if (success) battle.replySaved = true;
 		if (success && success.errorip) {
 			connection.popup(`This server's request IP ${success.errorip} is not a registered server.`);
 			return;

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4110,7 +4110,7 @@ const commands = {
 		if (!room || !room.battle || !this.can('joinbattle', null, room)) return;
 		if (room.hideReplay) return this.errorReply(`The replay for this battle is already set to hidden.`);
 		room.hideReplay = true;
-		this.parse('/savereplay');
+		if (room.battle.replaySaved) this.parse('/savereplay');
 		this.addModAction(`${user.name} hid the replay of this battle.`);
 	},
 

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4110,6 +4110,7 @@ const commands = {
 		if (!room || !room.battle || !this.can('joinbattle', null, room)) return;
 		if (room.hideReplay) return this.errorReply(`The replay for this battle is already set to hidden.`);
 		room.hideReplay = true;
+		this.parse('/savereplay');
 		this.addModAction(`${user.name} hid the replay of this battle.`);
 	},
 

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4095,7 +4095,7 @@ const commands = {
 			hidden: room.isPrivate || room.hideReplay ? '1' : '',
 			inputlog: battle.inputLog ? battle.inputLog.join('\n') : null,
 		});
-		if (success) battle.replySaved = true;
+		if (success) battle.replaySaved = true;
 		if (success && success.errorip) {
 			connection.popup(`This server's request IP ${success.errorip} is not a registered server.`);
 			return;

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -447,6 +447,7 @@ class RoomBattle extends RoomGames.RoomGame {
 		this.started = false;
 		this.ended = false;
 		this.active = false;
+		this.replaySaved = false;
 
 		// TypeScript bug: no `T extends RoomGamePlayer`
 		/** @type {{[userid: string]: RoomBattlePlayer}} */
@@ -773,7 +774,7 @@ class RoomBattle extends RoomGames.RoomGame {
 			this.logData = null;
 		}
 		if (Config.autosavereplays) {
-			let uploader = Users.get(winnerid || p1id);
+			const uploader = Users.get(winnerid || p1id);
 			if (uploader && uploader.connections[0]) {
 				Chat.parse('/savereplay', this.room, uploader, uploader.connections[0]);
 			}
@@ -786,10 +787,12 @@ class RoomBattle extends RoomGames.RoomGame {
 		if (this.room.hideReplay) {
 			this.room.modjoin = '%';
 			this.room.isPrivate = 'hidden';
-			// We also save the replay to make sure the hidden setting gets reflected
-			let uploader = Users.get(winnerid || p1id);
-			if (uploader && uploader.connections[0]) {
-				Chat.parse('/savereplay', this.room, uploader, uploader.connections[0]);
+			// We also resave the replay to make sure the hidden setting gets reflected
+			if (this.replaySaved) {
+				const uploader = Users.get(winnerid || p1id);
+				if (uploader && uploader.connections[0]) {
+					Chat.parse('/savereplay', this.room, uploader, uploader.connections[0]);
+				}
 			}
 		}
 		this.room.update();

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -783,7 +783,15 @@ class RoomBattle extends RoomGames.RoomGame {
 			parentGame.onBattleWin(this.room, winnerid);
 		}
 		// If the room's replay was hidden, disable users from joining after the game is over
-		if (this.room.hideReplay) this.room.modjoin = '%';
+		if (this.room.hideReplay) {
+			this.room.modjoin = '%';
+			this.room.isPrivate = 'hidden';
+			// We also save the replay to make sure the hidden setting gets reflected
+			let uploader = Users.get(winnerid || p1id);
+			if (uploader && uploader.connections[0]) {
+				Chat.parse('/savereplay', this.room, uploader, uploader.connections[0]);
+			}
+		}
 		this.room.update();
 	}
 	/**

--- a/server/room-battle.js
+++ b/server/room-battle.js
@@ -773,7 +773,10 @@ class RoomBattle extends RoomGames.RoomGame {
 		} else {
 			this.logData = null;
 		}
-		if (Config.autosavereplays) {
+		// If a replay was saved at any point or we were configured to autosavereplays,
+		// reupload when the battle is over to overwrite the partial data (and potentially
+		// reflect any changes that may have been made to the replay's hidden status).
+		if (this.replaySaved || Config.autosavereplays) {
 			const uploader = Users.get(winnerid || p1id);
 			if (uploader && uploader.connections[0]) {
 				Chat.parse('/savereplay', this.room, uploader, uploader.connections[0]);
@@ -787,13 +790,6 @@ class RoomBattle extends RoomGames.RoomGame {
 		if (this.room.hideReplay) {
 			this.room.modjoin = '%';
 			this.room.isPrivate = 'hidden';
-			// We also resave the replay to make sure the hidden setting gets reflected
-			if (this.replaySaved) {
-				const uploader = Users.get(winnerid || p1id);
-				if (uploader && uploader.connections[0]) {
-					Chat.parse('/savereplay', this.room, uploader, uploader.connections[0]);
-				}
-			}
 		}
 		this.room.update();
 	}


### PR DESCRIPTION
- hide the room as well so that it doesnt show up in a user's trainer card and end up auto-linking to replays
- upload a replay after the game to ensure the hidden setting is properly written

**NOTE:** this change does **not** fix private battles not properly getting passworded, but closes a few other loopholes that were found while investigating.