### PR TITLE
update blitz's description to proper timings

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -418,7 +418,7 @@ let BattleFormats = {
 	blitz: {
 		effectType: 'Rule',
 		name: 'Blitz',
-		desc: "Super-fast 'Blitz' timer giving 30 second Team Preview and 10 seconds per turn.",
+		desc: "Super-fast 'Blitz' timer giving 30 second Team Preview and 15 seconds per turn.",
 		onBegin() {
 			this.add('rule', 'Blitz: Super-fast timer');
 		},


### PR DESCRIPTION
it should be saying 15 seconds per turn like it actually is, currently says 10 seconds.