### PR TITLE
Clean up forcerename messages

### DIFF
--- a/server/chat-plugins/chat-monitor.js
+++ b/server/chat-plugins/chat-monitor.js
@@ -269,7 +269,7 @@ let loginfilter = function (user) {
 	if (Chat.namefilterwhitelist.has(user.userid)) return;
 	if (typeof forceRenamed === 'number') {
 		const count = forceRenamed ? ` (forcerenamed ${forceRenamed} time${Chat.plural(forceRenamed)})` : '';
-		Rooms.global.notifyRooms([/** @type {RoomID} */('staff')], Chat.html`|html|[NameMonitor] Forcerenamed name being reused${count}: <span class="username">${user.name}</span> ${user.getAccountStatusString()}`);
+		Rooms.global.notifyRooms([/** @type {RoomID} */('staff')], Chat.html`|html|[NameMonitor] Reused name${count}: <span class="username">${user.name}</span> ${user.getAccountStatusString()}`);
 	}
 };
 /** @type {NameFilter} */

--- a/server/users.ts
+++ b/server/users.ts
@@ -1554,7 +1554,7 @@ export class User extends Chat.MessageContext {
 		return this.trusted === this.userid ? `[trusted]`
 			: this.autoconfirmed === this.userid ? `[ac]`
 			: this.registered ? `[registered]`
-			: `[unregistered]`;
+			: ``;
 	}
 	destroy() {
 		// deallocate user


### PR DESCRIPTION
getAccountStatusString() is only used in forcerename messages to append the status of the name.  The main reason for displaying the account status is so leaders+ can disable registered bad names, but labeling every unregistered account makes the messages messier and doesn't add any valuable information.  I also shortened the notification for an FR'd name being reused; I ran this by several new people who were able to understand what it meant.

Old:
> «lobby» werwerara [unregistered] was forced to choose a new name by Anubis
[NameMonitor] Username used: aseraehshsd [unregistered] (forcerenamed from werwerara)
[NameMonitor] Forcerenamed name being reused (forcerenamed 1 time): werwerara [unregistered]

New:
> «lobby» g43tarsgga was forced to choose a new name by Anubis
> [NameMonitor] Username used: seraea (forcerenamed from g43tarsgga)
> [NameMonitor] Reused name (forcerenamed 1 time): g43tarsgga 