### PR TITLE
Update a link in the /intro command

### DIFF
--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -1511,7 +1511,7 @@ const commands = {
 			`New to competitive Pok&eacute;mon?<br />` +
 			`- <a href="https://www.smogon.com/forums/threads/3496279/">Beginner's Guide to Pok&eacute;mon Showdown</a><br />` +
 			`- <a href="https://www.smogon.com/dp/articles/intro_comp_pokemon">An introduction to competitive Pok&eacute;mon</a><br />` +
-			`- <a href="https://www.smogon.com/bw/articles/bw_tiers">What do 'OU', 'UU', etc mean?</a><br />` +
+			`- <a href="https://www.smogon.com/sm/articles/sm_tiers">What do 'OU', 'UU', etc mean?</a><br />` +
 			`- <a href="https://www.smogon.com/xyhub/tiers">What are the rules for each format? What is 'Sleep Clause'?</a>`
 		);
 	},


### PR DESCRIPTION
The link in /intro about "What do 'OU' and etc. mean" is from BW era so I am pushing an edit to replace it with the SM one.