### PR TITLE
Fix duplicate globalModlog entries in some cases

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -665,7 +665,7 @@ export class CommandContext extends MessageContext {
 		buf += note.replace(/\n/gm, ' ');
 
 		Rooms.global.modlog(buf);
-		this.room.modlog(buf);
+		if (this.room !== Rooms.global) this.room.modlog(buf);
 	}
 	modlog(
 		action: string,


### PR DESCRIPTION
Stops globalModlog from duplicating entries in the global modlog in specific cases.