### PR TITLE
Add a single event for a move's own immunity to a specific target

### DIFF
--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -271,6 +271,11 @@ let BattleScripts = {
 			}
 			return false;
 		}
+		hitResult = this.singleEvent('TryImmunity', move, null, target, pokemon, move);
+		if (hitResult === false) {
+			this.add('-immune', pokemon);
+			return false;
+		}
 
 		// Now, let's calculate the accuracy.
 		/** @type {number | true} */

--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -182,6 +182,12 @@ let BattleScripts = {
 			return false;
 		}
 
+		hitResult = this.singleEvent('TryImmunity', move, {}, target, pokemon, move);
+		if (hitResult === false) {
+			this.add('-immune', pokemon);
+			return false;
+		}
+
 		hitResult = this.runEvent('TryHit', target, pokemon, move);
 		if (!hitResult) {
 			if (hitResult === false) this.add('-fail', target);

--- a/data/mods/gen3/scripts.js
+++ b/data/mods/gen3/scripts.js
@@ -210,6 +210,11 @@ let BattleScripts = {
 
 		if ((!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) && !target.runImmunity(move.type)) {
 			naturalImmunity = true;
+		} else {
+			hitResult = this.singleEvent('TryImmunity', move, {}, target, pokemon, move);
+			if (hitResult === false) {
+				naturalImmunity = true;
+			}
 		}
 
 		let boostTable = [1, 4 / 3, 5 / 3, 2, 7 / 3, 8 / 3, 3];

--- a/data/mods/gen4/moves.js
+++ b/data/mods/gen4/moves.js
@@ -488,11 +488,8 @@ let BattleMovedex = {
 	dreameater: {
 		inherit: true,
 		desc: "The target is unaffected by this move unless it is asleep and does not have a substitute. The user recovers 1/2 the HP lost by the target, rounded down, but not less than 1 HP. If Big Root is held by the user, the HP recovered is 1.3x normal, rounded down.",
-		onTryHit(target) {
-			if (target.status !== 'slp' || target.volatiles['substitute']) {
-				this.add('-immune', target);
-				return null;
-			}
+		onTryImmunity(target) {
+			return target.status === 'slp' && !target.volatiles['substitute'];
 		},
 	},
 	earthquake: {

--- a/data/moves.js
+++ b/data/moves.js
@@ -2102,11 +2102,8 @@ let BattleMovedex = {
 		pp: 20,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
-		onTryHit(pokemon, source) {
-			if ((pokemon.gender === 'M' && source.gender === 'F') || (pokemon.gender === 'F' && source.gender === 'M')) {
-				return;
-			}
-			return false;
+		onTryImmunity(pokemon, source) {
+			return (pokemon.gender === 'M' && source.gender === 'F') || (pokemon.gender === 'F' && source.gender === 'M');
 		},
 		boosts: {
 			spa: -2,
@@ -4015,11 +4012,8 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, heal: 1},
 		drain: [1, 2],
-		onTryHit(target) {
-			if (target.status !== 'slp' && !target.hasAbility('comatose')) {
-				this.add('-immune', target);
-				return null;
-			}
+		onTryImmunity(target) {
+			return target.status === 'slp' || target.hasAbility('comatose');
 		},
 		secondary: null,
 		target: "normal",
@@ -4510,11 +4504,8 @@ let BattleMovedex = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onTry(pokemon, target) {
-			if (pokemon.hp >= target.hp) {
-				this.add('-immune', target);
-				return null;
-			}
+		onTryImmunity(target, pokemon) {
+			return pokemon.hp < target.hp;
 		},
 		secondary: null,
 		target: "normal",
@@ -9248,11 +9239,8 @@ let BattleMovedex = {
 				}
 			},
 		},
-		onTryHit(target) {
-			if (target.hasType('Grass')) {
-				this.add('-immune', target);
-				return null;
-			}
+		onTryImmunity(target) {
+			return !target.hasType('Grass');
 		},
 		secondary: null,
 		target: "normal",
@@ -17189,11 +17177,8 @@ let BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, mystery: 1},
-		onTryHit(target) {
-			if (target.hasAbility('stickyhold')) {
-				this.add('-immune', target);
-				return null;
-			}
+		onTryImmunity(target) {
+			return !target.hasAbility('stickyhold');
 		},
 		onHit(target, source, move) {
 			let yourItem = target.takeItem(source);
@@ -17262,11 +17247,8 @@ let BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		onTryHit(target, source) {
-			if (!target.hasType(source.getTypes())) {
-				this.add('-immune', target);
-				return null;
-			}
+		onTryImmunity(target, source) {
+			return target.hasType(source.getTypes());
 		},
 		secondary: null,
 		target: "allAdjacent",
@@ -18172,11 +18154,8 @@ let BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, mystery: 1},
-		onTryHit(target) {
-			if (target.hasAbility('stickyhold')) {
-				this.add('-immune', target);
-				return null;
-			}
+		onTryImmunity(target) {
+			return !target.hasAbility('stickyhold');
 		},
 		onHit(target, source, move) {
 			let yourItem = target.takeItem(source);

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -282,31 +282,25 @@ let BattleScripts = {
 			// 0. check for semi invulnerability
 			this.hitStepInvulnerabilityEvent,
 
-			// 1. run the 'TryHit' event (Protect, Magic Bounce, Volt Absorb, etc.) (this is step 2 in gens 5 & 6, and step 5 in gen 4)
+			// 1. run the 'TryHit' event (Protect, Magic Bounce, Volt Absorb, etc.) (this is step 2 in gens 5 & 6, and step 4 in gen 4)
 			this.hitStepTryHitEvent,
 
 			// 2. check for type immunity (this is step 1 in gens 4-6)
 			this.hitStepTypeImmunity,
 
-			// 3. check for powder immunity (gen 6+ only)
-			this.hitStepPowderImmunity,
+			// 3. check for various move-specific immunities
+			this.hitStepTryImmunity,
 
-			// 4. check for move-specific immunity
-			this.hitStepTryImmunityEvent,
-
-			// 5. check for prankster immunity (gen 7+ only)
-			this.hitStepPranksterImmunity,
-
-			// 6. check accuracy
+			// 4. check accuracy
 			this.hitStepAccuracy,
 
-			// 7. break protection effects
+			// 5. break protection effects
 			this.hitStepBreakProtect,
 
-			// 8. steal positive boosts (Spectral Thief)
+			// 6. steal positive boosts (Spectral Thief)
 			this.hitStepStealBoosts,
 
-			// 9. loop that processes each hit of the move (has its own steps per iteration)
+			// 7. loop that processes each hit of the move (has its own steps per iteration)
 			this.hitStepMoveHitLoop,
 		];
 		if (this.gen <= 6) {
@@ -314,8 +308,8 @@ let BattleScripts = {
 			[moveSteps[1], moveSteps[2]] = [moveSteps[2], moveSteps[1]];
 		}
 		if (this.gen === 4) {
-			// Swap step 6 with new step 2 (old step 1)
-			[moveSteps[2], moveSteps[6]] = [moveSteps[6], moveSteps[2]];
+			// Swap step 4 with new step 2 (old step 1)
+			[moveSteps[2], moveSteps[4]] = [moveSteps[4], moveSteps[2]];
 		}
 
 		this.setActiveMove(move, pokemon, targets[0]);
@@ -392,51 +386,17 @@ let BattleScripts = {
 
 		return hitResults;
 	},
-	hitStepPowderImmunity(targets, pokemon, move) {
+	hitStepTryImmunity(targets, pokemon, move) {
 		const hitResults = [];
-		if (!move.flags['powder']) {
-			for (let i = 0; i < targets.length; i++) {
-				hitResults[i] = true;
-			}
-			return hitResults;
-		}
 		for (let [i, target] of targets.entries()) {
-			if (target !== pokemon && !this.dex.getImmunity('powder', target)) {
+			if (this.gen >= 6 && move.flags['powder'] && target !== pokemon && !this.dex.getImmunity('powder', target)) {
 				this.debug('natural powder immunity');
 				this.add('-immune', target);
 				hitResults[i] = false;
-			} else {
-				hitResults[i] = true;
-			}
-		}
-		return hitResults;
-	},
-	hitStepTryImmunityEvent(targets, pokemon, move) {
-		const hitResults = [];
-		if (!move.onTryImmunity) {
-			for (let i = 0; i < targets.length; i++) {
-				hitResults[i] = true;
-			}
-			return hitResults;
-		}
-		for (let [i, target] of targets.entries()) {
-			hitResults[i] = this.singleEvent('TryImmunity', move, {}, target, pokemon, move);
-			if (!hitResults[i]) {
+			} else if (!this.singleEvent('TryImmunity', move, {}, target, pokemon, move)) {
 				this.add('-immune', target);
-			}
-		}
-		return hitResults;
-	},
-	hitStepPranksterImmunity(targets, pokemon, move) {
-		const hitResults = [];
-		if (this.gen < 7 || !move.pranksterBoosted || !pokemon.hasAbility('prankster')) {
-			for (let i = 0; i < targets.length; i++) {
-				hitResults[i] = true;
-			}
-			return hitResults;
-		}
-		for (let [i, target] of targets.entries()) {
-			if (targets[i].side !== pokemon.side && !this.dex.getImmunity('prankster', target)) {
+				hitResults[i] = false;
+			} else if (this.gen >= 7 && move.pranksterBoosted && pokemon.hasAbility('prankster') && targets[i].side !== pokemon.side && !this.dex.getImmunity('prankster', target)) {
 				this.debug('natural prankster immunity');
 				if (!target.illusion) this.hint("In gen 7, Dark is immune to Prankster moves.");
 				this.add('-immune', target);

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -291,19 +291,22 @@ let BattleScripts = {
 			// 3. check for powder immunity (gen 6+ only)
 			this.hitStepPowderImmunity,
 
-			// 4. check for prankster immunity (gen 6+ only)
+			// 4. check for move-specific immunity
+			this.hitStepTryImmunityEvent,
+
+			// 5. check for prankster immunity (gen 7+ only)
 			this.hitStepPranksterImmunity,
 
-			// 5. check accuracy
+			// 6. check accuracy
 			this.hitStepAccuracy,
 
-			// 6. break protection effects
+			// 7. break protection effects
 			this.hitStepBreakProtect,
 
-			// 7. steal positive boosts (Spectral Thief)
+			// 8. steal positive boosts (Spectral Thief)
 			this.hitStepStealBoosts,
 
-			// 8. loop that processes each hit of the move (has its own steps per iteration)
+			// 9. loop that processes each hit of the move (has its own steps per iteration)
 			this.hitStepMoveHitLoop,
 		];
 		if (this.gen <= 6) {
@@ -311,8 +314,8 @@ let BattleScripts = {
 			[moveSteps[1], moveSteps[2]] = [moveSteps[2], moveSteps[1]];
 		}
 		if (this.gen === 4) {
-			// Swap step 5 with new step 2 (old step 1)
-			[moveSteps[2], moveSteps[5]] = [moveSteps[5], moveSteps[2]];
+			// Swap step 6 with new step 2 (old step 1)
+			[moveSteps[2], moveSteps[6]] = [moveSteps[6], moveSteps[2]];
 		}
 
 		this.setActiveMove(move, pokemon, targets[0]);
@@ -404,6 +407,22 @@ let BattleScripts = {
 				hitResults[i] = false;
 			} else {
 				hitResults[i] = true;
+			}
+		}
+		return hitResults;
+	},
+	hitStepTryImmunityEvent(targets, pokemon, move) {
+		const hitResults = [];
+		if (!move.onTryImmunity) {
+			for (let i = 0; i < targets.length; i++) {
+				hitResults[i] = true;
+			}
+			return hitResults;
+		}
+		for (let [i, target] of targets.entries()) {
+			hitResults[i] = this.singleEvent('TryImmunity', move, {}, target, pokemon, move);
+			if (!hitResults[i]) {
+				this.add('-immune', target);
 			}
 		}
 		return hitResults;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3137,6 +3137,10 @@ export class Battle {
 		throw new UnimplementedError('hitStepPowderImmunity');
 	}
 
+	hitStepTryImmunityEvent(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove): boolean[] {
+		throw new UnimplementedError('hitStepTryImmunityEvent');
+	}
+
 	hitStepPranksterImmunity(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove): boolean[] {
 		throw new UnimplementedError('hitStepPranksterImmunity');
 	}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3133,16 +3133,8 @@ export class Battle {
 		throw new UnimplementedError('hitStepMoveHitLoop');
 	}
 
-	hitStepPowderImmunity(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove): boolean[] {
-		throw new UnimplementedError('hitStepPowderImmunity');
-	}
-
-	hitStepTryImmunityEvent(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove): boolean[] {
+	hitStepTryImmunity(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove): boolean[] {
 		throw new UnimplementedError('hitStepTryImmunityEvent');
-	}
-
-	hitStepPranksterImmunity(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove): boolean[] {
-		throw new UnimplementedError('hitStepPranksterImmunity');
 	}
 
 	hitStepStealBoosts(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove): undefined {

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1047,9 +1047,7 @@ interface BattleScriptsData {
 	hitStepAccuracy?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
 	hitStepBreakProtect?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => undefined
 	hitStepMoveHitLoop?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => SpreadMoveDamage
-	hitStepPowderImmunity?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
-	hitStepTryImmunityEvent?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
-	hitStepPranksterImmunity?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
+	hitStepTryImmunity?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
 	hitStepStealBoosts?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => undefined
 	hitStepTryHitEvent?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => (boolean | '')[]
 	hitStepInvulnerabilityEvent?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -157,6 +157,7 @@ interface MoveEventMethods {
 	onTryHit?: CommonHandlers['ExtResultSourceMove']
 	onTryHitField?: CommonHandlers['ResultMove']
 	onTryHitSide?: (this: Battle, side: Side, source: Pokemon, move: ActiveMove) => boolean | null | "" | void
+	onTryImmunity?: CommonHandlers['ResultMove']
 	onTryMove?: CommonHandlers['ResultSourceMove']
 	onUseMoveMessage?: CommonHandlers['VoidSourceMove']
 }
@@ -1047,6 +1048,7 @@ interface BattleScriptsData {
 	hitStepBreakProtect?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => undefined
 	hitStepMoveHitLoop?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => SpreadMoveDamage
 	hitStepPowderImmunity?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
+	hitStepTryImmunityEvent?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
 	hitStepPranksterImmunity?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
 	hitStepStealBoosts?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => undefined
 	hitStepTryHitEvent?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => (boolean | '')[]


### PR DESCRIPTION
Captivate, Dream Eater, Leech Seed and Synchronoise have a target-specific immunity calculation. These moves used to use the `TryHit` event, as this used to run once per target. However, this does not properly recreate cart mechanics, as the check should happen before the accuracy check. Additionally, the spread move effect order refactor (#5216) changed the mechanics of the `TryHit` event so that it only runs once (for the first target) thus breaking Captivate and Synchronoise.

This new `TryImmunity` (or I guess you want it just called `Immunity` right?) event allows the move to veto each target independently by returning `false` for immune targets. This also avoids having to specifically add the `-immune` message in each of those moves.