### PR TITLE
Centralise invulnerability checks for No Guard and Lock On

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2170,6 +2170,10 @@ let BattleAbilities = {
 	},
 	"noguard": {
 		shortDesc: "Every move used by or against this Pokemon will always hit.",
+		onAnyInvulnerabilityPriority: 1,
+		onAnyInvulnerability(target, source, move) {
+			if (move && (source === this.effectData.target || target === this.effectData.target)) return 0;
+		},
 		onAnyAccuracy(accuracy, target, source, move) {
 			if (move && (source === this.effectData.target || target === this.effectData.target)) {
 				return true;

--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -258,7 +258,7 @@ let BattleScripts = {
 
 		// First, check if the target is semi-invulnerable
 		let hitResult = this.runEvent('Invulnerability', target, pokemon, move);
-		if (!hitResult) {
+		if (hitResult === false) {
 			if (!move.spreadHit) this.attrLastMove('[miss]');
 			this.add('-miss', pokemon);
 			return false;

--- a/data/mods/gen2/moves.js
+++ b/data/mods/gen2/moves.js
@@ -461,6 +461,12 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "The next accuracy check against the target succeeds. The target will still avoid Earthquake, Fissure, and Magnitude if it is using Fly. If the target leaves the field using Baton Pass, the replacement remains under this effect. This effect ends when the target leaves the field or an accuracy check is done against it.",
 		shortDesc: "The next move will not miss the target.",
+		effect: {
+			duration: 2,
+			onSourceAccuracy(accuracy, target, source, move) {
+				if (move && source === this.effectData.target && target === this.effectData.source) return true;
+			},
+		},
 	},
 	lowkick: {
 		inherit: true,

--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -168,7 +168,7 @@ let BattleScripts = {
 		}
 
 		hitResult = this.runEvent('Invulnerability', target, pokemon, move);
-		if (!hitResult) {
+		if (hitResult === false) {
 			if (!move.spreadHit) this.attrLastMove('[miss]');
 			this.add('-miss', pokemon);
 			return false;

--- a/data/mods/gen3/scripts.js
+++ b/data/mods/gen3/scripts.js
@@ -198,7 +198,7 @@ let BattleScripts = {
 		}
 
 		hitResult = this.runEvent('Invulnerability', target, pokemon, move);
-		if (!hitResult) {
+		if (hitResult === false) {
 			if (!move.spreadHit) this.attrLastMove('[miss]');
 			this.add('-miss', pokemon, target);
 			return false;

--- a/data/mods/gen4/moves.js
+++ b/data/mods/gen4/moves.js
@@ -932,6 +932,16 @@ let BattleMovedex = {
 	lockon: {
 		inherit: true,
 		desc: "Until the end of the next turn, the target cannot avoid the user's moves, even if the target is in the middle of a two-turn move. When this effect is started against the target, this and Mind Reader's effects end for every other Pokemon against that target. If the target leaves the field using Baton Pass, the replacement remains under this effect. If the user leaves the field using Baton Pass, this effect is restarted against the same target for the replacement. The effect ends if either the user or the target leaves the field.",
+		effect: {
+			duration: 2,
+			onSourceInvulnerabilityPriority: 1,
+			onSourceInvulnerability(target, source, move) {
+				if (move && source === this.effectData.target && target === this.effectData.source) return 0;
+			},
+			onSourceAccuracy(accuracy, target, source, move) {
+				if (move && source === this.effectData.target && target === this.effectData.source) return true;
+			},
+		},
 	},
 	luckychant: {
 		inherit: true,

--- a/data/mods/gen4/scripts.js
+++ b/data/mods/gen4/scripts.js
@@ -93,11 +93,10 @@ let BattleScripts = {
 	hitStepInvulnerabilityEvent(targets, pokemon, move) {
 		const hitResults = this.runEvent('Invulnerability', targets, pokemon, move);
 		for (const [i, target] of targets.entries()) {
-			if (!hitResults[i]) {
+			if (hitResults[i] === false) {
 				this.attrLastMove('[miss]');
 				this.add('-miss', pokemon, target);
 			}
-			hitResults[i] = hitResults[i] || false;
 		}
 		return hitResults;
 	},

--- a/data/mods/gen5/moves.js
+++ b/data/mods/gen5/moves.js
@@ -127,10 +127,6 @@ let BattleMovedex = {
 				if (['gust', 'twister', 'skyuppercut', 'thunder', 'hurricane', 'smackdown', 'thousandarrows', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				return false;
 			},
 		},
@@ -246,10 +242,6 @@ let BattleMovedex = {
 				if (['earthquake', 'magnitude', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				return false;
 			},
 		},
@@ -261,10 +253,6 @@ let BattleMovedex = {
 				if (['surf', 'whirlpool', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				return false;
 			},
 		},
@@ -356,10 +344,6 @@ let BattleMovedex = {
 				if (['gust', 'twister', 'skyuppercut', 'thunder', 'hurricane', 'smackdown', 'thousandarrows', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				return false;
 			},
 		},
@@ -944,10 +928,6 @@ let BattleMovedex = {
 				if (move.id === 'helpinghand') {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				return false;
 			},
 		},
@@ -1014,10 +994,6 @@ let BattleMovedex = {
 				if (['gust', 'twister', 'skyuppercut', 'thunder', 'hurricane', 'smackdown', 'thousandarrows', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				return false;
 			},
 		},

--- a/data/moves.js
+++ b/data/moves.js
@@ -1652,10 +1652,6 @@ let BattleMovedex = {
 				if (['gust', 'twister', 'skyuppercut', 'thunder', 'hurricane', 'smackdown', 'thousandarrows', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				if (move.id === 'toxic' && source.hasType('Poison')) return;
 				return false;
 			},
@@ -3402,10 +3398,6 @@ let BattleMovedex = {
 				if (['earthquake', 'magnitude', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				if (move.id === 'toxic' && source.hasType('Poison')) return;
 				return false;
 			},
@@ -3568,10 +3560,6 @@ let BattleMovedex = {
 				if (['surf', 'whirlpool', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				if (move.id === 'toxic' && source.hasType('Poison')) return;
 				return false;
 			},
@@ -5661,10 +5649,6 @@ let BattleMovedex = {
 				if (['gust', 'twister', 'skyuppercut', 'thunder', 'hurricane', 'smackdown', 'thousandarrows', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				if (move.id === 'toxic' && source.hasType('Poison')) return;
 				return false;
 			},
@@ -9470,6 +9454,10 @@ let BattleMovedex = {
 		effect: {
 			noCopy: true, // doesn't get copied by Baton Pass
 			duration: 2,
+			onSourceInvulnerabilityPriority: 1,
+			onSourceInvulnerability(target, source, move) {
+				if (move && source === this.effectData.target && target === this.effectData.source) return 0;
+			},
 			onSourceAccuracy(accuracy, target, source, move) {
 				if (move && source === this.effectData.target && target === this.effectData.source) return true;
 			},
@@ -11860,10 +11848,6 @@ let BattleMovedex = {
 				if (move.id === 'helpinghand') {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				if (move.id === 'toxic' && source.hasType('Poison')) return;
 				return false;
 			},
@@ -14649,10 +14633,6 @@ let BattleMovedex = {
 				if (move.id === 'helpinghand') {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				if (move.id === 'toxic' && source.hasType('Poison')) return;
 				return false;
 			},
@@ -15285,10 +15265,6 @@ let BattleMovedex = {
 				if (['gust', 'twister', 'skyuppercut', 'thunder', 'hurricane', 'smackdown', 'thousandarrows', 'helpinghand'].includes(move.id)) {
 					return;
 				}
-				if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
-					return;
-				}
-				if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;
 				if (move.id === 'toxic' && source.hasType('Poison')) return;
 				return false;
 			},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -362,8 +362,6 @@ let BattleScripts = {
 			if (hitResults[i] === false) {
 				if (!move.spreadHit) this.attrLastMove('[miss]');
 				this.add('-miss', pokemon, target);
-			} else {
-				hitResults[i] = hitResults[i] || false;
 			}
 		}
 		return hitResults;

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -244,7 +244,7 @@ interface EventMethods {
 	onTryHit?: MoveEventMethods['onTryHit']
 	onTryHitField?: MoveEventMethods['onTryHitField']
 	onTryHitSide?: CommonHandlers['ResultMove']
-	onInvulnerability?: CommonHandlers['ResultMove']
+	onInvulnerability?: CommonHandlers['ExtResultMove']
 	onTryMove?: MoveEventMethods['onTryMove']
 	onTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => boolean | null | number | void
 	onType?: (this: Battle, types: string[], pokemon: Pokemon) => string[] | void
@@ -327,7 +327,7 @@ interface EventMethods {
 	onAllyTryHit?: MoveEventMethods['onTryHit']
 	onAllyTryHitField?: MoveEventMethods['onTryHitField']
 	onAllyTryHitSide?: CommonHandlers['ResultMove']
-	onAllyInvulnerability?: CommonHandlers['ResultMove']
+	onAllyInvulnerability?: CommonHandlers['ExtResultMove']
 	onAllyTryMove?: MoveEventMethods['onTryMove']
 	onAllyTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => boolean | null | number | void
 	onAllyType?: (this: Battle, types: string[], pokemon: Pokemon) => string[] | void
@@ -410,7 +410,7 @@ interface EventMethods {
 	onFoeTryHit?: MoveEventMethods['onTryHit']
 	onFoeTryHitField?: MoveEventMethods['onTryHitField']
 	onFoeTryHitSide?: CommonHandlers['ResultMove']
-	onFoeInvulnerability?: CommonHandlers['ResultMove']
+	onFoeInvulnerability?: CommonHandlers['ExtResultMove']
 	onFoeTryMove?: MoveEventMethods['onTryMove']
 	onFoeTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => boolean | null | number | void
 	onFoeType?: (this: Battle, types: string[], pokemon: Pokemon) => string[] | void
@@ -493,7 +493,7 @@ interface EventMethods {
 	onSourceTryHit?: MoveEventMethods['onTryHit']
 	onSourceTryHitField?: MoveEventMethods['onTryHitField']
 	onSourceTryHitSide?: CommonHandlers['ResultMove']
-	onSourceInvulnerability?: CommonHandlers['ResultMove']
+	onSourceInvulnerability?: CommonHandlers['ExtResultMove']
 	onSourceTryMove?: MoveEventMethods['onTryMove']
 	onSourceTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => boolean | null | number | void
 	onSourceType?: (this: Battle, types: string[], pokemon: Pokemon) => string[] | void
@@ -576,7 +576,7 @@ interface EventMethods {
 	onAnyTryHit?: MoveEventMethods['onTryHit']
 	onAnyTryHitField?: MoveEventMethods['onTryHitField']
 	onAnyTryHitSide?: CommonHandlers['ResultMove']
-	onAnyInvulnerability?: CommonHandlers['ResultMove']
+	onAnyInvulnerability?: CommonHandlers['ExtResultMove']
 	onAnyTryMove?: MoveEventMethods['onTryMove']
 	onAnyTryPrimaryHit?: (this: Battle, target: Pokemon, source: Pokemon, move: ActiveMove) => boolean | null | number | void
 	onAnyType?: (this: Battle, types: string[], pokemon: Pokemon) => string[] | void
@@ -593,6 +593,7 @@ interface EventMethods {
 	onAfterMoveSecondarySelfPriority?: number
 	onAfterMoveSelfPriority?: number
 	onAnyBasePowerPriority?: number
+	onAnyInvulnerabilityPriority?: number
 	onAnyFaintPriority?: number
 	onAllyBasePowerPriority?: number
 	onAllyModifyAtkPriority?: number
@@ -623,6 +624,7 @@ interface EventMethods {
 	onResidualPriority?: number
 	onResidualSubOrder?: number
 	onSourceBasePowerPriority?: number
+	onSourceInvulnerabilityPriority?: number
 	onSourceModifyAtkPriority?: number
 	onSourceModifySpAPriority?: number
 	onSwitchInPriority?: number


### PR DESCRIPTION
    if (source.hasAbility('noguard') || target.hasAbility('noguard')) {
       return;
    }
    if (source.volatiles['lockon'] && target === source.volatiles['lockon'].source) return;

Rather than copy/pasting this code block for every semi-invulnerability move, I thought that perhaps the tests could all be done centrally (except for Gen 2, which is a special snowflake), so I made a zero return from `onInvulnerability` mean not invulnerable due to No Guard or Lock On, while false continues to mean semi-invulnerable and true means neither of the above.

I wasn't sure what was going on with Lock On in Gen 4 though; the description differs from later gens in that Baton Pass is not specifically exempted, but there's no relevant code change? I added one in, but...