### PR TITLE
Automatically save replays for global warnings and autolocks

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -1896,6 +1896,9 @@ const commands = {
 		if (userid !== toID(this.inputUsername)) this.add(`|unlink|${toID(this.inputUsername)}`);
 
 		targetUser.lastWarnedAt = now;
+
+		// Automatically upload replays as evidence/reference to the punishment
+		if (globalWarn && room.battle) this.parse('/savereplay forpunishment');
 	},
 	warnhelp: [`/warn OR /k [username], [reason] - Warns a user showing them the Pok\u00e9mon Showdown Rules and [reason] in an overlay. Requires: % @ # & ~`],
 

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4151,7 +4151,6 @@ const commands = {
 		}
 
 		const forPunishment = target === 'forpunishment';
-		if (forPunishment && !this.can('lock')) return false;
 
 		const battle = room.battle;
 		// retrieve spectator log (0) if there are privacy concerns

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -679,6 +679,12 @@ export const Punishments = new class {
 		const ipStr = typeof user !== 'string' ? ` [${(user as User).latestIp}]` : '';
 		const roomid = typeof room !== 'string' ? (room as Room).roomid : room;
 		Rooms.global.modlog(`(${roomid}) AUTO${namelock ? `NAME` : ''}LOCK: [${userid}]${ipStr}: ${reason}`);
+
+		const roomObject = Rooms.get(room);
+		const userObject = Users.get(user);
+		if (roomObject && roomObject.battle && userObject && userObject.connections[0]) {
+			Chat.parse('/savereplay', roomObject, userObject, userObject.connections[0]);
+		}
 	}
 	unlock(name: string) {
 		const user = Users.get(name);

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -683,7 +683,7 @@ export const Punishments = new class {
 		const roomObject = Rooms.get(room);
 		const userObject = Users.get(user);
 		if (roomObject && roomObject.battle && userObject && userObject.connections[0]) {
-			Chat.parse('/savereplay', roomObject, userObject, userObject.connections[0]);
+			Chat.parse('/savereplay forpunishment', roomObject, userObject, userObject.connections[0]);
 		}
 	}
 	unlock(name: string) {


### PR DESCRIPTION
There is of course the problem that the savereplay command requires a user, which does not mesh well with the concept of an autolock. Current convention seems to be to just use the user who is getting locked, which works, but means they'll get the replay sent to them with the popup and all. I don't really like that but I'm not sure what else to do.