### PR TITLE
Change packed encoding of abilities

### DIFF
--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -1097,29 +1097,14 @@ export class ModdedDex {
 			buf += (set.name || set.species);
 
 			// species
-			let id = toID(set.species || set.name);
+			const id = toID(set.species || set.name);
 			buf += '|' + (toID(set.name || set.species) === id ? '' : id);
 
 			// item
 			buf += '|' + toID(set.item);
 
 			// ability
-			const template = dexes['base'].getTemplate(set.species || set.name);
-			const abilities = template.abilities;
-			id = toID(set.ability);
-			if (abilities) {
-				if (id === toID(abilities['0'])) {
-					buf += '|';
-				} else if (id === toID(abilities['1'])) {
-					buf += '|1';
-				} else if (id === toID(abilities['H'])) {
-					buf += '|H';
-				} else {
-					buf += '|' + id;
-				}
-			} else {
-				buf += '|' + id;
-			}
+			buf += '|' + toID(set.ability);
 
 			// moves
 			buf += '|' + set.moves.map(toID).join(',');
@@ -1139,6 +1124,7 @@ export class ModdedDex {
 			}
 
 			// gender
+			const template = dexes['base'].getTemplate(set.species || set.name);
 			if (set.gender && set.gender !== template.gender) {
 				buf += '|' + set.gender;
 			} else {

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -1124,8 +1124,7 @@ export class ModdedDex {
 			}
 
 			// gender
-			const template = dexes['base'].getTemplate(set.species || set.name);
-			if (set.gender && set.gender !== template.gender) {
+			if (set.gender) {
 				buf += '|' + set.gender;
 			} else {
 				buf += '|';


### PR DESCRIPTION
0|1|H saves minimal space over the ability ID and requires parsers have the data files, in addition to limiting the ability to search abilities in the teambuilder.

---

Some thoughts:

**1)** I assume we need to keep the logic for decoding `0|1|H` in `fastUnpackTeam` for a while for backwards compatibility? 
**2)** Client side changes obviously need to be made as well (though maybe this is the only place we need the backwards compatibility?)
**3)** Can we change gender's encoding as well to make things completely data-free?