### PR TITLE
Fix Blast Burn wording for consistency

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -1375,7 +1375,7 @@ let BattleMovedex = {
 		accuracy: 90,
 		basePower: 150,
 		category: "Special",
-		desc: "If this move is successful, the user must recharge on the following turn and cannot make a move.",
+		desc: "If this move is successful, the user must recharge on the following turn and cannot select a move.",
 		shortDesc: "User cannot move next turn.",
 		id: "blastburn",
 		name: "Blast Burn",


### PR DESCRIPTION
Blast Burn's desc changed from "cannot make a move" to "cannot select a move" to match with all other recharge moves