### PR TITLE
Allow trusted users to bypass blacklist/roomban if not directly punished

### DIFF
--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -1273,15 +1273,17 @@ export const Punishments = new class {
 			if (punishment && (punishment[0] === 'ROOMBAN' || punishment[0] === 'BLACKLIST')) return punishment;
 		}
 
-		for (const ip in user.ips) {
-			punishment = Punishments.roomIps.nestedGet(roomid, ip);
-			if (punishment) {
-				if (punishment[0] === 'ROOMBAN') {
-					return punishment;
-				} else if (punishment[0] === 'BLACKLIST') {
-					if (Punishments.sharedIps.has(ip) && user.autoconfirmed) return;
+		if (!user.trusted) {
+			for (const ip in user.ips) {
+				punishment = Punishments.roomIps.nestedGet(roomid, ip);
+				if (punishment) {
+					if (punishment[0] === 'ROOMBAN') {
+						return punishment;
+					} else if (punishment[0] === 'BLACKLIST') {
+						if (Punishments.sharedIps.has(ip) && user.autoconfirmed) return;
 
-					return punishment;
+						return punishment;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Request from Staff Suggestions: Currently, if the alt of a trusted user is roombanned or blacklisted, the trusted user remains in the room but can't rejoin from the same IP if they leave.  This bypasses that check since we assume trusted users on shared/mobile IPs aren't malicious if the punishment wasn't directed towards them.