### PR TITLE
Require normal targets to be adjacent in Triples battles

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2220,6 +2220,7 @@ export class Battle {
 				adjacentFoes = adjacentFoes.filter(active => active && !active.fainted);
 				if (adjacentFoes.length) return this.sample(adjacentFoes);
 				// no valid target at all, return a foe for any possible redirection
+				return foeActives[frontPosition];
 			}
 		}
 		return pokemon.side.foe.randomActive() || pokemon.side.foe.active[0];


### PR DESCRIPTION
If in a triples battle you use a move that would target an adjacent foe, but by the time it is your turn the only active foe is on the far side of the field, then this should causes the move to fail. Note that it's possible for your adjacent ally to redirect the move, so we can't get claim there is no target until after that check. Otherwise we get stuck in an infinite loop for some reason.