### PR TITLE
Run tsc before mocha in `npm run fulltest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "lint": "eslint --cache . && tslint --project .",
     "pretest": "npm run lint && npm run build",
     "test": "mocha",
-    "posttest": "npm run tsc",
-    "fulltest": "npm run pretest && mocha -g \".*\" && npm run posttest"
+    "fulltest": "npm run pretest && npm run tsc && mocha -g \".*\" "
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint": "eslint --cache . && tslint --project .",
     "pretest": "npm run lint && npm run build",
     "test": "mocha",
-    "fulltest": "npm run pretest && npm run tsc && mocha -g \".*\" "
+    "posttest": "npm run tsc",
+    "fulltest": "npm run pretest && npm run tsc && mocha -g \".*\""
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
It's kind of annoying to run 5 minutes of mocha test just for the test to fail in the TypeScript compiler which is at least 5x times faster.