### PR TITLE
Allow /blockpms to block locked and semilocked users

### DIFF
--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -679,7 +679,7 @@ const commands = {
 		if (target in Config.groups) {
 			user.blockPMs = target;
 			this.sendReply(`You are now blocking private messages, except from staff and ${target}.`);
-		} else if (target === 'autoconfirmed' || target === 'trusted') {
+		} else if (target === 'autoconfirmed' || target === 'trusted' || target === 'unlocked') {
 			user.blockPMs = target;
 			this.sendReply(`You are now blocking private messages, except from staff and ${target} users.`);
 		} else {
@@ -691,7 +691,7 @@ const commands = {
 	},
 	blockpmshelp: [
 		`/blockpms - Blocks private messages except from staff. Unblock them with /unblockpms.`,
-		`/blockpms [ac/trusted/+] - Blocks private messages except from staff and the specified group.`,
+		`/blockpms [unlocked/ac/trusted/+] - Blocks private messages except from staff and the specified group.`,
 	],
 
 	'!unblockpms': true,

--- a/server/users.ts
+++ b/server/users.ts
@@ -622,6 +622,7 @@ export class User extends Chat.MessageContext {
 	}
 	authAtLeast(minAuth: string, room: BasicChatRoom | null = null) {
 		if (!minAuth || minAuth === ' ') return true;
+		if (minAuth === 'unlocked') return !(this.locked || this.semilocked);
 		if (minAuth === 'trusted' && this.trusted) return true;
 		if (minAuth === 'autoconfirmed' && this.autoconfirmed) return true;
 


### PR DESCRIPTION
Per global staff discussion, allow gstaff to opt into blocking PMs from locked and semilocked users due to harassment issues. They're directed to a help ticket if they truly need help.