### PR TITLE
Mafia: Implement forced selflynch, disabling hammer

### DIFF
--- a/server/chat-plugins/mafia.js
+++ b/server/chat-plugins/mafia.js
@@ -2552,7 +2552,7 @@ const commands = {
 				game.forcelynch = false;
 				game.sendRoom(`Forcelynching has been disabled. You can lynch normally now!`, {declare: true});
 			} else {
-				this.parse('/help forcelynch');
+				this.parse('/help mafia forcelynch');
 			}
 		},
 		forcelynchhelp: [`/mafia forcelynch [yes/no] - Forces player's lynches onto themselves, and prevents unlynching. Requires host % @ # & ~`],


### PR DESCRIPTION
The latter feature relies on the nature of arithmetic with NaN to propagate the NaN value, so hammer counts and the like should always remain at NaN and fail.