### PR TITLE
Prevent overzealous spead of locks under some circumstances

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -2069,9 +2069,10 @@ const commands = {
 		let affected = [];
 
 		if (targetUser) {
-			affected = Punishments.lock(targetUser, duration, targetUser.locked, userReason);
+			const ignoreAlts = Punishments.sharedIps.has(targetUser.latestIP);
+			affected = Punishments.lock(targetUser, duration, targetUser.locked, ignoreAlts, userReason);
 		} else {
-			affected = Punishments.lock(null, duration, userid, userReason);
+			affected = Punishments.lock(null, duration, userid, false, userReason);
 		}
 
 		const globalReason = (target ? `: ${userReason} ${proof}` : '');
@@ -2269,7 +2270,7 @@ const commands = {
 			Rooms.get('staff').addByUser(user, `<<${room.id}>> ${banMessage}`);
 		}
 
-		let affected = Punishments.ban(targetUser, null, null, userReason);
+		let affected = Punishments.ban(targetUser, null, null, false, userReason);
 		let acAccount = (targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
 		let displayMessage = '';
 		if (affected.length > 1) {
@@ -2781,7 +2782,7 @@ const commands = {
 
 		this.globalModlog("NAMELOCK", targetUser, ` by ${user.userid}${reasonText}`);
 		Ladders.cancelSearches(targetUser);
-		Punishments.namelock(targetUser, null, null, reason);
+		Punishments.namelock(targetUser, null, null, false, reason);
 		targetUser.popup(`|modal|${user.name} has locked your name and you can't change names anymore${reasonText}`);
 		// Automatically upload replays as evidence/reference to the punishment
 		if (room.battle) this.parse('/savereplay forpunishment');

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -369,12 +369,12 @@ export const Punishments = new class {
 	 * Adding and removing
 	 *********************************************************/
 
-	punish(user: User | ID, punishment: Punishment) {
+	punish(user: User | ID, punishment: Punishment, ignoreAlts: boolean) {
 		if (typeof user === 'string') return Punishments.punishName(user, punishment);
 
 		const userids = new Set<ID>();
 		const ips = new Set<string>();
-		const affected = (user as User).getAltUsers(PUNISH_TRUSTED, true);
+		const affected = ignoreAlts ? [user as User] : (user as User).getAltUsers(PUNISH_TRUSTED, true);
 		for (const alt of affected) {
 			this.punishInner(alt, punishment, userids, ips);
 		}
@@ -610,13 +610,13 @@ export const Punishments = new class {
 	 * Specific punishments
 	 *********************************************************/
 
-	ban(user: User, expireTime: number, id: ID, ...reason: string[]) {
+	ban(user: User, expireTime: number, id: ID, ignoreAlts: boolean, ...reason: string[]) {
 		if (!id) id = user.getLastId();
 
 		if (!expireTime) expireTime = Date.now() + GLOBALBAN_DURATION;
 		const punishment = ['BAN', id, expireTime, ...reason] as Punishment;
 
-		const affected = Punishments.punish(user, punishment);
+		const affected = Punishments.punish(user, punishment, ignoreAlts);
 		for (const curUser of affected) {
 			curUser.locked = id;
 			curUser.disconnectAll();
@@ -627,7 +627,7 @@ export const Punishments = new class {
 	unban(name: string) {
 		return Punishments.unpunish(name, 'BAN');
 	}
-	lock(userOrUsername: User | string, expireTime: number | null, id: ID, ...reason: string[]) {
+	lock(userOrUsername: User | string, expireTime: number | null, id: ID, ignoreAlts: boolean, ...reason: string[]) {
 		const user = (typeof userOrUsername === 'string' ? Users.get(userOrUsername) : userOrUsername);
 		if (!id) id = user ? user.getLastId() : toID(userOrUsername);
 
@@ -637,9 +637,9 @@ export const Punishments = new class {
 		let affected;
 
 		if (user) {
-			affected = Punishments.punish(user, punishment);
+			affected = Punishments.punish(user, punishment, ignoreAlts);
 		} else {
-			affected = Punishments.punish(id, punishment);
+			affected = Punishments.punish(id, punishment, ignoreAlts);
 		}
 
 		for (const curUser of affected) {
@@ -671,14 +671,14 @@ export const Punishments = new class {
 		const name = typeof user === 'string' ? user : (user as User).name;
 		if (namelock) {
 			punishment = `NAMELOCKED`;
-			Punishments.namelock(user, expires, toID(namelock), `Autonamelock: ${name}: ${reason}`);
+			Punishments.namelock(user, expires, toID(namelock), false, `Autonamelock: ${name}: ${reason}`);
 		} else {
-			Punishments.lock(user, expires, toID(user), `Autolock: ${name}: ${reason}`);
+			Punishments.lock(user, expires, toID(user), false, `Autolock: ${name}: ${reason}`);
 		}
 		Monitor.log(`[${source}] ${punishment}: ${message}`);
 		const roomauth = Rooms.global.destroyPersonalRooms(userid);
 		// tslint:disable-next-line: max-line-length
-		if (roomauth.length) Monitor.log(`[CrisisMonitor] Autolocked ${name} has public roomauth (${roomauth.join(', ')}), and should probably be demoted.`);
+		if (roomauth.length) Monitor.log(`[CrisisMonitor] Autolocked user ${name} has public roomauth (${roomauth.join(', ')}), and should probably be demoted.`);
 
 		const ipStr = typeof user !== 'string' ? ` [${(user as User).latestIp}]` : '';
 		const roomid = typeof room !== 'string' ? (room as Room).id : room;
@@ -714,13 +714,13 @@ export const Punishments = new class {
 		}
 		return success;
 	}
-	namelock(user: User | ID, expireTime: number | null, id: ID, ...reason: string[]) {
+	namelock(user: User | ID, expireTime: number | null, id: ID, ignoreAlts: boolean, ...reason: string[]) {
 		if (!id) id = typeof user === 'string' ? toID(user) : (user as User).getLastId();
 
 		if (!expireTime) expireTime = Date.now() + LOCK_DURATION;
 		const punishment = ['NAMELOCK', id, expireTime, ...reason] as Punishment;
 
-		const affected = Punishments.punish(user, punishment);
+		const affected = Punishments.punish(user, punishment, ignoreAlts);
 		for (const curUser of affected) {
 			curUser.locked = id;
 			curUser.namelocked = id;
@@ -1111,7 +1111,7 @@ export const Punishments = new class {
 		if (registered && id === 'BAN') {
 			user.popup(`Your username (${user.name}) is banned${bannedUnder}. Your ban will expire in a few days.${reason}${Config.appealurl ? `||||Or you can appeal at: ${Config.appealurl}` : ``}`);
 			user.punishmentNotified = true;
-			Punishments.punish(user, punishment);
+			Punishments.punish(user, punishment, false);
 			user.disconnectAll();
 			return;
 		}

--- a/server/users.ts
+++ b/server/users.ts
@@ -901,9 +901,9 @@ export class User extends Chat.MessageContext {
 				this.autoconfirmed = userid;
 			} else if (userType === '5') {
 				this.permalocked = userid;
-				Punishments.lock(this, Date.now() + PERMALOCK_CACHE_TIME, userid, `Permalocked as ${name}`);
+				Punishments.lock(this, Date.now() + PERMALOCK_CACHE_TIME, userid, true, `Permalocked as ${name}`);
 			} else if (userType === '6') {
-				Punishments.lock(this, Date.now() + PERMALOCK_CACHE_TIME, userid, `Permabanned as ${name}`);
+				Punishments.lock(this, Date.now() + PERMALOCK_CACHE_TIME, userid, true, `Permabanned as ${name}`);
 				this.disconnectAll();
 			}
 		}


### PR DESCRIPTION
This is for the situations "permalocked user logging in" and "lock on shared IP". In both cases, existing alts are also locked by name right now. This tends to be overkill.
Unfortunately this had the side effect of not locking existing alts at all (not even based on the locked IP). 

Do we want that behavior? Do we need to re-run checkIP for every alt so it locks them properly (just without punishing their usernames)?