### PR TITLE
Take steps to statically type Config

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -83,7 +83,8 @@ Main's SSL deploy script from Let's Encrypt looks like:
  *   This can be either false (meaning not to trust any proxies) or an array
  *   of strings. Each string should be either an IP address or a subnet given
  *   in CIDR notation. You should usually leave this as `false` unless you
- *   know what you are doing.
+ *   know what you are doing
+ * @type {false | string[]}.
  */
 exports.proxyip = false;
 
@@ -255,14 +256,17 @@ exports.restrictLinks = false;
 
 /**
   * chat modchat - default minimum group for speaking in chatrooms; changeable with /modchat
+  * @type {false | string}
  */
 exports.chatmodchat = false;
 /**
  * battle modchat - default minimum group for speaking in battles; changeable with /modchat
+ * @type {false | string}
  */
 exports.battlemodchat = false;
 /**
  * pm modchat - minimum group for PMing other users, challenging other users
+ * @type {false | string}
  */
 exports.pmmodchat = false;
 /**
@@ -412,7 +416,7 @@ exports.forcedpublicprefixes = [];
 
 /**
  * permissions and groups:
- *   Each entry in `grouplist' is a seperate group. Some of the members are "special"
+ *   Each entry in `grouplist` is a seperate group. Some of the members are "special"
  *     while the rest is just a normal permission.
  *   The order of the groups determines their ranking.
  *   The special members are as follows:

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -1,5 +1,7 @@
 type ChildProcess = import('child_process').ChildProcess;
 
+type Config = typeof import('../config/config-example') & AnyObject;
+
 // Chat
 type CommandContext = Chat.CommandContext;
 type PageContext = Chat.PageContext;

--- a/server/global-variables.d.ts
+++ b/server/global-variables.d.ts
@@ -6,6 +6,8 @@ import * as TeamValidatorAsyncType from './team-validator-async';
 import * as UsersType from './users';
 import * as VerifierType from './verifier';
 
+import * as ConfigType from "../config/config-example";
+
 import * as StreamsType from '../lib/streams';
 
 import {IPTools as IPToolsType} from './ip-tools';
@@ -24,7 +26,7 @@ declare global {
 			__version: {head: string, origin?: string, tree?: string};
 		}
 	}
-	const Config: AnyObject;
+	const Config: typeof ConfigType & AnyObject;
 	const Chat: typeof ChatType.Chat;
 	const IPTools: typeof IPToolsType;
 	const Ladders: typeof LaddersType

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1431,7 +1431,7 @@ export class GameRoom extends BasicChatRoom {
 		options.reportJoins = !!Config.reportbattlejoins;
 		options.batchJoins = 0;
 		super(roomid, title, options);
-		this.modchat = (Config.battlemodchat || false);
+		this.modchat = (Config.battlemodchat || null);
 
 		this.type = 'battle';
 

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -616,7 +616,7 @@ if (cluster.isMaster) {
 	process.once('exit', cleanup);
 
 	// this is global so it can be hotpatched if necessary
-	let isTrustedProxyIp = IPTools.checker(Config.proxyip);
+	let isTrustedProxyIp = Config.proxyip ? IPTools.checker(Config.proxyip) : () => false;
 	let socketCounter = 0;
 	server.on('connection', socket => {
 		// For reasons that are not entirely clear, SockJS sometimes triggers
@@ -683,9 +683,10 @@ if (cluster.isMaster) {
 	console.log(`Worker ${cluster.worker.id} now listening on ${Config.bindaddress}:${Config.port}`);
 
 	if (appssl) {
-		// @ts-ignore
 		server.installHandlers(appssl, {});
+		// @ts-ignore - if appssl exists, then `Config.ssl` must also exist
 		appssl.listen(Config.ssl.port, Config.bindaddress);
+		// @ts-ignore - if appssl exists, then `Config.ssl` must also exist
 		console.log(`Worker ${cluster.worker.id} now listening for SSL on port ${Config.ssl.port}`);
 	}
 

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1329,7 +1329,7 @@ const commands: {basic: TourCommands, creation: TourCommands, moderation: TourCo
 			if (params.length < 1) {
 				return this.sendReply(`Usage: ${cmd} <comma-separated arguments>`);
 			}
-			let name = this.canTalk(params[0].trim());
+			const name = this.canTalk(params[0].trim());
 			if (!name || typeof name !== 'string') return;
 
 			if (name.length > MAX_CUSTOM_NAME_LENGTH) {

--- a/server/users.ts
+++ b/server/users.ts
@@ -244,6 +244,7 @@ function cacheGroupData() {
 				continue;
 			}
 
+			// @ts-ignore - dyanmically assigned property
 			groupData.rank = numGroups - i - 1;
 			groups[groupData.symbol] = groupData;
 			Config.groupsranking.unshift(groupData.symbol);


### PR DESCRIPTION
This commit changes the TypeScript global variable of `Config` from
`AnyObject` to `Config & AnyObject`.

It still falls back to `AnyObject` (hence the 'Take steps') because of
the main-specific `Config` properties that are used without being in the
`Config` object itself.

These can be added by someone with access to the PS main server.

Regardless, this is an improvement as IntelliSense can display and
autocomplete the known properties.

In addition, the TypeScript compiler will now report bugs
concerning the types of the properties, which I have fixed in this
commit.