### PR TITLE
Give trusted users a 100ms chat delay

### DIFF
--- a/server/users.ts
+++ b/server/users.ts
@@ -29,6 +29,7 @@ const PLAYER_SYMBOL = '\u2606';
 const HOST_SYMBOL = '\u2605';
 
 const THROTTLE_DELAY = 600;
+const THROTTLE_DELAY_TRUSTED = 100;
 const THROTTLE_BUFFER_LIMIT = 6;
 const THROTTLE_MULTILINE_WARN = 3;
 const THROTTLE_MULTILINE_WARN_STAFF = 6;
@@ -1482,7 +1483,7 @@ export class User extends Chat.MessageContext {
 	}
 	startChatQueue(delay: number | null = null) {
 		if (delay === null) {
-			delay = (this.group !== ' ' ? THROTTLE_DELAY / 2 : THROTTLE_DELAY) - (Date.now() - this.lastChatMessage);
+			delay = (this.trusted ? THROTTLE_DELAY_TRUSTED : THROTTLE_DELAY) - (Date.now() - this.lastChatMessage);
 		}
 
 		this.chatQueueTimeout = setTimeout(


### PR DESCRIPTION
down from 300ms for global auth