### PR TITLE
Don't escape HTML for tour names

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1331,7 +1331,7 @@ const commands: {basic: TourCommands, creation: TourCommands, moderation: TourCo
 			}
 			let name = this.canTalk(params[0].trim());
 			if (!name || typeof name !== 'string') return;
-			name = Chat.escapeHTML(name);
+
 			if (name.length > MAX_CUSTOM_NAME_LENGTH) {
 				return this.errorReply(`The tournament's name cannot exceed ${MAX_CUSTOM_NAME_LENGTH} characters.`);
 			}


### PR DESCRIPTION
The client already does this, and doing it twice causes `[Gen 7 Let&apos;s Go] OU Single Elimination Tournament!` this, which doesn't seem necessary