### PR TITLE
Make a couple improvements to /cmd

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4501,6 +4501,11 @@ const commands = {
 			target = '';
 		}
 		if (cmd === 'userdetails') {
+			if (target.length > 18) {
+				connection.send('|queryrespone|userdetails|null');
+				return false;
+			}
+
 			let targetUser = Users.get(target);
 			if (!trustable || !targetUser) {
 				connection.send('|queryresponse|userdetails|' + JSON.stringify({
@@ -4563,6 +4568,11 @@ const commands = {
 			});
 		} else if (cmd === 'roominfo') {
 			if (!trustable) return false;
+
+			if (target.length > 225) {
+				connection.end('|queryresponse|roominfo|null');
+				return false;
+			}
 
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom === Rooms.global || (

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4506,6 +4506,7 @@ const commands = {
 				connection.send('|queryresponse|userdetails|' + JSON.stringify({
 					id: target,
 					userid: toID(target),
+					name: target,
 					rooms: false,
 				}));
 				return false;
@@ -4534,6 +4535,7 @@ const commands = {
 			let userdetails = {
 				id: target,
 				userid: targetUser.userid,
+				name: targetUser.name,
 				avatar: targetUser.avatar,
 				group: targetUser.group,
 				autoconfirmed: !!targetUser.autoconfirmed,


### PR DESCRIPTION
PoS-Bot uses `/cmd userdetails` when PM commands are used and it is not actually aware of the user existing because they're not in any of its rooms. It expects a userid, name, group, and status of some sort when creating user objects, but `/cmd userdetails` doesn't include a name at the moment. It'd be nice if it did so I don't have to pass both a username and userid to the routine for getting users from the bot's state machine.

I'm not explaining the second commit. You should already know why it's included and why it wouldn't be a good idea to do so.