### PR TITLE
Fix SSB crash in Kay's innate ability when copied through Illusion

### DIFF
--- a/data/mods/ssb/statuses.js
+++ b/data/mods/ssb/statuses.js
@@ -838,7 +838,7 @@ let BattleStatuses = {
 		},
 		// Simple Innate
 		onBoost(boost, target, source, effect) {
-			if (source.illusion) return;
+			if (target && target.illusion) return;
 			if (effect && effect.id === 'zpower') return;
 			for (let i in boost) {
 				// @ts-ignore


### PR DESCRIPTION
Crash happened because an Illusion'd mon pretending to be Kay swapped into Sticky Web, which causes an undefined ``source``.  The line is meant to prevent Illusion from copying Kay's innate Simple ability, so the check is now on whether the ``target`` is an Illusion'd mon.