### PR TITLE
Change Acid Rain so Steel/Poison retain immunities; Rewrite Corrosive Toxic

### DIFF
--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -3341,7 +3341,7 @@ let BattleMovedex = {
 		accuracy: true,
 		basePower: 0,
 		category: "Status",
-		desc: "For 5 turns, the weather becomes Acid Rain.  Pokemon that are not Poison-type take damage every turn.  Special Defense of Poison-type pokemon is multiplied by 1.5.",
+		desc: "For 5 turns, the weather becomes Acid Rain. Pokemon that are not Poison-type take damage every turn. Special Defense of Poison-type pokemon is multiplied by 1.5.",
 		shortDesc: "5 turns: +Poison SpD, corrosive damage.",
 		id: "acidrain",
 		name: "Acid Rain",

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -3352,7 +3352,7 @@ let BattleMovedex = {
 		accuracy: true,
 		basePower: 0,
 		category: "Status",
-		desc: "For 5 turns, the weather becomes Acid Rain.  Pokemon that are not Poison-type take damage every turn.  Special Defense of Poison-type pokemon is multiplied by 1.5.  Poison moves ignore Steel immunity and Poison-type Pokemon can be poisoned.",
+		desc: "For 5 turns, the weather becomes Acid Rain.  Pokemon that are not Poison-type take damage every turn.  Special Defense of Poison-type pokemon is multiplied by 1.5.",
 		shortDesc: "5 turns: +Poison SpD, corrosive damage.",
 		id: "acidrain",
 		name: "Acid Rain",

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -3326,7 +3326,7 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 0,
 		category: "Status",
-		desc: "The user of this move will use will use Toxic followed by Venoshock and then attempt to use Rest and Sleep Talk.",
+		desc: "The user attempts to use Toxic followed by Venoshock, then Rest and Sleep Talk.",
 		shortDesc: "Toxic -> Venoshock -> Rest -> Sleep Talk.",
 		id: "teabreak",
 		name: "Tea Break",

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -3304,18 +3304,7 @@ let BattleMovedex = {
 		onPrepareHit(target, source) {
 			this.add('-anim', source, "Toxic", target);
 		},
-		onTryHit(target, source, move) {
-			// hacky way of forcing toxic to effect poison / steel types without corrosion usage
-			if (target.volatiles['substitute'] && !move.infiltrates) return;
-			if (target.hasType('Steel') || target.hasType('Poison')) {
-				if (target.status) return;
-				let status = this.getEffect(move.status);
-				target.status = status.id;
-				target.statusData = {id: status.id, target: target, source: source, stage: 0};
-				this.add('-status', target, target.status);
-				move.status = undefined;
-			}
-		},
+		// Innate corrosive implemented in BattleScripts#setStatus
 		status: 'tox',
 		secondary: null,
 		target: "normal",

--- a/data/mods/ssb/scripts.js
+++ b/data/mods/ssb/scripts.js
@@ -430,7 +430,8 @@ let BattleScripts = {
 			}
 
 			if (!ignoreImmunities && status.id &&
-					!(source && source.hasAbility('corrosion') && ['tox', 'psn'].includes(status.id))) {
+					!(source && source.hasAbility('corrosion') && ['tox', 'psn'].includes(status.id)) &&
+					!(sourceEffect && sourceEffect.id === 'corrosivetoxic')) {
 				// the game currently never ignores immunities
 				if (!this.runStatusImmunity(status.id === 'tox' ? 'psn' : status.id)) {
 					this.battle.debug('immune to status');

--- a/data/mods/ssb/scripts.js
+++ b/data/mods/ssb/scripts.js
@@ -430,9 +430,7 @@ let BattleScripts = {
 			}
 
 			if (!ignoreImmunities && status.id &&
-					!(source && source.hasAbility('corrosion') && ['tox', 'psn'].includes(status.id)) &&
-					// Acid Rain allows poison types to be posioned
-					!(this.battle.field.isWeather('acidrain') && ['tox', 'psn'].includes(status.id) && this.hasType('Poison'))) {
+					!(source && source.hasAbility('corrosion') && ['tox', 'psn'].includes(status.id))) {
 				// the game currently never ignores immunities
 				if (!this.runStatusImmunity(status.id === 'tox' ? 'psn' : status.id)) {
 					this.battle.debug('immune to status');


### PR DESCRIPTION
[10:18 AM] A Cake Wearing A Hat: Okay yeah @ Programmer acid rain will no longer allow poison types to be poisoned, and the description should also not erroneously state that steels are not immune to poison under acid rain

Paradise's Corrosive Toxic was acting up with Distortion Blast because of the hacky way it was implemented, so with the help of @whalemer, it's been changed over to use setStatus.