### PR TITLE
Bump max room FAQ length to 8KB

### DIFF
--- a/server/chat-plugins/room-faqs.js
+++ b/server/chat-plugins/room-faqs.js
@@ -4,6 +4,7 @@
 const FS = require(/** @type {any} */('../../.lib-dist/fs')).FS;
 
 const ROOMFAQ_FILE = 'config/chat-plugins/faqs.json';
+const MAX_ROOMFAQ_LENGTH = 8192;
 
 /** @type {{[k: string]: {[k: string]: string}}} */
 let roomFaqs = {};
@@ -48,7 +49,7 @@ const commands = {
 		if (!(topic && rest.length)) return this.parse('/help roomfaq');
 		let text = rest.join(',').trim();
 		if (topic.length > 25) return this.errorReply("FAQ topics should not exceed 25 characters.");
-		if (Chat.stripFormatting(text).length > 500) return this.errorReply("FAQ entries should not exceed 500 characters.");
+		if (Chat.stripFormatting(text).length > MAX_ROOMFAQ_LENGTH) return this.errorReply(`FAQ entries should not exceed ${MAX_ROOMFAQ_LENGTH} characters.`);
 
 		text = text.replace(/^>/, '&gt;');
 


### PR DESCRIPTION
Bot Development needs a much longer max room FAQ length limit because of its bot list in /rfaq bots. Even when excluding the formatting in the length limit, it's simply too short.