### PR TITLE
Use global modlog for queries in help tickets instead of failing

### DIFF
--- a/server/chat-plugins/modlog.js
+++ b/server/chat-plugins/modlog.js
@@ -522,7 +522,15 @@ exports.commands = {
 		let targetRoom = Rooms.search(roomid);
 		// if a room alias was used, replace alias with actual id
 		if (targetRoom) roomid = targetRoom.id;
-		if (roomid.includes('-')) return this.errorReply(`Battles and groupchats (and other rooms with - in their ID) don't have individual modlogs.`);
+
+		if (roomid.includes('-')) {
+			if (user.can('modlog')) {
+				// default to global modlog for staff convenience
+				roomid = 'global';
+			} else {
+				return this.errorReply(`Access to global modlog denied. Battles and groupchats (and other rooms with - in their ID) don't have individual modlogs.`);
+			}
+		}
 
 		let lines;
 		if (target.includes(LINES_SEPARATOR)) { // undocumented line specification


### PR DESCRIPTION
Based on a staff suggestion that turned out rather popular. Looking up modlogs in help tickets is somewhat of a common occurrence, so this'll save switching rooms or adding "global" manually.