### PR TITLE
Change weight units to hectograms

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1342,8 +1342,9 @@ let BattleAbilities = {
 	},
 	"heavymetal": {
 		shortDesc: "This Pokemon's weight is doubled.",
-		onModifyWeight(weight) {
-			return weight * 2;
+		onModifyWeightPriority: 1,
+		onModifyWeight(weighthg) {
+			return weighthg * 2;
 		},
 		id: "heavymetal",
 		name: "Heavy Metal",
@@ -1690,8 +1691,8 @@ let BattleAbilities = {
 	},
 	"lightmetal": {
 		shortDesc: "This Pokemon's weight is halved.",
-		onModifyWeight(weight) {
-			return weight / 2;
+		onModifyWeight(weighthg) {
+			return this.trunc(weighthg / 2);
 		},
 		id: "lightmetal",
 		name: "Light Metal",

--- a/data/items.js
+++ b/data/items.js
@@ -1884,8 +1884,8 @@ let BattleItems = {
 		fling: {
 			basePower: 30,
 		},
-		onModifyWeight(weight) {
-			return weight / 2;
+		onModifyWeight(weighthg) {
+			return this.trunc(weighthg / 2);
 		},
 		num: 539,
 		gen: 5,

--- a/data/mods/gen5/moves.js
+++ b/data/mods/gen5/moves.js
@@ -65,6 +65,35 @@ let BattleMovedex = {
 		inherit: true,
 		basePower: 90,
 	},
+	autotomize: {
+		inherit: true,
+		volatileStatus: 'autotomize',
+		onHit(pokemon) {
+		},
+		effect: {
+			noCopy: true, // doesn't get copied by Baton Pass
+			onStart(pokemon) {
+				if (pokemon.template.weighthg > 1) {
+					this.effectData.multiplier = 1;
+					this.add('-start', pokemon, 'Autotomize');
+				}
+			},
+			onRestart(pokemon) {
+				if (pokemon.template.weighthg - (this.effectData.multiplier * 1000) > 1) {
+					this.effectData.multiplier++;
+					this.add('-start', pokemon, 'Autotomize');
+				}
+			},
+			onModifyWeightPriority: 2,
+			onModifyWeight(weighthg, pokemon) {
+				if (this.effectData.multiplier) {
+					weighthg -= this.effectData.multiplier * 1000;
+					if (weighthg < 1) weighthg = 1;
+					return weighthg;
+				}
+			},
+		},
+	},
 	barrier: {
 		inherit: true,
 		pp: 30,

--- a/data/mods/letsgo/scripts.js
+++ b/data/mods/letsgo/scripts.js
@@ -56,11 +56,10 @@ let BattleScripts = {
 
 	pokemon: {
 		getWeight() {
-			let weight = this.template.weightkg;
-			weight = this.battle.runEvent('ModifyWeight', this, null, null, weight);
-			if (weight < 0.1) weight = 0.1;
+			let weighthg = this.battle.runEvent('ModifyWeight', this, null, null, this.weighthg);
+			if (weighthg < 1) weighthg = 1;
 			let weightModifierFinal = 20 * Math.random() * 0.01;
-			return weight + (weight * (this.battle.random(2) === 1 ? 1 : -1) * weightModifierFinal);
+			return weighthg + (weighthg * (this.battle.random(2) === 1 ? 1 : -1) * weightModifierFinal);
 		},
 	},
 };

--- a/data/mods/mixandmega/scripts.js
+++ b/data/mods/mixandmega/scripts.js
@@ -68,11 +68,11 @@ let BattleScripts = {
 	},
 	getMegaDeltas(megaTemplate) {
 		let baseTemplate = this.getTemplate(megaTemplate.baseSpecies);
-		/**@type {{ability: string, baseStats: {[k: string]: number}, weightkg: number, originalMega: string, requiredItem: string | undefined, type?: string, isMega?: boolean, isPrimal?: boolean}} */
+		/**@type {{ability: string, baseStats: {[k: string]: number}, weighthg: number, originalMega: string, requiredItem: string | undefined, type?: string, isMega?: boolean, isPrimal?: boolean}} */
 		let deltas = {
 			ability: megaTemplate.abilities['0'],
 			baseStats: {},
-			weightkg: megaTemplate.weightkg - baseTemplate.weightkg,
+			weighthg: megaTemplate.weighthg - baseTemplate.weighthg,
 			originalMega: megaTemplate.species,
 			requiredItem: megaTemplate.requiredItem,
 		};
@@ -104,7 +104,7 @@ let BattleScripts = {
 		for (let statName in baseStats) {
 			baseStats[statName] = this.clampIntRange(baseStats[statName] + deltas.baseStats[statName], 1, 255);
 		}
-		template.weightkg = Math.max(0.1, template.weightkg + deltas.weightkg);
+		template.weighthg = Math.max(1, template.weighthg + deltas.weighthg);
 		template.originalMega = deltas.originalMega;
 		template.requiredItem = deltas.requiredItem;
 		if (deltas.isMega) template.isMega = true;

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -4440,23 +4440,23 @@ let BattleMovedex = {
 		basePower: 0,
 		basePowerCallback(pokemon, target) {
 			let targetWeight = target.getWeight();
-			if (targetWeight >= 200) {
+			if (targetWeight >= 2000) {
 				this.debug('120 bp');
 				return 120;
 			}
-			if (targetWeight >= 100) {
+			if (targetWeight >= 1000) {
 				this.debug('100 bp');
 				return 100;
 			}
-			if (targetWeight >= 50) {
+			if (targetWeight >= 500) {
 				this.debug('80 bp');
 				return 80;
 			}
-			if (targetWeight >= 25) {
+			if (targetWeight >= 250) {
 				this.debug('60 bp');
 				return 60;
 			}
-			if (targetWeight >= 10) {
+			if (targetWeight >= 100) {
 				this.debug('40 bp');
 				return 40;
 			}

--- a/data/mods/ssb/statuses.js
+++ b/data/mods/ssb/statuses.js
@@ -1727,9 +1727,7 @@ let BattleStatuses = {
 		noCopy: true,
 		onStart(pokemon) {
 			this.add('-message', `${pokemon.illusion ? pokemon.illusion.name : pokemon.name}'s weight has doubled.`);
-		},
-		onModifyWeight(weight) {
-			return weight * 2;
+			pokemon.weighthg *= 2;
 		},
 	},
 	// Gooey volatile for Decem's move

--- a/data/moves.js
+++ b/data/moves.js
@@ -896,29 +896,11 @@ let BattleMovedex = {
 		boosts: {
 			spe: 2,
 		},
-		volatileStatus: 'autotomize',
-		effect: {
-			noCopy: true, // doesn't get copied by Baton Pass
-			onStart(pokemon) {
-				if (pokemon.template.weightkg > 0.1) {
-					this.effectData.multiplier = 1;
-					this.add('-start', pokemon, 'Autotomize');
-				}
-			},
-			onRestart(pokemon) {
-				if (pokemon.template.weightkg - (this.effectData.multiplier * 100) > 0.1) {
-					this.effectData.multiplier++;
-					this.add('-start', pokemon, 'Autotomize');
-				}
-			},
-			onModifyWeightPriority: 1,
-			onModifyWeight(weight, pokemon) {
-				if (this.effectData.multiplier) {
-					weight -= this.effectData.multiplier * 100;
-					if (weight < 0.1) weight = 0.1;
-					return weight;
-				}
-			},
+		onHit(pokemon) {
+			if (pokemon.weighthg > 1) {
+				pokemon.weighthg = Math.max(1, pokemon.weighthg - 1000);
+				this.add('-start', pokemon, 'Autotomize');
+			}
 		},
 		secondary: null,
 		target: "self",
@@ -6539,23 +6521,23 @@ let BattleMovedex = {
 		basePower: 0,
 		basePowerCallback(pokemon, target) {
 			let targetWeight = target.getWeight();
-			if (targetWeight >= 200) {
+			if (targetWeight >= 2000) {
 				this.debug('120 bp');
 				return 120;
 			}
-			if (targetWeight >= 100) {
+			if (targetWeight >= 1000) {
 				this.debug('100 bp');
 				return 100;
 			}
-			if (targetWeight >= 50) {
+			if (targetWeight >= 500) {
 				this.debug('80 bp');
 				return 80;
 			}
-			if (targetWeight >= 25) {
+			if (targetWeight >= 250) {
 				this.debug('60 bp');
 				return 60;
 			}
-			if (targetWeight >= 10) {
+			if (targetWeight >= 100) {
 				this.debug('40 bp');
 				return 40;
 			}
@@ -9521,19 +9503,19 @@ let BattleMovedex = {
 		basePower: 0,
 		basePowerCallback(pokemon, target) {
 			let targetWeight = target.getWeight();
-			if (targetWeight >= 200) {
+			if (targetWeight >= 2000) {
 				return 120;
 			}
-			if (targetWeight >= 100) {
+			if (targetWeight >= 1000) {
 				return 100;
 			}
-			if (targetWeight >= 50) {
+			if (targetWeight >= 500) {
 				return 80;
 			}
-			if (targetWeight >= 25) {
+			if (targetWeight >= 250) {
 				return 60;
 			}
-			if (targetWeight >= 10) {
+			if (targetWeight >= 100) {
 				return 40;
 			}
 			return 20;
@@ -15248,7 +15230,7 @@ let BattleMovedex = {
 				if (target.volatiles['substitute'] || target.side === source.side) {
 					return false;
 				}
-				if (target.getWeight() >= 200) {
+				if (target.getWeight() >= 2000) {
 					this.add('-fail', target, 'move: Sky Drop', '[heavy]');
 					return null;
 				}

--- a/old-simulator-doc.txt
+++ b/old-simulator-doc.txt
@@ -73,7 +73,7 @@ modifyPokemon(pokemon) [on pokemon]
 
 	These are the properties of pokemon you can modify:
 	- pokemon.stats
-	- pokemon.weightkg
+	- pokemon.weighthg
 	- pokemon.type
 
 	Whenever any effect is added or removed, the pokemon is reset and

--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -694,7 +694,7 @@ function runDexsearch(target, cmd, canAll, message) {
 						monStat += dex[mon].baseStats[monStats];
 					}
 				} else if (stat === 'weight') {
-					monStat = dex[mon].weightkg;
+					monStat = dex[mon].weighthg / 10;
 				} else if (stat === 'height') {
 					monStat = dex[mon].heightm;
 				} else if (stat === 'gen') {
@@ -761,8 +761,8 @@ function runDexsearch(target, cmd, canAll, message) {
 						monStat2 += mon2.baseStats[monStats];
 					}
 				} else if (stat === 'weight') {
-					monStat1 = mon1.weightkg;
-					monStat2 = mon2.weightkg;
+					monStat1 = mon1.weighthg;
+					monStat2 = mon2.weighthg;
 				} else if (stat === 'height') {
 					monStat1 = mon1.heightm;
 					monStat2 = mon2.heightm;

--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -515,22 +515,22 @@ const commands = {
 				buffer += `|raw|${Chat.getDataPokemonHTML(pokemon, mod.gen, tier)}\n`;
 				if (showDetails) {
 					let weighthit = 20;
-					if (pokemon.weightkg >= 200) {
+					if (pokemon.weighthg >= 2000) {
 						weighthit = 120;
-					} else if (pokemon.weightkg >= 100) {
+					} else if (pokemon.weighthg >= 1000) {
 						weighthit = 100;
-					} else if (pokemon.weightkg >= 50) {
+					} else if (pokemon.weighthg >= 500) {
 						weighthit = 80;
-					} else if (pokemon.weightkg >= 25) {
+					} else if (pokemon.weighthg >= 250) {
 						weighthit = 60;
-					} else if (pokemon.weightkg >= 10) {
+					} else if (pokemon.weighthg >= 100) {
 						weighthit = 40;
 					}
 					details = {
 						"Dex#": pokemon.num,
 						"Gen": pokemon.gen || 'CAP',
 						"Height": pokemon.heightm + " m",
-						"Weight": pokemon.weightkg + " kg <em>(" + weighthit + " BP)</em>",
+						"Weight": pokemon.weighthg / 10 + " kg <em>(" + weighthit + " BP)</em>",
 					};
 					if (pokemon.color && mod.gen >= 5) details["Dex Colour"] = pokemon.color;
 					if (pokemon.eggGroups && mod.gen >= 2) details["Egg Group(s)"] = pokemon.eggGroups.join(", ");

--- a/server/chat-plugins/othermetas.js
+++ b/server/chat-plugins/othermetas.js
@@ -120,10 +120,10 @@ const commands = {
 			megaTemplate = Dex.getTemplate("Kyogre-Primal");
 			baseTemplate = Dex.getTemplate("Kyogre");
 		}
-		/** @type {{baseStats: {[k: string]: number}, weightkg: number, type?: string}} */
+		/** @type {{baseStats: {[k: string]: number}, weighthg: number, type?: string}} */
 		let deltas = {
 			baseStats: {},
-			weightkg: megaTemplate.weightkg - baseTemplate.weightkg,
+			weighthg: megaTemplate.weighthg - baseTemplate.weighthg,
 		};
 		for (let statId in megaTemplate.baseStats) {
 			// @ts-ignore
@@ -147,18 +147,18 @@ const commands = {
 		for (let statName in template.baseStats) { // Add the changed stats and weight
 			mixedTemplate.baseStats[statName] = Dex.clampIntRange(mixedTemplate.baseStats[statName] + deltas.baseStats[statName], 1, 255);
 		}
-		mixedTemplate.weightkg = Math.round(Math.max(0.1, template.weightkg + deltas.weightkg) * 100) / 100;
+		mixedTemplate.weighthg = Math.max(1, template.weighthg + deltas.weighthg);
 		mixedTemplate.tier = "MnM";
 		let weighthit = 20;
-		if (mixedTemplate.weightkg >= 200) {
+		if (mixedTemplate.weighthg >= 2000) {
 			weighthit = 120;
-		} else if (mixedTemplate.weightkg >= 100) {
+		} else if (mixedTemplate.weighthg >= 1000) {
 			weighthit = 100;
-		} else if (mixedTemplate.weightkg >= 50) {
+		} else if (mixedTemplate.weighthg >= 500) {
 			weighthit = 80;
-		} else if (mixedTemplate.weightkg >= 25) {
+		} else if (mixedTemplate.weighthg >= 250) {
 			weighthit = 60;
-		} else if (mixedTemplate.weightkg >= 10) {
+		} else if (mixedTemplate.weighthg >= 100) {
 			weighthit = 40;
 		}
 		/** @type {{[k: string]: string}} */
@@ -166,7 +166,7 @@ const commands = {
 			"Dex#": '' + mixedTemplate.num,
 			"Gen": '' + mixedTemplate.gen,
 			"Height": mixedTemplate.heightm + " m",
-			"Weight": mixedTemplate.weightkg + " kg <em>(" + weighthit + " BP)</em>",
+			"Weight": mixedTemplate.weighthg / 10 + " kg <em>(" + weighthit + " BP)</em>",
 			"Dex Colour": mixedTemplate.color,
 		};
 		if (mixedTemplate.eggGroups) details["Egg Group(s)"] = mixedTemplate.eggGroups.join(", ");
@@ -215,10 +215,10 @@ const commands = {
 			baseTemplate = Dex.getTemplate("Kyogre");
 			megaTemplate = Dex.getTemplate("Kyogre-Primal");
 		}
-		/** @type {{baseStats: {[k: string]: number}, weightkg: number, type?: string}} */
+		/** @type {{baseStats: {[k: string]: number}, weighthg: number, type?: string}} */
 		let deltas = {
 			baseStats: {},
-			weightkg: megaTemplate.weightkg - baseTemplate.weightkg,
+			weighthg: megaTemplate.weighthg - baseTemplate.weighthg,
 		};
 		for (let statId in megaTemplate.baseStats) {
 			// @ts-ignore
@@ -233,7 +233,7 @@ const commands = {
 		}
 		let details = {
 			"Gen": 6,
-			"Weight": (JSON.stringify(deltas.weightkg).startsWith("-") ? "" : "+") + Math.round(deltas.weightkg * 100) / 100 + " kg",
+			"Weight": (deltas.weighthg < 0 ? "" : "+") + deltas.weighthg / 10 + " kg",
 		};
 		let tier;
 		if (['redorb', 'blueorb'].includes(stone.id)) {
@@ -414,9 +414,9 @@ const commands = {
 		if (crossTemplate.types[0] !== prevo.types[0]) mixedTemplate.types[0] = crossTemplate.types[0];
 		if (crossTemplate.types[1] !== prevo.types[1]) mixedTemplate.types[1] = crossTemplate.types[1] || crossTemplate.types[0];
 		if (mixedTemplate.types[0] === mixedTemplate.types[1]) mixedTemplate.types = [mixedTemplate.types[0]];
-		mixedTemplate.weightkg += crossTemplate.weightkg - prevo.weightkg;
-		if (mixedTemplate.weightkg <= 0) {
-			mixedTemplate.weightkg = 0.1;
+		mixedTemplate.weighthg += crossTemplate.weighthg - prevo.weighthg;
+		if (mixedTemplate.weighthg < 1) {
+			mixedTemplate.weighthg = 1;
 		}
 		for (const stat of Object.values(mixedTemplate.baseStats)) {
 			if (stat < 1 || stat > 255) {
@@ -426,15 +426,15 @@ const commands = {
 		}
 		mixedTemplate.tier = "CE";
 		let weighthit = 20;
-		if (mixedTemplate.weightkg >= 200) {
+		if (mixedTemplate.weighthg >= 2000) {
 			weighthit = 120;
-		} else if (mixedTemplate.weightkg >= 100) {
+		} else if (mixedTemplate.weighthg >= 1000) {
 			weighthit = 100;
-		} else if (mixedTemplate.weightkg >= 50) {
+		} else if (mixedTemplate.weighthg >= 500) {
 			weighthit = 80;
-		} else if (mixedTemplate.weightkg >= 25) {
+		} else if (mixedTemplate.weighthg >= 250) {
 			weighthit = 60;
-		} else if (mixedTemplate.weightkg >= 10) {
+		} else if (mixedTemplate.weighthg >= 100) {
 			weighthit = 40;
 		}
 		/** @type {{[k: string]: string}} */
@@ -442,7 +442,7 @@ const commands = {
 			"Dex#": mixedTemplate.num,
 			"Gen": mixedTemplate.gen,
 			"Height": mixedTemplate.heightm + " m",
-			"Weight": mixedTemplate.weightkg + " kg <em>(" + weighthit + " BP)</em>",
+			"Weight": mixedTemplate.weighthg / 10 + " kg <em>(" + weighthit + " BP)</em>",
 			"Dex Colour": mixedTemplate.color,
 		};
 		if (mixedTemplate.eggGroups) details["Egg Group(s)"] = mixedTemplate.eggGroups.join(", ");

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -550,8 +550,10 @@ export class Template extends BasicEffect implements Readonly<BasicEffect & Temp
 	readonly baseStats: StatsTable;
 	/** Max HP. Overrides usual HP calculations (for Shedinja). */
 	readonly maxHP?: number;
-	/** Weight (in kg). */
+	/** Weight (in kg). Not valid for OMs; use weighthg / 10 instead. */
 	readonly weightkg: number;
+	/** Weight (in integer multiples of 0.1kg). */
+	readonly weighthg: number;
 	/** Height (in m). */
 	readonly heightm: number;
 	/** Color. */
@@ -643,6 +645,7 @@ export class Template extends BasicEffect implements Readonly<BasicEffect & Temp
 		this.requiredItems = this.requiredItems || (this.requiredItem ? [this.requiredItem] : undefined);
 		this.baseStats = data.baseStats!;
 		this.weightkg = data.weightkg!;
+		this.weighthg = this.weightkg * 10;
 		this.heightm = data.heightm!;
 		this.color = data.color || '';
 		this.unreleasedHidden = !!data.unreleasedHidden;

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -257,7 +257,7 @@ interface EventMethods {
 	onModifySpA?: CommonHandlers['ModifierSourceMove']
 	onModifySpD?: CommonHandlers['ModifierMove']
 	onModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void
-	onModifyWeight?: (this: Battle, weight: number, pokemon: Pokemon) => number | void
+	onModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void
 	onMoveAborted?: CommonHandlers['VoidMove']
 	onNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean
 	onOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => string | void
@@ -340,7 +340,7 @@ interface EventMethods {
 	onAllyModifySpA?: CommonHandlers['ModifierSourceMove']
 	onAllyModifySpD?: CommonHandlers['ModifierMove']
 	onAllyModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void
-	onAllyModifyWeight?: (this: Battle, weight: number, pokemon: Pokemon) => number | void
+	onAllyModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void
 	onAllyMoveAborted?: CommonHandlers['VoidMove']
 	onAllyNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean
 	onAllyOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => string | void
@@ -423,7 +423,7 @@ interface EventMethods {
 	onFoeModifySpA?: CommonHandlers['ModifierSourceMove']
 	onFoeModifySpD?: CommonHandlers['ModifierMove']
 	onFoeModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void
-	onFoeModifyWeight?: (this: Battle, weight: number, pokemon: Pokemon) => number | void
+	onFoeModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void
 	onFoeMoveAborted?: CommonHandlers['VoidMove']
 	onFoeNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean
 	onFoeOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => string | void
@@ -506,7 +506,7 @@ interface EventMethods {
 	onSourceModifySpA?: CommonHandlers['ModifierSourceMove']
 	onSourceModifySpD?: CommonHandlers['ModifierMove']
 	onSourceModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void
-	onSourceModifyWeight?: (this: Battle, weight: number, pokemon: Pokemon) => number | void
+	onSourceModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void
 	onSourceMoveAborted?: CommonHandlers['VoidMove']
 	onSourceNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean
 	onSourceOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => string | void
@@ -589,7 +589,7 @@ interface EventMethods {
 	onAnyModifySpA?: CommonHandlers['ModifierSourceMove']
 	onAnyModifySpD?: CommonHandlers['ModifierMove']
 	onAnyModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void
-	onAnyModifyWeight?: (this: Battle, weight: number, pokemon: Pokemon) => number | void
+	onAnyModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void
 	onAnyMoveAborted?: CommonHandlers['VoidMove']
 	onAnyNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean
 	onAnyOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => string | void

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -192,6 +192,7 @@ export class Pokemon {
 	isStarted: boolean;
 	duringMove: boolean;
 
+	weighthg: number;
 	speed: number;
 	abilityOrder: number;
 
@@ -356,6 +357,7 @@ export class Pokemon {
 		this.isStarted = false;
 		this.duringMove = false;
 
+		this.weighthg = 1;
 		this.speed = 0;
 		this.abilityOrder = 0;
 
@@ -516,8 +518,8 @@ export class Pokemon {
 	*/
 
 	getWeight() {
-		const weight = this.battle.runEvent('ModifyWeight', this, null, null, this.template.weightkg);
-		return (weight < 0.1) ? 0.1 : weight;
+		const weighthg = this.battle.runEvent('ModifyWeight', this, null, null, this.weighthg);
+		return Math.max(1, weighthg);
 	}
 
 	getMoveData(move: string | Move) {
@@ -966,7 +968,7 @@ export class Pokemon {
 		this.apparentType = rawTemplate.types.join('/');
 		this.addedType = template.addedType || '';
 		this.knownType = true;
-		if (this.battle.gen >= 7) this.removeVolatile('autotomize');
+		this.weighthg = template.weighthg;
 
 		const stats = this.battle.spreadModify(this.template.baseStats, this.set);
 		if (!this.baseStoredStats) this.baseStoredStats = stats;

--- a/test/sim/misc/weight.js
+++ b/test/sim/misc/weight.js
@@ -134,4 +134,20 @@ describe('Autotomize', function () {
 		battle.makeChoices('move autotomize', 'move grassknot');
 		assert.strictEqual(basePower, 60);
 	});
+
+	it('should reset after a forme change', function () {
+		battle = common.createBattle([
+			[{species: "Aegislash", ability: 'stancechange', moves: ['autotomize', 'shadowsneak']}],
+			[{species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot']}],
+		]);
+		let basePower = 0;
+		battle.onEvent('BasePower', battle.getFormat(), function (bp, attacker, defender, move) {
+			if (move.id === 'grassknot') {
+				basePower = bp;
+			}
+		});
+		battle.makeChoices('move autotomize', 'move grassknot');
+		battle.makeChoices('move shadowsneak', 'move grassknot');
+		assert.strictEqual(basePower, 80);
+	});
 });


### PR DESCRIPTION
Mechanics implemented:

- Weight is calculated in positive integer multiples of hectograms, in particular for Light Metal
- Heavy Metal always applies before Float Stone
- Since Gen 6, weight is a property of the forme that is directly modified by Autotomize

My attempt to implement the mechanics described here:

https://www.smogon.com/forums/posts/8095060