### PR TITLE
Minor fix to /itemsearchhelp

### DIFF
--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -227,7 +227,7 @@ exports.commands = {
 		});
 	},
 	itemsearchhelp: [
-		`/itemsearch [move description] - finds items that match the given key words.`,
+		`/itemsearch [item description] - finds items that match the given key words.`,
 		`Command accepts natural language. (tip: fewer words tend to work better)`,
 		`Searches with "fling" in them will find items with the specified Fling behavior.`,
 		`Searches with "natural gift" in them will find items with the specified Natural Gift behavior.`,


### PR DESCRIPTION
it says [move description], I assume it meant [item description]

reported here: https://www.smogon.com/forums/threads/bug-reports-v3-read-original-post-before-posting.3634749/page-54#post-8211844