### PR TITLE
Fix SSB bug in Gracidea Mastery

### DIFF
--- a/data/mods/ssb/abilities.js
+++ b/data/mods/ssb/abilities.js
@@ -286,7 +286,7 @@ let BattleAbilities = {
 			source.formeChange('Shaymin', this.effect);
 		},
 		onAfterMove(pokemon) {
-			if (pokemon.template.baseSpecies !== 'Shaymin' || pokemon.transformed) return;
+			if (pokemon.template.speciesid !== 'shaymin' || pokemon.transformed) return;
 			pokemon.formeChange('Shaymin-Sky', this.effect);
 		},
 	},


### PR DESCRIPTION
Gracidea Mastery is making Shaymin-Sky transform into Shaymin-Sky after every move, when it should only be doing this if Shaymin is in its regular forme.