### PR TITLE
Fix activation of Defiant and Competitive when boosts are maxed

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -476,6 +476,7 @@ let BattleAbilities = {
 				}
 			}
 			if (statsLowered) {
+				this.add('-ability', target, 'Competitive');
 				this.boost({spa: 2}, target, target, null, true);
 			}
 		},
@@ -647,6 +648,7 @@ let BattleAbilities = {
 				}
 			}
 			if (statsLowered) {
+				this.add('-ability', target, 'Defiant');
 				this.boost({atk: 2}, target, target, null, true);
 			}
 		},
@@ -1582,7 +1584,7 @@ let BattleAbilities = {
 				if (target.volatiles['substitute']) {
 					this.add('-immune', target);
 				} else {
-					this.boost({atk: -1}, target, pokemon);
+					this.boost({atk: -1}, target, pokemon, null, true);
 				}
 			}
 		},
@@ -3589,7 +3591,7 @@ let BattleAbilities = {
 		onAfterDamage(damage, target, source, effect) {
 			if (effect && effect.flags['contact']) {
 				this.add('-ability', target, 'Tangling Hair');
-				this.boost({spe: -1}, source, target, null, false, true);
+				this.boost({spe: -1}, source, target, null, true);
 			}
 		},
 		id: "tanglinghair",

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1583,7 +1583,7 @@ export class Battle {
 		if (this.gen > 5 && !target.side.foe.pokemonLeft) return false;
 		boost = this.runEvent('Boost', target, source, effect, Object.assign({}, boost));
 		let success = null;
-		let boosted = false;
+		let boosted = isSecondary;
 		let boostName: BoostName;
 		for (boostName in boost) {
 			const currentBoost: SparseBoostsTable = {};
@@ -1603,9 +1603,6 @@ export class Battle {
 				case 'bellydrum2':
 					this.add(msg, target, boostName, boostBy, '[silent]');
 					this.hint("In Gen 2, Belly Drum boosts by 2 when it fails.");
-					break;
-				case 'intimidate': case 'gooey': case 'tanglinghair':
-					this.add(msg, target, boostName, boostBy);
 					break;
 				case 'zpower':
 					this.add(msg, target, boostName, boostBy, '[zeffect]');


### PR DESCRIPTION
Currently if you're already at `+6` when your Defiant or Competitive activates, you do get the "[POKEMON]'s [STAT] won't go any higher!" message, but without the Defiant or Competitive activation that showed why the stat tried to rise.

Compare Gooey which shows the activation and then the stat change, whether it succeeds or fails. It is granted a special case in the `boost` function to avoid the ability activation therein allowing it to enforce it prior to the invocation (necessary for Clear Body to function), so I could have just copied that hack for Defiant and Competitive.

But rather than having more special cases, I thought it was better to use the flag that Gooey was already passing in to `boost` to get special behaviour in the failure case and grant all the relevant Abilities special behaviour in the success case too.

Tangling Hair is a clone of Gooey, and so should be passing the same parameters to `boost`. I didn't bother to check how the invalid parameters make it misbehave. The change allows the removal of its special case from `boost` too.

Intimidate is supposed to display the "won't go any lower!" message if the victim is already at -6. I added the Gooey flag to fix that and this also allows the removal of its special case from `boost`.