### PR TITLE
Allow loading chat plugins from subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /logs/*
 /node_modules
 /eslint-cache
+/server/chat-plugins/private/*
 /server/chat-plugins/private.js
 /server/chat-plugins/*-private.js
 npm-debug.log

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -400,7 +400,7 @@ class FSPath {
 		return fs.statSync(this.path).isFile();
 	}
 
-	async isDir(): Promise<boolean> {
+	async isDirectory(): Promise<boolean> {
 		return new Promise((resolve, reject) => {
 			fs.stat(this.path, (err, stats) => {
 				err ? reject(err) : resolve(stats.isDirectory());
@@ -408,7 +408,7 @@ class FSPath {
 		});
 	}
 
-	isDirSync(): boolean {
+	isDirectorySync(): boolean {
 		return fs.statSync(this.path).isDirectory();
 	}
 }

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -388,27 +388,27 @@ class FSPath {
 		fs.unwatchFile(this.path);
 	}
 
-	async isFile(): Promise<boolean> {
-		return new Promise((resolve, reject) => {
+	async isFile() {
+		return new Promise<boolean>((resolve, reject) => {
 			fs.stat(this.path, (err, stats) => {
 				err ? reject(err) : resolve(stats.isFile());
 			});
 		});
 	}
 
-	isFileSync(): boolean {
+	isFileSync() {
 		return fs.statSync(this.path).isFile();
 	}
 
-	async isDirectory(): Promise<boolean> {
-		return new Promise((resolve, reject) => {
+	async isDirectory() {
+		return new Promise<boolean>((resolve, reject) => {
 			fs.stat(this.path, (err, stats) => {
 				err ? reject(err) : resolve(stats.isDirectory());
 			});
 		});
 	}
 
-	isDirectorySync(): boolean {
+	isDirectorySync() {
 		return fs.statSync(this.path).isDirectory();
 	}
 }

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -387,6 +387,30 @@ class FSPath {
 	unwatch() {
 		fs.unwatchFile(this.path);
 	}
+
+	async isFile(): Promise<boolean> {
+		return new Promise((resolve, reject) => {
+			fs.stat(this.path, (err, stats) => {
+				err ? reject(err) : resolve(stats.isFile());
+			});
+		});
+	}
+
+	isFileSync(): boolean {
+		return fs.statSync(this.path).isFile();
+	}
+
+	async isDir(): Promise<boolean> {
+		return new Promise((resolve, reject) => {
+			fs.stat(this.path, (err, stats) => {
+				err ? reject(err) : resolve(stats.isDirectory());
+			});
+		});
+	}
+
+	isDirSync(): boolean {
+		return fs.statSync(this.path).isDirectory();
+	}
 }
 
 class FileReadStream extends ReadStream {


### PR DESCRIPTION
As requested by @scheibo. This looks through all files in all subdirectories and tries to load them as chat plugins. I excluded hidden directories so it doesn't bother looking through .git in the case that someone checks out a chat plugin from a separate repository here.