### PR TITLE
Fix some small oldgens dexsearch issues

### DIFF
--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -689,6 +689,8 @@ function runDexsearch(target, cmd, canAll, message) {
 				let monStat = 0;
 				if (stat === 'bst') {
 					for (let monStats in dex[mon].baseStats) {
+						// account for merged Special stat in gen 1, don't count it twice
+						if (maxGen === 1 && monStats === 'spd') continue;
 						monStat += dex[mon].baseStats[monStats];
 					}
 				} else if (stat === 'weight') {

--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -655,8 +655,8 @@ function runDexsearch(target, cmd, canAll, message) {
 
 			for (let type in alts.resists) {
 				let effectiveness = 0;
-				let notImmune = Dex.getImmunity(type, dex[mon]);
-				if (notImmune) effectiveness = Dex.getEffectiveness(type, dex[mon]);
+				let notImmune = mod.getImmunity(type, dex[mon]);
+				if (notImmune) effectiveness = mod.getEffectiveness(type, dex[mon]);
 				if (!alts.resists[type]) {
 					if (notImmune && effectiveness >= 0) matched = true;
 				} else {
@@ -667,8 +667,8 @@ function runDexsearch(target, cmd, canAll, message) {
 
 			for (let type in alts.weak) {
 				let effectiveness = 0;
-				let notImmune = Dex.getImmunity(type, dex[mon]);
-				if (notImmune) effectiveness = Dex.getEffectiveness(type, dex[mon]);
+				let notImmune = mod.getImmunity(type, dex[mon]);
+				if (notImmune) effectiveness = mod.getEffectiveness(type, dex[mon]);
 				if (alts.weak[type]) {
 					if (notImmune && effectiveness >= 1) matched = true;
 				} else {


### PR DESCRIPTION
* Don't count the special stat twice for searching by BST in gen 1
* Use the type effectiveness from the gen we're actually searching in, not always gen 7's