### PR TITLE
Disallow regs from seeing their own IPs

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -593,7 +593,6 @@ exports.grouplist = [
 	},
 	{
 		symbol: ' ',
-		ip: 's',
 	},
 	{
 		name: 'Locked',

--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -158,7 +158,7 @@ const commands = {
 				buf += `<br />Semilocked: ${targetUser.semilocked}`;
 			}
 		}
-		if ((user.can('ip', targetUser) || user === targetUser)) {
+		if (user.can('ip', targetUser)) {
 			let ips = Object.keys(targetUser.ips);
 			ips = ips.map(ip => {
 				let status = [];

--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -182,6 +182,8 @@ const commands = {
 			if (user.group !== ' ' && targetUser.latestHost) {
 				buf += Chat.html`<br />Host: ${targetUser.latestHost} [${targetUser.latestHostType}]`;
 			}
+		} else {
+			buf += `<br /> IP: <a href="https://whatismyipaddress.com/ip/${connection.ip}" target="_blank">${connection.ip}</a>`;
 		}
 		if (canViewAlts && hiddenrooms) {
 			buf += `<br />Hidden rooms: ${hiddenrooms}`;

--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -182,7 +182,7 @@ const commands = {
 			if (user.group !== ' ' && targetUser.latestHost) {
 				buf += Chat.html`<br />Host: ${targetUser.latestHost} [${targetUser.latestHostType}]`;
 			}
-		} else {
+		} else if (user === targetUser) {
 			buf += `<br /> IP: <a href="https://whatismyipaddress.com/ip/${connection.ip}" target="_blank">${connection.ip}</a>`;
 		}
 		if (canViewAlts && hiddenrooms) {


### PR DESCRIPTION
Certain bad users are convincing people to merge their accounts as a way to find their IP, and most people don't have a real need to see their own IP through PS.