### PR TITLE
SSB: Fixes Pirate Princess's Tea Break vs Substitute

### DIFF
--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -3319,7 +3319,7 @@ let BattleMovedex = {
 		name: "Tea Break",
 		pp: 5,
 		priority: 0,
-		flags: {protect: 1},
+		flags: {protect: 1, authentic: 1},
 		sleepUsable: true,
 		onTryMove(pokemon) {
 			this.attrLastMove('[still]');


### PR DESCRIPTION
Fails currently if opponent's Substitute is up.  This allows it to still attempt to use the 4 moves.