### PR TITLE
Added new descriptions for certain tags in /descriptions

### DIFF
--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -616,6 +616,8 @@ const commands = {
 					if (move.flags['punch']) details["&#10003; Punch"] = "";
 					if (move.flags['powder']) details["&#10003; Powder"] = "";
 					if (move.flags['reflectable']) details["&#10003; Bounceable"] = "";
+					if (move.flags['charge']) details["&#10003; Two-turn move"] = "";
+					if (move.flags['recharge']) details["&#10003; Has recharge turn"] = "";
 					if (move.flags['gravity'] && mod.gen >= 4) details["&#10007; Suppressed by Gravity"] = "";
 					if (move.flags['dance'] && mod.gen >= 7) details["&#10003; Dance move"] = "";
 


### PR DESCRIPTION
Charge moves and Recharge moves will have a tag when using /dt, similar to other tags like "Supressed by Gravity" or "Bite".