### PR TITLE
Fix ticketbans logging reasons

### DIFF
--- a/server/chat-plugins/helptickets.js
+++ b/server/chat-plugins/helptickets.js
@@ -1328,7 +1328,7 @@ let commands = {
 			notifyStaff();
 			notifyStaff(true);
 
-			this.globalModlog(`TICKETBAN`, targetUser || userid, ` by ${user.name}${target}`);
+			this.globalModlog(`TICKETBAN`, targetUser || userid, ` by ${user.name}${(target ? `: ${target}` : ``)}`);
 			return true;
 		},
 		banhelp: [`/helpticket ban [user], (reason) - Bans a user from creating tickets for 2 days. Requires: % @ & ~`],


### PR DESCRIPTION
Ticketbans with reasons currently show up in modlog like "by Anubisbad user" when they should show "by Anubis: bad user".